### PR TITLE
QVAC-18048 chore: validate merge-guard no-op path for uncovered package (registry-server)

### DIFF
--- a/packages/registry-server/NOTICE
+++ b/packages/registry-server/NOTICE
@@ -1,4 +1,5 @@
 QVAC Registry Server
+
 Copyright 2024-2026 Tether Operations Limited
 
 This product distributes third-party AI model weights under their


### PR DESCRIPTION
Throwaway validation PR for QVAC-18048. registry-server is not named in pr-gate-merge.yml's sanity-checks/prebuilds-caller matrix nor in .github/sdk-pod-checks.json, so it only ever hits the generic pkg-any (packages/**) filter. Expect: sanity-checks skips cleanly, sdk-pod-checks no-ops (no SDK pod files touched), merge-guard/validate-pr passes. Not a real change — will be closed and branch deleted once confirmed.