### PR TITLE
QVAC-21928 feat[api]: add CosyVoice3 engine to @qvac/tts-ggml

### DIFF
--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -154,6 +154,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/JSAdapter.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/supertonic/SupertonicModel.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
 )
 
 target_include_directories(
@@ -316,6 +317,7 @@ if(BUILD_TESTING)
       addon/tests/test_backend_utils.cpp
       addon/tests/test_chatterbox_config.cpp
       addon/tests/test_supertonic_config.cpp
+      addon/tests/test_cosyvoice_config.cpp
       addon/tests/test_time_stretch.cpp
       addon/tests/test_streaming_enhancer.cpp
       addon/tests/test_output_resampler.cpp
@@ -323,6 +325,7 @@ if(BUILD_TESTING)
       addon/tests/AddonCppTest.cpp
       addon/src/model-interface/chatterbox/ChatterboxModel.cpp
       addon/src/model-interface/supertonic/SupertonicModel.cpp
+      addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
   )
 
   target_include_directories(tts_ggml_tests

--- a/packages/tts-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/tts-ggml/addon/src/addon/AddonJs.hpp
@@ -18,6 +18,7 @@
 
 #include "js-interface/JSAdapter.hpp"
 #include "model-interface/chatterbox/ChatterboxModel.hpp"
+#include "model-interface/cosyvoice/CosyvoiceModel.hpp"
 #include "model-interface/supertonic/SupertonicModel.hpp"
 
 namespace qvac::ttsggml::addon_js {
@@ -25,6 +26,7 @@ namespace qvac::ttsggml::addon_js {
 namespace js = qvac_lib_inference_addon_cpp::js;
 
 using chatterbox::ChatterboxModel;
+using cosyvoice::CosyvoiceModel;
 using supertonic::SupertonicModel;
 
 struct JsAudioOutputHandler
@@ -108,6 +110,12 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
         outSr > 0 ? outSr
                   : (enhanced ? kLavasrEnhancedSampleRate : stm->sampleRate());
     model = std::move(stm);
+  } else if (engineType == EngineType::Cosyvoice) {
+    auto cfg = adapter.buildCosyvoiceConfig(configurationParams, env);
+    const int outSr = cfg.outputSampleRate.value_or(0);
+    auto cvm = make_unique<CosyvoiceModel>(std::move(cfg));
+    sampleRate = outSr > 0 ? outSr : cvm->sampleRate();  // native 24 kHz
+    model = std::move(cvm);
   } else {
     auto cfg = adapter.buildChatterboxConfig(configurationParams, env);
     const bool enhanced = !cfg.enhancerGgufPath.empty();
@@ -149,6 +157,21 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
   if (auto* st = dynamic_cast<SupertonicModel*>(&instance.addonCpp->model.get())) {
     SupertonicModel::AnyInput modelInput;
     modelInput.text = js::String(env, jsInput).as<std::string>(env);
+    return instance.runJob(std::any(std::move(modelInput)));
+  }
+
+  if (dynamic_cast<CosyvoiceModel*>(&instance.addonCpp->model.get())) {
+    // CosyVoice3 is a native token-by-token streaming model: wire the same
+    // per-chunk PCM sink Chatterbox uses so streamChunkTokens delivers chunks
+    // through the JS streaming output handler.
+    CosyvoiceModel::AnyInput modelInput;
+    modelInput.text = js::String(env, jsInput).as<std::string>(env);
+    auto outputQueue = instance.addonCpp->outputQueue;
+    modelInput.chunkCallback = [outputQueue](
+        std::vector<int16_t>&& pcm, int chunkIndex, bool isLast) {
+      StreamingPcmChunk chunk{std::move(pcm), chunkIndex, isLast};
+      outputQueue->queueResult(std::any(std::move(chunk)));
+    };
     return instance.runJob(std::any(std::move(modelInput)));
   }
 
@@ -206,6 +229,23 @@ inline js_value_t* reload(js_env_t* env, js_callback_info_t* info) try {
           }
           stm->setConfig(std::move(newCfg));
           stm->reload();
+        });
+  }
+
+  if (dynamic_cast<CosyvoiceModel*>(&instance.addonCpp->model.get())) {
+    auto newCfg = adapter.buildCosyvoiceConfig(configurationParams, env);
+    return js::JsAsyncTask::run(
+        env,
+        [addonCpp = instance.addonCpp, newCfg = std::move(newCfg)]() mutable {
+          auto* cvm =
+              dynamic_cast<CosyvoiceModel*>(&addonCpp->model.get());
+          if (cvm == nullptr) {
+            throw qvac_errors::StatusError(
+                qvac_errors::general_error::InternalError,
+                "reload: model is not a CosyvoiceModel");
+          }
+          cvm->setConfig(std::move(newCfg));
+          cvm->reload();
         });
   }
 

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -81,12 +81,21 @@ EngineType JSAdapter::readEngineType(
       readOptionalString(configurationParams, env, "engineType");
   if (explicitType == "chatterbox") return EngineType::Chatterbox;
   if (explicitType == "supertonic") return EngineType::Supertonic;
+  if (explicitType == "cosyvoice3") return EngineType::Cosyvoice;
   if (!explicitType.empty()) {
     throw qvac_errors::StatusError(
         general_error::InvalidArgument,
-        "engineType must be 'chatterbox' or 'supertonic' (got '" +
+        "engineType must be 'chatterbox', 'supertonic' or 'cosyvoice3' (got '" +
             explicitType + "')");
   }
+
+  const std::string cosyvoiceDir =
+      readOptionalString(configurationParams, env, "cosyvoiceModelDir");
+  if (!cosyvoiceDir.empty()) return EngineType::Cosyvoice;
+
+  const std::string cosyvoiceLlm =
+      readOptionalString(configurationParams, env, "cosyvoiceLlmModelPath");
+  if (!cosyvoiceLlm.empty()) return EngineType::Cosyvoice;
 
   const std::string supertonicPath =
       readOptionalString(configurationParams, env, "supertonicModelPath");
@@ -171,6 +180,36 @@ supertonic::SupertonicConfig JSAdapter::buildSupertonicConfig(
   // qvac-ext-lib-whisper.cpp PR #78 (activates once the pinned tts-cpp has it).
   cfg.denoiserGgufPath =
       readOptionalString(configurationParams, env, "lavasrDenoiserPath");
+  return cfg;
+}
+
+cosyvoice::CosyvoiceConfig JSAdapter::buildCosyvoiceConfig(
+    js::Object configurationParams, js_env_t* env) {
+  cosyvoice::CosyvoiceConfig cfg;
+  cfg.modelDir          = readOptionalString(configurationParams, env, "cosyvoiceModelDir");
+  cfg.llmModelPath      = readOptionalString(configurationParams, env, "cosyvoiceLlmModelPath");
+  cfg.flowModelPath     = readOptionalString(configurationParams, env, "cosyvoiceFlowModelPath");
+  cfg.hiftModelPath     = readOptionalString(configurationParams, env, "cosyvoiceHiftModelPath");
+  cfg.s3tokModelPath    = readOptionalString(configurationParams, env, "cosyvoiceS3tokModelPath");
+  cfg.campplusModelPath = readOptionalString(configurationParams, env, "cosyvoiceCampplusModelPath");
+  cfg.referenceAudio    = readOptionalString(configurationParams, env, "referenceAudio");
+  cfg.promptText        = readOptionalString(configurationParams, env, "promptText");
+  cfg.voice             = readOptionalString(configurationParams, env, "voice");
+  cfg.instruct          = readOptionalString(configurationParams, env, "instruct");
+  {
+    auto lang = readOptionalString(configurationParams, env, "language");
+    if (!lang.empty()) cfg.language = std::move(lang);
+  }
+  cfg.seed                    = readOptionalInt(configurationParams, env, "seed");
+  cfg.threads                 = readOptionalInt(configurationParams, env, "threads");
+  cfg.nGpuLayers              = readOptionalInt(configurationParams, env, "nGpuLayers");
+  cfg.useGpu                  = readOptionalBool(configurationParams, env, "useGPU");
+  cfg.outputSampleRate        = readOptionalInt(configurationParams, env, "outputSampleRate");
+  cfg.cfmSteps                = readOptionalInt(configurationParams, env, "cfmSteps");
+  cfg.streamChunkTokens       = readOptionalInt(configurationParams, env, "streamChunkTokens");
+  cfg.streamFirstChunkTokens  = readOptionalInt(configurationParams, env, "streamFirstChunkTokens");
+  cfg.streamLeftContextTokens = readOptionalInt(configurationParams, env, "streamLeftContextTokens");
+  cfg.backendsDir             = readOptionalString(configurationParams, env, "backendsDir");
   return cfg;
 }
 

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.hpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.hpp
@@ -6,6 +6,7 @@
 #include <inference-addon-cpp/JsUtils.hpp>
 
 #include "model-interface/chatterbox/ChatterboxConfig.hpp"
+#include "model-interface/cosyvoice/CosyvoiceConfig.hpp"
 #include "model-interface/supertonic/SupertonicConfig.hpp"
 
 namespace qvac::ttsggml {
@@ -13,6 +14,7 @@ namespace qvac::ttsggml {
 enum class EngineType {
   Chatterbox,
   Supertonic,
+  Cosyvoice,
 };
 
 class JSAdapter {
@@ -28,6 +30,10 @@ public:
       js_env_t* env);
 
   supertonic::SupertonicConfig buildSupertonicConfig(
+      qvac_lib_inference_addon_cpp::js::Object configurationParams,
+      js_env_t* env);
+
+  cosyvoice::CosyvoiceConfig buildCosyvoiceConfig(
       qvac_lib_inference_addon_cpp::js::Object configurationParams,
       js_env_t* env);
 };

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceConfig.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace qvac::ttsggml::cosyvoice {
+
+/**
+ * Configuration for the CosyVoice3 engine wrapping tts-cpp::tts-cpp.
+ *
+ * ITERATION 1 (SCAFFOLD): maps 1:1 into `tts_cpp::cosyvoice::EngineOptions`
+ * via {@link CosyvoiceModel::load}. The underlying tts-cpp engine is the
+ * wiring skeleton — synthesize() returns placeholder audio until the real CPU
+ * graphs (Qwen2 LM -> S3 tokenizer -> DiT flow -> HiFT vocoder) land. The
+ * option surface here is intended to stay stable across that work.
+ */
+struct CosyvoiceConfig {
+  /**
+   * Directory holding the standard CosyVoice3 GGUFs
+   * (cosyvoice3-{llm,flow,hift,s3tok,campplus,voices}-*.gguf). Either set
+   * this, or set the per-component paths below (explicit paths win).
+   */
+  std::string modelDir;
+
+  std::string llmModelPath;       // Qwen2.5 LM (text -> speech tokens)
+  std::string flowModelPath;      // DiT conditional-flow-matching (tokens -> mel)
+  std::string hiftModelPath;      // CausalHiFT vocoder (mel -> 24 kHz PCM)
+  std::string s3tokModelPath;     // supervised S3 speech tokenizer (zero-shot)
+  std::string campplusModelPath;  // CAM++ speaker encoder (zero-shot)
+
+  /** Zero-shot voice cloning: reference wav + its transcript. */
+  std::string referenceAudio;
+  std::string promptText;
+  /** Or a voice baked into voices.gguf (reference audio wins when both set). */
+  std::string voice;
+
+  /**
+   * Natural-language control instruction (CosyVoice3 instruct2): selects a
+   * Chinese dialect, emotion, speaking speed, volume, or style. The JS layer
+   * renders a structured `instruct` (e.g. { dialect: 'cantonese' }) into the
+   * trained instruction string ("请用广东话表达。") before it reaches here;
+   * the engine wraps it as "You are a helpful assistant. " + instruct +
+   * "<|endofprompt|>" and drops the LM prompt speech tokens. Empty = zero-shot.
+   */
+  std::string instruct;
+
+  /** Language hint for the multilingual text frontend. */
+  std::string language = "en";
+
+  std::optional<int> seed;
+  /** std::thread::hardware_concurrency() override. */
+  std::optional<int> threads;
+  /** Layers to move to the GPU backend. Iteration 1 is CPU-only (ignored). */
+  std::optional<int> nGpuLayers;
+  /**
+   * Tri-state GPU intent (mirrors ChatterboxConfig::useGpu). Iteration 1 runs
+   * CPU-only, but the field is plumbed and conflict-checked so the option
+   * surface matches the sibling engines. Conflicts with nGpuLayers (true + 0,
+   * or false + !=0) are rejected by CosyvoiceModel::validateConfig.
+   */
+  std::optional<bool> useGpu;
+  /**
+   * Desired output sample rate in Hz (8000–192000), or unset/0 to keep the
+   * engine's native 24 kHz.
+   */
+  std::optional<int> outputSampleRate;
+  /** Flow-matching Euler steps. Unset/0 = model default (10). */
+  std::optional<int> cfmSteps;
+
+  /**
+   * Native streaming controls. CosyVoice3 is a token-by-token streaming model
+   * (the LM emits speech tokens, token2wav vocodes them in hops). When
+   * `streamChunkTokens > 0` and the job passes a chunk callback, the engine
+   * runs the chunked loop and emits PCM per chunk. 0 = batch synthesis.
+   */
+  std::optional<int> streamChunkTokens;
+  /** Smaller first chunk for low first-audio latency. 0 = same as streamChunkTokens. */
+  std::optional<int> streamFirstChunkTokens;
+  /** Left context carried into each chunk (bounds per-chunk cost). */
+  std::optional<int> streamLeftContextTokens;
+
+  /** Forwarded to `tts_cpp::cosyvoice::EngineOptions::backends_dir`. */
+  std::string backendsDir;
+};
+
+} // namespace qvac::ttsggml::cosyvoice

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
@@ -1,0 +1,266 @@
+#include "model-interface/cosyvoice/CosyvoiceModel.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <tts-cpp/cosyvoice/engine.h>
+
+#include "addon/TTSErrors.hpp"
+#include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/BackendUtils.hpp"
+
+namespace qvac::ttsggml::cosyvoice {
+
+namespace {
+
+using qvac_errors::createTTSError;
+using qvac_errors::StatusError;
+using qvac_errors::tts_error::TTSErrorCode;
+namespace general_error = qvac_errors::general_error;
+
+tts_cpp::cosyvoice::EngineOptions toEngineOptions(const CosyvoiceConfig& cfg) {
+  tts_cpp::cosyvoice::EngineOptions opts;
+  opts.model_dir          = cfg.modelDir;
+  opts.llm_gguf_path      = cfg.llmModelPath;
+  opts.flow_gguf_path     = cfg.flowModelPath;
+  opts.hift_gguf_path     = cfg.hiftModelPath;
+  opts.s3tok_gguf_path    = cfg.s3tokModelPath;
+  opts.campplus_gguf_path = cfg.campplusModelPath;
+  opts.reference_audio    = cfg.referenceAudio;
+  opts.prompt_text        = cfg.promptText;
+  opts.voice              = cfg.voice;
+  opts.instruct_text      = cfg.instruct;
+  if (!cfg.language.empty()) opts.language = cfg.language;
+  if (cfg.seed.has_value())    opts.seed      = *cfg.seed;
+  if (cfg.threads.has_value()) opts.n_threads = *cfg.threads;
+  if (cfg.nGpuLayers.has_value()) {
+    opts.n_gpu_layers = *cfg.nGpuLayers;
+  } else if (cfg.useGpu.has_value()) {
+    opts.n_gpu_layers = *cfg.useGpu ? 99 : 0;
+  }
+  if (cfg.outputSampleRate.has_value()) opts.output_sample_rate = *cfg.outputSampleRate;
+  if (cfg.cfmSteps.has_value())         opts.cfm_steps = *cfg.cfmSteps;
+  if (cfg.streamChunkTokens.has_value())       opts.stream_chunk_tokens = *cfg.streamChunkTokens;
+  if (cfg.streamFirstChunkTokens.has_value())  opts.stream_first_chunk_tokens = *cfg.streamFirstChunkTokens;
+  if (cfg.streamLeftContextTokens.has_value()) opts.stream_left_context_tokens = *cfg.streamLeftContextTokens;
+
+  // Compose `cfg.backendsDir / BACKENDS_SUBDIR` before forwarding, mirroring
+  // SupertonicModel::toEngineOptions so a host that passes
+  // path.join(__dirname, 'prebuilds') gets the expected per-arch scan dir.
+  if (!cfg.backendsDir.empty()) {
+    std::filesystem::path backendsDirPath(cfg.backendsDir);
+#ifdef BACKENDS_SUBDIR
+    backendsDirPath =
+        (backendsDirPath / std::filesystem::path(BACKENDS_SUBDIR)).lexically_normal();
+#endif
+    opts.backends_dir = backendsDirPath.string();
+  }
+  return opts;
+}
+
+std::vector<int16_t> pcmFloatToInt16(const float* pcm, size_t samples) {
+  std::vector<int16_t> out;
+  out.resize(samples);
+  for (size_t i = 0; i < samples; ++i) {
+    float s = std::clamp(pcm[i], -1.0f, 1.0f);
+    out[i] = static_cast<int16_t>(std::lround(s * 32767.0f));
+  }
+  return out;
+}
+
+} // namespace
+
+CosyvoiceModel::CosyvoiceModel(CosyvoiceConfig config)
+    : cfg_(std::move(config)) {
+  validateConfig(cfg_);
+  // load() is deferred to waitForLoadInitialization() so any heavy model
+  // parse runs off the JS event loop via JsAsyncTask::run-driven activate().
+}
+
+CosyvoiceModel::~CosyvoiceModel() noexcept = default;
+
+void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
+  if (cfg.modelDir.empty() && cfg.llmModelPath.empty()) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "cosyvoiceModelDir (or cosyvoiceLlmModelPath) is required");
+  }
+  if (!cfg.modelDir.empty() && !std::filesystem::exists(cfg.modelDir)) {
+    throw createTTSError(TTSErrorCode::ModelFileNotFound,
+                         "cosyvoice model dir not found: " + cfg.modelDir);
+  }
+  if (!cfg.referenceAudio.empty() &&
+      !std::filesystem::exists(cfg.referenceAudio)) {
+    throw createTTSError(TTSErrorCode::ModelFileNotFound,
+                         "reference audio not found: " + cfg.referenceAudio);
+  }
+  if (cfg.cfmSteps.has_value() && *cfg.cfmSteps < 0) {
+    throw StatusError(general_error::InvalidArgument, "cfmSteps must be >= 0");
+  }
+  // useGPU / nGpuLayers conflict check — mirrors the sibling engines so the
+  // option surface behaves identically even though iteration 1 runs CPU-only.
+  if (cfg.useGpu.has_value() && cfg.nGpuLayers.has_value()) {
+    const bool wantsGpuFlag  = *cfg.useGpu;
+    const int  layers        = *cfg.nGpuLayers;
+    const bool layersWantGpu = layers != 0;
+    if (wantsGpuFlag != layersWantGpu) {
+      throw StatusError(
+          general_error::InvalidArgument,
+          std::string("CosyvoiceModel: useGPU=") +
+              (wantsGpuFlag ? "true" : "false") +
+              " conflicts with nGpuLayers=" + std::to_string(layers) +
+              ". Either drop one of the two, or make them agree "
+              "(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).");
+    }
+  }
+}
+
+void CosyvoiceModel::load() {
+  std::lock_guard lk(engineMu_);
+  loadLocked();
+}
+
+void CosyvoiceModel::unload() {
+  std::lock_guard lk(engineMu_);
+  unloadLocked();
+}
+
+void CosyvoiceModel::reload() {
+  std::lock_guard lk(engineMu_);
+  unloadLocked();
+  loadLocked();
+}
+
+void CosyvoiceModel::loadLocked() {
+  if (engine_) return;
+
+  try {
+    engine_ = std::make_shared<tts_cpp::cosyvoice::Engine>(toEngineOptions(cfg_));
+  } catch (const std::exception& e) {
+    engine_.reset();
+    throw createTTSError(
+        TTSErrorCode::InitializationFailed,
+        std::string("CosyvoiceModel::load: ") + e.what());
+  }
+
+  backendName_    = engine_->backend_name();
+  backendDevice_  = backendDeviceCode(engine_->backend_device());
+  backendId_      = backendIdFromName(backendName_);
+  gpuUnsupported_ = engine_->gpu_unsupported();
+}
+
+void CosyvoiceModel::unloadLocked() { engine_.reset(); }
+
+void CosyvoiceModel::cancel() const {
+  cancelRequested_.store(true, std::memory_order_relaxed);
+  std::shared_ptr<tts_cpp::cosyvoice::Engine> e;
+  {
+    std::lock_guard lk(engineMu_);
+    e = engine_;
+  }
+  if (e) e->cancel();
+}
+
+CosyvoiceModel::Output CosyvoiceModel::synthesize(
+    const std::string& text, const ChunkCallback& onChunk) {
+  std::shared_ptr<tts_cpp::cosyvoice::Engine> engine;
+  {
+    std::lock_guard lk(engineMu_);
+    engine = engine_;
+  }
+  if (!engine) {
+    throw createTTSError(TTSErrorCode::InitializationFailed,
+                         "CosyvoiceModel::synthesize: engine not loaded");
+  }
+  if (cancelRequested_.load(std::memory_order_relaxed)) {
+    throw createTTSError(TTSErrorCode::SynthesisFailed,
+                         "synthesis cancelled before it started");
+  }
+
+  textLength_ = text.size();
+
+  const bool streaming =
+      cfg_.streamChunkTokens.value_or(0) > 0 && static_cast<bool>(onChunk);
+
+  const auto t0 = std::chrono::steady_clock::now();
+  tts_cpp::cosyvoice::SynthesisResult result;
+  try {
+    if (streaming) {
+      // Bridge the engine's float chunk callback to the JS int16 sink.
+      auto engineCb = [&onChunk](const float* pcm, std::size_t samples,
+                                 int chunkIndex, bool isLast) {
+        onChunk(pcmFloatToInt16(pcm, samples), chunkIndex, isLast);
+      };
+      result = engine->synthesize(text, engineCb);
+    } else {
+      result = engine->synthesize(text);
+    }
+  } catch (const std::exception& e) {
+    throw createTTSError(TTSErrorCode::SynthesisFailed,
+                         std::string("cosyvoice.synthesize: ") + e.what());
+  }
+
+  const auto t1 = std::chrono::steady_clock::now();
+
+  sampleRate_ = result.sample_rate;
+  totalSamples_ = static_cast<int64_t>(result.pcm.size());
+  audioDurationMs_ = result.duration_s > 0.0f
+      ? result.duration_s * 1000.0
+      : (sampleRate_ > 0 ? (static_cast<double>(totalSamples_) * 1000.0 /
+                            static_cast<double>(sampleRate_))
+                         : 0.0);
+  totalTime_ = std::chrono::duration<double>(t1 - t0).count();
+  realTimeFactor_ = audioDurationMs_ > 0.0
+      ? (totalTime_ * 1000.0) / audioDurationMs_
+      : 0.0;
+  tokensPerSecond_ = totalTime_ > 0.0
+      ? static_cast<double>(textLength_) / totalTime_
+      : 0.0;
+
+  return pcmFloatToInt16(result.pcm.data(), result.pcm.size());
+}
+
+std::any CosyvoiceModel::process(const std::any& input) {
+  const auto* anyInput = std::any_cast<AnyInput>(&input);
+  if (!anyInput) {
+    throw StatusError(general_error::InvalidArgument,
+                      "CosyvoiceModel::process: input must be AnyInput");
+  }
+
+  bool expected = false;
+  if (!jobInProgress_.compare_exchange_strong(expected, true,
+                                              std::memory_order_acq_rel)) {
+    throw StatusError(general_error::InternalError,
+                      "CosyvoiceModel::process: job already in progress");
+  }
+  struct InProgressGuard {
+    std::atomic_bool& flag;
+    ~InProgressGuard() { flag.store(false, std::memory_order_release); }
+  } guard{jobInProgress_};
+
+  cancelRequested_.store(false, std::memory_order_relaxed);
+  return std::any(synthesize(anyInput->text, anyInput->chunkCallback));
+}
+
+qvac_lib_inference_addon_cpp::RuntimeStats CosyvoiceModel::runtimeStats() const {
+  qvac_lib_inference_addon_cpp::RuntimeStats stats;
+  stats.emplace_back("totalTime", totalTime_);
+  stats.emplace_back("tokensPerSecond", tokensPerSecond_);
+  stats.emplace_back("realTimeFactor", realTimeFactor_);
+  stats.emplace_back("audioDurationMs", audioDurationMs_);
+  stats.emplace_back("totalSamples", totalSamples_);
+  stats.emplace_back("backendDevice", static_cast<int64_t>(backendDevice_));
+  stats.emplace_back("backendId",     static_cast<int64_t>(backendId_));
+  stats.emplace_back("gpuUnsupported", static_cast<int64_t>(gpuUnsupported_));
+  return stats;
+}
+
+} // namespace qvac::ttsggml::cosyvoice

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <any>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "inference-addon-cpp/ModelInterfaces.hpp"
+#include "inference-addon-cpp/RuntimeStats.hpp"
+
+#include "model-interface/cosyvoice/CosyvoiceConfig.hpp"
+
+namespace tts_cpp::cosyvoice {
+class Engine;
+}
+
+namespace qvac::ttsggml::cosyvoice {
+
+class CosyvoiceModel
+    : public qvac_lib_inference_addon_cpp::model::IModel,
+      public qvac_lib_inference_addon_cpp::model::IModelCancel,
+      public qvac_lib_inference_addon_cpp::model::IModelAsyncLoad {
+public:
+  using Output = std::vector<int16_t>;
+
+  // Streaming chunk sink: called per token2wav hop with 16-bit PCM. Mirrors
+  // ChatterboxModel's chunkCallback so the native chunk-streaming path flows
+  // through the same JS output handler.
+  using ChunkCallback =
+      std::function<void(std::vector<int16_t>&&, int chunkIndex, bool isLast)>;
+
+  struct AnyInput {
+    std::string text;
+    ChunkCallback chunkCallback;
+  };
+
+  explicit CosyvoiceModel(CosyvoiceConfig config);
+  ~CosyvoiceModel() noexcept override;
+
+  std::string getName() const override { return "CosyvoiceModel"; }
+  std::any process(const std::any& input) override;
+  qvac_lib_inference_addon_cpp::RuntimeStats runtimeStats() const override;
+
+  void cancel() const override;
+
+  void load();
+  void unload();
+  void reload();
+  bool isLoaded() const {
+    std::lock_guard lk(engineMu_);
+    return static_cast<bool>(engine_);
+  }
+
+  // IModelAsyncLoad — the deferred load() runs on a worker thread via
+  // AddonCpp::activate(); load() is idempotent.
+  void waitForLoadInitialization() override { load(); }
+  void setWeightsForFile(
+      const std::string&,
+      std::unique_ptr<std::basic_streambuf<char>>&&) override {}
+
+  void setConfig(CosyvoiceConfig config) { cfg_ = std::move(config); }
+  const CosyvoiceConfig& config() const { return cfg_; }
+
+  int sampleRate() const { return sampleRate_; }
+
+private:
+  Output synthesize(const std::string& text, const ChunkCallback& onChunk);
+  static void validateConfig(const CosyvoiceConfig& cfg);
+
+  void loadLocked();
+  void unloadLocked();
+
+  CosyvoiceConfig cfg_;
+
+  mutable std::mutex engineMu_;
+  std::shared_ptr<tts_cpp::cosyvoice::Engine> engine_;
+
+  std::atomic_bool jobInProgress_{false};
+  mutable std::atomic_bool cancelRequested_{false};
+
+  double totalTime_ = 0.0;
+  double audioDurationMs_ = 0.0;
+  int64_t totalSamples_ = 0;
+  double realTimeFactor_ = 0.0;
+  double tokensPerSecond_ = 0.0;
+  size_t textLength_ = 0;
+  int sampleRate_ = 24000;
+
+  int backendDevice_ = 0;
+  int backendId_ = 0;
+  bool gpuUnsupported_ = false;
+  std::string backendName_ = "CPU";
+};
+
+} // namespace qvac::ttsggml::cosyvoice

