### PR TITLE
QVAC-18048 fix: avoid concurrency deadlock between Merge Guard and sdk-pod-checks

### DIFF
--- a/.github/workflows/pr-gate-merge.yml
+++ b/.github/workflows/pr-gate-merge.yml
@@ -17,7 +17,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pr-gate-merge-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `Merge Guard` (`pr-gate-merge.yml`) runs jobs got cancelled with "Canceling since a deadlock was detected for concurrency group: 'Merge Guard-<pr>' between a top level workflow and 'sdk-pod-checks'" — the `sdk-pod-checks` job never ran, so PRs never got a real SDK Pod Checks result from this gate.

- Root cause: the top-level concurrency group used `${{ github.workflow }}`, which resolves to the *caller's* workflow name ("Merge Guard") even when evaluated inside `pr-checks-sdk-pod.yml` (invoked from `sdk-pod-checks` via `workflow_call`). Both workflows ended up computing the identical group name (`Merge Guard-<pr>`), so the still-running parent run (holding that group, `cancel-in-progress: false`) and the child job needing the same group to start deadlocked each other.

## 📝 How does it solve it?

- Changed `pr-gate-merge.yml`'s concurrency group prefix from `${{ github.workflow }}` to the hardcoded literal `pr-gate-merge`, tied to the workflow's own filename instead of a name that collapses to the top-level caller inside `workflow_call` chains.
- Still groups by PR number (`pr-gate-merge-<pr>`), so consecutive pushes to the same PR continue to queue/dedupe against each other as before — only the exact group string changes, so it can no longer collide with `pr-checks-sdk-pod.yml`'s own group (`PR Checks (SDK Pod)-<pr>`).
- `pr-checks-sdk-pod.yml` itself is untouched — this fixes the collision from the caller side only.

## 🧪 How was it tested?

- Confirmed root cause directly from the failing run on PR #3374: https://github.com/tetherto/qvac/actions/runs/29841048482?pr=3374 — job logs showed the cancellation message naming group `Merge Guard-3374` for both the top-level run and the `sdk-pod-checks` job.
- Verified via GitHub context docs (`github.workflow` resolves to the top-level workflow name for the whole run, including inside called reusable workflows) that this was the actual mechanism, not a one-off fluke.
- Local `actionlint` / YAML syntax check on `pr-gate-merge.yml` after the edit.
- Follow-up: open a throwaway validation PR (same approach as the existing QVAC-18048 validation plan) to confirm `sdk-pod-checks` now runs to completion without a concurrency-group cancellation on two consecutive pushes to the same PR.
