### PR TITLE
QVAC-19132 fix: preserve atomic vision blocks during context slides

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/CacheManager.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/CacheManager.cpp
@@ -1,8 +1,8 @@
 #include "CacheManager.hpp"
 
-#include <array>
 #include <filesystem>
 #include <system_error>
+#include <vector>
 
 #include <inference-addon-cpp/Errors.hpp>
 #include <llama.h>
@@ -18,54 +18,6 @@
 using namespace qvac_lib_inference_addon_llama::errors;
 using namespace qvac_lib_inference_addon_cpp::logger;
 using namespace qvac_lib_inference_addon_llama::logging;
-
-namespace {
-
-struct SessionMetadata {
-  std::array<llama_token, SESSION_METADATA_FIELD_COUNT> tokens = {};
-
-  static SessionMetadata fromContext(const LlmContext& context) {
-    SessionMetadata metadata;
-    auto& tokens = metadata.tokens;
-    using Field = SessionMetadataField;
-    tokens[static_cast<size_t>(Field::NPast)] =
-        static_cast<llama_token>(context.getNPast());
-    tokens[static_cast<size_t>(Field::FirstMsgTokens)] =
-        static_cast<llama_token>(context.getFirstMsgTokens());
-    tokens[static_cast<size_t>(Field::CacheTokens)] =
-        static_cast<llama_token>(context.getCacheTokens());
-    tokens[static_cast<size_t>(Field::FirstMsgCacheTokens)] =
-        static_cast<llama_token>(context.getFirstMsgCacheTokens());
-    return metadata;
-  }
-
-  llama_token* data() { return tokens.data(); }
-  const llama_token* data() const { return tokens.data(); }
-  size_t size() const { return tokens.size(); }
-
-  llama_token field(SessionMetadataField which) const {
-    return tokens[static_cast<size_t>(which)];
-  }
-  llama_token nPast() const { return field(SessionMetadataField::NPast); }
-  llama_token firstMsgTokens() const {
-    return field(SessionMetadataField::FirstMsgTokens);
-  }
-  llama_token cacheTokens() const {
-    return field(SessionMetadataField::CacheTokens);
-  }
-  llama_token firstMsgCacheTokens() const {
-    return field(SessionMetadataField::FirstMsgCacheTokens);
-  }
-
-  void applyTo(LlmContext& context) const {
-    context.setNPast(nPast());
-    context.setFirstMsgTokens(firstMsgTokens());
-    context.setCacheTokens(cacheTokens());
-    context.setFirstMsgCacheTokens(firstMsgCacheTokens());
-  }
-};
-
-} // namespace
 
 CacheManager::CacheManager(
     LlmContext* llmContext, llama_pos configuredNDiscarded,
@@ -184,7 +136,8 @@ bool CacheManager::loadCache() {
 
   auto* ctx = llmContext_->getCtx();
   size_t nTokenCount = 0;
-  SessionMetadata sessionMetadata;
+  std::vector<llama_token> sessionTokens(
+      llmContext_->sessionMetadataCapacity(), 0);
 
   QLOG_IF(
       Priority::DEBUG,
@@ -204,8 +157,8 @@ bool CacheManager::loadCache() {
           ctx,
           sessionPath_.c_str(),
           llmContext_->getSeqId(),
-          sessionMetadata.data(),
-          sessionMetadata.size(),
+          sessionTokens.data(),
+          sessionTokens.size(),
           &nTokenCount) == 0) {
     std::string errorMsg = string_format(
         "%s: failed to load session file '%s'\n",
@@ -228,7 +181,9 @@ bool CacheManager::loadCache() {
     }
   });
 
-  if (nTokenCount > 1 && nTokenCount < sessionMetadata.size()) {
+  const auto applyResult =
+      llmContext_->applySessionMetadata(sessionTokens.data(), nTokenCount);
+  if (applyResult == SessionMetadataApplyResult::Invalid) {
     std::string errorMsg = string_format(
         "%s: cache file '%s' uses an unsupported metadata layout with %zu "
         "fields\n",
@@ -238,22 +193,21 @@ bool CacheManager::loadCache() {
     throw qvac_errors::StatusError(
         ADDON_ID, toString(UnableToLoadSessionFile), errorMsg);
   }
-
-  if (nTokenCount < sessionMetadata.size()) {
+  if (applyResult == SessionMetadataApplyResult::CacheMiss) {
     return false;
   }
-  if (sessionMetadata.nPast() > llama_n_ctx(ctx)) {
+
+  if (llmContext_->getNPast() > llama_n_ctx(ctx)) {
     std::string errorMsg = string_format(
         "%s: cache file '%s' contains %zu tokens, which exceeds the current "
         "context size of %d tokens\n",
         __func__,
         sessionPath_.c_str(),
-        static_cast<size_t>(sessionMetadata.nPast()),
+        static_cast<size_t>(llmContext_->getNPast()),
         llama_n_ctx(ctx));
     throw qvac_errors::StatusError(
         ADDON_ID, toString(ContextLengthExeeded), errorMsg);
   }
-  sessionMetadata.applyTo(*llmContext_);
 
   if (configuredNDiscarded_ >
       llama_n_ctx(ctx) - llmContext_->getFirstMsgTokens()) {
@@ -276,7 +230,7 @@ bool CacheManager::loadCache() {
 
   const llama_pos restoredNPast =
       llama_memory_seq_pos_max(mem, llmContext_->getSeqId()) + 1;
-  const auto expectedNPast = static_cast<llama_pos>(sessionMetadata.nPast());
+  const llama_pos expectedNPast = llmContext_->getNPast();
   if (restoredNPast != expectedNPast) {
     throw qvac_errors::StatusError(
         ADDON_ID,
@@ -291,8 +245,7 @@ bool CacheManager::loadCache() {
   }
   const llama_pos restoredCacheTokens = static_cast<llama_pos>(
       llama_memory_seq_token_count(mem, llmContext_->getSeqId()));
-  const auto expectedCacheTokens =
-      static_cast<llama_pos>(sessionMetadata.cacheTokens());
+  const llama_pos expectedCacheTokens = llmContext_->getCacheTokens();
   if (restoredCacheTokens != expectedCacheTokens) {
     throw qvac_errors::StatusError(
         ADDON_ID,
@@ -305,7 +258,7 @@ bool CacheManager::loadCache() {
             restoredCacheTokens,
             expectedCacheTokens));
   }
-  llama_memory_seq_rm(mem, -1, sessionMetadata.nPast(), -1);
+  llama_memory_seq_rm(mem, -1, expectedNPast, -1);
   restoredKvGuard.dismiss();
   return true;
 }
@@ -370,14 +323,14 @@ void CacheManager::writeCacheFile(const std::string& path) {
   QLOG_IF(
       Priority::DEBUG,
       string_format("%s: saving cache to '%s'\n", __func__, path.c_str()));
-  const SessionMetadata sessionMetadata =
-      SessionMetadata::fromContext(*llmContext_);
+  const std::vector<llama_token> sessionTokens =
+      llmContext_->encodeSessionMetadata();
   if (llama_state_seq_save_file(
           ctx,
           tmpPath.c_str(),
           llmContext_->getSeqId(),
-          sessionMetadata.data(),
-          sessionMetadata.size()) == 0) {
+          sessionTokens.data(),
+          sessionTokens.size()) == 0) {
     std::error_code ec;
     std::filesystem::remove(tmpPath, ec);
     throw qvac_errors::StatusError(

--- a/packages/llm-llamacpp/addon/src/model-interface/ContextShifter.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContextShifter.cpp
@@ -26,7 +26,8 @@ ContextShifter::ContextShifter(
 ContextShifter::Outcome ContextShifter::applyGenerationDiscard(
     ::llama_context* ctx, llama_seq_id seqId, llama_pos pos,
     llama_pos protectedPrefixPos, llama_pos effectiveCtx, llama_pos cacheTokens,
-    const char* labelTag, const IContextSliderOps& ops) {
+    const char* labelTag, const IContextSliderOps& ops,
+    const std::vector<VisionBlockRange>& visionBlocks) {
   // Slide notification is routed through the compactor's tools
   // controller so we keep a single tools reference per inference.
   auto outcome = trySlideGeneration(
@@ -38,7 +39,8 @@ ContextShifter::Outcome ContextShifter::applyGenerationDiscard(
       compactor_.toolsController(),
       ops,
       effectiveCtx,
-      cacheTokens);
+      cacheTokens,
+      visionBlocks);
 
   Outcome out;
   if (outcome.kind == ContextSlideOutcome::Kind::Slid) {

--- a/packages/llm-llamacpp/addon/src/model-interface/ContextShifter.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContextShifter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 #include <llama.h>
 
@@ -64,7 +65,8 @@ public:
       ::llama_context* ctx, llama_seq_id seqId, llama_pos pos,
       llama_pos protectedPrefixPos, llama_pos effectiveCtx,
       llama_pos cacheTokens, const char* labelTag,
-      const IContextSliderOps& ops = defaultContextSliderOps());
+      const IContextSliderOps& ops = defaultContextSliderOps(),
+      const std::vector<VisionBlockRange>& visionBlocks = {});
 
 private:
   ReasoningBlockCompactor& compactor_;

--- a/packages/llm-llamacpp/addon/src/model-interface/ContextSlider.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContextSlider.cpp
@@ -1,5 +1,8 @@
 #include "ContextSlider.hpp"
 
+#include <algorithm>
+#include <vector>
+
 #include "ToolsCompactController.hpp"
 #include "common/common.h"
 #include "inference-addon-cpp/Logger.hpp"
@@ -8,6 +11,22 @@
 using namespace qvac_lib_inference_addon_cpp::logger;
 
 namespace {
+llama_pos cacheTokensDiscardedBy(
+    llama_pos protectedPrefixPos, llama_pos discard,
+    const std::vector<VisionBlockRange>& visionBlocks) {
+  const llama_pos discardEnd = protectedPrefixPos + discard;
+  llama_pos cacheDiscard = discard;
+  for (const auto& block : visionBlocks) {
+    if (block.startPos >= protectedPrefixPos && block.endPos <= discardEnd) {
+      const llama_pos positionTokens = block.endPos - block.startPos;
+      const llama_pos blockCacheTokens =
+          block.cacheTokens > 0 ? block.cacheTokens : positionTokens;
+      cacheDiscard += blockCacheTokens - positionTokens;
+    }
+  }
+  return cacheDiscard;
+}
+
 class ContextSliderOps final : public IContextSliderOps {
 public:
   llama_pos nCtx(llama_context* lctx) const override {
@@ -35,7 +54,7 @@ ContextSlideOutcome trySlidePrefillImpl(
     llama_context* lctx, llama_seq_id seqId, ContextUsage current,
     ContextUsage protectedPrefix, ContextUsage append, llama_pos nDiscarded,
     ToolsCompactController& tools, const IContextSliderOps& ops,
-    llama_pos effectiveCtx) {
+    llama_pos effectiveCtx, const std::vector<VisionBlockRange>& visionBlocks) {
 
   // In batch mode the slot's usable window is the per-sequence cap, smaller
   // than the whole context; <= 0 means single-sequence, use the full context.
@@ -54,12 +73,26 @@ ContextSlideOutcome trySlidePrefillImpl(
 
   // Clamp discard so it never eats into tool tokens
   llama_pos discard = tools.clampDiscard(nDiscarded, protectedPrefixPos);
+  // Image embeddings must remain an atomic unit. If the nominal trim edge
+  // lands inside a tile, extend it to the tile's end so the oldest affected
+  // tile is dropped whole. Text-only ranges retain the configured partial
+  // trim behavior.
+  const llama_pos nominalEnd = protectedPrefixPos + discard;
+  llama_pos alignedEnd = nominalEnd;
+  for (const auto& block : visionBlocks) {
+    if (block.startPos < nominalEnd && nominalEnd < block.endPos) {
+      alignedEnd = std::max(alignedEnd, block.endPos);
+    }
+  }
+  discard = alignedEnd - protectedPrefixPos;
   llama_pos leftTokens = currentPos - protectedPrefixPos - discard;
+  const llama_pos cacheDiscard =
+      cacheTokensDiscardedBy(protectedPrefixPos, discard, visionBlocks);
 
   // Try partial slide
   if (leftTokens >= 0 && discard > 0 &&
       currentPos + appendPos - discard < nCtx &&
-      currentCacheTokens + appendCacheTokens - discard < nCtx) {
+      currentCacheTokens + appendCacheTokens - cacheDiscard < nCtx) {
     auto mem = ops.memory(lctx);
     if (!ops.seqRm(
             mem, seqId, protectedPrefixPos, protectedPrefixPos + discard)) {
@@ -94,13 +127,15 @@ ContextSlideOutcome trySlidePrefill(
       nDiscarded,
       tools,
       ops,
-      effectiveCtx);
+      effectiveCtx,
+      {});
 }
 
 ContextSlideOutcome trySlidePrefill(
     llama_context* lctx, llama_seq_id seqId, ContextUsage current,
     ContextUsage protectedPrefix, ContextUsage append, llama_pos nDiscarded,
-    ToolsCompactController& tools, const IContextSliderOps& ops) {
+    ToolsCompactController& tools, const IContextSliderOps& ops,
+    const std::vector<VisionBlockRange>& visionBlocks) {
   constexpr llama_pos effectiveCtx = -1;
   return trySlidePrefillImpl(
       lctx,
@@ -111,7 +146,8 @@ ContextSlideOutcome trySlidePrefill(
       nDiscarded,
       tools,
       ops,
-      effectiveCtx);
+      effectiveCtx,
+      visionBlocks);
 }
 
 CompactRangeOutcome compactKvRange(
@@ -135,7 +171,8 @@ ContextSlideOutcome trySlideGeneration(
     llama_context* lctx, llama_seq_id seqId, llama_pos nPast,
     llama_pos firstMsgTokens, llama_pos nDiscarded,
     ToolsCompactController& tools, const IContextSliderOps& ops,
-    llama_pos effectiveCtx, llama_pos nCacheTokens) {
+    llama_pos effectiveCtx, llama_pos nCacheTokens,
+    const std::vector<VisionBlockRange>& visionBlocks) {
 
   const auto nCtx = effectiveCtx > 0 ? effectiveCtx : ops.nCtx(lctx);
   const llama_pos cacheTokens = nCacheTokens >= 0 ? nCacheTokens : nPast;
@@ -179,6 +216,15 @@ ContextSlideOutcome trySlideGeneration(
             tools.enabled() ? "true" : "false"));
     return {ContextSlideOutcome::Kind::NotNeeded, nPast, 0};
   }
+
+  const llama_pos nominalEnd = firstMsgTokens + discard;
+  llama_pos alignedEnd = nominalEnd;
+  for (const auto& block : visionBlocks) {
+    if (block.startPos < nominalEnd && nominalEnd < block.endPos) {
+      alignedEnd = std::max(alignedEnd, block.endPos);
+    }
+  }
+  discard = alignedEnd - firstMsgTokens;
 
   // Perform the slide
   auto mem = ops.memory(lctx);

--- a/packages/llm-llamacpp/addon/src/model-interface/ContextSlider.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContextSlider.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <llama.h>
 
 class ToolsCompactController;
@@ -27,6 +29,17 @@ const IContextSliderOps& defaultContextSliderOps();
 
 struct ContextUsage {
   llama_pos pos = 0;
+  llama_pos cacheTokens = 0;
+};
+
+/// Positional range occupied by one independently decodable vision tile.
+///
+/// The range is tracked in the same position coordinate space used by
+/// llama_memory_seq_rm. A multi-tile image therefore contributes one range per
+/// tile, which permits eviction tile-by-tile without splitting a tile.
+struct VisionBlockRange {
+  llama_pos startPos = 0;
+  llama_pos endPos = 0;
   llama_pos cacheTokens = 0;
 };
 
@@ -79,7 +92,8 @@ ContextSlideOutcome trySlidePrefill(
     llama_context* lctx, llama_seq_id seqId, ContextUsage current,
     ContextUsage protectedPrefix, ContextUsage append, llama_pos nDiscarded,
     ToolsCompactController& tools,
-    const IContextSliderOps& ops = defaultContextSliderOps());
+    const IContextSliderOps& ops = defaultContextSliderOps(),
+    const std::vector<VisionBlockRange>& visionBlocks = {});
 
 /// Attempts to slide the context window during generation phase.
 ///
@@ -104,7 +118,8 @@ ContextSlideOutcome trySlideGeneration(
     llama_pos firstMsgTokens, llama_pos nDiscarded,
     ToolsCompactController& tools,
     const IContextSliderOps& ops = defaultContextSliderOps(),
-    llama_pos effectiveCtx = -1, llama_pos nCacheTokens = -1);
+    llama_pos effectiveCtx = -1, llama_pos nCacheTokens = -1,
+    const std::vector<VisionBlockRange>& visionBlocks = {});
 
 /// Outcome of an in-place KV-cache range compaction.
 struct CompactRangeOutcome {

--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "SequenceDriver.hpp"
 #include "addon/LlmErrors.hpp"
@@ -183,6 +184,13 @@ enum class SessionMetadataField : uint8_t {
 
 /// Number of `llama_token` fields in the session metadata contract above.
 inline constexpr size_t SESSION_METADATA_FIELD_COUNT = 4;
+
+/// Result of applying session-file metadata tokens onto a live context.
+enum class SessionMetadataApplyResult {
+  Applied,  // Metadata accepted and applied to the context
+  CacheMiss, // Layout is recognised as unsupported/legacy; caller clears KV
+  Invalid,  // Corrupt or unexpected layout; caller should throw
+};
 
 class LlmContext { // NOLINT(cppcoreguidelines-special-member-functions)
 public:
@@ -484,6 +492,49 @@ public:
   /// per-slot batch drivers, or null for text-only contexts. Used by the
   /// scheduler factory to detect media capability without a `dynamic_cast`.
   [[nodiscard]] virtual mtmd_context* visionContext() const { return nullptr; }
+
+  /// Capacity of the token buffer passed to `llama_state_seq_load_file`.
+  /// Text contexts keep the four-field contract; multimodal contexts may
+  /// request a larger buffer for versioned vision-block metadata.
+  [[nodiscard]] virtual size_t sessionMetadataCapacity() const {
+    return SESSION_METADATA_FIELD_COUNT;
+  }
+
+  /// Encode the session metadata that should be persisted alongside the
+  /// sequence KV state. Default is the four-field cursor contract.
+  [[nodiscard]] virtual std::vector<llama_token> encodeSessionMetadata() const {
+    return {
+        static_cast<llama_token>(getNPast()),
+        static_cast<llama_token>(getFirstMsgTokens()),
+        static_cast<llama_token>(getCacheTokens()),
+        static_cast<llama_token>(getFirstMsgCacheTokens()),
+    };
+  }
+
+  /// Apply metadata tokens restored from a session file. Must not mutate
+  /// the context on `CacheMiss` / `Invalid` so callers can clear stranded
+  /// KV without leaving a half-applied cursor.
+  [[nodiscard]] virtual SessionMetadataApplyResult applySessionMetadata(
+      const llama_token* tokens, size_t count) {
+    if (tokens == nullptr) {
+      return SessionMetadataApplyResult::Invalid;
+    }
+    if (count > 1 && count < SESSION_METADATA_FIELD_COUNT) {
+      return SessionMetadataApplyResult::Invalid;
+    }
+    if (count < SESSION_METADATA_FIELD_COUNT) {
+      return SessionMetadataApplyResult::CacheMiss;
+    }
+    setNPast(static_cast<llama_pos>(tokens[static_cast<size_t>(
+        SessionMetadataField::NPast)]));
+    setFirstMsgTokens(static_cast<llama_pos>(tokens[static_cast<size_t>(
+        SessionMetadataField::FirstMsgTokens)]));
+    setCacheTokens(static_cast<llama_pos>(tokens[static_cast<size_t>(
+        SessionMetadataField::CacheTokens)]));
+    setFirstMsgCacheTokens(static_cast<llama_pos>(tokens[static_cast<size_t>(
+        SessionMetadataField::FirstMsgCacheTokens)]));
+    return SessionMetadataApplyResult::Applied;
+  }
 
 protected:
   void clearSequenceMemory(

--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -165,9 +165,10 @@ struct LlmModelContext {
   const llama_vocab* vocab = nullptr;
 };
 
-/// Canonical layout of the per-session cache metadata that every cache
-/// (de)serializer must persist and restore. Any driver implementing
-/// `loadCache`/`saveCache` MUST round-trip all four fields in this order.
+/// Canonical four-field cursor layout for text session caches. Text drivers
+/// persist exactly these fields in this order. Multimodal drivers wrap them
+/// in a versioned header that also stores vision-block ranges (see
+/// `MTMD_SESSION_METADATA_VERSION` in MtmdLlmContext.hpp).
 ///
 /// `cacheTokens`/`firstMsgCacheTokens` (physical KV-cell usage) are owned
 /// separately from `nPast`/`firstMsgTokens` (logical positional span) because
@@ -524,6 +525,11 @@ public:
     }
     if (count < SESSION_METADATA_FIELD_COUNT) {
       return SessionMetadataApplyResult::CacheMiss;
+    }
+    // Text caches use an exact four-field contract. Larger payloads belong to
+    // versioned multimodal metadata and must not be partially applied here.
+    if (count > SESSION_METADATA_FIELD_COUNT) {
+      return SessionMetadataApplyResult::Invalid;
     }
     setNPast(static_cast<llama_pos>(tokens[static_cast<size_t>(
         SessionMetadataField::NPast)]));

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -506,11 +506,13 @@ LlmContext::EvalMessageResult MtmdLlmContext::evalMessageWithTools(
         ContextUsage{nPositions, nTokens},
         shifter_.discardBudget(),
         tools_,
-        defaultContextSliderOps());
+        defaultContextSliderOps(),
+        visionBlocks_);
     switch (outcome.kind) {
     case ContextSlideOutcome::Kind::Slid:
       current_.pos = outcome.newNPast;
       refreshCurrentCacheTokensFromMemory();
+      applyVisionBlockSlide(protectedPrefix_.pos, outcome.discarded);
       shifter_.noteSlide();
       QLOG_IF(
           Priority::DEBUG,
@@ -653,6 +655,9 @@ LlmContext::EvalMessageResult MtmdLlmContext::evalMessageWithTools(
       // fabric expose the encode time so this copy can be dropped and the
       // helper called directly.
       const auto encT0 = std::chrono::steady_clock::now();
+      const llama_pos imageStart = nPastLocal;
+      const llama_pos imageCacheStart = static_cast<llama_pos>(
+          llama_memory_seq_token_count(llama_get_memory(modelCtx_.lctx), seqId_));
       res = mtmd_encode_chunk(visionContext(), chunk);
       visionEncodeMs_ += std::chrono::duration<double, std::milli>(
                              std::chrono::steady_clock::now() - encT0)
@@ -671,6 +676,13 @@ LlmContext::EvalMessageResult MtmdLlmContext::evalMessageWithTools(
             &nPastLocal,
             /*callback=*/nullptr,
             /*user_data=*/nullptr);
+        if (res == 0) {
+          const llama_pos imageCacheEnd = static_cast<llama_pos>(
+              llama_memory_seq_token_count(
+                  llama_get_memory(modelCtx_.lctx), seqId_));
+          recordVisionBlock(
+              imageStart, nPastLocal, imageCacheEnd - imageCacheStart);
+        }
       }
     } else {
       res = mtmd_helper_eval_chunk_single(
@@ -767,6 +779,7 @@ bool MtmdLlmContext::cancelGenerationCleanup(
   });
 
   protectedPrefix_ = preRequestProtectedPrefix_;
+  visionBlocks_ = preRequestVisionBlocks_;
   rollbackState_.clearPrefillEntry();
   rollbackState_.clearReasoningBoundary();
   rollbackState_.clearPostReasoning();
@@ -799,11 +812,38 @@ void MtmdLlmContext::applyContextDiscard() {
       protectedPrefix_.pos,
       /*effectiveCtx=*/-1,
       current_.cacheTokens,
-      "[MtmdLlm]");
+      "[MtmdLlm]",
+      defaultContextSliderOps(),
+      visionBlocks_);
   if (outcome.kind == ContextShifter::Outcome::Kind::Slid) {
     current_.pos = outcome.newPos;
     refreshCurrentCacheTokensFromMemory();
+    applyVisionBlockSlide(protectedPrefix_.pos, outcome.discarded);
   }
+}
+
+void MtmdLlmContext::recordVisionBlock(
+    llama_pos startPos, llama_pos endPos, llama_pos cacheTokens) {
+  if (endPos > startPos) {
+    visionBlocks_.push_back({startPos, endPos, cacheTokens});
+  }
+}
+
+void MtmdLlmContext::applyVisionBlockSlide(
+    llama_pos protectedPrefixPos, llama_pos discarded) {
+  const llama_pos removedEnd = protectedPrefixPos + discarded;
+  std::vector<VisionBlockRange> remaining;
+  remaining.reserve(visionBlocks_.size());
+  for (const auto& block : visionBlocks_) {
+    if (block.endPos <= protectedPrefixPos) {
+      remaining.push_back(block);
+    } else if (block.startPos >= removedEnd) {
+      remaining.push_back(
+          {block.startPos - discarded, block.endPos - discarded,
+           block.cacheTokens});
+    }
+  }
+  visionBlocks_ = std::move(remaining);
 }
 
 LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
@@ -1474,6 +1514,8 @@ void MtmdLlmContext::resetState(bool resetStats) {
   tools_.reset();
   current_ = {};
   protectedPrefix_ = {};
+  visionBlocks_.clear();
+  preRequestVisionBlocks_.clear();
 
   // On partial reset (resetStats=false), preserve the slide counter,
   // block discards, and vision-encode accumulators so `runtimeStats()`
@@ -1710,6 +1752,12 @@ llama_pos MtmdLlmContext::evalMediaSegment(size_t mediaIndex, llama_pos pos) {
         mediaIndex,
         res);
     throw qvac_errors::StatusError(ADDON_ID, toString(EncoderFailed), errorMsg);
+  }
+  if (mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+    recordVisionBlock(
+        pos,
+        newPos,
+        static_cast<llama_pos>(mtmd_input_chunk_get_n_tokens(chunk)));
   }
 
   // Commit accounting only after a successful eval, so a throwing/failing
@@ -2021,6 +2069,8 @@ bool MtmdLlmContext::loadCache(
     }
     current_ = {};
     protectedPrefix_ = {};
+    visionBlocks_.clear();
+    preRequestVisionBlocks_.clear();
     tools_.reset();
   });
 
@@ -2101,6 +2151,11 @@ bool MtmdLlmContext::loadCache(
   }
 
   llama_memory_seq_rm(mem, seqId_, getNPast(), -1);
+  // Sequence state restores KV cells and position metadata, but not the
+  // per-request mtmd chunk boundaries. Clear any stale ranges rather than
+  // applying offsets from an unrelated in-memory sequence.
+  visionBlocks_.clear();
+  preRequestVisionBlocks_.clear();
   restoredKvGuard.dismiss();
   return true;
 }
@@ -2138,6 +2193,7 @@ void MtmdLlmContext::saveCache(const std::string& cacheKey) const {
 void MtmdLlmContext::snapshotPreRequestCursor() {
   preRequestUsage_ = current_;
   preRequestProtectedPrefix_ = protectedPrefix_;
+  preRequestVisionBlocks_ = visionBlocks_;
 }
 
 void MtmdLlmContext::snapshotPreRequestRollbackAnchor() {

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -780,7 +780,14 @@ bool MtmdLlmContext::cancelGenerationCleanup(
   });
 
   protectedPrefix_ = preRequestProtectedPrefix_;
-  visionBlocks_ = preRequestVisionBlocks_;
+  // Vision ranges must stay aligned with live KV. Restore the pre-request
+  // snapshot only when cancel returned the cursor to that snapshot. A
+  // generation slide that discarded past the snapshot is not undone by
+  // cancel; keeping the live (already rebased) ranges avoids stranding
+  // mismatched image/tile boundaries on the slid KV.
+  if (current_.pos == preRequestUsage_.pos) {
+    visionBlocks_ = preRequestVisionBlocks_;
+  }
   rollbackState_.clearPrefillEntry();
   rollbackState_.clearReasoningBoundary();
   rollbackState_.clearPostReasoning();
@@ -2027,6 +2034,13 @@ size_t MtmdLlmContext::sessionMetadataCapacity() const {
 }
 
 std::vector<llama_token> MtmdLlmContext::encodeSessionMetadata() const {
+  if (visionBlocks_.size() > MTMD_MAX_VISION_BLOCKS) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToSaveSessionFile),
+        "MtmdLlmContext::encodeSessionMetadata: vision-block count exceeds "
+        "session metadata capacity");
+  }
   MtmdSessionMetadata metadata;
   metadata.nPast = getNPast();
   metadata.firstMsgTokens = getFirstMsgTokens();

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -634,6 +634,7 @@ LlmContext::EvalMessageResult MtmdLlmContext::evalMessageWithTools(
           rollbackOk = false;
         }
       }
+      visionBlocks_ = preRequestVisionBlocks_;
       stopGeneration_.store(false);
       return {.ok = false, .cancelled = true, .rollbackOk = rollbackOk};
     }

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -2013,18 +2013,53 @@ void MtmdLlmContext::validatePromptPolicy(
   tools_.validatePrompt(chatMsgs, tools, layout, hasKvCacheContext);
 }
 
-/// Prompt caching on the multimodal batch path round-trips the full four-field
-/// session-metadata contract (`SessionMetadataField` in LlmContext.hpp),
-/// exactly as `CacheManager` does. All four fields are required: copying only
-/// the text path's two positional fields would drop
-/// `cacheTokens`/`firstMsgCacheTokens`, and for M-RoPE media those KV-cell
-/// counts diverge from the positional span (`current_.pos` vs
-/// `current_.cacheTokens`), so losing them would break context shifting after
-/// restore.
+/// Prompt caching on the multimodal path round-trips versioned session
+/// metadata: the four cursor fields plus each tracked vision-block range.
+/// Legacy exact-four-field headers are a cache miss (re-prime) so a later
+/// slide cannot split restored image tokens that lack boundary metadata.
 static_assert(
     SESSION_METADATA_FIELD_COUNT == 4,
-    "MTMD cache (de)serialization must persist all four session-metadata "
-    "fields; update the implementation when the contract changes");
+    "MTMD cache (de)serialization builds on the four cursor fields; update "
+    "the versioned encoder when the base contract changes");
+
+size_t MtmdLlmContext::sessionMetadataCapacity() const {
+  return MTMD_SESSION_METADATA_CAPACITY;
+}
+
+std::vector<llama_token> MtmdLlmContext::encodeSessionMetadata() const {
+  MtmdSessionMetadata metadata;
+  metadata.nPast = getNPast();
+  metadata.firstMsgTokens = getFirstMsgTokens();
+  metadata.cacheTokens = getCacheTokens();
+  metadata.firstMsgCacheTokens = getFirstMsgCacheTokens();
+  metadata.visionBlocks = visionBlocks_;
+  return encodeMtmdSessionMetadata(metadata);
+}
+
+SessionMetadataApplyResult MtmdLlmContext::applySessionMetadata(
+    const llama_token* tokens, size_t count) {
+  MtmdSessionMetadata metadata;
+  const auto status = decodeMtmdSessionMetadata(tokens, count, metadata);
+  switch (status) {
+  case MtmdSessionMetadataDecodeStatus::LegacyFourField:
+    return SessionMetadataApplyResult::CacheMiss;
+  case MtmdSessionMetadataDecodeStatus::Invalid:
+    return SessionMetadataApplyResult::Invalid;
+  case MtmdSessionMetadataDecodeStatus::Ok:
+    break;
+  }
+  if (!validateMtmdVisionBlocks(metadata)) {
+    return SessionMetadataApplyResult::Invalid;
+  }
+
+  setNPast(metadata.nPast);
+  setFirstMsgTokens(metadata.firstMsgTokens);
+  setCacheTokens(metadata.cacheTokens);
+  setFirstMsgCacheTokens(metadata.firstMsgCacheTokens);
+  visionBlocks_ = std::move(metadata.visionBlocks);
+  preRequestVisionBlocks_.clear();
+  return SessionMetadataApplyResult::Applied;
+}
 
 bool MtmdLlmContext::loadCache(
     const std::string& cacheKey, llama_pos configuredNDiscarded) {
@@ -2033,19 +2068,16 @@ bool MtmdLlmContext::loadCache(
     return false;
   }
 
-  // Restore the full four-field metadata contract (SessionMetadataField order:
-  // NPast, FirstMsgTokens, CacheTokens, FirstMsgCacheTokens). For M-RoPE media
-  // the KV-cell counts diverge from the positional span, so all four must
-  // survive — see the static_assert above. The per-cell llama_kv_cell_ext
-  // (x/y) is restored by the GGSQ sequence-state loader itself.
+  // Restore versioned multimodal metadata (cursors + vision-block ranges).
+  // The per-cell llama_kv_cell_ext (x/y) is restored by the GGSQ loader.
   size_t tokenCount = 0;
-  llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {0, 0, 0, 0};
+  std::vector<llama_token> sessionTokens(MTMD_SESSION_METADATA_CAPACITY, 0);
   const auto loadedBytes = llama_state_seq_load_file(
       modelCtx_.lctx,
       cacheKey.c_str(),
       seqId_,
-      sessionTokens,
-      SESSION_METADATA_FIELD_COUNT,
+      sessionTokens.data(),
+      sessionTokens.size(),
       &tokenCount);
   if (loadedBytes == 0) {
     throw qvac_errors::StatusError(
@@ -2075,27 +2107,21 @@ bool MtmdLlmContext::loadCache(
     tools_.reset();
   });
 
-  // Accepting a partial header would leave `cacheTokens`/`firstMsgCacheTokens`
-  // defaulted to zero (they diverge from `nPast` under M-RoPE, breaking later
-  // cap checks). Require the full four-field contract; the guard above clears
-  // the restored KV on reject, mirroring `CacheManager::loadCache`.
-  if (!mtmdSessionMetadataIsComplete(tokenCount)) {
+  const auto applyResult =
+      applySessionMetadata(sessionTokens.data(), tokenCount);
+  if (applyResult == SessionMetadataApplyResult::CacheMiss) {
+    // Legacy four-field multimodal caches lack vision-block boundaries.
+    // Clear restored KV and report a miss so the session re-primes.
+    return false;
+  }
+  if (applyResult != SessionMetadataApplyResult::Applied) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         toString(UnableToLoadSessionFile),
         "MtmdLlmContext::loadCache: cache '" + cacheKey +
-            "' has incomplete session metadata (" + std::to_string(tokenCount) +
-            " of " + std::to_string(SESSION_METADATA_FIELD_COUNT) + " fields)");
+            "' has unsupported or corrupt session metadata (" +
+            std::to_string(tokenCount) + " fields)");
   }
-
-  setNPast(sessionTokens[static_cast<size_t>(SessionMetadataField::NPast)]);
-  setFirstMsgTokens(
-      sessionTokens[static_cast<size_t>(SessionMetadataField::FirstMsgTokens)]);
-  setCacheTokens(
-      sessionTokens[static_cast<size_t>(SessionMetadataField::CacheTokens)]);
-  setFirstMsgCacheTokens(
-      sessionTokens[static_cast<size_t>(
-          SessionMetadataField::FirstMsgCacheTokens)]);
 
   if (getNPast() > llama_n_ctx(modelCtx_.lctx)) {
     throw qvac_errors::StatusError(
@@ -2152,11 +2178,6 @@ bool MtmdLlmContext::loadCache(
   }
 
   llama_memory_seq_rm(mem, seqId_, getNPast(), -1);
-  // Sequence state restores KV cells and position metadata, but not the
-  // per-request mtmd chunk boundaries. Clear any stale ranges rather than
-  // applying offsets from an unrelated in-memory sequence.
-  visionBlocks_.clear();
-  preRequestVisionBlocks_.clear();
   restoredKvGuard.dismiss();
   return true;
 }
@@ -2166,20 +2187,15 @@ void MtmdLlmContext::saveCache(const std::string& cacheKey) const {
     return;
   }
 
-  // Persist all four metadata fields in SessionMetadataField order so the
-  // physical KV-cell counts that diverge under M-RoPE survive restore.
-  const llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {
-      static_cast<llama_token>(getNPast()),
-      static_cast<llama_token>(getFirstMsgTokens()),
-      static_cast<llama_token>(getCacheTokens()),
-      static_cast<llama_token>(getFirstMsgCacheTokens())};
+  // Persist versioned metadata so vision-block boundaries survive reload.
+  const std::vector<llama_token> sessionTokens = encodeSessionMetadata();
   const std::string tmpCacheKey = cacheKey + ".tmp";
   const auto savedBytes = llama_state_seq_save_file(
       modelCtx_.lctx,
       tmpCacheKey.c_str(),
       seqId_,
-      sessionTokens,
-      SESSION_METADATA_FIELD_COUNT);
+      sessionTokens.data(),
+      sessionTokens.size());
   if (savedBytes == 0) {
     std::error_code ec;
     std::filesystem::remove(tmpCacheKey, ec);

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <optional>
 #include <vector>
@@ -19,14 +20,155 @@
 #include "ToolsCompactController.hpp"
 #include "inference-addon-cpp/Logger.hpp"
 
-/// A multimodal session cache is only safe to restore when its header carries
-/// the full four-field metadata contract (`SessionMetadataField`). The GGSQ
-/// loader restores the sequence KV before this check, so any other count — a
-/// truncated/legacy header (`< 4`) or an unexpected layout (`> 4`) — must be
-/// rejected and the restored KV cleared, never accepted with defaulted
-/// `cacheTokens`/`firstMsgCacheTokens`. See `MtmdLlmContext::loadCache`.
-[[nodiscard]] inline bool mtmdSessionMetadataIsComplete(size_t tokenCount) {
+/// Versioned multimodal session-metadata layout (llama_token array):
+///   [0] version (== MTMD_SESSION_METADATA_VERSION)
+///   [1] nPast
+///   [2] firstMsgTokens
+///   [3] cacheTokens
+///   [4] firstMsgCacheTokens
+///   [5] visionBlockCount
+///   [6..] triples (startPos, endPos, cacheTokens) per vision tile
+///
+/// Legacy exact-four-field headers are treated as a cache miss so restored
+/// sessions re-prime rather than sliding through untracked image blocks.
+inline constexpr llama_token MTMD_SESSION_METADATA_VERSION = 1;
+inline constexpr size_t MTMD_SESSION_METADATA_HEADER_COUNT = 6;
+inline constexpr size_t MTMD_VISION_BLOCK_FIELD_COUNT = 3;
+inline constexpr size_t MTMD_MAX_VISION_BLOCKS = 512;
+inline constexpr size_t MTMD_SESSION_METADATA_CAPACITY =
+    MTMD_SESSION_METADATA_HEADER_COUNT +
+    (MTMD_VISION_BLOCK_FIELD_COUNT * MTMD_MAX_VISION_BLOCKS);
+
+struct MtmdSessionMetadata {
+  llama_pos nPast = 0;
+  llama_pos firstMsgTokens = 0;
+  llama_pos cacheTokens = 0;
+  llama_pos firstMsgCacheTokens = 0;
+  std::vector<VisionBlockRange> visionBlocks;
+};
+
+enum class MtmdSessionMetadataDecodeStatus {
+  Ok,
+  LegacyFourField,
+  Invalid,
+};
+
+[[nodiscard]] inline bool mtmdSessionMetadataIsLegacyFourField(
+    size_t tokenCount) {
   return tokenCount == SESSION_METADATA_FIELD_COUNT;
+}
+
+[[nodiscard]] inline bool mtmdSessionMetadataHasVersionedShape(
+    size_t tokenCount) {
+  if (tokenCount < MTMD_SESSION_METADATA_HEADER_COUNT) {
+    return false;
+  }
+  const size_t trailing = tokenCount - MTMD_SESSION_METADATA_HEADER_COUNT;
+  return trailing % MTMD_VISION_BLOCK_FIELD_COUNT == 0 &&
+         (trailing / MTMD_VISION_BLOCK_FIELD_COUNT) <= MTMD_MAX_VISION_BLOCKS;
+}
+
+/// Complete means a versioned header that is safe to decode (not legacy four-
+/// field, not truncated, not over-long). Semantic range validation happens
+/// separately against the restored sequence.
+[[nodiscard]] inline bool mtmdSessionMetadataIsComplete(size_t tokenCount) {
+  return mtmdSessionMetadataHasVersionedShape(tokenCount);
+}
+
+[[nodiscard]] inline std::vector<llama_token> encodeMtmdSessionMetadata(
+    const MtmdSessionMetadata& metadata) {
+  const size_t blockCount =
+      std::min(metadata.visionBlocks.size(), MTMD_MAX_VISION_BLOCKS);
+  std::vector<llama_token> tokens;
+  tokens.reserve(
+      MTMD_SESSION_METADATA_HEADER_COUNT +
+      (blockCount * MTMD_VISION_BLOCK_FIELD_COUNT));
+  tokens.push_back(MTMD_SESSION_METADATA_VERSION);
+  tokens.push_back(static_cast<llama_token>(metadata.nPast));
+  tokens.push_back(static_cast<llama_token>(metadata.firstMsgTokens));
+  tokens.push_back(static_cast<llama_token>(metadata.cacheTokens));
+  tokens.push_back(static_cast<llama_token>(metadata.firstMsgCacheTokens));
+  tokens.push_back(static_cast<llama_token>(blockCount));
+  for (size_t i = 0; i < blockCount; ++i) {
+    const auto& block = metadata.visionBlocks[i];
+    tokens.push_back(static_cast<llama_token>(block.startPos));
+    tokens.push_back(static_cast<llama_token>(block.endPos));
+    tokens.push_back(static_cast<llama_token>(block.cacheTokens));
+  }
+  return tokens;
+}
+
+[[nodiscard]] inline MtmdSessionMetadataDecodeStatus decodeMtmdSessionMetadata(
+    const llama_token* tokens, size_t tokenCount,
+    MtmdSessionMetadata& metadata) {
+  metadata = {};
+  if (tokens == nullptr) {
+    return MtmdSessionMetadataDecodeStatus::Invalid;
+  }
+  if (mtmdSessionMetadataIsLegacyFourField(tokenCount)) {
+    return MtmdSessionMetadataDecodeStatus::LegacyFourField;
+  }
+  if (!mtmdSessionMetadataHasVersionedShape(tokenCount)) {
+    return MtmdSessionMetadataDecodeStatus::Invalid;
+  }
+  if (tokens[0] != MTMD_SESSION_METADATA_VERSION) {
+    return MtmdSessionMetadataDecodeStatus::Invalid;
+  }
+
+  const auto blockCount = static_cast<size_t>(tokens[5]);
+  if (blockCount > MTMD_MAX_VISION_BLOCKS) {
+    return MtmdSessionMetadataDecodeStatus::Invalid;
+  }
+  if (tokenCount != MTMD_SESSION_METADATA_HEADER_COUNT +
+                        (blockCount * MTMD_VISION_BLOCK_FIELD_COUNT)) {
+    return MtmdSessionMetadataDecodeStatus::Invalid;
+  }
+
+  metadata.nPast = static_cast<llama_pos>(tokens[1]);
+  metadata.firstMsgTokens = static_cast<llama_pos>(tokens[2]);
+  metadata.cacheTokens = static_cast<llama_pos>(tokens[3]);
+  metadata.firstMsgCacheTokens = static_cast<llama_pos>(tokens[4]);
+  metadata.visionBlocks.reserve(blockCount);
+  for (size_t i = 0; i < blockCount; ++i) {
+    const size_t base =
+        MTMD_SESSION_METADATA_HEADER_COUNT + (i * MTMD_VISION_BLOCK_FIELD_COUNT);
+    VisionBlockRange block{
+        static_cast<llama_pos>(tokens[base]),
+        static_cast<llama_pos>(tokens[base + 1]),
+        static_cast<llama_pos>(tokens[base + 2])};
+    metadata.visionBlocks.push_back(block);
+  }
+  return MtmdSessionMetadataDecodeStatus::Ok;
+}
+
+[[nodiscard]] inline bool validateMtmdVisionBlocks(
+    const MtmdSessionMetadata& metadata) {
+  if (metadata.nPast < 0 || metadata.cacheTokens < 0 ||
+      metadata.firstMsgTokens < 0 || metadata.firstMsgCacheTokens < 0) {
+    return false;
+  }
+  if (metadata.firstMsgTokens > metadata.nPast ||
+      metadata.firstMsgCacheTokens > metadata.cacheTokens) {
+    return false;
+  }
+
+  llama_pos prevEnd = 0;
+  for (const auto& block : metadata.visionBlocks) {
+    if (block.endPos <= block.startPos) {
+      return false;
+    }
+    if (block.startPos < 0 || block.endPos > metadata.nPast) {
+      return false;
+    }
+    if (block.cacheTokens <= 0) {
+      return false;
+    }
+    if (block.startPos < prevEnd) {
+      return false;
+    }
+    prevEnd = block.endPos;
+  }
+  return true;
 }
 
 /// Multimodal LLM context. Implements both the legacy `LlmContext` API
@@ -273,13 +415,23 @@ public:
       const std::vector<common_chat_tool>& tools, const PromptLayout& layout,
       bool hasKvCacheContext) const override;
 
-  /// Disk prompt-cache for a multimodal batch slot, round-tripping the full
-  /// four-field session metadata (see MtmdLlmContext.cpp). `loadCache` records
-  /// the discard budget and returns false (cache miss) on an empty key, a
-  /// missing file, or a header that fails the four-field metadata check.
+  /// Disk prompt-cache for a multimodal batch slot, round-tripping the
+  /// versioned session metadata (cursors + vision-block ranges). `loadCache`
+  /// records the discard budget and returns false (cache miss) on an empty
+  /// key, a missing file, or a legacy four-field header.
   [[nodiscard]] bool loadCache(
       const std::string& cacheKey, llama_pos configuredNDiscarded) override;
   void saveCache(const std::string& cacheKey) const override;
+
+  [[nodiscard]] size_t sessionMetadataCapacity() const override;
+  [[nodiscard]] std::vector<llama_token> encodeSessionMetadata() const override;
+  [[nodiscard]] SessionMetadataApplyResult applySessionMetadata(
+      const llama_token* tokens, size_t count) override;
+
+  /// Decoded image/tile ranges currently tracked for atomic sliding.
+  [[nodiscard]] const std::vector<VisionBlockRange>& getVisionBlocks() const {
+    return visionBlocks_;
+  }
 
   void snapshotPreRequestCursor() override;
   void snapshotPreRequestRollbackAnchor() override;

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <atomic>
 #include <optional>
 #include <vector>
@@ -77,8 +76,9 @@ enum class MtmdSessionMetadataDecodeStatus {
 
 [[nodiscard]] inline std::vector<llama_token> encodeMtmdSessionMetadata(
     const MtmdSessionMetadata& metadata) {
-  const size_t blockCount =
-      std::min(metadata.visionBlocks.size(), MTMD_MAX_VISION_BLOCKS);
+  // Callers must reject oversized block lists before save; never silently
+  // truncate boundaries that sliding later depends on.
+  const size_t blockCount = metadata.visionBlocks.size();
   std::vector<llama_token> tokens;
   tokens.reserve(
       MTMD_SESSION_METADATA_HEADER_COUNT +
@@ -89,8 +89,7 @@ enum class MtmdSessionMetadataDecodeStatus {
   tokens.push_back(static_cast<llama_token>(metadata.cacheTokens));
   tokens.push_back(static_cast<llama_token>(metadata.firstMsgCacheTokens));
   tokens.push_back(static_cast<llama_token>(blockCount));
-  for (size_t i = 0; i < blockCount; ++i) {
-    const auto& block = metadata.visionBlocks[i];
+  for (const auto& block : metadata.visionBlocks) {
     tokens.push_back(static_cast<llama_token>(block.startPos));
     tokens.push_back(static_cast<llama_token>(block.endPos));
     tokens.push_back(static_cast<llama_token>(block.cacheTokens));

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -321,6 +321,10 @@ private:
   /// text spans, so every position advance keeps the KV-cell count honest.
   void advanceTextSpan(llama_pos newPos);
   void applyContextDiscard();
+  void recordVisionBlock(
+      llama_pos startPos, llama_pos endPos, llama_pos cacheTokens);
+  void applyVisionBlockSlide(
+      llama_pos protectedPrefixPos, llama_pos discarded);
   void initializeCommonState();
   [[nodiscard]] llama_pos ctxCeiling() const;
 
@@ -387,6 +391,10 @@ private:
   mtmd::input_chunks stagedChunks_;
   ContextUsage current_;
   ContextUsage protectedPrefix_;
+  /// Decoded image/tile position ranges currently resident in the KV cache.
+  /// Ranges are rebased after every slide and restored on cancellation.
+  std::vector<VisionBlockRange> visionBlocks_;
+  std::vector<VisionBlockRange> preRequestVisionBlocks_;
   llama_pos perSeqCtxCeiling_ = -1;
   double visionEncodeMs_ = 0.0;
   int32_t visionEncodeTiles_ = 0;

--- a/packages/llm-llamacpp/docs/architecture.md
+++ b/packages/llm-llamacpp/docs/architecture.md
@@ -442,7 +442,8 @@ graph TB
 
 - Saves/loads llama.cpp KV cache to disk for conversation continuity
 - Handles cache invalidation on context changes
-- Configurable discard policy via `n_discarded` parameter
+- Configurable discard policy via `n_discarded` parameter; multimodal slides
+  retain whole decoded image/tile blocks rather than trimming through them
 - Connected to JS `runOptions.cacheKey` and `runOptions.saveCacheToDisk`, which select and persist per-request inference context.
 
 #### **Notable C++ modules**

--- a/packages/llm-llamacpp/docs/architecture.md
+++ b/packages/llm-llamacpp/docs/architecture.md
@@ -444,6 +444,10 @@ graph TB
 - Handles cache invalidation on context changes
 - Configurable discard policy via `n_discarded` parameter; multimodal slides
   retain whole decoded image/tile blocks rather than trimming through them
+- Multimodal sessions persist a versioned metadata payload (cursor fields plus
+  each image/tile boundary) so restored caches keep atomic slide behavior.
+  Legacy exact-four-field multimodal caches are treated as a miss and re-primed
+  instead of sliding through untracked vision tokens
 - Connected to JS `runOptions.cacheKey` and `runOptions.saveCacheToDisk`, which select and persist per-request inference context.
 
 #### **Notable C++ modules**

--- a/packages/llm-llamacpp/test/integration/qwen3-5-multimodal-cache-stress.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-multimodal-cache-stress.test.js
@@ -548,3 +548,68 @@ safeTest(
     )
   }
 )
+
+safeTest(
+  'Qwen3.5-VL restored image cache slides without splitting vision blocks',
+  {
+    timeout: 1_200_000,
+    skip: skipStress
+  },
+  async (t) => {
+    const imagePath = getMediaPath('fruitPlate.png')
+    t.ok(fs.existsSync(imagePath), 'fruitPlate.png image fixture should exist')
+    const imageBytes = new Uint8Array(fs.readFileSync(imagePath))
+
+    const cachePath = path.join(os.tmpdir(), `qwen35-mtmd-restored-vision-slide-${Date.now()}.bin`)
+    cleanupIntegrationCacheFiles(cachePath)
+    t.teardown(() => {
+      try {
+        fs.unlinkSync(cachePath)
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err
+      }
+    })
+
+    // Persist an image-bearing session, then reload it in a fresh addon so the
+    // only vision-block metadata available is what the versioned cache header
+    // restored from disk.
+    {
+      const writer = await setupModel(t, {
+        n_discarded: String(N_DISCARDED),
+        ctx_size: String(CTX_SIZE)
+      })
+      const primed = await runAndCollect(writer, makeFixedImagePrefillTurn(imageBytes, 'persist'), {
+        cacheKey: cachePath,
+        saveCacheToDisk: true,
+        prefill: true
+      })
+      t.is(primed.text, '', 'persisted image prefill emits no text')
+      t.ok(
+        toNumber(primed.stats.CacheTokens) > MIN_QWEN35_IMAGE_CACHE_TOKENS,
+        `persisted image cache holds vision cells (${primed.stats.CacheTokens})`
+      )
+      t.ok(fs.existsSync(cachePath), 'versioned multimodal cache file was written')
+      await writer.unload().catch(() => {})
+    }
+
+    const reader = await setupModel(t, {
+      n_discarded: String(N_DISCARDED),
+      ctx_size: String(CTX_SIZE)
+    })
+    const cacheOpts = { cacheKey: cachePath, saveCacheToDisk: true }
+
+    const restoredPressure = await runAndCollect(
+      reader,
+      makePrefillPressureTurn(MIN_QWEN35_IMAGE_CACHE_TOKENS),
+      {
+        ...cacheOpts,
+        generationParams: { predict: 16 }
+      }
+    )
+    t.ok(
+      toNumber(restoredPressure.stats.contextSlides) > 0,
+      `restored image cache slides under prefill pressure (${restoredPressure.stats.contextSlides})`
+    )
+    assertCachedStats(t, restoredPressure.stats, 'restored image cache slide')
+  }
+)

--- a/packages/llm-llamacpp/test/integration/qwen3-5-multimodal-cache-stress.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-multimodal-cache-stress.test.js
@@ -367,9 +367,12 @@ safeTest(
     )
     assertCachedStats(t, first.stats, 'first multimodal turn')
     t.ok(fs.existsSync(cachePath), 'first turn saved cache to disk')
-    await runNoCacheSeparator(t, addon, 'after first multimodal turn')
 
-    const prefillSlide = await runAndCollect(
+    // Keep the image-bearing cache resident for this request. The nominal
+    // 1024-token trim edge lands inside Qwen3.5-VL's image KV region, so this
+    // covers the in-memory atomic vision-block slide rather than only a cache
+    // restore path.
+    const atomicPrefillSlide = await runAndCollect(
       addon,
       makePrefillPressureTurn(first.stats.CacheTokens),
       {
@@ -377,18 +380,19 @@ safeTest(
         prefill: true
       }
     )
-    t.is(prefillSlide.text, '', 'prefill stress run emits no text')
+    t.is(atomicPrefillSlide.text, '', 'atomic image prefill stress emits no text')
     t.is(
-      toNumber(prefillSlide.stats.generatedTokens),
+      toNumber(atomicPrefillSlide.stats.generatedTokens),
       0,
-      'prefill stress run reports zero generated tokens'
+      'atomic image prefill stress reports zero generated tokens'
     )
     t.ok(
-      toNumber(prefillSlide.stats.contextSlides) > 0,
-      `prefill stress run triggered context sliding (${prefillSlide.stats.contextSlides})`
+      toNumber(atomicPrefillSlide.stats.contextSlides) > 0,
+      'atomic image prefill stress triggered context sliding ' +
+        `(${atomicPrefillSlide.stats.contextSlides})`
     )
-    assertCachedStats(t, prefillSlide.stats, 'prefill stress run')
-    await runNoCacheSeparator(t, addon, 'after prefill stress run')
+    assertCachedStats(t, atomicPrefillSlide.stats, 'atomic image prefill stress')
+    await runNoCacheSeparator(t, addon, 'after atomic image prefill stress')
 
     const canceledPrefillResult = await runAndCancelDuringPrefill(
       addon,
@@ -398,7 +402,7 @@ safeTest(
         prefill: true
       }
     )
-    assertCanceledPrefillRolledBack(t, prefillSlide.stats, canceledPrefillResult)
+    assertCanceledPrefillRolledBack(t, atomicPrefillSlide.stats, canceledPrefillResult)
     await runNoCacheSeparator(t, addon, 'after canceled prefill')
 
     const afterPrefillCancel = await runAndCollect(

--- a/packages/llm-llamacpp/test/unit/test_context_slider.cpp
+++ b/packages/llm-llamacpp/test/unit/test_context_slider.cpp
@@ -278,6 +278,33 @@ TEST_F(ContextSliderTest, PrefillSlidesWhenCacheTokensOverflowButPositionsFit) {
   EXPECT_EQ(ops.seqAddCalls()[0].delta, -40);
 }
 
+TEST_F(
+    ContextSliderTest,
+    PrefillSlideAccountsForVisionKvCellsWhenCheckingCacheCapacity) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/600);
+  const std::vector<VisionBlockRange> visionBlocks = {
+      {/*startPos=*/120, /*endPos=*/220, /*cacheTokens=*/300}};
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/300, /*cacheTokens=*/500},
+      ContextUsage{/*pos=*/50, /*cacheTokens=*/50},
+      ContextUsage{/*pos=*/100, /*cacheTokens=*/300},
+      /*nDiscarded=*/100,
+      controller,
+      ops,
+      visionBlocks);
+
+  // The 100-position image block occupies 300 KV cells. Sliding through it
+  // removes 370 cache cells, making the cache-only overflow fit.
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.newNPast, 130);
+  EXPECT_EQ(outcome.discarded, 170);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 220}));
+}
+
 TEST_F(ContextSliderTest, PrefillSlideReturnsMemoryFailureWhenSeqRmFails) {
   ToolsCompactController controller(std::nullopt);
   FakeLlamaContextOps ops(/*ctxSize=*/400);

--- a/packages/llm-llamacpp/test/unit/test_context_slider.cpp
+++ b/packages/llm-llamacpp/test/unit/test_context_slider.cpp
@@ -148,6 +148,110 @@ TEST_F(ContextSliderTest, PrefillSlidInvokesLlamaOpsWithExpectedRanges) {
   EXPECT_EQ(ops.seqAddCalls()[0].delta, -100);
 }
 
+TEST_F(ContextSliderTest, PrefillSlideDropsSingleVisionBlockAtomically) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+  const std::vector<VisionBlockRange> visionBlocks = {{120, 220}};
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/300, /*cacheTokens=*/300},
+      ContextUsage{/*pos=*/50, /*cacheTokens=*/50},
+      ContextUsage{/*pos=*/180, /*cacheTokens=*/180},
+      /*nDiscarded=*/100,
+      controller,
+      ops,
+      visionBlocks);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.discarded, 170);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 220}));
+}
+
+TEST_F(ContextSliderTest, PrefillSlideDropsOnlyOldestVisionTile) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+  const std::vector<VisionBlockRange> visionBlocks = {{100, 180}, {180, 260}};
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/300, /*cacheTokens=*/300},
+      ContextUsage{/*pos=*/50, /*cacheTokens=*/50},
+      ContextUsage{/*pos=*/180, /*cacheTokens=*/180},
+      /*nDiscarded=*/100,
+      controller,
+      ops,
+      visionBlocks);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.discarded, 130);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 180}));
+}
+
+TEST_F(ContextSliderTest, PrefillSlideKeepsPartialTextTrimBeforeVisionBlock) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+  const std::vector<VisionBlockRange> visionBlocks = {{180, 260}};
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/300, /*cacheTokens=*/300},
+      ContextUsage{/*pos=*/50, /*cacheTokens=*/50},
+      ContextUsage{/*pos=*/180, /*cacheTokens=*/180},
+      /*nDiscarded=*/100,
+      controller,
+      ops,
+      visionBlocks);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.discarded, 100);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 150}));
+}
+
+TEST_F(ContextSliderTest, PrefillSlideDropsImageOnlyWindowAtomically) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+  const std::vector<VisionBlockRange> visionBlocks = {{0, 300}};
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/300, /*cacheTokens=*/300},
+      ContextUsage{/*pos=*/0, /*cacheTokens=*/0},
+      ContextUsage{/*pos=*/150, /*cacheTokens=*/150},
+      /*nDiscarded=*/100,
+      controller,
+      ops,
+      visionBlocks);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.newNPast, 0);
+  EXPECT_EQ(outcome.discarded, 300);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 0, 300}));
+}
+
+TEST_F(ContextSliderTest, PrefillSlideWithoutVisionBlocksKeepsTextBehavior) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/300, /*cacheTokens=*/300},
+      ContextUsage{/*pos=*/50, /*cacheTokens=*/50},
+      ContextUsage{/*pos=*/180, /*cacheTokens=*/180},
+      /*nDiscarded=*/100,
+      controller,
+      ops);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.discarded, 100);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 150}));
+}
+
 TEST_F(ContextSliderTest, PrefillSlidesWhenCacheTokensOverflowButPositionsFit) {
   ToolsCompactController controller(std::nullopt);
   FakeLlamaContextOps ops(/*ctxSize=*/400);
@@ -335,6 +439,28 @@ TEST_F(ContextSliderTest, GenerationSlidInvokesLlamaOpsWithExpectedRanges) {
   EXPECT_EQ(ops.seqAddCalls()[0].startPos, 170);
   EXPECT_EQ(ops.seqAddCalls()[0].endPos, 400);
   EXPECT_EQ(ops.seqAddCalls()[0].delta, -120);
+}
+
+TEST_F(ContextSliderTest, GenerationSlideDropsVisionBlockAtomically) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+  const std::vector<VisionBlockRange> visionBlocks = {{120, 220}};
+
+  const auto outcome = trySlideGeneration(
+      /*lctx=*/nullptr,
+      kSeqId,
+      /*nPast=*/400,
+      /*firstMsgTokens=*/50,
+      /*nDiscarded=*/100,
+      controller,
+      ops,
+      /*effectiveCtx=*/-1,
+      /*nCacheTokens=*/-1,
+      visionBlocks);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.discarded, 170);
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 220}));
 }
 
 TEST_F(

--- a/packages/llm-llamacpp/test/unit/test_context_slider.cpp
+++ b/packages/llm-llamacpp/test/unit/test_context_slider.cpp
@@ -166,7 +166,32 @@ TEST_F(ContextSliderTest, PrefillSlideDropsSingleVisionBlockAtomically) {
 
   EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
   EXPECT_EQ(outcome.discarded, 170);
-  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 50, 220}));
+}
+
+/// Same alignment policy used after a disk-cache restore: ranges hydrated
+/// from versioned session metadata must still force an atomic tile drop.
+TEST_F(ContextSliderTest, RestoredVisionBlocksForceAtomicPrefillSlide) {
+  ToolsCompactController controller(std::nullopt);
+  FakeLlamaContextOps ops(/*ctxSize=*/400);
+  const std::vector<VisionBlockRange> restoredVisionBlocks = {
+      {/*startPos=*/90, /*endPos=*/190, /*cacheTokens=*/180},
+      {/*startPos=*/190, /*endPos=*/290, /*cacheTokens=*/180}};
+
+  const auto outcome = trySlidePrefill(
+      /*lctx=*/nullptr,
+      kSeqId,
+      ContextUsage{/*pos=*/320, /*cacheTokens=*/500},
+      ContextUsage{/*pos=*/40, /*cacheTokens=*/40},
+      ContextUsage{/*pos=*/100, /*cacheTokens=*/100},
+      /*nDiscarded=*/120,
+      controller,
+      ops,
+      restoredVisionBlocks);
+
+  EXPECT_EQ(outcome.kind, ContextSlideOutcome::Kind::Slid);
+  EXPECT_EQ(outcome.discarded, 150);
+  ASSERT_FALSE(ops.seqRmCalls().empty());
+  EXPECT_EQ(ops.seqRmCalls()[0], (SeqRmCall{kSeqId, 40, 190}));
 }
 
 TEST_F(ContextSliderTest, PrefillSlideDropsOnlyOldestVisionTile) {

--- a/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
@@ -740,13 +740,18 @@ TEST_F(MtmdLlmContextTest, LoadCacheRollsBackRestoredKvOnPostRestoreFailure) {
   ASSERT_GT(ctx->getNPast(), 0);
 
   // Persist the genuine KV but with a doctored NPast that exceeds the
-  // context window. All four metadata fields are present so the
-  // completeness gate passes and execution reaches the NPast bounds check.
+  // context window. Use the versioned multimodal header so the completeness
+  // gate passes and execution reaches the NPast bounds check.
   const llama_token overflowNPast =
       static_cast<llama_token>(llama_n_ctx(lctx)) + 1;
   const llama_token plausible = static_cast<llama_token>(ctx->getNPast());
-  const llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {
-      overflowNPast, plausible, plausible, plausible};
+  MtmdSessionMetadata overflowMeta;
+  overflowMeta.nPast = overflowNPast;
+  overflowMeta.firstMsgTokens = plausible;
+  overflowMeta.cacheTokens = plausible;
+  overflowMeta.firstMsgCacheTokens = plausible;
+  const std::vector<llama_token> sessionTokens =
+      encodeMtmdSessionMetadata(overflowMeta);
 
   const fs::path cachePath =
       fs::temp_directory_path() / "qvac-mtmd-loadcache-rollback.bin";
@@ -755,8 +760,8 @@ TEST_F(MtmdLlmContextTest, LoadCacheRollsBackRestoredKvOnPostRestoreFailure) {
       lctx,
       cachePath.string().c_str(),
       seqId,
-      sessionTokens,
-      SESSION_METADATA_FIELD_COUNT);
+      sessionTokens.data(),
+      sessionTokens.size());
   ASSERT_GT(savedBytes, 0u);
 
   // Clear the sequence so restoration is observable from a clean baseline.
@@ -827,32 +832,36 @@ TEST_F(MtmdLlmContextTest, LoadCacheRejectsRestoredMemoryMetadataMismatch) {
   fs::remove(nPastMismatchPath);
   fs::remove(cacheTokensMismatchPath);
 
-  const llama_token nPastMismatch[SESSION_METADATA_FIELD_COUNT] = {
-      static_cast<llama_token>(nPast + 1),
-      firstMsgTokens,
-      cacheTokens,
-      firstMsgCacheTokens};
+  MtmdSessionMetadata nPastMismatchMeta;
+  nPastMismatchMeta.nPast = nPast + 1;
+  nPastMismatchMeta.firstMsgTokens = firstMsgTokens;
+  nPastMismatchMeta.cacheTokens = cacheTokens;
+  nPastMismatchMeta.firstMsgCacheTokens = firstMsgCacheTokens;
+  const std::vector<llama_token> nPastMismatch =
+      encodeMtmdSessionMetadata(nPastMismatchMeta);
   ASSERT_GT(
       llama_state_seq_save_file(
           lctx,
           nPastMismatchPath.string().c_str(),
           seqId,
-          nPastMismatch,
-          SESSION_METADATA_FIELD_COUNT),
+          nPastMismatch.data(),
+          nPastMismatch.size()),
       0u);
 
-  const llama_token cacheTokensMismatch[SESSION_METADATA_FIELD_COUNT] = {
-      nPast,
-      firstMsgTokens,
-      static_cast<llama_token>(cacheTokens + 1),
-      firstMsgCacheTokens};
+  MtmdSessionMetadata cacheTokensMismatchMeta;
+  cacheTokensMismatchMeta.nPast = nPast;
+  cacheTokensMismatchMeta.firstMsgTokens = firstMsgTokens;
+  cacheTokensMismatchMeta.cacheTokens = cacheTokens + 1;
+  cacheTokensMismatchMeta.firstMsgCacheTokens = firstMsgCacheTokens;
+  const std::vector<llama_token> cacheTokensMismatch =
+      encodeMtmdSessionMetadata(cacheTokensMismatchMeta);
   ASSERT_GT(
       llama_state_seq_save_file(
           lctx,
           cacheTokensMismatchPath.string().c_str(),
           seqId,
-          cacheTokensMismatch,
-          SESSION_METADATA_FIELD_COUNT),
+          cacheTokensMismatch.data(),
+          cacheTokensMismatch.size()),
       0u);
 
   ctx->resetState(true);