--- a/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
@@ -1,0 +1,177 @@
+// Constructor-validation + real-GGUF round-trip tests for CosyvoiceModel.
+//
+// Same shape as test_supertonic_config.cpp: validateConfig is private so we
+// drive it indirectly via the public constructor and assert the throw path.
+// The CosyVoice3 engine requires real weights (LM + flow + HiFT + voice +
+// tokenizer), so load()/synthesize round-trips are gated behind
+// QVAC_TEST_COSYVOICE_MODEL_DIR (a directory assembled by
+// tts-cpp/scripts/assemble-cosyvoice3-model.py); without it, load() must throw.
+
+#include <any>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/cosyvoice/CosyvoiceConfig.hpp"
+#include "model-interface/cosyvoice/CosyvoiceModel.hpp"
+
+using qvac::ttsggml::cosyvoice::CosyvoiceConfig;
+using qvac::ttsggml::cosyvoice::CosyvoiceModel;
+using qvac_errors::StatusError;
+
+namespace {
+
+std::string envOrEmpty(const char* name) {
+  if (const char* v = std::getenv(name)) return v;
+  return "";
+}
+
+// A directory that exists but holds no CosyVoice3 weights: construction (which
+// only validates the directory exists) succeeds, but load() must fail because
+// the engine can't resolve the LM/flow/HiFT/voice/tokenizer components.
+std::filesystem::path emptyModelDir() {
+  auto dir = std::filesystem::temp_directory_path() /
+             "qvac-tts-ggml-cosyvoice-tests";
+  std::filesystem::create_directories(dir);
+  return dir;
+}
+
+CosyvoiceConfig configWithExistingDir() {
+  CosyvoiceConfig cfg;
+  cfg.modelDir = emptyModelDir().string();
+  return cfg;
+}
+
+} // namespace
+
+TEST(CosyvoiceValidate, EmptyConfigRejected) {
+  CosyvoiceConfig cfg;
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, NonexistentModelDirRejected) {
+  CosyvoiceConfig cfg;
+  cfg.modelDir = "/definitely/does/not/exist/cosyvoice3";
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, NonexistentReferenceAudioRejected) {
+  auto cfg = configWithExistingDir();
+  cfg.referenceAudio = "/definitely/does/not/exist/ref.wav";
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, NegativeCfmStepsRejected) {
+  auto cfg = configWithExistingDir();
+  cfg.cfmSteps = -1;
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, UseGpuNGpuLayersConflictRejected) {
+  auto cfg = configWithExistingDir();
+  cfg.useGpu = true;
+  cfg.nGpuLayers = 0;
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, ConfigDefaultsAreCpuFriendly) {
+  CosyvoiceConfig cfg;
+  EXPECT_EQ(cfg.language, "en");
+  EXPECT_FALSE(cfg.useGpu.has_value());
+  EXPECT_FALSE(cfg.nGpuLayers.has_value());
+  EXPECT_FALSE(cfg.cfmSteps.has_value());
+  EXPECT_FALSE(cfg.streamChunkTokens.has_value());
+}
+
+TEST(CosyvoiceModelLifecycle, ConstructDefersLoad) {
+  auto cfg = configWithExistingDir();
+  CosyvoiceModel m(cfg);
+  EXPECT_EQ(m.getName(), "CosyvoiceModel");
+  EXPECT_FALSE(m.isLoaded()) << "load is deferred until activate()/load()";
+}
+
+TEST(CosyvoiceModelLifecycle, LoadWithoutWeightsThrows) {
+  // A directory with no CosyVoice3 GGUFs: the engine can't resolve its
+  // components, so the deferred load must raise (not silently succeed).
+  auto cfg = configWithExistingDir();
+  CosyvoiceModel m(cfg);
+  EXPECT_THROW(m.load(), StatusError);
+  EXPECT_FALSE(m.isLoaded());
+}
+
+TEST(CosyvoiceModelLifecycle, ProcessRejectsWrongAnyInputType) {
+  // The input-type check happens before any engine work, so this needs no
+  // weights: a non-AnyInput payload is rejected up front.
+  auto cfg = configWithExistingDir();
+  CosyvoiceModel m(cfg);
+  EXPECT_THROW(m.process(std::any{int64_t{42}}), StatusError);
+}
+
+// ---- Real-GGUF round-trips (opt-in) -------------------------------------
+// Set QVAC_TEST_COSYVOICE_MODEL_DIR to a directory holding
+// cosyvoice3-{llm,flow,hift}*.gguf + voice.gguf + vocab.json + merges.txt.
+
+TEST(CosyvoiceRealGguf, ConstructLoadSynthesizeUnload) {
+  const auto dir = envOrEmpty("QVAC_TEST_COSYVOICE_MODEL_DIR");
+  if (dir.empty()) GTEST_SKIP() << "Set QVAC_TEST_COSYVOICE_MODEL_DIR to enable.";
+
+  CosyvoiceConfig cfg;
+  cfg.modelDir = dir;
+  CosyvoiceModel m(cfg);
+  EXPECT_FALSE(m.isLoaded());
+  ASSERT_NO_THROW(m.load());
+  EXPECT_TRUE(m.isLoaded());
+  EXPECT_EQ(m.sampleRate(), 24000);
+
+  CosyvoiceModel::AnyInput input;
+  input.text = "Hello from a fully on device pipeline.";
+  std::any out;
+  ASSERT_NO_THROW(out = m.process(std::any(input)));
+  const auto* pcm = std::any_cast<std::vector<int16_t>>(&out);
+  ASSERT_NE(pcm, nullptr);
+  EXPECT_GT(pcm->size(), 0u);
+
+  EXPECT_NO_THROW(m.unload());
+  EXPECT_FALSE(m.isLoaded());
+}
+
+TEST(CosyvoiceRealGguf, StreamingDeliversChunks) {
+  const auto dir = envOrEmpty("QVAC_TEST_COSYVOICE_MODEL_DIR");
+  if (dir.empty()) GTEST_SKIP() << "Set QVAC_TEST_COSYVOICE_MODEL_DIR to enable.";
+
+  CosyvoiceConfig cfg;
+  cfg.modelDir = dir;
+  cfg.streamChunkTokens = 25;       // ~1 s hops
+  cfg.streamFirstChunkTokens = 10;  // smaller first chunk
+  CosyvoiceModel m(cfg);
+  m.load();
+
+  int chunks = 0;
+  bool sawLast = false;
+  size_t streamedSamples = 0;
+  CosyvoiceModel::AnyInput input;
+  input.text = "Streaming synthesis over several chunks.";
+  input.chunkCallback = [&](std::vector<int16_t>&& pcm, int idx, bool isLast) {
+    EXPECT_EQ(idx, chunks);
+    streamedSamples += pcm.size();
+    ++chunks;
+    if (isLast) sawLast = true;
+  };
+
+  std::any out;
+  ASSERT_NO_THROW(out = m.process(std::any(std::move(input))));
+  EXPECT_GT(chunks, 1) << "expected multiple streaming chunks";
+  EXPECT_TRUE(sawLast);
+
+  // The returned batch PCM must equal the concatenation of streamed chunks.
+  const auto* full = std::any_cast<std::vector<int16_t>>(&out);
+  ASSERT_NE(full, nullptr);
+  EXPECT_EQ(full->size(), streamedSamples);
+}

