### PR TITLE
Draft: chore: overlay addon-cpp 1.3.0 dev port in all consumer addons

### DIFF
--- a/packages/bci-whispercpp/vcpkg-configuration.json
+++ b/packages/bci-whispercpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "a9d7e924de8cb7133c54c5b1d446e4d9c0508ec8",

--- a/packages/bci-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/bci-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/bci-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/classification-ggml/vcpkg-configuration.json
+++ b/packages/classification-ggml/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",

--- a/packages/classification-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/classification-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/classification-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/classification-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/diffusion-cpp/vcpkg-configuration.json
+++ b/packages/diffusion-cpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "d1b2497b1707baf7bd1f352eb08097c7f9d5cfd9",

--- a/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/embed-llamacpp/vcpkg-configuration.json
+++ b/packages/embed-llamacpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",

--- a/packages/embed-llamacpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/embed-llamacpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/embed-llamacpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/ocr-ggml/vcpkg-configuration.json
+++ b/packages/ocr-ggml/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "c5955445a221df255d2204be964647c08c82c28f",

--- a/packages/ocr-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/ocr-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/ocr-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/ocr-onnx/vcpkg-configuration.json
+++ b/packages/ocr-onnx/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "9503ea89fa282691596d0ab9cf74a6c5a178f5ae",

--- a/packages/ocr-onnx/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/ocr-onnx/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/ocr-onnx/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/ocr-onnx/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/transcription-parakeet/vcpkg-configuration.json
+++ b/packages/transcription-parakeet/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "74d2dfd03d1c2c0767bac6d892ec43a2a0e29c10",

--- a/packages/transcription-parakeet/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/transcription-parakeet/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/transcription-whispercpp/addon/tests/test_core.cpp
+++ b/packages/transcription-whispercpp/addon/tests/test_core.cpp
@@ -212,7 +212,9 @@ TEST_F(StreamingProcessorTest, EmitsVadStateUpdatesAlongsideTranscriptOutput) {
   bool hasVadState = false;
   bool hasTranscriptOutput = false;
 
-  for (const auto& output : outputs) {
+  for (const auto& entry : outputs) {
+    // addon-cpp >= 1.3.0 drains (JobId, payload) pairs.
+    const std::any& output = entry.second;
     if (const auto* vadState = std::any_cast<VadStateUpdate>(&output);
         vadState != nullptr) {
       hasVadState = true;

--- a/packages/transcription-whispercpp/vcpkg-configuration.json
+++ b/packages/transcription-whispercpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "a9d7e924de8cb7133c54c5b1d446e4d9c0508ec8",

--- a/packages/transcription-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/transcription-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/transcription-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/translation-nmtcpp/vcpkg-configuration.json
+++ b/packages/translation-nmtcpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "1b499699dc209ed0fbc17649f6174335ce5a2743",

--- a/packages/translation-nmtcpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/translation-nmtcpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/translation-nmtcpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "4dbe15d8c3a181d691289739c9531a09d46eae27",

--- a/packages/tts-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/tts-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/tts-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/tts-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/vla-ggml/vcpkg-configuration.json
+++ b/packages/vla-ggml/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",

--- a/packages/vla-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/vla-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,38 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.0 from the addon-cpp
+# snapshot branch (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1) instead
+# of the published registry version, to verify this addon builds unchanged
+# against the 1.3.0 multi-job scheduler (backwards-compatibility check; same
+# REF/SHA512 as the llm-llamacpp portfile_dev overlay). Bump REF/SHA512 (and
+# the overlay port-version) when that branch moves. To fall back to the
+# registry version, remove this port directory and the "overlay-ports" entry
+# in vcpkg-configuration.json.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jesusmb1995/qvac
+  REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4
+  SHA512 b5644504a0973d8d8602ed5c29cf94f9c04115fdb514c211a5de4300a9914301d854399ebf0261765e087e5fb80aea9fc9ef6b069e41d3a5b7de88db52e8667e
+  HEAD_REF continuousBatchingD10AddonCpp1
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/vla-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/vla-ggml/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.0",
+  "port-version": 112,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Backwards-compatibility check for the inference-addon-cpp 1.3.0 multi-job scheduler (PR #2990): every addon that consumes qvac-lib-inference-addon-cpp now builds against the same dev snapshot that llm-llamacpp's portfile_dev overlay uses (jesusmb1995/qvac @ continuousBatchingD10AddonCpp1, REF 229f2c0bdcbc88dc683a2657651a5b224d4ab1c4), reusing its SHA512, instead of the published 1.2.x registry port. The addons themselves are unchanged; CI building them green proves 1.3.0 is a drop-in replacement.

addon-cpp PR https://github.com/tetherto/qvac/pull/2990

Covered addons: bci-whispercpp, classification-ggml, diffusion-cpp, embed-llamacpp, ocr-ggml, ocr-onnx, transcription-parakeet, transcription-whispercpp, translation-nmtcpp, tts-ggml, vla-ggml. (llm-llamacpp already carries this overlay on PR #2728.)

Not intended to merge: drop the overlays once 1.3.0 is published to the vcpkg registry and the manifests get a real version bump.

## Tests made
CI run and report https://github.com/tetherto/qvac/pull/3388#issuecomment-5045683092