### PR TITLE
chore(diffusion-cpp): prepare 0.17.0 release

### DIFF
--- a/packages/diffusion-cpp/CHANGELOG.md
+++ b/packages/diffusion-cpp/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.17.0] - 2026-07-23
+
+This release adds the validated Wan 2.2 TI2V-5B Turbo Q5_K_S workflow for
+high-quality text-to-video generation.
+
+### Features
+
+#### Wan 2.2 Turbo text-to-video workflow
+
+The package now provides a pinned downloader, manifest entries, runnable
+example, and opt-in smoke coverage for the community-distilled TI2V-5B Turbo
+Q5_K_S GGUF. The example uses the validated espresso product-film prompt with
+1280×704 output, 121 frames at 24 fps, four denoising steps, and CFG 1.
+
+#### Model-derived video validation
+
+Wan 2.2 TI2V models now derive their 32-pixel spatial alignment from GGUF
+tensor descriptors at load time. Renaming a checkpoint can no longer bypass
+the native constraint, while Wan 2.1 retains its 16-pixel grid.
+
+### Fixed
+
+- Wan 2.2 A14B progress reporting now treats a `high_noise_steps: -1` request
+  with `moe_boundary: 0` as a single denoising sequence, preventing VAE
+  progress from being classified as a second sampler phase.
+- The native `high_noise_steps` sentinel is preserved for A14B
+  `moe_boundary`-based routing.
+
+### Pull Requests
+
+- [#3415](https://github.com/tetherto/qvac/pull/3415) - QVAC-22493 feat(diffusion-cpp): focus Wan 2.2 on Turbo Q5
+
 ## [0.16.0] - 2026-07-23
 
 This release makes TypeScript the source of truth for the diffusion runtime

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
This PR bumps the diffusion-cpp package to 0.17.0 and adds the corresponding Wan 2.2 Turbo release notes to the CHANGELOG.