### PR TITLE
feat(llm-llamacpp): expose DRY sampler + auto-enable it for deepseek2-ocr OCR models

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.38.2] - 2026-07-24
+
+Exposes the DRY sampler through the config surface and auto-enables sane DRY defaults for `deepseek2-ocr` OCR models, which otherwise degenerate into endless repeated layout boxes under greedy decoding.
+
+### Added
+
+- `dry_multiplier`, `dry_base`, `dry_allowed_length`, `dry_penalty_last_n` config keys (documented in `index.d.ts` + the config table). The DRY sampler penalizes repeated token *sequences* — catching runaway loops that `repeat_penalty` (single-token) misses. `dry_multiplier=0` (default) keeps it off for all other models.
+
+### Changed
+
+- When a model with architecture `deepseek2-ocr` (e.g. Unlimited-OCR) is loaded and the caller has not set any `dry_*` key, the addon seeds `dry_multiplier=2.0`, `dry_base=1.75`, `dry_allowed_length=2`, `dry_penalty_last_n=-1`. This prevents the model from spilling unbounded `<|det|>image` boxes after finishing a page (the upstream model uses `no_repeat_ngram_size` for the same purpose). Any explicit `dry_*` config disables the auto-default.
+
 ## [0.38.1] - 2026-07-22
 
 This patch release guarantees that a content token follows the EOS-inside-reasoning recovery, so the forced `</think>` substitution can no longer be immediately followed by another end-of-generation token and produce an empty answer. It also exposes the generation stop reason as a new runtime stat.

--- a/packages/llm-llamacpp/README.md
+++ b/packages/llm-llamacpp/README.md
@@ -172,6 +172,10 @@ const config = {
 | repeat_penalty    | float                                       | 1.1                          | Repetition penalty                                    |
 | presence_penalty  | float                                       | 0                            | Presence penalty for sampling                         |
 | frequency_penalty | float                                       | 0                            | Frequency penalty for sampling                        |
+| dry_multiplier    | float                                       | 0 (off; auto for OCR)        | DRY sampler multiplier — penalizes repeated token *sequences* (catches runaway loops `repeat_penalty` misses). `0` disables. Auto-enabled for `deepseek2-ocr` OCR models (see DRY below) |
+| dry_base          | float                                       | 1.75                         | DRY penalty base — penalty grows as `base^(len - allowed_length)` |
+| dry_allowed_length| integer                                     | 2                            | Longest repeated sequence allowed before DRY penalizes |
+| dry_penalty_last_n| integer                                     | -1                           | DRY look-back window in tokens (`-1` = whole context, `0` = disabled) |
 | tools             | `"true"` or `"false"`                       | `"false"`                    | Enable tool calling with jinja templating             |
 | tools_compact      | `"true"` or `"false"`                       | `"false"`                    | Compact tool tokens from KV cache between turns ([details](./docs/tools-compact.md)) |
 | verbosity         | 0 – 3 (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG) | 0                            | Logging verbosity level                               |
@@ -192,6 +196,16 @@ The addon picks a safe KV-cache type when `cache-type-k`/`cache-type-v` are unse
 - **Auto-default:** on a **Metal / Vulkan GPU** (with flash attention on) both K and V default to **`q8_0`** — quality-neutral vs `f16` and ~47% smaller KV cache. **CPU** and **OpenCL (Adreno)** keep **`f16`** (ARM CPU `q8_0` has a quality/throughput cost; quantized KV is unsafe on OpenCL — see below). Finetuning manages its own KV types and is left untouched.
 - **OpenCL (Adreno) accepts only `f16`/`f32`/`bf16`:** any other cache type — quantized (`q8_0`, `q4_0`, `q4_1`, `q5_0`, …) or unrecognized — throws a `StatusError`. A quantized K or V cache aborts in `llama_kv_cache::update` on KV-cache shifts / cache management (sliding context, state restore) because ggml-opencl has no `F32→quantized` requantize kernel. Use `f16`/`f32`/`bf16`, or a Vulkan GPU / CPU.
 - **Mixed K≠V is a warning, not an error:** if K and V differ and at least one is quantized, the addon logs a warning (asymmetric quantized K/V falls off the fused flash-attention path — a notable GPU decode penalty — for no quality benefit, and is unsupported on Adreno OpenCL) but proceeds. Prefer a symmetric type. (This may be relaxed once qvac-fabric handles asymmetric quantized K/V efficiently.)
+
+
+#### DRY sampler & the `deepseek2-ocr` OCR auto-default
+
+`repeat_penalty` acts on individual tokens, so it can't break *structured* loops where a template repeats with changing content. The **DRY** sampler (`dry_multiplier > 0`) penalizes repeated token *sequences*, with a penalty that grows the longer the run — which does break them.
+
+OCR vision-language models whose architecture is **`deepseek2-ocr`** (e.g. Unlimited-OCR) have no clean stopping point once a page is transcribed: under greedy decoding they degenerate into an unbounded run of repeated `<|det|>image …` layout boxes and never emit EOS, filling the context. The upstream model guards this with `no_repeat_ngram_size`; the addon's closest equivalent is DRY.
+
+- **Auto-default:** when a `deepseek2-ocr` model is loaded and you have **not** set any `dry_*` key, the addon enables `dry_multiplier=2.0`, `dry_base=1.75`, `dry_allowed_length=2`, `dry_penalty_last_n=-1`. The choice is logged at verbosity ≥ 2 as `deepseek2-ocr detected; enabling DRY sampler defaults …`.
+- **Override:** setting **any** `dry_*` key disables the auto-default and uses your values instead (use `dry_multiplier=0` to turn DRY off entirely). All other architectures are unaffected — DRY stays off (`0`) by default everywhere else.
 
 
 #### IGPU/GPU  selection logic:

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -1300,6 +1300,38 @@ void LlamaModel::commonParamsParse(
         "embedded chat template is applied\n");
   }
 
