### PR TITLE
EOS-inside-reasoning recovery guard

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
@@ -784,6 +784,7 @@ LlmContext::GenerateResponseResult TextLlmContext::generateResponse(
   assistantOutput_.clear();
   generationStarted_ = false;
   generationStopReason_ = GenerationStopReason::None;
+  banEogAfterReasoningRecovery_ = false;
 
   // The chat template force-opened the reasoning channel in the prompt (e.g.
   // Qwen3 / DeepSeek-R1 templates end with "<think>\n"). Emit the matching
@@ -909,6 +910,19 @@ SequenceStepResult TextLlmContext::onLogitsReady(
   llama_token tokenId = LLAMA_TOKEN_NULL;
   if (sampledToken) {
     tokenId = common_sampler_sample(smpl_.get(), modelCtx_.lctx, logitIdx);
+    if (banEogAfterReasoningRecovery_) {
+      banEogAfterReasoningRecovery_ = false;
+      for (int rerolls = 0;
+           rerolls < 8 && llama_vocab_is_eog(modelCtx_.vocab, tokenId);
+           ++rerolls) {
+        float* logits = llama_get_logits_ith(modelCtx_.lctx, logitIdx);
+        if (logits == nullptr) {
+          break;
+        }
+        logits[tokenId] = -INFINITY;
+        tokenId = common_sampler_sample(smpl_.get(), modelCtx_.lctx, logitIdx);
+      }
+    }
     common_sampler_accept(smpl_.get(), tokenId, true);
   } else {
     tokenId = forcedTokens_.front();
@@ -1012,6 +1026,7 @@ SequenceStepResult TextLlmContext::onLogitsReady(
         forcedTokens_.push_back(reasoningState_.cached_newline_token);
         forcedTokens_.push_back(reasoningState_.cached_newline_token);
       }
+      banEogAfterReasoningRecovery_ = true;
       const std::string completeChars = utf8Buffer_.addToken(tokenStr);
       if (!completeChars.empty()) {
         emitOutputPiece(outputCallback, completeChars);
@@ -1695,6 +1710,7 @@ void TextLlmContext::resetState(bool resetStats) {
   forcedTokens_.clear();
   assistantOutput_.clear();
   generationStarted_ = false;
+  banEogAfterReasoningRecovery_ = false;
   thinkingForcedOpen_ = false;
   thinkingForcedOpenText_.clear();
   compactor_.reset();
@@ -1861,5 +1877,6 @@ bool TextLlmContext::handleReasoningEOS(
     }
   }
 
+  banEogAfterReasoningRecovery_ = true;
   return true;
 }

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
@@ -364,6 +364,12 @@ private:
   // compaction stay family-agnostic via `reasoningEnabled_`.
   bool isQwen3ReasoningFamily_ = false;
 
+  // EOS-inside-reasoning recovery: the recovery substitutes `</think>\n\n` so
+  // the model produces an answer after thinking, but on marginal prompts
+  // the very next sampled token is EOG again, which would defeat the
+  // recovery with an empty answer.
+  bool banEogAfterReasoningRecovery_ = false;
+
   // GPT-OSS Harmony: <|call|> is a frame delimiter, not a stop signal
   bool isHarmonyModel_ = false;
   llama_token harmonyCallToken_ = LLAMA_TOKEN_NULL;


### PR DESCRIPTION
When Qwen3 or other models (we have only seen this issue for Qwen3 so far) emits EOS inside an open `<think>` block, qvac substitutes `</think>` so the model can produce a visible answer. Without this guard the model can immediately re-emit EOS, yielding balanced tags with an empty answer.