### PR TITLE
[DO NOT MERGE] probe: parakeet desktop-integration baseline on unmodified main

### DIFF
--- a/packages/transcription-parakeet/README.md
+++ b/packages/transcription-parakeet/README.md
@@ -549,3 +549,5 @@ Thrown errors are `QvacErrorAddonParakeet` instances (extending `QvacErrorBase`)
 This project is licensed under the Apache-2.0 License -- see [LICENSE](LICENSE) for details. Model files are distributed under the **NVIDIA Open Model License**; see the upstream HuggingFace cards for the per-checkpoint terms.
 
 For questions or issues, please open an issue on the GitHub repository.
+
+<!-- CI source-build baseline probe (no functional change) -->


### PR DESCRIPTION
No-op change to run the transcription-parakeet desktop integration suites on **unmodified main** — establishing whether the `delete process.env.QVAC_TEST_GGUF_SORTFORMERSTREAMING` teardown crash (introduced with `sortformer-streaming-alias.test.js` in [#3231](https://github.com/tetherto/qvac/pull/3231), merged 2026-07-13) reproduces with zero repo-reorg content anywhere in the build.

Context: the failure was first observed on the reorg overlay branch ([#3310](https://github.com/tetherto/qvac/pull/3310)); audit of every `on-pr-transcription-parakeet` run between #3231's merge and that observation shows **0 executed desktop-integration jobs** (all label-gated skips, including on #3231 itself, which carried no labels) — i.e. the test had never run in desktop CI before. This probe provides the run-level proof. Closes after one CI cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)