### PR TITLE
QVAC-18048 chore: validate qvac-merge-guard rename (throwaway)

### DIFF
--- a/.github/workflows/pr-gate-merge.yml
+++ b/.github/workflows/pr-gate-merge.yml
@@ -191,7 +191,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/pr-checks-sdk-pod.yml
 
-  merge-guard:
+  qvac-merge-guard:
     needs: [authorize, label-gate, changes, sanity-checks, prebuilds-caller, sdk-pod-checks]
     if: |
       always() && !cancelled() &&

--- a/packages/sdk/CONTRIBUTING.md
+++ b/packages/sdk/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Welcome to the QVAC SDK! This document outlines our contribution guidelines designed to establish **high trust, high velocity, and high reliability** development practices.
 
+
 ## 🎯 Core principles
 
 **The purpose of each contribution should be to solve a specific problem, not to add code to the SDK.**


### PR DESCRIPTION
Throwaway validation PR for the qvac-merge-guard rename in #3413. Inert packages/sdk/** edit to trigger Merge Guard. Expect: check named qvac-merge-guard / validate-pr appears and passes; no check named merge-guard / validate-pr produced by this run. Will be closed once confirmed.