### PR TITLE
fix[notask]: pin fork PR checkouts to head.sha (merge-guard + sanity-checks)

### DIFF
--- a/.github/actions/sanity-checks/action.yaml
+++ b/.github/actions/sanity-checks/action.yaml
@@ -28,7 +28,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         token: ${{ inputs.pat-token }}
         fetch-depth: 0
 

--- a/.github/workflows/pr-gate-merge.yml
+++ b/.github/workflows/pr-gate-merge.yml
@@ -177,7 +177,7 @@ jobs:
     with:
       changed-packages: ${{ needs.changes.outputs.packages || '[]' }}
       repository: ${{ github.event.pull_request.head.repo.full_name }}
-      ref: ${{ github.event.pull_request.head.ref }}
+      ref: ${{ github.event.pull_request.head.sha }}
 
   merge-guard:
     needs: [authorize, label-gate, changes, sanity-checks, prebuilds-caller]


### PR DESCRIPTION
## What problem does this PR solve?

`pull_request_target` workflows authorize a specific reviewed commit via the `verified` label, but two checkouts flagged in the security audit of #3245 checked out the **mutable** branch ref `github.event.pull_request.head.ref`.

A fork author can push a new commit **after** the run is authorized. Because the checkout resolves the branch *name* at run time — and `cancel-in-progress: false` keeps the already-authorized run alive — that run would build the new, unreviewed commit with `PAT_TOKEN` / AWS OIDC secrets on self-hosted runners. Classic TOCTOU ("mutable ref race").

## How does it solve it?

Pin both audit-flagged checkouts to the immutable `github.event.pull_request.head.sha` from the event payload, so a run only ever builds the exact commit it was authorized for. `repository:` stays `head.repo.full_name` (the SHA lives on the fork).

- `.github/workflows/pr-gate-merge.yml` — merge-guard prebuilds-caller passthrough
- `.github/actions/sanity-checks/action.yaml` — shared PR-head checkout (also fixes every `on-pr-*` caller of this composite)

## Scope

Only the **two** checkouts called out in the audit. The remaining `pull_request_target` `head.ref` checkouts across `on-pr-*.yml` and other reusables are the same class and are tracked for a follow-up sweep (kept out of this PR to keep the security fix minimal and reviewable).

## Label stripping (already in place — verified)

New commits to a fork PR arrive as `synchronize`. `label-gate` (`gate.mjs`, authoritative via `PAT_TOKEN`) and `authorize-pr` already strip the `verified` label on `synchronize` from untrusted actors, denying the *new* commit its own run. The `head.sha` pin closes the complementary gap (the *in-flight* authorized run). Verified locally: **58/58** label-gate unit tests pass, including `synchronize from non-team-member -> strip label, not authorised`.

## How was it tested?

- `actionlint` on both changed files: **no new findings**. The only reported item is the pre-existing `sanity-checks` composite `type: string` input-schema warning, present on `main` and unrelated to the `ref:` change.
- Inverse check: `head.repo` occurrences unchanged; only `ref:` lines changed; no `env:` / `repository:` line touched.
- `head.sha` fork checkout is already the established pattern in ~8 existing workflows here (`test-node/ios/android-sdk`, `on-pr-bare-sdk-e2e`, `pr-models-validation-registry-server`, `cpp-test-coverage-tts-onnx`, …), so there is no runtime-behavior change for normal PRs: for any PR with no post-authorization push, `head.sha` is the same commit `head.ref` resolves to.

## Security

Closes the TOCTOU reported against #3245. No secrets touched. No evidence of prior exploitation; external contributions are TL-gated, limiting practical exposure.

---
🤖 Prepared by a Cursor DevOps agent (manual CI hardening — `head.sha` pin). Please review the trust/checkout semantics with extra care.
