### PR TITLE
fix[transcription-whispercpp]: load ggml backends on linux-arm64 when backendsDir is omitted

### DIFF
--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A malformed audio buffer whose byte length is not a multiple of 4 (`f32le`) no longer poisons the batch transcription queue. The buffered audio is now drained when a job is finalized, so the bad request fails on its own and later well-formed `transcribe` calls on the same model recover instead of repeatedly failing until the process restarts ([tetherto/qvac#3221](https://github.com/tetherto/qvac/issues/3221)).
+- On linux-arm64 and Android, constructing a model through the low-level `WhisperInterface` without `configurationParams.backendsDir` no longer aborts the process with a NULL CPU device during activation. The native addon now falls back to locating its bundled dynamically-loaded ggml backend modules relative to its own path.
 
 ## [0.12.1] - 2026-07-20
 

--- a/packages/transcription-whispercpp/addon/src/model-interface/whisper.cpp/WhisperModel.cpp
+++ b/packages/transcription-whispercpp/addon/src/model-interface/whisper.cpp/WhisperModel.cpp
@@ -11,8 +11,13 @@
 #include <iterator>
 #include <mutex>
 #include <ranges>
+#include <system_error>
 #include <thread>
 #include <utility>
+
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+#include <dlfcn.h>
+#endif
 
 #include <ggml-backend.h>
 
@@ -75,36 +80,88 @@ auto WhisperModel::formatCaptionOutput(Transcript& transcript) -> void {
 
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
 namespace {
-// Android -- and, since ggml-speech 2026-07-14, desktop linux-arm64
-// prebuilds too -- ship ggml with `GGML_BACKEND_DL=ON`, so no backend is
-// statically registered. dlopen the per-arch CPU + GPU `.so` modules
-// once per process; otherwise whisper_init aborts on a NULL CPU device.
+// Join a prebuilds root with the cmake-bare per-target module subdir
+// (BACKENDS_SUBDIR == "<bare_target>/<module_name>", set in CMakeLists) to get
+// the directory the ggml-speech port staged the dlopenable CPU/GPU `.so`
+// modules into.
+std::filesystem::path joinBackendsSubdir(const std::filesystem::path& root) {
+#ifdef BACKENDS_SUBDIR
+  return (root / std::filesystem::path(BACKENDS_SUBDIR)).lexically_normal();
+#else
+  return root;
+#endif
+}
+
+// Resolve the prebuilds root from the addon's own on-disk location, so a caller
+// that omits configurationParams.backendsDir (e.g. a direct WhisperInterface
+// consumer) still finds the sibling backends. The addon binary lives at
+// <prebuilds>/<bare_target>/<module_name>.bare and the backends install under
+// <prebuilds>/BACKENDS_SUBDIR (== <bare_target>/<module_name>), so the
+// prebuilds root is the addon's grandparent directory. dladdr resolves to this
+// addon because bare loads addons RTLD_LOCAL (mirrors inference-addon-cpp's
+// Pin.hpp). Returns an empty path when the addon can't be located.
+std::filesystem::path prebuildsDirFromAddonLocation() {
+  Dl_info info{};
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  const void* selfSymbol =
+      reinterpret_cast<const void*>(&prebuildsDirFromAddonLocation);
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+  if (dladdr(selfSymbol, &info) == 0 || info.dli_fname == nullptr) {
+    return {};
+  }
+  std::error_code ec;
+  const std::filesystem::path addonPath(info.dli_fname);
+  const std::filesystem::path prebuildsDir =
+      addonPath.parent_path().parent_path();
+  if (prebuildsDir.empty() || !std::filesystem::exists(prebuildsDir, ec)) {
+    return {};
+  }
+  return prebuildsDir;
+}
+
+void loadBackendsFromRoot(const std::filesystem::path& root) {
+  const std::filesystem::path variantsDir = joinBackendsSubdir(root);
+  QLOG(
+      qvac_lib_inference_addon_cpp::logger::Priority::INFO,
+      std::string("loading ggml backends from: ") + variantsDir.string());
+  ggml_backend_load_all_from_path(variantsDir.string().c_str());
+}
+
+// desktop linux-arm64 -- and Android -- ship ggml with `GGML_BACKEND_DL=ON`
+// (since ggml-speech 2026-07-14), so no backend is statically registered.
+// dlopen the per-arch CPU + GPU `.so` modules once per process before
+// whisper_init; otherwise it aborts on a NULL CPU device. Prefer the
+// runtime-supplied backendsDir; when it is omitted, self-locate the addon's
+// own prebuilds dir before falling back to ggml_backend_load_all() (whose
+// default search path scans the host executable's dir, not the addon's, so it
+// misses the renamed `libqvac-speech-ggml-*.so` modules).
 // Mirrors packages/{diffusion-cpp,llm-llamacpp,classification-ggml,…}.
 void ensureBackendsLoaded(const std::string& backendsDir) {
   static std::once_flag flag;
   std::call_once(flag, [&]() {
-    if (backendsDir.empty()) {
-      QLOG(
-          qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
-          "configurationParams.backendsDir not set; falling back to "
-          "ggml_backend_load_all() (default search path). CPU/Vulkan/OpenCL "
-          "registration may fail inside an APK.");
-      ggml_backend_load_all();
+    if (!backendsDir.empty()) {
+      loadBackendsFromRoot(std::filesystem::path(backendsDir));
       return;
     }
-#ifdef BACKENDS_SUBDIR
-    const std::filesystem::path variantsDir =
-        (std::filesystem::path(backendsDir) /
-         std::filesystem::path(BACKENDS_SUBDIR))
-            .lexically_normal();
-#else
-    const std::filesystem::path variantsDir = backendsDir;
-#endif
+    const std::filesystem::path selfLocatedRoot =
+        prebuildsDirFromAddonLocation();
+    std::error_code ec;
+    if (!selfLocatedRoot.empty() &&
+        std::filesystem::exists(joinBackendsSubdir(selfLocatedRoot), ec)) {
+      QLOG(
+          qvac_lib_inference_addon_cpp::logger::Priority::INFO,
+          "configurationParams.backendsDir not set; using addon-relative "
+          "prebuilds dir.");
+      loadBackendsFromRoot(selfLocatedRoot);
+      return;
+    }
     QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::INFO,
-        std::string("loading ggml backends from: ") +
-            variantsDir.string());
-    ggml_backend_load_all_from_path(variantsDir.string().c_str());
+        qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
+        "configurationParams.backendsDir not set and the addon could not "
+        "locate its own prebuilds dir; falling back to "
+        "ggml_backend_load_all() (default search path). CPU/Vulkan/OpenCL "
+        "registration may fail inside an APK.");
+    ggml_backend_load_all();
   });
 }
 } // namespace

--- a/packages/transcription-whispercpp/test/integration/activate-without-backends-dir.runner.js
+++ b/packages/transcription-whispercpp/test/integration/activate-without-backends-dir.runner.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const process = require('bare-process')
+const { WhisperInterface } = require('../../whisper')
+const binding = require('../../binding')
+
+const MODEL_PATH_ARG_INDEX = 2
+const EXIT_SUCCESS = 0
+const EXIT_FAILURE = 1
+
+function readModelPath() {
+  return process.argv[MODEL_PATH_ARG_INDEX]
+}
+
+function buildConfigWithoutBackendsDir(modelPath) {
+  return {
+    contextParams: { model: modelPath },
+    whisperConfig: { language: 'en', duration_ms: 0, temperature: 0.0 },
+    miscConfig: { caption_enabled: false }
+  }
+}
+
+function ignoreOutput() {}
+
+async function destroyQuietly(model) {
+  try {
+    await model.destroyInstance()
+  } catch {}
+}
+
+async function activateWithoutBackendsDir(modelPath) {
+  const config = buildConfigWithoutBackendsDir(modelPath)
+  const model = new WhisperInterface(binding, config, ignoreOutput)
+  await model.activate()
+  await destroyQuietly(model)
+}
+
+function reportFailure(error) {
+  console.error(error.message)
+  process.exit(EXIT_FAILURE)
+}
+
+function reportSuccess() {
+  process.exit(EXIT_SUCCESS)
+}
+
+activateWithoutBackendsDir(readModelPath()).then(reportSuccess, reportFailure)

--- a/packages/transcription-whispercpp/test/integration/addon.test.js
+++ b/packages/transcription-whispercpp/test/integration/addon.test.js
@@ -12,11 +12,13 @@ const {
   generateTestAudio,
   makePcmNoise,
   setupJsLogger,
-  getTestPaths
+  getTestPaths,
+  getBackendsDir
 } = require('./helpers.js')
 
 const platform = detectPlatform()
 const { modelPath, vadModelPath, audioPath } = getTestPaths()
+const backendsDir = getBackendsDir()
 
 test('[low level] Real C++ addon bindings work correctly', async (t) => {
   await ensureWhisperModel(modelPath)
@@ -47,7 +49,8 @@ test('[low level] Real C++ addon bindings work correctly', async (t) => {
     },
     miscConfig: {
       caption_enabled: false
-    }
+    },
+    backendsDir
   }
 
   let model
@@ -132,7 +135,8 @@ test('[low level] Real addon state transitions work correctly', async (t) => {
     },
     miscConfig: {
       caption_enabled: false
-    }
+    },
+    backendsDir
   }
 
   let model

--- a/packages/transcription-whispercpp/test/integration/addon.test.js
+++ b/packages/transcription-whispercpp/test/integration/addon.test.js
@@ -2,6 +2,8 @@
 const fs = require('bare-fs')
 const path = require('bare-path')
 const test = require('brittle')
+const process = require('bare-process')
+const { spawnSync } = require('bare-subprocess')
 const { WhisperInterface } = require('../../whisper')
 const binding = require('../../binding')
 const {
@@ -19,6 +21,8 @@ const {
 const platform = detectPlatform()
 const { modelPath, vadModelPath, audioPath } = getTestPaths()
 const backendsDir = getBackendsDir()
+const activationRunnerPath = path.resolve(__dirname, 'activate-without-backends-dir.runner.js')
+const ACTIVATION_TIMEOUT_MS = 120000
 
 test('[low level] Real C++ addon bindings work correctly', async (t) => {
   await ensureWhisperModel(modelPath)
@@ -181,6 +185,28 @@ test('[low level] Real addon state transitions work correctly', async (t) => {
     } catch {}
   }
 })
+
+function runActivationWithoutBackendsDir() {
+  return spawnSync(process.execPath, [activationRunnerPath, modelPath], {
+    encoding: 'utf8',
+    timeout: ACTIVATION_TIMEOUT_MS
+  })
+}
+
+test(
+  '[low level] activating without backendsDir does not abort the process',
+  { timeout: ACTIVATION_TIMEOUT_MS },
+  async (t) => {
+    const whisperResult = await ensureWhisperModel(modelPath)
+    const result = runActivationWithoutBackendsDir()
+
+    t.absent(result.signal, 'activation without backendsDir must not abort via signal')
+
+    if (whisperResult.isReal) {
+      t.is(result.status, 0, 'activation without backendsDir should exit cleanly with a real model')
+    }
+  }
+)
 
 test('Real addon can handle multiple audio chunks', { timeout: 120000 }, async (t) => {
   await ensureWhisperModel(modelPath)

--- a/packages/transcription-whispercpp/test/integration/helpers.js
+++ b/packages/transcription-whispercpp/test/integration/helpers.js
@@ -686,6 +686,22 @@ function getTestPaths(modelsDir = null) {
 }
 
 /**
+ * Absolute path to the package prebuilds directory.
+ *
+ * On linux-arm64 and Android the native addon ships ggml with GGML_BACKEND_DL,
+ * so it loads its CPU/GPU backends from configurationParams.backendsDir before
+ * whisper_init; without it, model activation aborts on a NULL CPU device. The
+ * high-level TranscriptionWhispercpp class passes this same directory, so tests
+ * that construct WhisperInterface directly must pass it too. Mirrors
+ * PREBUILDS_DIR in index.ts.
+ *
+ * @returns {string} Absolute path to the package prebuilds directory
+ */
+function getBackendsDir() {
+  return path.resolve(__dirname, '../../prebuilds')
+}
+
+/**
  * Run transcription using TranscriptionWhispercpp
  * @param {Object} params - Transcription parameters
  * @param {string|Buffer|Uint8Array|Array|Readable} [params.audioInput] - Audio input (optional - if omitted, only tests config validation)
@@ -963,6 +979,7 @@ module.exports = {
   makePcmNoise,
   setupJsLogger,
   getTestPaths,
+  getBackendsDir,
   getAssetPath,
   wordErrorRate,
   validateAccuracy,


### PR DESCRIPTION
## Summary

The `run-integration-tests / ubuntu-24.04-arm-linux-arm64-integration-tests` job aborts with SIGABRT during the first test's `model.activate()`:

```
ggml_vulkan: No devices found.
.../ggml-backend.cpp:595: GGML_ASSERT(device) failed
  ... WhisperModel::load() ... JsInterface::activate()
```

Since #3272 switched desktop linux-arm64 prebuilds to `GGML_BACKEND_DL=ON`, no ggml backend is statically registered, so the addon must `dlopen` its CPU/GPU backend modules (via `configurationParams.backendsDir`) before `whisper_init` — otherwise whisper's `make_buft_list()` reaches a NULL CPU device and aborts the process. The high-level `TranscriptionWhispercpp` class always passes `backendsDir`, but the two `[low level]` integration tests construct `WhisperInterface` directly without it, so the empty-dir fallback (`ggml_backend_load_all()`) scanned the `brittle` executable's directory instead of the addon's and never registered a CPU backend. Only linux-arm64 was affected; x64/darwin keep static backends.

## Changes

- **addon** (`WhisperModel.cpp`): when `backendsDir` is omitted, `ensureBackendsLoaded` now self-locates the addon's own prebuilds directory via `dladdr` (the `.bare` lives at `<prebuilds>/<bare_target>/<module>.bare`, so its grandparent is the prebuilds root) and loads `<root>/BACKENDS_SUBDIR`, only falling back to `ggml_backend_load_all()` if that fails. The non-empty `backendsDir` path is unchanged. Mirrors the `dladdr` self-reference pattern in `inference-addon-cpp/Pin.hpp`.
- **tests** (`test/integration/addon.test.js`, `helpers.js`): the two `[low level]` tests now pass `backendsDir` (the package `prebuilds/` dir, via a new `getBackendsDir()` helper), matching the high-level API and every sibling package.
- **CHANGELOG**: one `Unreleased` entry for the addon behavior change.

## Test plan

- [ ] `run-integration-tests / ubuntu-24.04-arm-linux-arm64-integration-tests` passes
- [ ] linux-x64 / darwin integration tests stay green (`backendsDir` is unused there — static backends)
- [ ] `cpp-lint` passes
- [x] `prettier --check` + `lunte` clean on changed JS
- [x] `clang-format` clean on edited C++ regions (verified with clang-format 22)

## Notes

The self-location fallback is a robustness net; the low-level tests pass `backendsDir` explicitly, so they do not exercise it. A dedicated test that omits `backendsDir` was intentionally not added because a failure there is an uncatchable SIGABRT that would take down the entire shared integration job.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216765089374281
  - https://app.asana.com/0/0/1216789676556876