### PR TITLE
QVAC-22644 test[transcription-parakeet]: extract Bare-safe env teardown helper + regression test

### DIFF
--- a/packages/transcription-parakeet/test/integration/env.js
+++ b/packages/transcription-parakeet/test/integration/env.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const process = require('bare-process')
+
+function unsetEnvVar(key) {
+  try {
+    delete process.env[key]
+  } catch {}
+}
+
+function restoreEnvVar(key, previousValue) {
+  if (previousValue === undefined) {
+    unsetEnvVar(key)
+    return
+  }
+  process.env[key] = previousValue
+}
+
+module.exports = {
+  unsetEnvVar,
+  restoreEnvVar
+}

--- a/packages/transcription-parakeet/test/integration/sortformer-streaming-alias.test.js
+++ b/packages/transcription-parakeet/test/integration/sortformer-streaming-alias.test.js
@@ -26,6 +26,7 @@ const {
   MODEL_TYPE_ALIASES,
   getTestPaths
 } = require('./helpers.js')
+const { restoreEnvVar } = require('./env.js')
 
 const ALIAS = 'sortformer-streaming'
 const CANONICAL = 'sortformerStreaming'
@@ -62,15 +63,7 @@ test('ensureGgufForType(sortformer-streaming) resolves via the canonical env-key
   process.env[envKey] = sentinel
 
   t.teardown(() => {
-    // Bare's process.env proxy rejects `delete` (deleteProperty returns false),
-    // which would abort the whole test process; best-effort unset instead.
-    if (previous === undefined) {
-      try {
-        delete process.env[envKey]
-      } catch (_) {}
-    } else {
-      process.env[envKey] = previous
-    }
+    restoreEnvVar(envKey, previous)
     try {
       fs.unlinkSync(sentinel)
     } catch (_) {}

--- a/packages/transcription-parakeet/test/unit/env.test.js
+++ b/packages/transcription-parakeet/test/unit/env.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const test = require('brittle')
+const process = require('bare-process')
+const { unsetEnvVar, restoreEnvVar } = require('../integration/env.js')
+
+const KEY = 'QVAC_TEST_ENV_HELPER_PROBE'
+
+test('unsetEnvVar removes a set variable without aborting on the Bare env proxy', (t) => {
+  process.env[KEY] = 'sentinel'
+  t.execution(() => unsetEnvVar(KEY), 'unsetEnvVar does not throw on the Bare process.env proxy')
+  t.is(process.env[KEY], undefined, 'variable is unset')
+})
+
+test('unsetEnvVar is a no-op when the variable is already absent', (t) => {
+  unsetEnvVar(KEY)
+  t.execution(() => unsetEnvVar(KEY), 'unsetEnvVar does not throw for an absent key')
+  t.is(process.env[KEY], undefined, 'variable stays absent')
+})
+
+test('restoreEnvVar reinstates the previous value', (t) => {
+  process.env[KEY] = 'original'
+  const previous = process.env[KEY]
+  process.env[KEY] = 'overwritten'
+  restoreEnvVar(KEY, previous)
+  t.is(process.env[KEY], 'original', 'previous value is restored')
+  unsetEnvVar(KEY)
+})
+
+test('restoreEnvVar unsets the variable when there was no previous value', (t) => {
+  unsetEnvVar(KEY)
+  const previous = process.env[KEY]
+  process.env[KEY] = 'temporary'
+  restoreEnvVar(KEY, previous)
+  t.is(process.env[KEY], undefined, 'variable is unset when previous was undefined')
+})


### PR DESCRIPTION
## Summary
- The `sortformer-streaming-alias` integration teardown unset `QVAC_TEST_GGUF_SORTFORMERSTREAMING` via `delete process.env[key]`, which throws under Bare's `process.env` proxy (`deleteProperty` returns `false`) and aborts the integration process (exit 134) when the variable was not previously set. The inline crash guard already landed on `main` via #3379; this hardens it and adds regression coverage.
- Extract `unsetEnvVar`/`restoreEnvVar` into `test/integration/env.js` and call it from the teardown, replacing the inline try/catch + explanatory comment with a self-documenting helper.
- Add `test/unit/env.test.js` (addon-free) so the Bare-safe behavior is covered by the always-run unit suite, not only the label-gated desktop-integration job that let the original regression slip.

## Test plan
- [x] `brittle-bare test/unit/env.test.js` — 4 tests / 6 asserts pass under Bare.
- [x] `prettier --check` and `lunte` pass on the changed files.
- [x] `sortformer-streaming-alias` integration assertions unchanged; only the teardown mechanism is refactored.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216789676556811