+  // Unlimited-OCR / DeepSeek-OCR (arch "deepseek2-ocr") has no clean stopping
+  // point once it has finished transcribing a page: under greedy decoding it
+  // degenerates into an unbounded run of repeated `<|det|>image ...` bounding
+  // boxes and never emits EOS, filling the context window. The upstream HF
+  // model prevents this with `no_repeat_ngram_size`; llama.cpp's closest
+  // equivalent is the DRY sampler. Seed sane DRY defaults for this architecture
+  // so callers get clean output out of the box — unless they configured DRY
+  // themselves, in which case their values are left untouched.
+  if (metadata_.tryGetString("general.architecture") == "deepseek2-ocr") {
+    const bool userConfiguredDry =
+        configFilemap.count("dry-multiplier") ||
+        configFilemap.count("dry_multiplier") ||
+        configFilemap.count("dry-base") || configFilemap.count("dry_base") ||
+        configFilemap.count("dry-allowed-length") ||
+        configFilemap.count("dry_allowed_length") ||
+        configFilemap.count("dry-penalty-last-n") ||
+        configFilemap.count("dry_penalty_last_n") ||
+        configFilemap.count("dry-sequence-breaker") ||
+        configFilemap.count("dry_sequence_breaker");
+    if (!userConfiguredDry) {
+      configFilemap.emplace("dry-multiplier", "2.0");
+      configFilemap.emplace("dry-base", "1.75");
+      configFilemap.emplace("dry-allowed-length", "2");
+      configFilemap.emplace("dry-penalty-last-n", "-1");
+      QLOG_IF(
+          Priority::INFO,
+          "[LlamaModel] deepseek2-ocr detected; enabling DRY sampler defaults "
+          "(dry-multiplier=2.0, dry-allowed-length=2) to prevent OCR output "
+          "from degenerating. Set any dry-* config key to override.\n");
+    }
+  }
+
   // reasoning-budget controls the size of the model's <think> reasoning
   // channel: -1 (default) leaves it unrestricted, 0 disables thinking
   // entirely, any positive N caps the reasoning channel at N tokens (the