--- a/packages/tts-ggml/examples/cosyvoice-tts.js
+++ b/packages/tts-ggml/examples/cosyvoice-tts.js
@@ -1,0 +1,119 @@
+'use strict'
+
+/**
+ * CosyVoice3 TTS batch synthesis for @qvac/tts-ggml.
+ *
+ * Loads the Fun-CosyVoice3-0.5B model directory (Qwen2 speech LM + DiT flow +
+ * CausalHiFT vocoder, plus the Qwen2 BPE tokenizer and a baked default voice)
+ * and synthesizes a single utterance.  CPU-only (iteration 1); native 24 kHz.
+ *
+ * Usage:
+ *   bare examples/cosyvoice-tts.js "text to synthesize" [modelDir]
+ *
+ * Examples:
+ *   bare examples/cosyvoice-tts.js "Hello from a fully on-device C++ pipeline."
+ *   bare examples/cosyvoice-tts.js "Peer to peer, local first." /path/to/cosyvoice3
+ *
+ * The model directory is produced by
+ * qvac-ext-lib-whisper.cpp/tts-cpp/scripts/assemble-cosyvoice3-model.py and
+ * must contain:
+ *   cosyvoice3-llm-*.gguf  cosyvoice3-flow-*.gguf  cosyvoice3-hift-*.gguf
+ *   voice.gguf  vocab.json  merges.txt
+ * Default location: models/cosyvoice3/ (override with the 2nd arg or
+ * COSYVOICE_MODEL_DIR).
+ */
+
+const fs = require('bare-fs')
+const path = require('bare-path')
+const TTSGgml = require('../')
+const { createWav } = require('./wav-helper')
+const { setLogger, releaseLogger } = require('../addonLogging')
+
+const COSYVOICE_SAMPLE_RATE = 24000
+
+const argv = global.Bare ? global.Bare.argv : process.argv
+const env = (global.Bare && global.Bare.env) || (typeof process !== 'undefined' && process.env) || {}
+const textArg = argv[2]
+const modelDirArg = argv[3]
+
+if (!textArg || typeof textArg !== 'string' || textArg.trim().length === 0) {
+  console.error('Usage: cosyvoice-tts.js "<text to synthesize>" [modelDir]')
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+}
+
+const pkgRoot = path.join(__dirname, '..')
+const cosyvoiceModelDir =
+  modelDirArg || env.COSYVOICE_MODEL_DIR || path.join(pkgRoot, 'models', 'cosyvoice3')
+
+if (!fs.existsSync(cosyvoiceModelDir)) {
+  console.error(`Missing CosyVoice3 model directory: ${cosyvoiceModelDir}`)
+  console.error(
+    'Assemble one with tts-cpp/scripts/assemble-cosyvoice3-model.py, then pass it ' +
+      'as the 2nd arg or set COSYVOICE_MODEL_DIR.'
+  )
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+}
+
+async function main () {
+  setLogger((priority, message) => {
+    if (priority > 1) return
+    const names = { 0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG', 4: 'OFF' }
+    const name = names[priority] || 'UNKNOWN'
+    console.log(`[${new Date().toISOString()}] [C++ log] [${name}]: ${message}`)
+  })
+
+  const outputFile = path.join(__dirname, 'cosyvoice-output.wav')
+
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_COSYVOICE3,
+    files: { cosyvoiceModelDir },
+    config: { language: 'en' },
+    logger: console,
+    opts: { stats: true }
+  })
+
+  try {
+    console.log('Loading CosyVoice3 TTS model...')
+    await model.load()
+    console.log('Model loaded.')
+
+    console.log(`Running TTS on: "${textArg}"`)
+
+    const response = await model.run({ input: textArg, type: 'text' })
+
+    let buffer = []
+    await response
+      .onUpdate(data => {
+        if (data && data.outputArray) {
+          buffer = buffer.concat(Array.from(data.outputArray))
+        }
+      })
+      .await()
+
+    console.log('TTS finished!')
+    if (response.stats) {
+      const s = response.stats
+      console.log(`Inference stats: totalTime=${s.totalTime.toFixed(2)}s, realTimeFactor=${s.realTimeFactor.toFixed(3)}, audioDuration=${s.audioDurationMs}ms, totalSamples=${s.totalSamples}`)
+    }
+
+    console.log('\nWriting to .wav file...')
+    createWav(buffer, COSYVOICE_SAMPLE_RATE, outputFile)
+    console.log(`Finished writing to ${outputFile}`)
+  } catch (err) {
+    console.error('Error during TTS processing:', err)
+    throw err
+  } finally {
+    console.log('Unloading model...')
+    await model.unload()
+    console.log('Model unloaded.')
+    releaseLogger()
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+})

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -2,7 +2,61 @@ import { type QvacResponse } from "@qvac/infer-base";
 import { type SentenceDelimiterPreset } from "./lib/textStreamAccumulator";
 declare const ENGINE_CHATTERBOX = "chatterbox";
 declare const ENGINE_SUPERTONIC = "supertonic";