@@ -880,6 +889,120 @@ TEST_F(MtmdLlmContextTest, LoadCacheRejectsRestoredMemoryMetadataMismatch) {
 
   fs::remove(nPastMismatchPath);
   fs::remove(cacheTokensMismatchPath);
+}
+
+TEST_F(MtmdLlmContextTest, LoadCacheRestoresVisionBlocksFromDisk) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  const fs::path imagePath = multimodalTestImagePath();
+  ASSERT_TRUE(fs::exists(imagePath)) << imagePath.string();
+
+  auto model = createModel();
+  if (!model) {
+    FAIL() << "Model failed to load";
+  }
+
+  auto* base = LlamaModelTestPeer::llmContext(*model);
+  ASSERT_NE(base, nullptr);
+  auto* ctx = dynamic_cast<MtmdLlmContext*>(base);
+  ASSERT_NE(ctx, nullptr);
+
+  const fs::path cachePath =
+      fs::temp_directory_path() / "qvac-mtmd-vision-block-roundtrip.bin";
+  fs::remove(cachePath);
+
+  LlamaModel::Prompt prompt;
+  prompt.input =
+      R"([{"role": "user", "type": "media", "content": ""},)"
+      R"( {"role": "user", "content": "Describe the image briefly."}])";
+  prompt.media.push_back(readBinaryFile(imagePath));
+  prompt.prefill = true;
+  prompt.cacheKey = cachePath.string();
+  prompt.saveCacheToDisk = true;
+  ASSERT_NO_THROW(model->processPrompt(prompt));
+  ASSERT_TRUE(fs::exists(cachePath));
+  ASSERT_FALSE(ctx->getVisionBlocks().empty())
+      << "image prefill must record at least one vision block";
+  const auto savedBlocks = ctx->getVisionBlocks();
+  const llama_pos savedNPast = ctx->getNPast();
+  const llama_pos savedCacheTokens = ctx->getCacheTokens();
+
+  ctx->resetState(true);
+  ASSERT_TRUE(ctx->getVisionBlocks().empty());
+  ASSERT_EQ(ctx->getNPast(), 0);
+
+  ASSERT_TRUE(ctx->loadCache(cachePath.string(), 0));
+  EXPECT_EQ(ctx->getNPast(), savedNPast);
+  EXPECT_EQ(ctx->getCacheTokens(), savedCacheTokens);
+  ASSERT_EQ(ctx->getVisionBlocks().size(), savedBlocks.size());
+  for (size_t i = 0; i < savedBlocks.size(); ++i) {
+    EXPECT_EQ(ctx->getVisionBlocks()[i].startPos, savedBlocks[i].startPos);
+    EXPECT_EQ(ctx->getVisionBlocks()[i].endPos, savedBlocks[i].endPos);
+    EXPECT_EQ(
+        ctx->getVisionBlocks()[i].cacheTokens, savedBlocks[i].cacheTokens);
+    EXPECT_GT(ctx->getVisionBlocks()[i].endPos, ctx->getVisionBlocks()[i].startPos);
+    EXPECT_LE(ctx->getVisionBlocks()[i].endPos, ctx->getNPast());
+  }
+
+  fs::remove(cachePath);
+}
+
+TEST_F(MtmdLlmContextTest, LoadCacheTreatsLegacyFourFieldAsMiss) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  auto model = createModel();
+  if (!model) {
+    FAIL() << "Model failed to load";
+  }
+
+  auto* base = LlamaModelTestPeer::llmContext(*model);
+  ASSERT_NE(base, nullptr);
+  auto* ctx = dynamic_cast<MtmdLlmContext*>(base);
+  ASSERT_NE(ctx, nullptr);
+  auto* lctx = model->getContext();
+  ASSERT_NE(lctx, nullptr);
+  const llama_seq_id seqId = ctx->getSeqId();
+
+  LlamaModel::Prompt prompt;
+  prompt.input = R"([{"role": "user", "content": "Hello"}])";
+  prompt.prefill = true;
+  ASSERT_NO_THROW(model->processPrompt(prompt));
+  ASSERT_GT(ctx->getNPast(), 0);
+
+  const llama_token legacy[SESSION_METADATA_FIELD_COUNT] = {
+      static_cast<llama_token>(ctx->getNPast()),
+      static_cast<llama_token>(ctx->getFirstMsgTokens()),
+      static_cast<llama_token>(ctx->getCacheTokens()),
+      static_cast<llama_token>(ctx->getFirstMsgCacheTokens())};
+  const fs::path cachePath =
+      fs::temp_directory_path() / "qvac-mtmd-legacy-four-field.bin";
+  fs::remove(cachePath);
+  ASSERT_GT(
+      llama_state_seq_save_file(
+          lctx,
+          cachePath.string().c_str(),
+          seqId,
+          legacy,
+          SESSION_METADATA_FIELD_COUNT),
+      0u);
+
+  ctx->resetState(true);
+  auto* mem = llama_get_memory(lctx);
+  ASSERT_NE(mem, nullptr);
+  ASSERT_EQ(llama_memory_seq_token_count(mem, seqId), 0u);
+
+  EXPECT_FALSE(ctx->loadCache(cachePath.string(), 0))
+      << "legacy four-field multimodal caches must be treated as a miss";
+  EXPECT_EQ(llama_memory_seq_token_count(mem, seqId), 0u)
+      << "legacy miss must clear restored KV so the session re-primes";
+  EXPECT_EQ(ctx->getNPast(), 0);
+  EXPECT_TRUE(ctx->getVisionBlocks().empty());
+
+  fs::remove(cachePath);
 }
 
 TEST_F(MtmdLlmContextTest, InvalidMedia) {
@@ -1110,18 +1233,74 @@ TEST_F(MtmdLlmContextTest, ProcessWithMultipleTools) {
 }
 
 /// `loadCache` may only restore a multimodal session when the GGSQ header
-/// carried all four `SessionMetadataField` values. The old gate accepted any
-/// `tokenCount > 1`, so a partial header (2 or 3 fields) was restored with
-/// `cacheTokens`/`firstMsgCacheTokens` defaulted to zero — which diverges from
-/// `nPast` under M-RoPE and corrupts later cap checks. An over-long layout
-/// (`> 4`) is equally unexpected. Only an exact four-field header is complete.
-TEST(MtmdSessionMetadataGate, AcceptsOnlyTheFullFourFieldContract) {
+/// carries the versioned multimodal metadata layout. Legacy exact-four-field
+/// headers are treated as a cache miss; truncated or non-triple-aligned
+/// versioned payloads are invalid.
+TEST(MtmdSessionMetadataGate, AcceptsOnlyVersionedMultimodalMetadata) {
   EXPECT_FALSE(mtmdSessionMetadataIsComplete(0));
   EXPECT_FALSE(mtmdSessionMetadataIsComplete(1));
   EXPECT_FALSE(mtmdSessionMetadataIsComplete(2));
   EXPECT_FALSE(mtmdSessionMetadataIsComplete(3));
-  EXPECT_TRUE(mtmdSessionMetadataIsComplete(SESSION_METADATA_FIELD_COUNT));
-  EXPECT_FALSE(mtmdSessionMetadataIsComplete(SESSION_METADATA_FIELD_COUNT + 1));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(SESSION_METADATA_FIELD_COUNT));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(5));
+  EXPECT_TRUE(
+      mtmdSessionMetadataIsComplete(MTMD_SESSION_METADATA_HEADER_COUNT));
+  EXPECT_TRUE(mtmdSessionMetadataIsComplete(
+      MTMD_SESSION_METADATA_HEADER_COUNT + MTMD_VISION_BLOCK_FIELD_COUNT));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(
+      MTMD_SESSION_METADATA_HEADER_COUNT + 1));
+  EXPECT_TRUE(mtmdSessionMetadataIsLegacyFourField(
+      SESSION_METADATA_FIELD_COUNT));
+}
+
+TEST(MtmdSessionMetadataCodec, RoundTripsVisionBlocks) {
+  MtmdSessionMetadata original;
+  original.nPast = 400;
+  original.firstMsgTokens = 40;
+  original.cacheTokens = 520;
+  original.firstMsgCacheTokens = 40;
+  original.visionBlocks = {{80, 180, 160}, {220, 320, 180}};
+
+  const std::vector<llama_token> tokens = encodeMtmdSessionMetadata(original);
+  MtmdSessionMetadata decoded;
+  ASSERT_EQ(
+      decodeMtmdSessionMetadata(tokens.data(), tokens.size(), decoded),
+      MtmdSessionMetadataDecodeStatus::Ok);
+  EXPECT_TRUE(validateMtmdVisionBlocks(decoded));
+  EXPECT_EQ(decoded.nPast, original.nPast);
+  EXPECT_EQ(decoded.firstMsgTokens, original.firstMsgTokens);
+  EXPECT_EQ(decoded.cacheTokens, original.cacheTokens);
+  EXPECT_EQ(decoded.firstMsgCacheTokens, original.firstMsgCacheTokens);
+  ASSERT_EQ(decoded.visionBlocks.size(), 2u);
+  EXPECT_EQ(decoded.visionBlocks[0].startPos, 80);
+  EXPECT_EQ(decoded.visionBlocks[0].endPos, 180);
+  EXPECT_EQ(decoded.visionBlocks[0].cacheTokens, 160);
+  EXPECT_EQ(decoded.visionBlocks[1].startPos, 220);
+  EXPECT_EQ(decoded.visionBlocks[1].endPos, 320);
+  EXPECT_EQ(decoded.visionBlocks[1].cacheTokens, 180);
+}
+
+TEST(MtmdSessionMetadataCodec, LegacyFourFieldIsCacheMiss) {
+  const llama_token legacy[SESSION_METADATA_FIELD_COUNT] = {100, 20, 140, 20};
+  MtmdSessionMetadata decoded;
+  EXPECT_EQ(
+      decodeMtmdSessionMetadata(legacy, SESSION_METADATA_FIELD_COUNT, decoded),
+      MtmdSessionMetadataDecodeStatus::LegacyFourField);
+  EXPECT_TRUE(decoded.visionBlocks.empty());
+}
+
+TEST(MtmdSessionMetadataCodec, RejectsOverlappingOrOutOfRangeBlocks) {
+  MtmdSessionMetadata overlapping;
+  overlapping.nPast = 200;
+  overlapping.cacheTokens = 200;
+  overlapping.visionBlocks = {{10, 50, 40}, {40, 80, 40}};
+  EXPECT_FALSE(validateMtmdVisionBlocks(overlapping));
+
+  MtmdSessionMetadata outOfRange;
+  outOfRange.nPast = 100;
+  outOfRange.cacheTokens = 100;
+  outOfRange.visionBlocks = {{80, 120, 40}};
+  EXPECT_FALSE(validateMtmdVisionBlocks(outOfRange));
 }
 
 TEST_F(MtmdLlmContextTest, RejectMediaMarkerWithoutBuffer) {

--- a/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
@@ -1005,6 +1005,68 @@ TEST_F(MtmdLlmContextTest, LoadCacheTreatsLegacyFourFieldAsMiss) {
   fs::remove(cachePath);
 }
 
+TEST_F(MtmdLlmContextTest, LoadCacheRejectsInvalidVisionMetadataWithoutHalfApply) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  auto model = createModel();
+  if (!model) {
+    FAIL() << "Model failed to load";
+  }
+
+  auto* base = LlamaModelTestPeer::llmContext(*model);
+  ASSERT_NE(base, nullptr);
+  auto* ctx = dynamic_cast<MtmdLlmContext*>(base);
+  ASSERT_NE(ctx, nullptr);
+  auto* lctx = model->getContext();
+  ASSERT_NE(lctx, nullptr);
+  const llama_seq_id seqId = ctx->getSeqId();
+
+  LlamaModel::Prompt prompt;
+  prompt.input = R"([{"role": "user", "content": "Hello"}])";
+  prompt.prefill = true;
+  ASSERT_NO_THROW(model->processPrompt(prompt));
+  ASSERT_GT(ctx->getNPast(), 0);
+
+  MtmdSessionMetadata badMeta;
+  badMeta.nPast = ctx->getNPast();
+  badMeta.firstMsgTokens = ctx->getFirstMsgTokens();
+  badMeta.cacheTokens = ctx->getCacheTokens();
+  badMeta.firstMsgCacheTokens = ctx->getFirstMsgCacheTokens();
+  // Overlapping ranges are structurally shaped but semantically invalid.
+  badMeta.visionBlocks = {{1, 5, 4}, {4, 8, 4}};
+  std::vector<llama_token> tokens = encodeMtmdSessionMetadata(badMeta);
+
+  const fs::path cachePath =
+      fs::temp_directory_path() / "qvac-mtmd-invalid-vision-meta.bin";
+  fs::remove(cachePath);
+  ASSERT_GT(
+      llama_state_seq_save_file(
+          lctx,
+          cachePath.string().c_str(),
+          seqId,
+          tokens.data(),
+          tokens.size()),
+      0u);
+
+  ctx->resetState(true);
+  auto* mem = llama_get_memory(lctx);
+  ASSERT_NE(mem, nullptr);
+  ASSERT_EQ(llama_memory_seq_token_count(mem, seqId), 0u);
+
+  EXPECT_THROW(
+      { (void)ctx->loadCache(cachePath.string(), 0); },
+      qvac_errors::StatusError);
+  EXPECT_EQ(llama_memory_seq_token_count(mem, seqId), 0u)
+      << "invalid metadata must clear restored KV";
+  EXPECT_EQ(ctx->getNPast(), 0)
+      << "invalid metadata must not leave a half-applied cursor";
+  EXPECT_TRUE(ctx->getVisionBlocks().empty());
+
+  fs::remove(cachePath);
+}
+
 TEST_F(MtmdLlmContextTest, InvalidMedia) {
   if (!hasValidModel()) {
     FAIL() << "Multimodal model or projection file not found";
@@ -1301,6 +1363,29 @@ TEST(MtmdSessionMetadataCodec, RejectsOverlappingOrOutOfRangeBlocks) {
   outOfRange.cacheTokens = 100;
   outOfRange.visionBlocks = {{80, 120, 40}};
   EXPECT_FALSE(validateMtmdVisionBlocks(outOfRange));
+}
+
+TEST(MtmdSessionMetadataCodec, RejectsWrongVersionAndMismatchedBlockCount) {
+  MtmdSessionMetadata ok;
+  ok.nPast = 100;
+  ok.firstMsgTokens = 10;
+  ok.cacheTokens = 120;
+  ok.firstMsgCacheTokens = 10;
+  ok.visionBlocks = {{20, 40, 30}};
+  std::vector<llama_token> wrongVersion = encodeMtmdSessionMetadata(ok);
+  wrongVersion[0] = MTMD_SESSION_METADATA_VERSION + 1;
+  MtmdSessionMetadata decoded;
+  EXPECT_EQ(
+      decodeMtmdSessionMetadata(
+          wrongVersion.data(), wrongVersion.size(), decoded),
+      MtmdSessionMetadataDecodeStatus::Invalid);
+
+  std::vector<llama_token> mismatched = encodeMtmdSessionMetadata(ok);
+  // Claim two blocks but only serialize one triple.
+  mismatched[5] = 2;
+  EXPECT_EQ(
+      decodeMtmdSessionMetadata(mismatched.data(), mismatched.size(), decoded),
+      MtmdSessionMetadataDecodeStatus::Invalid);
 }
 
 TEST_F(MtmdLlmContextTest, RejectMediaMarkerWithoutBuffer) {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Sliding-window context trim could split multimodal image/tile KV ranges, leaving partial vision embeddings in cache and corrupting later inference.
- Disk-restored multimodal sessions had no persisted vision-block boundaries, so the same byte-naive trims could occur after `loadCache()`.

## 📝 How does it solve it?

- Track vision blocks in `MtmdLlmContext` and align `ContextSlider` / `ContextShifter` slide boundaries to whole image/tile ranges.
- Persist versioned multimodal session metadata (cursor fields + vision-block triples) in the llama session file; legacy four-field caches are treated as cache misses.
- Validate restored boundaries (overlap, out-of-range, version/count mismatch) and reject malformed metadata without half-applying cursor state.
- Harden cancel rollback and save paths: restore vision snapshots only when the cursor matches the pre-request state; reject oversized block lists instead of truncating.

## 🧪 How was it tested?

- C++ unit: `ContextSliderTest.*`, `MtmdSessionMetadata*`, `MtmdLlmContextTest.LoadCache*` (40 tests, all passed locally)
- Integration: extended `qwen3-5-multimodal-cache-stress.test.js` for restored image cache slides
- Docs: updated `packages/llm-llamacpp/docs/architecture.md`

**Note:** `package.json` version is unchanged vs `main`. Bump before release if this fix should ship in a published addon build.