--- a/packages/llm-llamacpp/index.d.ts
+++ b/packages/llm-llamacpp/index.d.ts
@@ -62,6 +62,25 @@ export interface LlamaConfig {
   repeat_penalty?: NumericLike
   presence_penalty?: NumericLike
   frequency_penalty?: NumericLike
+  /**
+   * DRY ("Don't Repeat Yourself") sampler multiplier. DRY penalizes repeated
+   * token *sequences* with a penalty that grows the longer the repetition runs,
+   * catching runaway loops that `repeat_penalty` (which only nudges individual
+   * tokens) misses. `0` (default) disables it.
+   *
+   * Note: for OCR vision-language models whose architecture is `deepseek2-ocr`
+   * (e.g. Unlimited-OCR), sane DRY defaults are enabled automatically at load —
+   * these models otherwise degenerate into endless repeated layout boxes under
+   * greedy decoding. Setting any `dry_*` key here disables that auto-default and
+   * uses your values instead.
+   */
+  dry_multiplier?: NumericLike
+  /** DRY base: the penalty grows as `base^(sequence_length - allowed_length)`. Default `1.75`. */
+  dry_base?: NumericLike
+  /** DRY: longest repeated sequence allowed before the penalty kicks in. Default `2`. */
+  dry_allowed_length?: NumericLike
+  /** DRY look-back window in tokens: `-1` = whole context, `0` = disabled. */
+  dry_penalty_last_n?: NumericLike
   tools?: boolean | string
   verbosity?: NumericLike
   n_discarded?: NumericLike

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## What

Adds first-class support for the **DRY sampler** in `@qvac/llm-llamacpp`, and **auto-enables sane DRY defaults for `deepseek2-ocr` OCR models** (e.g. Unlimited-OCR).

## Why

OCR VLMs with arch `deepseek2-ocr` have no clean stopping point after they finish transcribing a page: under greedy decoding they **degenerate into an unbounded run of repeated `<|det|>image …` layout boxes and never emit EOS**, filling the context window. `repeat_penalty` can't stop it — the loop is structured but the coordinates vary, so it only *looks* repetitive at the token level. The upstream HF model uses `no_repeat_ngram_size`; llama.cpp's closest equivalent is **DRY** (penalizes repeated token *sequences*).

## Changes

- **`LlamaModel::commonParamsParse`** — when a `deepseek2-ocr` model is loaded and the caller set no `dry_*` key, seed `dry-multiplier=2.0`, `dry-base=1.75`, `dry-allowed-length=2`, `dry-penalty-last-n=-1`. Mirrors the existing MedPsy-jinja / Adreno auto-config in the same function. Explicit `dry_*` config always wins; every other architecture is untouched (DRY stays `0`).
- **`index.d.ts` + README config table** — document `dry_multiplier` / `dry_base` / `dry_allowed_length` / `dry_penalty_last_n` and a "DRY sampler & the `deepseek2-ocr` OCR auto-default" section. (These keys already reached `common_params_sampling` via the load-config arg forwarding — this makes them discoverable + adds the OCR default.)
- Bump `0.38.1 → 0.38.2` + CHANGELOG.

## Verification

On Unlimited-OCR (BF16) at full **32k** context, `document parsing.`, CPU:

| | without DRY | with seeded DRY defaults |
|---|---|---|
| Wall clock | **10:14** | **1:07** |
| Output | full page **+ thousands of junk `<|det|>image` boxes** to the 8192-token cap | **full page, then stops** at the last field |
| Termination | ran to `-n` limit | natural |

Legitimate repeated structure (the ~21 `<|det|>text/header/table` lines) is preserved — DRY's penalty only escalates on the runaway loop, not the handful of real layout lines.

## Notes

- Independent of #3419 (which registers the Unlimited-OCR model + tests). Both bump the addon patch version, so whichever merges second will need a trivial version rebase.
- The auto-config is inline in `commonParamsParse`, matching the existing model-specific auto-config there (MedPsy jinja, Adreno backend injection), which isn't unit-tested at that seam either; behavior verified manually as above. An on-device integration test rides naturally on the Unlimited-OCR model added in #3419.