-type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC;
+declare const ENGINE_COSYVOICE3 = "cosyvoice3";
+declare const COSYVOICE_DIALECTS: {
+    readonly cantonese: "广东话";
+    readonly northeastern: "东北话";
+    readonly gansu: "甘肃话";
+    readonly guizhou: "贵州话";
+    readonly henan: "河南话";
+    readonly hubei: "湖北话";
+    readonly hunan: "湖南话";
+    readonly jiangxi: "江西话";
+    readonly minnan: "闽南话";
+    readonly ningxia: "宁夏话";
+    readonly shanxi: "山西话";
+    readonly shaanxi: "陕西话";
+    readonly shandong: "山东话";
+    readonly shanghai: "上海话";
+    readonly sichuan: "四川话";
+    readonly tianjin: "天津话";
+    readonly yunnan: "云南话";
+};
+declare const COSYVOICE_EMOTIONS: {
+    readonly happy: "请非常开心地说一句话。";
+    readonly sad: "请非常伤心地说一句话。";
+    readonly angry: "请非常生气地说一句话。";
+};
+declare const COSYVOICE_SPEEDS: {
+    readonly slow: "请用尽可能慢地语速说一句话。";
+    readonly fast: "请用尽可能快地语速说一句话。";
+};
+declare const COSYVOICE_VOLUMES: {
+    readonly loud: "Please say a sentence as loudly as possible.";
+    readonly soft: "Please say a sentence in a very soft voice.";
+};
+declare const COSYVOICE_STYLES: {
+    readonly peppa: "我想体验一下小猪佩奇风格，可以吗？";
+    readonly robot: "你可以尝试用机器人的方式解答吗？";
+};
+/**
+ * Structured CosyVoice3 control. Exactly one field takes effect per synthesis,
+ * resolved by precedence dialect > emotion > speed > volume > style. Pass a raw
+ * string instead for an arbitrary instruction (advanced escape hatch).
+ */
+interface CosyvoiceInstruct {
+    /** Chinese dialect; renders "请用{dialect}表达。". */
+    dialect?: keyof typeof COSYVOICE_DIALECTS;
+    /** Emotion. */
+    emotion?: keyof typeof COSYVOICE_EMOTIONS;
+    /** Speaking speed. */
+    speed?: keyof typeof COSYVOICE_SPEEDS;
+    /** Loudness. */
+    volume?: keyof typeof COSYVOICE_VOLUMES;
+    /** Playful style preset. */
+    style?: keyof typeof COSYVOICE_STYLES;
+}
+type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC | typeof ENGINE_COSYVOICE3;
 /**
  * Model file paths for the GGML TTS backend. Engine is auto-detected
  * from these fields (Chatterbox vs Supertonic) unless overridden via
@@ -29,6 +83,23 @@ interface TTSGgmlFiles {
     supertonicModel?: string;
     supertonicModelPath?: string;
     supertonic?: string;
+    /**
+     * CosyVoice3 model directory holding the sub-model GGUFs
+     * (`cosyvoice3-{llm,flow,hift,s3tok,campplus,voices}-*.gguf`). Routes to the
+     * CosyVoice3 engine. Falls back to the shared `modelDir` when unset.
+     */
+    cosyvoiceModelDir?: string;
+    /** CosyVoice3 per-component GGUF paths (override discovery under the model dir). */
+    cosyvoiceLlmModel?: string;
+    cosyvoiceLlmModelPath?: string;
+    cosyvoiceFlowModel?: string;
+    cosyvoiceFlowModelPath?: string;
+    cosyvoiceHiftModel?: string;
+    cosyvoiceHiftModelPath?: string;
+    cosyvoiceS3tokModel?: string;
+    cosyvoiceS3tokModelPath?: string;
+    cosyvoiceCampplusModel?: string;
+    cosyvoiceCampplusModelPath?: string;
     /**
      * LavaSR enhancer GGUF: single-file Vocos bandwidth extension produced by
      * tts-cpp/scripts/convert-lavasr-enhancer-to-gguf.py. When supplied, output
@@ -142,6 +213,8 @@ interface TTSGgmlOptions {
     streamChunkTokens?: number;
     /** Chatterbox-only smaller first chunk for low first-audio-out latency. */
     streamFirstChunkTokens?: number;
+    /** CosyVoice3-only: left-context speech tokens carried into each streaming chunk. */
+    streamLeftContextTokens?: number;
     /** Chatterbox-only CFM Euler step count. */
     cfmSteps?: number;
     /**
@@ -151,6 +224,16 @@ interface TTSGgmlOptions {
      * model's baked rate. Omit it to retain the baked rate.
      */
     cfgRate?: number;
+    /** CosyVoice3: transcript of `referenceAudio` for zero-shot voice cloning (conditions the LM prompt). */
+    promptText?: string;
+    /**
+     * CosyVoice3: natural-language control (instruct2) — Chinese dialect, emotion,
+     * speed, volume, or style. Pass a structured object (e.g. `{ dialect:
+     * 'cantonese' }`, `{ emotion: 'happy' }`) which renders to the trained
+     * instruction, or a raw string for an arbitrary instruction. Applied on top of
+     * the selected voice's timbre; one control takes effect per synthesis.
+     */
+    instruct?: string | CosyvoiceInstruct;
     /** Supertonic voice id baked into the GGUF, such as `F1` or `M1`. */
     voice?: string;
     /** Alias for `voice` for compatibility with `@qvac/tts-onnx`. */
@@ -279,6 +362,7 @@ declare class TTSGgml {
     };
     static readonly ENGINE_CHATTERBOX = "chatterbox";
     static readonly ENGINE_SUPERTONIC = "supertonic";
+    static readonly ENGINE_COSYVOICE3 = "cosyvoice3";
     opts: object;
     exclusiveRun: boolean;
     logger: object;
