### PR TITLE
QVAC-22626 fix: drop baseUrl from the @qvac/inference tsconfig

### DIFF
--- a/packages/inference/tsconfig.json
+++ b/packages/inference/tsconfig.json
@@ -7,7 +7,6 @@
     "types": [],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "paths": {
       "@qvac/inference": ["./src/index.ts"],
       "@qvac/inference/*": ["./src/plugins/builtin/*"]


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- TypeScript 7.0 removed the `baseUrl` compiler option, so `tsc` now errors with `TS5102: Option 'baseUrl' has been removed`.
- This breaks `@qvac/inference`'s build (`prepare` → `tsc -p tsconfig.build.json`), so the package fails to publish under a newer TypeScript.

## 📝 How does it solve it?

- Removes `"baseUrl"` from `tsconfig.json`.
- The `paths` entries are already relative (`./src/...`), and since TypeScript 5.x `paths` resolves relative to the config file without `baseUrl` — so alias resolution is unchanged. No other changes.

## 🧪 How was it tested?

- Reproduced the failure with TypeScript 7.0.2: `tsconfig.build.json(5,3): error TS5102: Option 'baseUrl' has been removed`.
- After the change: `tsc -p tsconfig.build.json` is clean on TypeScript 7.0.2, and `typecheck` + `build` still pass on the pinned 5.9.x.
