### PR TITLE
QVAC-22622 fix: terminate generation at context boundary

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -243,11 +243,12 @@ public:
    * The generate response method. It generates the response token by token.
    *
    * @param outputCallback - the output callback.
-   * @return - ok=false for context overflow; cancelled=true when generation
-   * was stopped by user cancellation; rollbackOk=false when a cancellation
-   * or prediction-limit truncation inside reasoning could not restore the
-   * pre-request recurrent state and callers must skip cache persistence for
-   * this request.
+   * @return - cancelled=true when generation was stopped by user cancellation;
+   * rollbackOk=false when a cancellation or prediction-limit truncation inside
+   * reasoning could not restore the pre-request recurrent state and callers
+   * must skip cache persistence for this request. Generation-time context
+   * exhaustion is a successful terminal outcome exposed through runtime stats;
+   * prompt admission overflow still throws before this method runs.
    */
   virtual GenerateResponseResult generateResponse(
       const std::function<void(const std::string&)>& outputCallback) = 0;

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -875,7 +875,7 @@ LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
               tools_.anchor(),
               tools_.enabled() ? "true" : "false"));
       generationStopReason_ = GenerationStopReason::ContextOverflow;
-      return {.ok = false};
+      break;
     }
     applyContextDiscard();
 

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
@@ -833,7 +833,7 @@ LlmContext::GenerateResponseResult TextLlmContext::generateResponse(
         onLogitsReady(-1, generatedAfterAccept, outputCallback, &batch);
     if (step.contextOverflow) {
       generationStopReason_ = GenerationStopReason::ContextOverflow;
-      return {.ok = false};
+      break;
     }
     if (step.decodedInline) {
       continue;

--- a/packages/llm-llamacpp/index.d.ts
+++ b/packages/llm-llamacpp/index.d.ts
@@ -324,6 +324,9 @@ export interface RuntimeStats {
   CacheTokens: number
   generatedTokens: number
   promptTokens: number
+  /** Why the most recent single-sequence generation stopped. */
+  stopReason?:
+    'none' | 'eos' | 'antiprompt' | 'predictionLimit' | 'sequenceLimit' | 'contextOverflow'
   /** Context-window slides for single requests, or the sum across completed batch slots. */
   contextSlides: number
   /**

--- a/packages/llm-llamacpp/test/integration/sliding-context.test.js
+++ b/packages/llm-llamacpp/test/integration/sliding-context.test.js
@@ -153,7 +153,7 @@ safeTest(
 
 // n_discarded=0, n_predict=SLIDE_PREDICT
 safeTest(
-  'Generation fails with context overflow when sliding disabled',
+  'Generation stops at the context boundary when sliding is disabled',
   {
     timeout: 900_000,
     skip
@@ -165,13 +165,11 @@ safeTest(
       n_discarded: '0'
     })
 
-    try {
-      await runAndCollect(model, STORY_PROMPT)
-      t.fail('expected context overflow error but generation completed without error')
-    } catch (err) {
-      const msg = err?.message || String(err)
-      t.ok(/context|overflow/i.test(msg), `context overflow error surfaced: "${msg.slice(0, 120)}"`)
-    }
+    const { text, stats } = await runAndCollect(model, STORY_PROMPT)
+
+    t.ok(text.length > 0, 'tokens generated before the context boundary')
+    t.is(stats.stopReason, 'contextOverflow', 'runtime stats identify context exhaustion')
+    t.ok(stats.generatedTokens < SLIDE_PREDICT, 'context boundary stopped generation early')
 
     // sleep for 10 seconds to allow the model to cleanup
     await new Promise((resolve) => setTimeout(resolve, 10000))

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stats.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stats.ts
@@ -39,3 +39,24 @@ export function normalizeCompletionStats(stats: LlmStats | undefined) {
 
   return normalized
 }
+
+export function stoppedByLength({
+  cancelled,
+  effectivePredict,
+  generatedTokens,
+  stoppedAtContextBoundary
+}: {
+  cancelled: boolean
+  effectivePredict: number | undefined
+  generatedTokens: number | undefined
+  stoppedAtContextBoundary: boolean
+}): boolean {
+  if (cancelled) return false
+  if (stoppedAtContextBoundary) return true
+  return (
+    effectivePredict !== undefined &&
+    effectivePredict > 0 &&
+    generatedTokens !== undefined &&
+    generatedTokens >= effectivePredict
+  )
+}

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
@@ -56,6 +56,7 @@ interface CompletionResult {
   modelExecutionMs: number
   stats?: CompletionStats
   toolCalls: ToolCall[]
+  stoppedAtContextBoundary: boolean
 }
 
 interface ProcessModelResponseResult extends CompletionResult {
@@ -349,7 +350,8 @@ async function* processModelResponse(
     ...buildStreamResult(modelExecutionMs, stats),
     toolCalls: toolCallsResult,
     responseText: accumulatedText,
-    producedTokens
+    producedTokens,
+    stoppedAtContextBoundary: responseWithStats.stats?.stopReason === 'contextOverflow'
   }
 }
 

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -44,6 +44,7 @@ import {
   isAddonContextOverflowError,
   parseContextOverflowMessage
 } from '@/server/bare/plugins/llamacpp-completion/ops/context-overflow'
+import { stoppedByLength } from '@/server/bare/plugins/llamacpp-completion/ops/completion-stats'
 import { isAddonCancelledError } from '@/server/bare/plugins/llamacpp-completion/ops/batch-cancelled'
 import { isMobile } from '@/server/bare/registry/runtime-context-registry'
 import { stripMultiGpuKeys } from '@/server/utils/multi-gpu-mobile'
@@ -411,7 +412,7 @@ export const llmPlugin = definePlugin({
             result = await stream.next()
           }
 
-          const { modelExecutionMs, stats, toolCalls } = result.value
+          const { modelExecutionMs, stats, toolCalls, stoppedAtContextBoundary } = result.value
           // Cancellation rides the done path: observable via the last event's
           // stopReason; client aggregates reject with InferenceCancelledError.
           const cancelled = ctx.signal.aborted
@@ -422,17 +423,17 @@ export const llmPlugin = definePlugin({
           // -1 (unlimited) and -2 (context fill) must never trigger this.
           const effectivePredict =
             request.generationParams?.predict ?? (modelCfg as LlmConfig).predict
-          const stoppedByBudget =
-            !cancelled &&
-            effectivePredict !== undefined &&
-            effectivePredict > 0 &&
-            stats?.generatedTokens !== undefined &&
-            stats.generatedTokens >= effectivePredict
+          const lengthStop = stoppedByLength({
+            cancelled,
+            effectivePredict,
+            generatedTokens: stats?.generatedTokens,
+            stoppedAtContextBoundary
+          })
           const terminalEvents = normalizer.finish({
             ...(stats && { stats }),
             ...(toolCalls.length > 0 && { toolCalls }),
             ...(cancelled && { stopReason: 'cancelled' as const }),
-            ...(stoppedByBudget && { stopReason: 'length' as const })
+            ...(lengthStop && { stopReason: 'length' as const })
           })
 
           if (!request.stream) {

--- a/packages/sdk/server/bare/types/addon-responses.ts
+++ b/packages/sdk/server/bare/types/addon-responses.ts
@@ -6,6 +6,8 @@ export interface LlmStats {
   generatedTokens?: number
   avgConcurrentSeq?: number
   backendDevice?: 'cpu' | 'gpu'
+  stopReason?:
+    'none' | 'eos' | 'antiprompt' | 'predictionLimit' | 'sequenceLimit' | 'contextOverflow'
 }
 
 export interface LlmResponse {

--- a/packages/sdk/test/unit/completion-stats.test.ts
+++ b/packages/sdk/test/unit/completion-stats.test.ts
@@ -1,6 +1,9 @@
 import test from 'brittle'
 import { completionStatsSchema } from '@/schemas'
-import { normalizeCompletionStats } from '@/server/bare/plugins/llamacpp-completion/ops/completion-stats'
+import {
+  normalizeCompletionStats,
+  stoppedByLength
+} from '@/server/bare/plugins/llamacpp-completion/ops/completion-stats'
 import type { LlmStats } from '@/server/bare/types/addon-responses'
 
 test('normalizeCompletionStats: drops non-finite addon numbers', (t) => {
@@ -30,4 +33,40 @@ test('normalizeCompletionStats: returns undefined when no finite stats remain', 
   })
 
   t.is(normalized, undefined)
+})
+
+test('stoppedByLength: context boundary is a length stop', (t) => {
+  t.is(
+    stoppedByLength({
+      cancelled: false,
+      effectivePredict: 1024,
+      generatedTokens: 984,
+      stoppedAtContextBoundary: true
+    }),
+    true
+  )
+})
+
+test('stoppedByLength: cancellation takes precedence over context exhaustion', (t) => {
+  t.is(
+    stoppedByLength({
+      cancelled: true,
+      effectivePredict: 1024,
+      generatedTokens: 984,
+      stoppedAtContextBoundary: true
+    }),
+    false
+  )
+})
+
+test('stoppedByLength: positive prediction budget exhaustion remains a length stop', (t) => {
+  t.is(
+    stoppedByLength({
+      cancelled: false,
+      effectivePredict: 8,
+      generatedTokens: 8,
+      stoppedAtContextBoundary: false
+    }),
+    true
+  )
 })


### PR DESCRIPTION
## What problem does this PR solve?

A single-sequence completion that fills its context window is detected by the native addon after streaming content, but the addon rejects the run as `ContextOverflow`. The OpenAI-compatible SSE response has already started by then, so it cannot emit a terminal `finish_reason`, optional usage, or `[DONE]`.

Closes #3384.

## How does it solve it?

- Treat generation-time context exhaustion as a successful native terminal outcome while keeping prompt-admission overflow as an error.
- Preserve the native `contextOverflow` stop statistic internally and map it to the SDK’s existing `completionDone` reason `length`.
- Keep cancellation precedence over all length outcomes.
- Update the sliding-context regression to require generated output, a `contextOverflow` native stop reason, and termination before the requested prediction budget.

Design note: this does not change the public completion-stats schema or the prompt-too-large error path. It also does not include the structured-output behavior from #3225.

## How was it tested?

- `npx --yes bun run build` in `packages/sdk`
- `npx --yes bun run test:unit` in `packages/sdk` (full unit suite passed)
- `npm run test:dts` in `packages/llm-llamacpp`
- `VCPKG_ROOT=/tmp/qvac-vcpkg-2025.12.12 npx --yes bare-make build --target addon-test`
- `./addon-test --gtest_filter='LlamaModelTest.ProcessContextOverflow*'` (2/2 passed; prompt overflow remains an error)
- `npx --yes bare test/integration/sliding-context.test.js --exit` (7/7 tests, 24/24 assertions)
- Current-source SDK reproduction on macOS arm64 with Llama 3.2 1B, `ctx_size: 256`, `n_discarded: 0`: 201 content events, terminal `completionDone.stopReason: "length"`, prompt/completion stats returned, and the run closed normally.

Platform tested: macOS arm64 with Metal. CI should provide the repository’s other native-platform coverage.