@@ -296,6 +380,12 @@ declare class TTSGgml {
     private _supertonicModelPath?;
     private _t3ModelPath?;
     private _s3genModelPath?;
+    private _cosyvoiceModelDir?;
+    private _cosyvoiceLlmModelPath?;
+    private _cosyvoiceFlowModelPath?;
+    private _cosyvoiceHiftModelPath?;
+    private _cosyvoiceS3tokModelPath?;
+    private _cosyvoiceCampplusModelPath?;
     private _mecabDictPath?;
     private _cangjieTsvPath?;
     private _referenceAudio?;
@@ -307,8 +397,11 @@ declare class TTSGgml {
     private _threads?;
     private _streamChunkTokens?;
     private _streamFirstChunkTokens?;
+    private _streamLeftContextTokens?;
     private _cfmSteps?;
     private _cfgRate?;
+    private _promptText?;
+    private _instruct?;
     private _voice?;
     private _steps?;
     private _speed?;
@@ -356,6 +449,7 @@ declare class TTSGgml {
     private _sentenceStreamDriveBody;
     private _load;
     private _buildTtsParams;
+    private _buildCosyvoiceParams;
     private _buildChatterboxParams;
     private _buildSupertonicParams;
     private _assignCommonNativeParams;

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -13,6 +13,10 @@ const textStreamAccumulator_1 = require("./lib/textStreamAccumulator");
 const { platform } = bareOs;
 const ENGINE_CHATTERBOX = "chatterbox";
 const ENGINE_SUPERTONIC = "supertonic";
+// CosyVoice3 (Fun-CosyVoice3-0.5B / 1.5B). Ships as a small set of GGUFs
+// (cosyvoice3-{llm,flow,hift,s3tok,campplus,voices}-*.gguf); a modelDir holding
+// them (or an explicit `files.cosyvoiceModelDir`) routes here.
+const ENGINE_COSYVOICE3 = "cosyvoice3";
 const MIN_OUTPUT_SAMPLE_RATE = 8000;
 const MAX_OUTPUT_SAMPLE_RATE = 192000;
 const CHATTERBOX_T3_TURBO = "chatterbox-t3-turbo.gguf";
@@ -28,6 +32,74 @@ const SUPERTONIC_V3_QUANT_ORDER = [
     "q8_0",
     "q4_0",
 ];
+// The LLM sub-model is the tell for CosyVoice3 modelDir auto-detection.
+const COSYVOICE3_LLM_RE = /^cosyvoice3-llm(-[a-z0-9_]+)?\.gguf$/i;
+// CosyVoice3 instruct2 control vocabulary (cosyvoice/utils/common.py
+// instruct_list). The structured `instruct` option renders to the exact
+// trained instruction string; the native engine wraps it as
+// "You are a helpful assistant. " + <instruction> + "<|endofprompt|>" and
+// drops the LM prompt speech tokens. One control applies per synthesis
+// (the model is trained on single instructions).
+const COSYVOICE_DIALECTS = {
+    cantonese: "广东话",
+    northeastern: "东北话",
+    gansu: "甘肃话",
+    guizhou: "贵州话",
+    henan: "河南话",
+    hubei: "湖北话",
+    hunan: "湖南话",
+    jiangxi: "江西话",
+    minnan: "闽南话",
+    ningxia: "宁夏话",
+    shanxi: "山西话",
+    shaanxi: "陕西话",
+    shandong: "山东话",
+    shanghai: "上海话",
+    sichuan: "四川话",
+    tianjin: "天津话",
+    yunnan: "云南话",
+};
+const COSYVOICE_EMOTIONS = {
+    happy: "请非常开心地说一句话。",
+    sad: "请非常伤心地说一句话。",
+    angry: "请非常生气地说一句话。",
+};
+const COSYVOICE_SPEEDS = {
+    slow: "请用尽可能慢地语速说一句话。",
+    fast: "请用尽可能快地语速说一句话。",
+};
+const COSYVOICE_VOLUMES = {
+    loud: "Please say a sentence as loudly as possible.",
+    soft: "Please say a sentence in a very soft voice.",
+};
+const COSYVOICE_STYLES = {
+    peppa: "我想体验一下小猪佩奇风格，可以吗？",
+    robot: "你可以尝试用机器人的方式解答吗？",
+};
+/**
+ * Render a CosyVoice3 `instruct` option to the trained instruction string.
+ * A raw string passes through (trimmed); the structured form emits exactly one
+ * control by precedence dialect > emotion > speed > volume > style. Returns ""
+ * for no instruction (zero-shot).
+ */
+function renderCosyvoiceInstruct(instruct) {
+    if (instruct == null)
+        return "";
+    if (typeof instruct === "string")
+        return instruct.trim();
+    if (instruct.dialect) {
+        return `请用${COSYVOICE_DIALECTS[instruct.dialect]}表达。`;
+    }
+    if (instruct.emotion)
+        return COSYVOICE_EMOTIONS[instruct.emotion];
+    if (instruct.speed)
+        return COSYVOICE_SPEEDS[instruct.speed];
+    if (instruct.volume)
+        return COSYVOICE_VOLUMES[instruct.volume];
+    if (instruct.style)
+        return COSYVOICE_STYLES[instruct.style];
+    return "";
+}
 function normalizeError(error) {
     return typeof error === "string"
         ? error
@@ -79,6 +151,22 @@ function findSupertonicV3InDir(modelDir) {
     matches.sort((left, right) => rank(left) - rank(right));
     return path.join(modelDir, matches[0]);
 }
+/**
+ * True when `modelDir` contains a CosyVoice3 LLM GGUF (the sub-model that
+ * unambiguously identifies a CosyVoice3 model directory).
+ */
+function dirHasCosyvoice3(modelDir) {
+    if (!modelDir)
+        return false;
+    let entries;
+    try {
+        entries = fs.readdirSync(modelDir);
+    }
+    catch {
+        return false;
+    }
+    return entries.some((name) => COSYVOICE3_LLM_RE.test(name));
+}
 function normalizeGgmlFiles(files) {
     if (files == null || typeof files !== "object")
         return {};
@@ -87,6 +175,14 @@ function normalizeGgmlFiles(files) {
         t3Model: firstNonEmpty(files.t3Model, files.t3ModelPath, files.t3),
         s3genModel: firstNonEmpty(files.s3genModel, files.s3genModelPath, files.s3gen),
         supertonicModel: firstNonEmpty(files.supertonicModel, files.supertonicModelPath, files.supertonic),
+        // CosyVoice3: either a dedicated modelDir of cosyvoice3-*.gguf files, or
+        // explicit per-component paths. Falls back to the shared `modelDir`.
+        cosyvoiceModelDir: firstNonEmpty(files.cosyvoiceModelDir),
+        cosyvoiceLlmModel: firstNonEmpty(files.cosyvoiceLlmModel, files.cosyvoiceLlmModelPath),
+        cosyvoiceFlowModel: firstNonEmpty(files.cosyvoiceFlowModel, files.cosyvoiceFlowModelPath),
+        cosyvoiceHiftModel: firstNonEmpty(files.cosyvoiceHiftModel, files.cosyvoiceHiftModelPath),
+        cosyvoiceS3tokModel: firstNonEmpty(files.cosyvoiceS3tokModel, files.cosyvoiceS3tokModelPath),
+        cosyvoiceCampplusModel: firstNonEmpty(files.cosyvoiceCampplusModel, files.cosyvoiceCampplusModelPath),
         voicesDir: firstNonEmpty(files.voicesDir),
         lavasrEnhancer: firstNonEmpty(files.lavasrEnhancer),
         lavasrDenoiser: firstNonEmpty(files.lavasrDenoiser),
@@ -95,18 +191,26 @@ function normalizeGgmlFiles(files) {
     };
 }
 function detectEngineType(engine, files) {
-    if (engine === ENGINE_CHATTERBOX || engine === ENGINE_SUPERTONIC) {
+    if (engine === ENGINE_CHATTERBOX ||
+        engine === ENGINE_SUPERTONIC ||
+        engine === ENGINE_COSYVOICE3) {
         return engine;
     }
     if (engine != null && engine !== "") {
-        throw new Error("tts-ggml: 'engine' option must be 'chatterbox' or 'supertonic' " +
-            `(got '${String(engine)}')`);
+        throw new Error("tts-ggml: 'engine' option must be 'chatterbox', 'supertonic' or " +
+            `'cosyvoice3' (got '${String(engine)}')`);
+    }
+    // Explicit CosyVoice3 files/dir take precedence over shared-modelDir sniffing.
+    if (files.cosyvoiceModelDir || files.cosyvoiceLlmModel) {
+        return ENGINE_COSYVOICE3;
     }
     if (files.t3Model || files.s3genModel)
         return ENGINE_CHATTERBOX;
     if (files.supertonicModel)
         return ENGINE_SUPERTONIC;
     if (files.modelDir) {
+        if (dirHasCosyvoice3(files.modelDir))
+            return ENGINE_COSYVOICE3;
         const hasChatterbox = fileExistsSafe(path.join(files.modelDir, CHATTERBOX_T3_TURBO)) ||
             fileExistsSafe(path.join(files.modelDir, CHATTERBOX_T3_MTL));
         const hasSupertonic = fileExistsSafe(path.join(files.modelDir, SUPERTONIC_DEFAULT)) ||
@@ -265,6 +369,7 @@ class TTSGgml {
     };
     static ENGINE_CHATTERBOX = ENGINE_CHATTERBOX;
     static ENGINE_SUPERTONIC = ENGINE_SUPERTONIC;
+    static ENGINE_COSYVOICE3 = ENGINE_COSYVOICE3;
     opts;
     exclusiveRun;
     logger;
@@ -282,6 +387,12 @@ class TTSGgml {
     _supertonicModelPath;
     _t3ModelPath;
     _s3genModelPath;
+    _cosyvoiceModelDir;
+    _cosyvoiceLlmModelPath;
+    _cosyvoiceFlowModelPath;
+    _cosyvoiceHiftModelPath;
+    _cosyvoiceS3tokModelPath;
+    _cosyvoiceCampplusModelPath;
     _mecabDictPath;
     _cangjieTsvPath;
     _referenceAudio;
@@ -293,8 +404,11 @@ class TTSGgml {
     _threads;
     _streamChunkTokens;
     _streamFirstChunkTokens;
+    _streamLeftContextTokens;
     _cfmSteps;
     _cfgRate;
+    _promptText;
+    _instruct;
     _voice;
     _steps;
     _speed;
@@ -347,6 +461,18 @@ class TTSGgml {
     }
     _resolveEngineAndModelPaths(files) {
         this._voicesDir = files.voicesDir;
+        if (this._engineType === ENGINE_COSYVOICE3) {
+            // CosyVoice3 discovers its sub-model GGUFs from a model directory; the
+            // native engine resolves the individual components. Explicit
+            // per-component paths win over the directory.
+            this._cosyvoiceModelDir = firstNonEmpty(files.cosyvoiceModelDir, files.modelDir);
+            this._cosyvoiceLlmModelPath = files.cosyvoiceLlmModel;
+            this._cosyvoiceFlowModelPath = files.cosyvoiceFlowModel;
+            this._cosyvoiceHiftModelPath = files.cosyvoiceHiftModel;
+            this._cosyvoiceS3tokModelPath = files.cosyvoiceS3tokModel;
+            this._cosyvoiceCampplusModelPath = files.cosyvoiceCampplusModel;
+            return;
+        }
         if (this._engineType === ENGINE_SUPERTONIC) {
             this._supertonicModelPath = firstNonEmpty(files.supertonicModel, files.modelDir
                 ? resolveSupertonicModelDirPath(files.modelDir)
@@ -373,8 +499,14 @@ class TTSGgml {
         this._threads = options.threads;
         this._streamChunkTokens = options.streamChunkTokens;
         this._streamFirstChunkTokens = options.streamFirstChunkTokens;
+        // CosyVoice3-only: left-context speech tokens carried into each streaming chunk.
+        this._streamLeftContextTokens = options.streamLeftContextTokens;
         this._cfmSteps = options.cfmSteps;
         this._cfgRate = options.cfgRate;
+        // CosyVoice3-only: transcript of the reference audio for zero-shot cloning.
+        this._promptText = options.promptText;
+        // CosyVoice3-only: render the structured/raw instruct2 control to its string.
+        this._instruct = renderCosyvoiceInstruct(options.instruct) || undefined;
         this._voice = firstNonEmpty(options.voice, options.voiceName);
         this._steps = firstNonEmpty(options.steps, options.numInferenceSteps);
         this._speed = options.speed;
@@ -682,9 +814,58 @@ class TTSGgml {
         }
     }
     _buildTtsParams() {
-        return this._engineType === ENGINE_SUPERTONIC
-            ? this._buildSupertonicParams()
-            : this._buildChatterboxParams();
+        if (this._engineType === ENGINE_SUPERTONIC) {
+            return this._buildSupertonicParams();
+        }
+        if (this._engineType === ENGINE_COSYVOICE3) {
+            return this._buildCosyvoiceParams();
+        }
+        return this._buildChatterboxParams();
+    }
+    _buildCosyvoiceParams() {
+        const parameters = {
+            engineType: ENGINE_COSYVOICE3,
+            cosyvoiceModelDir: this._cosyvoiceModelDir || "",
+            language: this._config.language || "en",
+        };
+        if (this._cosyvoiceLlmModelPath) {
+            parameters.cosyvoiceLlmModelPath = this._cosyvoiceLlmModelPath;
+        }
+        if (this._cosyvoiceFlowModelPath) {
+            parameters.cosyvoiceFlowModelPath = this._cosyvoiceFlowModelPath;
+        }
+        if (this._cosyvoiceHiftModelPath) {
+            parameters.cosyvoiceHiftModelPath = this._cosyvoiceHiftModelPath;
+        }
+        if (this._cosyvoiceS3tokModelPath) {
+            parameters.cosyvoiceS3tokModelPath = this._cosyvoiceS3tokModelPath;
+        }
+        if (this._cosyvoiceCampplusModelPath) {
+            parameters.cosyvoiceCampplusModelPath = this._cosyvoiceCampplusModelPath;
+        }
+        if (this._referenceAudio != null) {
+            parameters.referenceAudio = this._referenceAudio;
+        }
+        if (this._promptText != null) {
+            parameters.promptText = String(this._promptText);
+        }
+        if (this._instruct)
+            parameters.instruct = this._instruct;
+        if (this._voice)
+            parameters.voice = this._voice;
+        this._assignCommonNativeParams(parameters);
+        if (this._cfmSteps != null)
+            parameters.cfmSteps = this._cfmSteps | 0;
+        if (this._streamChunkTokens != null) {
+            parameters.streamChunkTokens = this._streamChunkTokens | 0;
+        }
+        if (this._streamFirstChunkTokens != null) {
+            parameters.streamFirstChunkTokens = this._streamFirstChunkTokens | 0;
+        }
+        if (this._streamLeftContextTokens != null) {
+            parameters.streamLeftContextTokens = this._streamLeftContextTokens | 0;
+        }
+        return parameters;
     }
     _buildChatterboxParams() {
         const parameters = {

--- a/packages/tts-ggml/ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/ports/tts-cpp/portfile.cmake
@@ -1,0 +1,89 @@
+# LOCAL OVERLAY of the tts-cpp port.
+#
+# Builds tts-cpp from a working-tree checkout of qvac-ext-lib-whisper.cpp
+# instead of the registry-pinned GitHub tarball, so the not-yet-published
+# CosyVoice3 engine (tts-cpp/include/tts-cpp/cosyvoice/engine.h + the shared
+# pipeline) is available to the @qvac/tts-ggml addon build.
+#
+# Source dir precedence:
+#   1. $ENV{TTS_CPP_LOCAL_SOURCE}                (explicit override)
+#   2. <this-registry>/../../../../qvac-ext-lib-whisper.cpp/tts-cpp   (sibling repo)
+#
+# Everything below (configure options, features, install) mirrors the registry
+# port so the produced package is drop-in identical apart from the source.
+# Remove this overlay once the CosyVoice3 pin lands in qvac-registry-vcpkg.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+if(DEFINED ENV{TTS_CPP_LOCAL_SOURCE} AND NOT "$ENV{TTS_CPP_LOCAL_SOURCE}" STREQUAL "")
+    set(SOURCE_PATH "$ENV{TTS_CPP_LOCAL_SOURCE}")
+else()
+    # ports/tts-cpp -> ports -> tts-ggml -> packages -> qvac -> v
+    get_filename_component(_v_root "${CMAKE_CURRENT_LIST_DIR}/../../../../.." ABSOLUTE)
+    set(SOURCE_PATH "${_v_root}/qvac-ext-lib-whisper.cpp/tts-cpp")
+endif()
+
+message(STATUS "tts-cpp OVERLAY: building from local source ${SOURCE_PATH}")
+
+if(NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "tts-cpp overlay: ${SOURCE_PATH}/CMakeLists.txt missing. Set "
+        "TTS_CPP_LOCAL_SOURCE to your local qvac-ext-lib-whisper.cpp/tts-cpp dir.")
+endif()
+if(NOT EXISTS "${SOURCE_PATH}/include/tts-cpp/cosyvoice/engine.h")
+    message(FATAL_ERROR
+        "tts-cpp overlay: ${SOURCE_PATH} has no cosyvoice/engine.h -- point "
+        "TTS_CPP_LOCAL_SOURCE at the branch with the CosyVoice3 engine.")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        cuda    GGML_CUDA
+        opencl  GGML_OPENCL
+)
+
+set(PLATFORM_OPTIONS)
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DTTS_CPP_BUILD_LIBRARY=ON
+        -DTTS_CPP_BUILD_SHARED=OFF
+        -DTTS_CPP_BUILD_EXECUTABLES=OFF
+        -DTTS_CPP_BUILD_TESTS=OFF
+        -DTTS_CPP_INSTALL=ON
+        -DTTS_CPP_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DTTS_CPP_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DTTS_CPP_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME tts-cpp CONFIG_PATH share/tts-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if(VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/ports/tts-cpp/vcpkg.json
+++ b/packages/tts-ggml/ports/tts-cpp/vcpkg.json
@@ -1,0 +1,62 @@
+{
+  "name": "tts-cpp",
+  "version-date": "2026-07-17",
+  "description": "LOCAL OVERLAY of tts-cpp built from a working-tree checkout of qvac-ext-lib-whisper.cpp/tts-cpp (adds the CosyVoice3 engine ahead of the registry pin). Set TTS_CPP_LOCAL_SOURCE to the local tts-cpp dir, or it defaults to ../../../qvac-ext-lib-whisper.cpp/tts-cpp. Do NOT publish; drop this overlay once the CosyVoice3 pin lands in qvac-registry-vcpkg.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/tts-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-07-14"
+    },
+    "mecab",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        { "name": "ggml-speech", "features": ["cuda"] }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        { "name": "ggml-speech", "features": ["metal"] }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        { "name": "ggml-speech", "features": ["opencl"] }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        { "name": "ggml-speech", "features": ["vulkan"] }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -33,6 +33,10 @@ const { platform } = bareOs;
 
 const ENGINE_CHATTERBOX = "chatterbox";
 const ENGINE_SUPERTONIC = "supertonic";
+// CosyVoice3 (Fun-CosyVoice3-0.5B / 1.5B). Ships as a small set of GGUFs
+// (cosyvoice3-{llm,flow,hift,s3tok,campplus,voices}-*.gguf); a modelDir holding
+// them (or an explicit `files.cosyvoiceModelDir`) routes here.
+const ENGINE_COSYVOICE3 = "cosyvoice3";
 const MIN_OUTPUT_SAMPLE_RATE = 8000;
 const MAX_OUTPUT_SAMPLE_RATE = 192000;
 const CHATTERBOX_T3_TURBO = "chatterbox-t3-turbo.gguf";
@@ -48,10 +52,95 @@ const SUPERTONIC_V3_QUANT_ORDER = [
   "q8_0",
   "q4_0",
 ];
+// The LLM sub-model is the tell for CosyVoice3 modelDir auto-detection.
+const COSYVOICE3_LLM_RE = /^cosyvoice3-llm(-[a-z0-9_]+)?\.gguf$/i;
+
+// CosyVoice3 instruct2 control vocabulary (cosyvoice/utils/common.py
+// instruct_list). The structured `instruct` option renders to the exact
+// trained instruction string; the native engine wraps it as
+// "You are a helpful assistant. " + <instruction> + "<|endofprompt|>" and
+// drops the LM prompt speech tokens. One control applies per synthesis
+// (the model is trained on single instructions).
+const COSYVOICE_DIALECTS = {
+  cantonese: "广东话",
+  northeastern: "东北话",
+  gansu: "甘肃话",
+  guizhou: "贵州话",
+  henan: "河南话",
+  hubei: "湖北话",
+  hunan: "湖南话",
+  jiangxi: "江西话",
+  minnan: "闽南话",
+  ningxia: "宁夏话",
+  shanxi: "山西话",
+  shaanxi: "陕西话",
+  shandong: "山东话",
+  shanghai: "上海话",
+  sichuan: "四川话",
+  tianjin: "天津话",
+  yunnan: "云南话",
+} as const;
+const COSYVOICE_EMOTIONS = {
+  happy: "请非常开心地说一句话。",
+  sad: "请非常伤心地说一句话。",
+  angry: "请非常生气地说一句话。",
+} as const;
+const COSYVOICE_SPEEDS = {
+  slow: "请用尽可能慢地语速说一句话。",
+  fast: "请用尽可能快地语速说一句话。",
+} as const;
+const COSYVOICE_VOLUMES = {
+  loud: "Please say a sentence as loudly as possible.",
+  soft: "Please say a sentence in a very soft voice.",
+} as const;
+const COSYVOICE_STYLES = {
+  peppa: "我想体验一下小猪佩奇风格，可以吗？",
+  robot: "你可以尝试用机器人的方式解答吗？",
+} as const;
+
+/**
+ * Structured CosyVoice3 control. Exactly one field takes effect per synthesis,
+ * resolved by precedence dialect > emotion > speed > volume > style. Pass a raw
+ * string instead for an arbitrary instruction (advanced escape hatch).
+ */
+interface CosyvoiceInstruct {
+  /** Chinese dialect; renders "请用{dialect}表达。". */
+  dialect?: keyof typeof COSYVOICE_DIALECTS;
+  /** Emotion. */
+  emotion?: keyof typeof COSYVOICE_EMOTIONS;
+  /** Speaking speed. */
+  speed?: keyof typeof COSYVOICE_SPEEDS;
+  /** Loudness. */
+  volume?: keyof typeof COSYVOICE_VOLUMES;
+  /** Playful style preset. */
+  style?: keyof typeof COSYVOICE_STYLES;
+}
+
+/**
+ * Render a CosyVoice3 `instruct` option to the trained instruction string.
+ * A raw string passes through (trimmed); the structured form emits exactly one
+ * control by precedence dialect > emotion > speed > volume > style. Returns ""
+ * for no instruction (zero-shot).
+ */
+function renderCosyvoiceInstruct(
+  instruct: string | CosyvoiceInstruct | undefined,
+): string {
+  if (instruct == null) return "";
+  if (typeof instruct === "string") return instruct.trim();
+  if (instruct.dialect) {
+    return `请用${COSYVOICE_DIALECTS[instruct.dialect]}表达。`;
+  }
+  if (instruct.emotion) return COSYVOICE_EMOTIONS[instruct.emotion];
+  if (instruct.speed) return COSYVOICE_SPEEDS[instruct.speed];
+  if (instruct.volume) return COSYVOICE_VOLUMES[instruct.volume];
+  if (instruct.style) return COSYVOICE_STYLES[instruct.style];
+  return "";
+}
 
 type EngineType =
   | typeof ENGINE_CHATTERBOX
-  | typeof ENGINE_SUPERTONIC;
+  | typeof ENGINE_SUPERTONIC
+  | typeof ENGINE_COSYVOICE3;
 
 /**
  * Model file paths for the GGML TTS backend. Engine is auto-detected
@@ -79,6 +168,23 @@ interface TTSGgmlFiles {
   supertonicModel?: string;
   supertonicModelPath?: string;
   supertonic?: string;
+  /**
+   * CosyVoice3 model directory holding the sub-model GGUFs
+   * (`cosyvoice3-{llm,flow,hift,s3tok,campplus,voices}-*.gguf`). Routes to the
+   * CosyVoice3 engine. Falls back to the shared `modelDir` when unset.
+   */
+  cosyvoiceModelDir?: string;
+  /** CosyVoice3 per-component GGUF paths (override discovery under the model dir). */
+  cosyvoiceLlmModel?: string;
+  cosyvoiceLlmModelPath?: string;
+  cosyvoiceFlowModel?: string;
+  cosyvoiceFlowModelPath?: string;
+  cosyvoiceHiftModel?: string;
+  cosyvoiceHiftModelPath?: string;
+  cosyvoiceS3tokModel?: string;
+  cosyvoiceS3tokModelPath?: string;
+  cosyvoiceCampplusModel?: string;
+  cosyvoiceCampplusModelPath?: string;
   /**
    * LavaSR enhancer GGUF: single-file Vocos bandwidth extension produced by
    * tts-cpp/scripts/convert-lavasr-enhancer-to-gguf.py. When supplied, output
@@ -196,6 +302,8 @@ interface TTSGgmlOptions {
   streamChunkTokens?: number;
   /** Chatterbox-only smaller first chunk for low first-audio-out latency. */
   streamFirstChunkTokens?: number;
+  /** CosyVoice3-only: left-context speech tokens carried into each streaming chunk. */
+  streamLeftContextTokens?: number;
   /** Chatterbox-only CFM Euler step count. */
   cfmSteps?: number;
   /**
@@ -205,6 +313,16 @@ interface TTSGgmlOptions {
    * model's baked rate. Omit it to retain the baked rate.
    */
   cfgRate?: number;
+  /** CosyVoice3: transcript of `referenceAudio` for zero-shot voice cloning (conditions the LM prompt). */
+  promptText?: string;
+  /**
+   * CosyVoice3: natural-language control (instruct2) — Chinese dialect, emotion,
+   * speed, volume, or style. Pass a structured object (e.g. `{ dialect:
+   * 'cantonese' }`, `{ emotion: 'happy' }`) which renders to the trained
+   * instruction, or a raw string for an arbitrary instruction. Applied on top of
+   * the selected voice's timbre; one control takes effect per synthesis.
+   */
+  instruct?: string | CosyvoiceInstruct;
   /** Supertonic voice id baked into the GGUF, such as `F1` or `M1`. */
   voice?: string;
   /** Alias for `voice` for compatibility with `@qvac/tts-onnx`. */
@@ -259,6 +377,12 @@ interface NormalizedFiles {
   t3Model?: string;
   s3genModel?: string;
   supertonicModel?: string;
+  cosyvoiceModelDir?: string;
+  cosyvoiceLlmModel?: string;
+  cosyvoiceFlowModel?: string;
+  cosyvoiceHiftModel?: string;
+  cosyvoiceS3tokModel?: string;
+  cosyvoiceCampplusModel?: string;
   voicesDir?: string;
   lavasrEnhancer?: string;
   lavasrDenoiser?: string;
@@ -430,6 +554,21 @@ function findSupertonicV3InDir(
   return path.join(modelDir, matches[0]);
 }
 
+/**
+ * True when `modelDir` contains a CosyVoice3 LLM GGUF (the sub-model that
+ * unambiguously identifies a CosyVoice3 model directory).
+ */
+function dirHasCosyvoice3(modelDir?: string): boolean {
+  if (!modelDir) return false;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(modelDir);
+  } catch {
+    return false;
+  }
+  return entries.some((name) => COSYVOICE3_LLM_RE.test(name));
+}
+
 function normalizeGgmlFiles(
   files: TTSGgmlFiles | null | undefined,
 ): NormalizedFiles {
@@ -451,6 +590,29 @@ function normalizeGgmlFiles(
       files.supertonicModelPath,
       files.supertonic,
     ),
+    // CosyVoice3: either a dedicated modelDir of cosyvoice3-*.gguf files, or
+    // explicit per-component paths. Falls back to the shared `modelDir`.
+    cosyvoiceModelDir: firstNonEmpty(files.cosyvoiceModelDir),
+    cosyvoiceLlmModel: firstNonEmpty(
+      files.cosyvoiceLlmModel,
+      files.cosyvoiceLlmModelPath,
+    ),
+    cosyvoiceFlowModel: firstNonEmpty(
+      files.cosyvoiceFlowModel,
+      files.cosyvoiceFlowModelPath,
+    ),
+    cosyvoiceHiftModel: firstNonEmpty(
+      files.cosyvoiceHiftModel,
+      files.cosyvoiceHiftModelPath,
+    ),
+    cosyvoiceS3tokModel: firstNonEmpty(
+      files.cosyvoiceS3tokModel,
+      files.cosyvoiceS3tokModelPath,
+    ),
+    cosyvoiceCampplusModel: firstNonEmpty(
+      files.cosyvoiceCampplusModel,
+      files.cosyvoiceCampplusModelPath,
+    ),
     voicesDir: firstNonEmpty(files.voicesDir),
     lavasrEnhancer: firstNonEmpty(files.lavasrEnhancer),
     lavasrDenoiser: firstNonEmpty(files.lavasrDenoiser),
@@ -469,18 +631,27 @@ function detectEngineType(
   engine: EngineType | undefined,
   files: NormalizedFiles,
 ): EngineType {
-  if (engine === ENGINE_CHATTERBOX || engine === ENGINE_SUPERTONIC) {
+  if (
+    engine === ENGINE_CHATTERBOX ||
+    engine === ENGINE_SUPERTONIC ||
+    engine === ENGINE_COSYVOICE3
+  ) {
     return engine;
   }
   if (engine != null && engine !== "") {
     throw new Error(
-      "tts-ggml: 'engine' option must be 'chatterbox' or 'supertonic' " +
-        `(got '${String(engine)}')`,
+      "tts-ggml: 'engine' option must be 'chatterbox', 'supertonic' or " +
+        `'cosyvoice3' (got '${String(engine)}')`,
     );
+  }
+  // Explicit CosyVoice3 files/dir take precedence over shared-modelDir sniffing.
+  if (files.cosyvoiceModelDir || files.cosyvoiceLlmModel) {
+    return ENGINE_COSYVOICE3;
   }
   if (files.t3Model || files.s3genModel) return ENGINE_CHATTERBOX;
   if (files.supertonicModel) return ENGINE_SUPERTONIC;
   if (files.modelDir) {
+    if (dirHasCosyvoice3(files.modelDir)) return ENGINE_COSYVOICE3;
     const hasChatterbox =
       fileExistsSafe(path.join(files.modelDir, CHATTERBOX_T3_TURBO)) ||
       fileExistsSafe(path.join(files.modelDir, CHATTERBOX_T3_MTL));
@@ -700,6 +871,7 @@ class TTSGgml {
   };
   static readonly ENGINE_CHATTERBOX = ENGINE_CHATTERBOX;
   static readonly ENGINE_SUPERTONIC = ENGINE_SUPERTONIC;
+  static readonly ENGINE_COSYVOICE3 = ENGINE_COSYVOICE3;
 
   opts: object;
   exclusiveRun: boolean;
@@ -719,6 +891,12 @@ class TTSGgml {
   private _supertonicModelPath?: string;
   private _t3ModelPath?: string;
   private _s3genModelPath?: string;
+  private _cosyvoiceModelDir?: string;
+  private _cosyvoiceLlmModelPath?: string;
+  private _cosyvoiceFlowModelPath?: string;
+  private _cosyvoiceHiftModelPath?: string;
+  private _cosyvoiceS3tokModelPath?: string;
+  private _cosyvoiceCampplusModelPath?: string;
   private _mecabDictPath?: string;
   private _cangjieTsvPath?: string;
   private _referenceAudio?: string;
@@ -730,8 +908,11 @@ class TTSGgml {
   private _threads?: number;
   private _streamChunkTokens?: number;
   private _streamFirstChunkTokens?: number;
+  private _streamLeftContextTokens?: number;
   private _cfmSteps?: number;
   private _cfgRate?: number;
+  private _promptText?: string;
+  private _instruct?: string;
   private _voice?: string;
   private _steps?: number;
   private _speed?: number;
@@ -826,6 +1007,21 @@ class TTSGgml {
 
   private _resolveEngineAndModelPaths(files: NormalizedFiles): void {
     this._voicesDir = files.voicesDir;
+    if (this._engineType === ENGINE_COSYVOICE3) {
+      // CosyVoice3 discovers its sub-model GGUFs from a model directory; the
+      // native engine resolves the individual components. Explicit
+      // per-component paths win over the directory.
+      this._cosyvoiceModelDir = firstNonEmpty(
+        files.cosyvoiceModelDir,
+        files.modelDir,
+      );
+      this._cosyvoiceLlmModelPath = files.cosyvoiceLlmModel;
+      this._cosyvoiceFlowModelPath = files.cosyvoiceFlowModel;
+      this._cosyvoiceHiftModelPath = files.cosyvoiceHiftModel;
+      this._cosyvoiceS3tokModelPath = files.cosyvoiceS3tokModel;
+      this._cosyvoiceCampplusModelPath = files.cosyvoiceCampplusModel;
+      return;
+    }
     if (this._engineType === ENGINE_SUPERTONIC) {
       this._supertonicModelPath = firstNonEmpty(
         files.supertonicModel,
@@ -858,8 +1054,14 @@ class TTSGgml {
     this._threads = options.threads;
     this._streamChunkTokens = options.streamChunkTokens;
     this._streamFirstChunkTokens = options.streamFirstChunkTokens;
+    // CosyVoice3-only: left-context speech tokens carried into each streaming chunk.
+    this._streamLeftContextTokens = options.streamLeftContextTokens;
     this._cfmSteps = options.cfmSteps;
     this._cfgRate = options.cfgRate;
+    // CosyVoice3-only: transcript of the reference audio for zero-shot cloning.
+    this._promptText = options.promptText;
+    // CosyVoice3-only: render the structured/raw instruct2 control to its string.
+    this._instruct = renderCosyvoiceInstruct(options.instruct) || undefined;
     this._voice = firstNonEmpty(options.voice, options.voiceName);
     this._steps = firstNonEmpty(
       options.steps,
@@ -1288,9 +1490,56 @@ class TTSGgml {
   }
 
   private _buildTtsParams(): TTSConfigurationParams {
-    return this._engineType === ENGINE_SUPERTONIC
-      ? this._buildSupertonicParams()
-      : this._buildChatterboxParams();
+    if (this._engineType === ENGINE_SUPERTONIC) {
+      return this._buildSupertonicParams();
+    }
+    if (this._engineType === ENGINE_COSYVOICE3) {
+      return this._buildCosyvoiceParams();
+    }
+    return this._buildChatterboxParams();
+  }
+
+  private _buildCosyvoiceParams(): TTSConfigurationParams {
+    const parameters: TTSConfigurationParams = {
+      engineType: ENGINE_COSYVOICE3,
+      cosyvoiceModelDir: this._cosyvoiceModelDir || "",
+      language: this._config.language || "en",
+    };
+    if (this._cosyvoiceLlmModelPath) {
+      parameters.cosyvoiceLlmModelPath = this._cosyvoiceLlmModelPath;
+    }
+    if (this._cosyvoiceFlowModelPath) {
+      parameters.cosyvoiceFlowModelPath = this._cosyvoiceFlowModelPath;
+    }
+    if (this._cosyvoiceHiftModelPath) {
+      parameters.cosyvoiceHiftModelPath = this._cosyvoiceHiftModelPath;
+    }
+    if (this._cosyvoiceS3tokModelPath) {
+      parameters.cosyvoiceS3tokModelPath = this._cosyvoiceS3tokModelPath;
+    }
+    if (this._cosyvoiceCampplusModelPath) {
+      parameters.cosyvoiceCampplusModelPath = this._cosyvoiceCampplusModelPath;
+    }
+    if (this._referenceAudio != null) {
+      parameters.referenceAudio = this._referenceAudio;
+    }
+    if (this._promptText != null) {
+      parameters.promptText = String(this._promptText);
+    }
+    if (this._instruct) parameters.instruct = this._instruct;
+    if (this._voice) parameters.voice = this._voice;
+    this._assignCommonNativeParams(parameters);
+    if (this._cfmSteps != null) parameters.cfmSteps = this._cfmSteps | 0;
+    if (this._streamChunkTokens != null) {
+      parameters.streamChunkTokens = this._streamChunkTokens | 0;
+    }
+    if (this._streamFirstChunkTokens != null) {
+      parameters.streamFirstChunkTokens = this._streamFirstChunkTokens | 0;
+    }
+    if (this._streamLeftContextTokens != null) {
+      parameters.streamLeftContextTokens = this._streamLeftContextTokens | 0;
+    }
+    return parameters;
   }
 
   private _buildChatterboxParams(): TTSConfigurationParams {

--- a/packages/tts-ggml/test/unit/cosyvoice3.inference.test.js
+++ b/packages/tts-ggml/test/unit/cosyvoice3.inference.test.js
@@ -1,0 +1,218 @@
+'use strict'
+
+const test = require('brittle')
+const path = require('bare-path')
+const TTSGgml = require('../../index.js')
+const { TTSInterface } = require('../../tts.js')
+const MockedBinding = require('../mock/MockedBinding.js')
+const process = require('bare-process')
+
+global.process = process
+
+// CosyVoice3 (Fun-CosyVoice3-0.5B / 1.5B) — iteration 1 scaffold. These unit
+// tests exercise the JS wiring (engine detection, param building, mocked
+// synthesis) without the native addon; the C++ scaffold + real inference are
+// covered by addon/tests/test_cosyvoice_config.cpp.
+
+function createMockedCosyvoiceModel({
+  onOutput = () => {},
+  binding,
+  files,
+  language = 'en',
+  exclusiveRun = false,
+  extra = {}
+} = {}) {
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_COSYVOICE3,
+    files: files || { cosyvoiceModelDir: './models/cosyvoice3' },
+    config: { language, useGPU: false },
+    opts: { stats: true },
+    exclusiveRun,
+    ...extra
+  })
+
+  model._createAddon = (configurationParams, outputCb) => {
+    const _binding = binding || new MockedBinding()
+    const addon = new TTSInterface(_binding, configurationParams, outputCb)
+    if (_binding.setBaseInferenceCallback) {
+      _binding.setBaseInferenceCallback(onOutput)
+    }
+    return addon
+  }
+  return model
+}
+
+test('CosyVoice3: explicit engine option routes to cosyvoice3', (t) => {
+  const model = createMockedCosyvoiceModel()
+  t.is(model.getEngineType(), TTSGgml.ENGINE_COSYVOICE3, 'engine: cosyvoice3 detected')
+  t.is(model._cosyvoiceModelDir, './models/cosyvoice3')
+  t.absent(model._t3ModelPath, 'no chatterbox t3 path on cosyvoice3')
+  t.absent(model._supertonicModelPath, 'no supertonic path on cosyvoice3')
+})
+
+test('CosyVoice3: cosyvoiceModelDir file input alone routes to cosyvoice3', (t) => {
+  const model = new TTSGgml({
+    files: { cosyvoiceModelDir: './models/cv3' },
+    config: { language: 'en' }
+  })
+  t.is(model.getEngineType(), TTSGgml.ENGINE_COSYVOICE3, 'cosyvoiceModelDir detected')
+})
+
+test('CosyVoice3: cosyvoiceLlmModel path alone routes to cosyvoice3', (t) => {
+  const model = new TTSGgml({
+    files: { cosyvoiceLlmModel: './models/cv3/cosyvoice3-llm-f16.gguf' },
+    config: { language: 'en' }
+  })
+  t.is(model.getEngineType(), TTSGgml.ENGINE_COSYVOICE3, 'cosyvoiceLlmModel detected')
+})
+
+test('CosyVoice3: modelDir auto-detects cosyvoice3-llm gguf', async (t) => {
+  const fs = require('bare-fs')
+  const os = require('bare-os')
+  const tmpRoot = path.join(os.tmpdir(), 'tts-ggml-cosyvoice-detect-' + Date.now())
+  try {
+    fs.mkdirSync(tmpRoot, { recursive: true })
+    fs.writeFileSync(path.join(tmpRoot, 'cosyvoice3-llm-f16.gguf'), 'cv3-marker')
+
+    const model = new TTSGgml({
+      files: { modelDir: tmpRoot },
+      config: { language: 'en', useGPU: false }
+    })
+    t.is(
+      model.getEngineType(),
+      TTSGgml.ENGINE_COSYVOICE3,
+      'modelDir with cosyvoice3-llm*.gguf detected'
+    )
+    t.is(model._cosyvoiceModelDir, tmpRoot, 'cosyvoiceModelDir resolved from modelDir')
+  } finally {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    } catch (_e) {}
+  }
+})
+
+test('CosyVoice3: ttsParams shape forwards dir/language/streaming/cfm/promptText', (t) => {
+  const model = createMockedCosyvoiceModel({
+    extra: {
+      streamChunkTokens: 25,
+      streamFirstChunkTokens: 10,
+      streamLeftContextTokens: 50,
+      cfmSteps: 10,
+      promptText: 'reference transcript',
+      seed: 7,
+      threads: 2,
+      nGpuLayers: 0
+    }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.engineType, TTSGgml.ENGINE_COSYVOICE3)
+  t.is(params.cosyvoiceModelDir, './models/cosyvoice3')
+  t.is(params.language, 'en')
+  t.is(params.streamChunkTokens, 25)
+  t.is(params.streamFirstChunkTokens, 10)
+  t.is(params.streamLeftContextTokens, 50)
+  t.is(params.cfmSteps, 10)
+  t.is(params.promptText, 'reference transcript')
+  t.is(params.seed, 7)
+  t.is(params.threads, 2)
+  t.is(params.nGpuLayers, 0)
+  t.is(params.useGPU, false, 'useGPU follows config.useGPU')
+  t.absent(params.t3ModelPath, 'no chatterbox fields leaked')
+  t.absent(params.supertonicModelPath, 'no supertonic fields leaked')
+})
+
+test('CosyVoice3: per-component model paths forward to params', (t) => {
+  const model = createMockedCosyvoiceModel({
+    files: {
+      cosyvoiceModelDir: './models/cv3',
+      cosyvoiceLlmModel: './models/cv3/llm.gguf',
+      cosyvoiceFlowModel: './models/cv3/flow.gguf',
+      cosyvoiceHiftModel: './models/cv3/hift.gguf'
+    }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.cosyvoiceLlmModelPath, './models/cv3/llm.gguf')
+  t.is(params.cosyvoiceFlowModelPath, './models/cv3/flow.gguf')
+  t.is(params.cosyvoiceHiftModelPath, './models/cv3/hift.gguf')
+})
+
+test('CosyVoice3: instruct renders structured control to the trained instruction', (t) => {
+  const dialect = createMockedCosyvoiceModel({ extra: { instruct: { dialect: 'cantonese' } } })
+  t.is(dialect._buildTtsParams().instruct, '请用广东话表达。', 'dialect renders')
+
+  const emotion = createMockedCosyvoiceModel({ extra: { instruct: { emotion: 'happy' } } })
+  t.is(emotion._buildTtsParams().instruct, '请非常开心地说一句话。', 'emotion renders')
+
+  const speed = createMockedCosyvoiceModel({ extra: { instruct: { speed: 'slow' } } })
+  t.is(speed._buildTtsParams().instruct, '请用尽可能慢地语速说一句话。', 'speed renders')
+
+  const raw = createMockedCosyvoiceModel({ extra: { instruct: '请用四川话表达。' } })
+  t.is(raw._buildTtsParams().instruct, '请用四川话表达。', 'raw string passes through')
+
+  const precedence = createMockedCosyvoiceModel({ extra: { instruct: { dialect: 'sichuan', emotion: 'sad' } } })
+  t.is(precedence._buildTtsParams().instruct, '请用四川话表达。', 'dialect wins over emotion')
+
+  const none = createMockedCosyvoiceModel({})
+  t.absent(none._buildTtsParams().instruct, 'no instruct -> field absent')
+})
+
+test('CosyVoice3: streamChunkTokens is NOT rejected (native streaming model)', (t) => {
+  // Unlike Supertonic, CosyVoice3 supports native sub-utterance chunk streaming.
+  t.execution(
+    () =>
+      new TTSGgml({
+        engine: TTSGgml.ENGINE_COSYVOICE3,
+        files: { cosyvoiceModelDir: './models/cv3' },
+        streamChunkTokens: 25,
+        config: { language: 'en' }
+      }),
+    'streamChunkTokens accepted on cosyvoice3'
+  )
+})
+
+test('CosyVoice3: referenceAudio forwards for zero-shot cloning', (t) => {
+  const model = createMockedCosyvoiceModel({
+    extra: { referenceAudio: '/abs/ref.wav', promptText: 'hi there' }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.referenceAudio, '/abs/ref.wav')
+  t.is(params.promptText, 'hi there')
+})
+
+test('CosyVoice3: synthesis returns audio output and stats (mocked)', async (t) => {
+  const events = []
+  const model = createMockedCosyvoiceModel({
+    onOutput: (addon, event, data, error) => events.push({ event, data, error })
+  })
+  await model.load()
+
+  const response = await model.run({ type: 'text', input: 'Hello cosyvoice.' })
+  const outputs = []
+  await response.onUpdate((d) => outputs.push(d)).await()
+
+  t.ok(outputs.length > 0, 'cosyvoice emits at least one update')
+  t.ok(
+    outputs.some((d) => d.outputArray),
+    'cosyvoice output has outputArray'
+  )
+  t.ok(response.stats.totalSamples > 0, 'cosyvoice stats include totalSamples')
+  await model.unload()
+})
+
+test('CosyVoice3: cancel propagates as job failure (mocked)', async (t) => {
+  const model = createMockedCosyvoiceModel()
+  await model.load()
+
+  const response = await model.run({ type: 'text', input: 'Cancel this' })
+  await response.cancel()
+
+  let failed = false
+  try {
+    await response.await()
+  } catch (error) {
+    failed = true
+    t.ok(String(error.message).includes('cancel'), 'cancelled cosyvoice response rejects')
+  }
+  t.ok(failed, 'cancelled cosyvoice response should fail')
+  await model.unload()
+})


### PR DESCRIPTION
## What problem does this PR solve?

Exposes the native CosyVoice3 engine (qvac-ext-lib-whisper.cpp#99) through the
`@qvac/tts-ggml` addon so it can synthesize on-device.

**Scope:** `packages/tts-ggml` only. The `@qvac/sdk` route (schemas + plugin +
example) is intentionally **left for a separate follow-up PR** — this PR lands the
addon first.

**Depends on** the ext-lib engine PR (tetherto/qvac-ext-lib-whisper.cpp#99) + the
`tts-cpp` registry pin. Opened in parallel (not waiting on #99 merge). Until the pin
lands, the addon builds tts-cpp from a local overlay (`packages/tts-ggml/ports/`,
see build note); that overlay is dropped in a follow-up once the registry pin is in.

## How does it solve it?

Adds a third TTS engine, `"cosyvoice3"`, alongside chatterbox/supertonic.

- **Addon (C++):** `CosyvoiceModel` (`addon/src/model-interface/cosyvoice/`) wraps
  `tts_cpp::cosyvoice::Engine` (deferred async load, single in-flight job, cancel,
  streaming, RuntimeStats); `EngineType::Cosyvoice` dispatch + `buildCosyvoiceConfig`
  (JSAdapter); `createInstance`/`runJob`/`reload` branches (AddonJs); CMake wiring.
- **Addon (JS/TS):** cosyvoice3 wiring authored in the TypeScript source
  (`src/index.ts`) — `ENGINE_COSYVOICE3`, model-dir detection (`cosyvoice3-llm*.gguf`),
  per-component + `cosyvoiceModelDir` file inputs, `promptText` (zero-shot) +
  `streamLeftContextTokens`, streaming. `index.js`/`index.d.ts` regenerated via `tsc`
  (`check:generated` clean).
- **Tests:** C++ `test_cosyvoice_config.cpp` (9 always-run + 2 opt-in `CosyvoiceRealGguf`
  round-trips gated on `QVAC_TEST_COSYVOICE_MODEL_DIR`); JS `cosyvoice3.inference.test.js`
  (**10/10**, mocked addon). Example: `examples/cosyvoice-tts.js`.

## Rebase note
Rebased onto main's tts-ggml TypeScript migration (v0.5.1): `index.js`/`index.d.ts`
are generated from `src/index.ts`, so the cosyvoice3 wiring lives in the TS source and
the wrappers are regenerated. Net changeset: 15 files.

## Validation
Addon stack verified locally (JS `TTSGgml` → `CosyvoiceModel` → `Engine` → 24 kHz WAV,
Whisper-intelligible). Engine is numerically parity-gated vs. the PyTorch reference
(LM/flow/DiT cosine 1.0, HiFT waveform corr 0.996, instruct-path token match
bit-identical — see #99). JS wiring tests 10/10.

## Breaking changes

None — additive engine variant. Existing chatterbox/supertonic configs and addon
behavior are unchanged (cosyvoice3 is a new `ttsEngine` discriminant value).

## Build note (until registry pin lands)
```
export VCPKG_OVERLAY_PORTS=<pkg>/packages/tts-ggml/ports
export TTS_CPP_LOCAL_SOURCE=<checkout>/qvac-ext-lib-whisper.cpp/tts-cpp
bare-make generate && bare-make build && bare-make install
```

## Follow-ups
- **`@qvac/sdk` cosyvoice3 route** (schemas + plugin + example) — separate PR.
- Drop the overlay after the `tts-cpp` registry pin; add the model-registry entry
  (`TTS_COSYVOICE3_0_5B_EN`).
- Rebuild the addon prebuild against #99 so the packaged binary carries the HiFT fix +
  instruct mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
