### PR TITLE
QVAC-21930 chore[mod]: add Fun-CosyVoice3 models to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -7990,5 +7990,115 @@
     ],
     "notes": "",
     "link": "https://huggingface.co/ACE-Step/Ace-Step1.5/tree/main/vae"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/cosyvoice3-flow-f32.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 flow matching model (GGUF, multilingual)",
+    "quantization": "fp32",
+    "params": "0.5B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "flow",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/cosyvoice3-hift-f32.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 HiFT vocoder (GGUF, multilingual)",
+    "quantization": "fp32",
+    "params": "0.5B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "hift",
+      "vocoder",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/cosyvoice3-llm-q8_0.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 language model (GGUF, multilingual)",
+    "quantization": "q8_0",
+    "params": "0.5B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "llm",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/voice-en.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 English speaker voice embedding (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "voice",
+      "en",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/voice-zh-2.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 Chinese speaker voice embedding (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "voice",
+      "zh",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/voice-zh-female.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 Chinese female speaker voice embedding (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "voice",
+      "zh",
+      "female",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
   }
 ]


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The newly compiled Fun-CosyVoice3 GGUF models (uploaded to S3 under `qvac_models_compiled/ggml/cosy_voice/2026-07-23/`) were not discoverable through the registry server.

## 📝 How does it solve it?

- Adds 6 Fun-CosyVoice3 entries to `packages/registry-server/data/models.prod.json`, all under the `@qvac/tts-ggml` engine:
  - `cosyvoice3-flow-f32.gguf` — flow matching model (fp32)
  - `cosyvoice3-hift-f32.gguf` — HiFT vocoder (fp32)
  - `cosyvoice3-llm-q8_0.gguf` — language model (q8_0)
  - `voice-en.gguf` — English speaker voice embedding
  - `voice-zh-2.gguf` — Chinese speaker voice embedding
  - `voice-zh-female.gguf` — Chinese female speaker voice embedding
- Each entry sets `licenseId: Apache-2.0` and links to the upstream repo `https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512`.

## 🧪 How was it tested?

- Validated `models.prod.json` parses as valid JSON.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216355574251680