### PR TITLE
QVAC-18048 fix: rename merge-guard job to avoid check-name collision

### DIFF
--- a/.github/workflows/pr-gate-merge.yml
+++ b/.github/workflows/pr-gate-merge.yml
@@ -191,7 +191,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/pr-checks-sdk-pod.yml
 
-  merge-guard:
+  qvac-merge-guard:
     needs: [authorize, label-gate, changes, sanity-checks, prebuilds-caller, sdk-pod-checks]
     if: |
       always() && !cancelled() &&


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `merge-guard`'s check context (`merge-guard / validate-pr`) is identical to the check produced by 15 legacy per-addon `on-pr-<pkg>.yml` workflows, which each still define their own job at the same id calling `public-pr.yml`.

- GitHub's required-status-checks match by literal context string with no workflow-scoping, so registering `merge-guard / validate-pr` as required (the next step of QVAC-18048's rollout, once `Merge Guard` is enforced org-wide) would let **any** of those 16 workflows satisfy it — including a stale legacy per-addon copy unrelated to the actual centralized gate. Confirmed via a live test in a throwaway repo (`sidj-thr-org/merge-guard-check`) that the check context is job-id-based (`merge-guard / validate-pr`), not workflow-name-based, which is exactly why this collision is real.

## 📝 How does it solve it?

- Renames the job id in `pr-gate-merge.yml` from `merge-guard` to `qvac-merge-guard` — job body (`needs`, `if`, `permissions`, `uses`, `with`) is unchanged. New check context: `qvac-merge-guard / validate-pr`, unique and safe to register as a required status check.

- The 15 legacy `on-pr-<pkg>.yml` jobs are untouched — they keep running under the old name (dead weight, not required by anything after this change) and can be cleaned up separately as tech debt.

- Verified no other job depends on the `merge-guard` job id as a `needs:` target anywhere in `.github/workflows/` — the only other match is the unrelated `release-merge-guard` job id in `on-merge-classification-ggml.yml`/`on-merge-vla.yml`.

## 🧪 How was it tested?

- Confirmed the check-context-naming assumption empirically in a disposable test repo (`sidj-thr-org/merge-guard-check`) mirroring this exact `workflow_call` shape (caller job id `merge-guard` inside a workflow named `Merge Guard`, calling a job id `validate-pr`) — the resulting GitHub check context was `merge-guard / validate-pr` (job-id-based), confirming this rename produces `qvac-merge-guard / validate-pr` as expected.
- Pending before merge: a throwaway draft PR off this branch with an inert `packages/sdk/**` commit and the `verified` label, to confirm `qvac-merge-guard / validate-pr` appears and passes, and that this workflow no longer produces a check named `merge-guard / validate-pr`.
- Pending after merge: re-validated on a real PR against post-merge `main`, since `pull_request_target` always runs the workflow version from `main` — pre-merge validation alone isn't sufficient to confirm live behavior.
