### PR TITLE
[DO NOT MERGE] probe: whisper mobile source-build baseline on unmodified main

### DIFF
--- a/packages/transcription-whispercpp/README.md
+++ b/packages/transcription-whispercpp/README.md
@@ -573,3 +573,5 @@ This project is licensed under the Apache-2.0 License – see the LICENSE file f
 
 For questions or issues, please open an issue on the GitHub repository.
 
+
+<!-- CI mobile source-build baseline probe (no functional change) -->


### PR DESCRIPTION
No-op change to run the transcription-whispercpp **mobile e2e from a source build** on unmodified main (registry whisper-cpp port, current baseline ggml-speech).

Context: source-built whisper (via the reorg overlay on [#3310](https://github.com/tetherto/qvac/pull/3310)) SIGABRTs in the addon .so during `runMobilePerfSweepGpuTest` on Samsung Galaxy S25 Ultra (Adreno 830), 2/2 runs. All standalone-dispatched mobile runs silently fall back to **published npm prebuilds** (`Found 0 artifact(s)` → `npm pack @latest`), so none of them tested source-built native bits — this probe fills the missing cell: source build + old-layout registry port + current ggml-speech (2026-07-15 Adreno OpenCL decode, registry #253).

- Fails on S25 the same way → pre-existing source-build-input regression (suspect ggml-speech Adreno OpenCL decode), reorg exonerated — same pattern as the linux-arm64 finding (#3321)
- Passes → the reorg-built whisper port is implicated and blocks qvac#3405

🤖 Generated with [Claude Code](https://claude.com/claude-code)