### PR TITLE
QVAC-21928 feat[mod]: register Fun-CosyVoice3-0.5B GGUFs

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -11348,5 +11348,115 @@
     ],
     "notes": "",
     "link": "https://github.com/Jackchows/Cangjie5"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/cosyvoice3-flow-f32.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 flow matching model (GGUF, multilingual)",
+    "quantization": "fp32",
+    "params": "0.5B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "flow",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/cosyvoice3-hift-f32.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 HiFT vocoder (GGUF, multilingual)",
+    "quantization": "fp32",
+    "params": "0.5B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "hift",
+      "vocoder",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/cosyvoice3-llm-q8_0.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 language model (GGUF, multilingual)",
+    "quantization": "q8_0",
+    "params": "0.5B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "llm",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/voice-en.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 English speaker voice embedding (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "voice",
+      "en",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/voice-zh-2.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 Chinese speaker voice embedding (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "voice",
+      "zh",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/voice-zh-female.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Fun-CosyVoice3 Chinese female speaker voice embedding (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "tts",
+      "cosyvoice",
+      "cosyvoice3",
+      "voice",
+      "zh",
+      "female",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
   }
 ]


### PR DESCRIPTION
## What

Registers the on-device **CosyVoice3-0.5B** TTS model in the registry — 6 entries
under `s3:///qvac_models_compiled/ggml/cosy_voice/2026-07-23/`:

| file | role | quant |
|---|---|---|
| `cosyvoice3-llm-q8_0.gguf` | Qwen2.5-0.5B speech LM | q8_0 |
| `cosyvoice3-flow-f32.gguf` | DiT flow-matching estimator | fp32 |
| `cosyvoice3-hift-f32.gguf` | CausalHiFT vocoder | fp32 |
| `voice-zh-female.gguf` | Chinese female voice | — |
| `voice-zh-2.gguf` | Chinese 2nd-timbre voice | — |
| `voice-en.gguf` | English voice | — |

Engine: `@qvac/tts-ggml` (qvac-ext-lib-whisper.cpp#99); addon: qvac#3369. Apache-2.0.

## Validation

`node scripts/validate-models-json.js --file=./data/models.prod.json` passes —
`s3:///` no-bucket form, `/2026-07-23/` date folder, valid license, no duplicate
sources. Additive only (+6 entries; existing 713 untouched).

## Dependencies / follow-ups

- **S3 upload** of the same files must land in the `2026-07-23/` folder (SHA256s in
  the ticket handoff).
- ⚠️ **Tokenizer**: `vocab.json` + `merges.txt` must be uploaded into the **same
  folder** as the LLM GGUF — the engine loads the Qwen2 tokenizer from
  `dirname(llm)`. They are **not** among these 6 entries; confirm delivery (extra
  registry entries, or SDK `vocabSrc`/`mergesSrc` resolution) so a registry-loaded
  model can find its tokenizer.
- After merge + sync to the production registry, regenerate the SDK catalog:
  `cd packages/ai-sdk-provider && bun run update-models` (commits `constants.ts`).
