### PR TITLE
QVAC-18397:  Continuous batching multi job addon cpp fixup

### DIFF
--- a/packages/inference-addon-cpp/CHANGELOG.md
+++ b/packages/inference-addon-cpp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.1] - 2026-07-24
+
+### Fixed
+- `MultiJobScheduler` cancel entry points (`cancel(id)`, `cancelAll()`, `cancelJobs()`) now return only once every job they delivered a model-side cancel for has fully left the scheduler (queue and in-flight set, i.e. its admission slot is released). Previously they returned as soon as the cancel was forwarded to the model, so a model that applies per-id cancels on its own worker (llm-llamacpp's continuous batch scheduler records the cancel and tears the slot down between decode steps) left a window where `activeJobs()` still counted the cancelled job — a consumer admitting a follow-up job the moment its cancel resolved was spuriously refused as busy, and the JS `cancel()` promise contract ("resolves when cancellation completes") silently regressed relative to `SingleJobScheduler`, whose cancel waits for the in-flight job to back out (`ProcessingSync::waitInactive`). Cancel paths that deliver no model-side cancel (no `cancelById` / no whole-model `cancel()`) still return immediately, and scheduler teardown is unchanged (never waits for the model).
+
 ## [1.3.0] - 2026-07-06
 
 ### Added

--- a/packages/inference-addon-cpp/src/inference-addon-cpp/job/MultiJobScheduler.hpp
+++ b/packages/inference-addon-cpp/src/inference-addon-cpp/job/MultiJobScheduler.hpp
@@ -49,7 +49,19 @@ namespace qvac_lib_inference_addon_cpp {
 /// only implement cancelById (teardown cancels the same way); that
 /// id -> internal-slot mapping is the model's concern. cancelJobs(liveJobIds())
 /// is the snapshot form the JS binding uses for cancel-all, so jobs admitted
-/// after the cancel was requested survive it. Dequeue announces the
+/// after the cancel was requested survive it.
+///
+/// Every cancel entry point returns only once each job it delivered a
+/// model-side cancel for has fully left the scheduler (its slot released), so
+/// a returned cancel means "the job is gone": activeJobs() no longer counts
+/// it and an immediate follow-up admission cannot be spuriously refused as
+/// busy. This is the guarantee SingleJobScheduler gives by construction
+/// (ProcessingSync::waitInactive) and matters for models that apply a per-id
+/// cancel on their own worker, later than the cancelById() call. It obliges
+/// the model to eventually end a cancelled job, and forbids calling a cancel
+/// entry point from a scheduler worker (it would wait on itself); cancels
+/// that reach no model (unsupported surface) still return immediately — there
+/// is nothing whose completion could be awaited. Dequeue announces the
 /// job to the model (IModelJobLifecycle::jobStarting) under the same lock the
 /// cancel paths take, so every cancel finds each admitted job either still
 /// queued (dropped here) or already announced (cancellable model-side) — never
@@ -83,6 +95,9 @@ class MultiJobScheduler final : public IJobScheduler {
 
   mutable std::mutex mtx_;
   mutable std::condition_variable workCv_;
+  /// Signalled on every slot release, for cancel callers blocked in
+  /// awaitJobsGone() until their cancelled jobs have left the scheduler.
+  mutable std::condition_variable jobsGoneCv_;
   std::list<PendingJob> queued_;
   /// id -> queued_ node, so cancelling a not-yet-started job unlinks it in O(1)
   /// instead of scanning the queue. Ids are unique across the scheduler, so
@@ -123,6 +138,7 @@ class MultiJobScheduler final : public IJobScheduler {
       exclusiveActive_ = false;
     }
     lock.unlock();
+    jobsGoneCv_.notify_all();
   }
 
   /// Unlink @p id if still queued, releasing its slot and exclusivity. Caller
@@ -166,6 +182,24 @@ class MultiJobScheduler final : public IJobScheduler {
   std::vector<JobId> inFlightIds() const {
     std::lock_guard lock(mtx_);
     return {inFlight_.begin(), inFlight_.end()};
+  }
+
+  /// Block until none of @p ids is still admitted (queued or in flight).
+  /// Called by the cancel paths after a model-side cancel was issued, so the
+  /// model is already unwinding these jobs; the workers' slot releases
+  /// notify. Ids never recur once gone (monotonic minting), so the predicate
+  /// can only flip false -> true. Must not run on a scheduler worker: the
+  /// wait needs that worker to release the job's slot.
+  void awaitJobsGone(const std::vector<JobId>& ids) const {
+    std::unique_lock lock(mtx_);
+    jobsGoneCv_.wait(lock, [this, &ids] {
+      for (const JobId id : ids) {
+        if (inFlight_.count(id) != 0 || queuedIndex_.count(id) != 0) {
+          return false;
+        }
+      }
+      return true;
+    });
   }
 
   /// Worker body. Per-job input/id are copied onto the stack while the lock is
@@ -230,12 +264,15 @@ class MultiJobScheduler final : public IJobScheduler {
           return;
         }
         released = true;
-        std::lock_guard relock(mtx_);
-        --admittedCount_;
-        inFlight_.erase(job.id);
-        if (job.exclusive) {
-          exclusiveActive_ = false;
+        {
+          std::lock_guard relock(mtx_);
+          --admittedCount_;
+          inFlight_.erase(job.id);
+          if (job.exclusive) {
+            exclusiveActive_ = false;
+          }
         }
+        jobsGoneCv_.notify_all();
       };
 
       try {
@@ -390,6 +427,9 @@ public:
     }
     if (cancelById_ != nullptr) {
       cancelById_->cancelById(id);
+      // The model may apply the cancel later, on its own worker; only the
+      // job's departure makes "cancel returned" mean "job gone".
+      awaitJobsGone({id});
       return;
     }
     QLOG(logger::Priority::WARNING,
@@ -400,17 +440,22 @@ public:
     for (const JobId id : dropQueued()) {
       outputQueue_->queueException(std::runtime_error("Job cancelled"), id);
     }
+    // Await only this snapshot: jobs admitted while the wait runs are not
+    // cancelled and must not extend it.
+    const std::vector<JobId> inFlightSnapshot = inFlightIds();
     if (cancel_ != nullptr) {
       cancel_->cancel();
+      awaitJobsGone(inFlightSnapshot);
       return;
     }
     if (cancelById_ != nullptr) {
       // No whole-model cancel (a per-job-context model may have no global
       // stop switch): the scheduler owns the id set, cancel each in-flight
       // job individually.
-      for (const JobId id : inFlightIds()) {
+      for (const JobId id : inFlightSnapshot) {
         cancelById_->cancelById(id);
       }
+      awaitJobsGone(inFlightSnapshot);
       return;
     }
     QLOG(logger::Priority::WARNING, "Model does not support cancellation (of all jobs in a single-call)");
@@ -437,25 +482,26 @@ public:
       return;
     }
     std::vector<JobId> dropped;
-    bool anyInFlight = false;
+    std::vector<JobId> inFlightTargets;
     {
       std::lock_guard lock(mtx_);
       for (const JobId id : ids) {
         if (dropQueuedJob(id)) {
           dropped.push_back(id);
         } else if (inFlight_.count(id) != 0) {
-          anyInFlight = true;
+          inFlightTargets.push_back(id);
         }
       }
     }
     for (const JobId id : dropped) {
       outputQueue_->queueException(std::runtime_error("Job cancelled"), id);
     }
-    if (!anyInFlight) {
+    if (inFlightTargets.empty()) {
       return;
     }
     if (cancel_ != nullptr) {
       cancel_->cancel();
+      awaitJobsGone(inFlightTargets);
       return;
     }
     QLOG(logger::Priority::WARNING, "Model does not support cancellation");

--- a/packages/inference-addon-cpp/tests/multi_job_scheduler_test.cpp
+++ b/packages/inference-addon-cpp/tests/multi_job_scheduler_test.cpp
@@ -443,6 +443,86 @@ public:
   }
 };
 
+/// Model whose per-job cancel is deferred, the llm-llamacpp continuous batch
+/// scheduler shape: cancelById() only records the request; the job's slot
+/// tears down later, when the test opens its release gate. Reproduces the
+/// window between "cancel issued" and "slot actually freed" deterministically
+/// — no timing assumptions, the gate is provably still closed. Whole-model
+/// cancel() releases every gate at once so the scheduler destructor can
+/// always drain in-flight jobs.
+class DeferredCancelTestModel final : public model::IModel,
+                                      public model::IModelMultiprocessor,
+                                      public model::IModelCancel,
+                                      public model::IModelCancelById,
+                                      public model::IModelJobLifecycle {
+  mutable std::mutex mtx_;
+  mutable std::condition_variable cv_;
+  std::unordered_set<JobId> entered_;
+  std::unordered_set<JobId> requested_;
+  std::unordered_set<JobId> released_;
+  bool releaseAll_{false};
+
+public:
+  std::string getName() const override { return "DeferredCancelTestModel"; }
+
+  RuntimeStats runtimeStats() const override { return RuntimeStats{}; }
+
+  std::any process(const std::any& input) override { return input; }
+
+  /// Satisfies the ctor's cancelById-requires-lifecycle contract.
+  void jobStarting(JobId /*id*/) override {}
+
+  std::any process(const std::any& input, JobId id) override {
+    std::unique_lock lock(mtx_);
+    entered_.insert(id);
+    cv_.notify_all();
+    cv_.wait(
+        lock, [this, id] { return releaseAll_ || released_.count(id) != 0; });
+    return input;
+  }
+
+  /// Records the request only — the slot is torn down at release(), later,
+  /// mirroring a cancel applied by the model's own worker between steps.
+  void cancelById(JobId id) const override {
+    auto* self = const_cast<DeferredCancelTestModel*>(this);
+    std::lock_guard lock(self->mtx_);
+    self->requested_.insert(id);
+    self->cv_.notify_all();
+  }
+
+  void cancel() const override {
+    auto* self = const_cast<DeferredCancelTestModel*>(this);
+    std::lock_guard lock(self->mtx_);
+    self->releaseAll_ = true;
+    self->cv_.notify_all();
+  }
+
+  /// Apply the deferred teardown for @p id: lets its process() return.
+  void release(JobId id) {
+    std::lock_guard lock(mtx_);
+    released_.insert(id);
+    cv_.notify_all();
+  }
+
+  void releaseAll() {
+    std::lock_guard lock(mtx_);
+    releaseAll_ = true;
+    cv_.notify_all();
+  }
+
+  bool waitEntered(JobId id, std::chrono::milliseconds timeout) const {
+    std::unique_lock lock(mtx_);
+    return cv_.wait_for(
+        lock, timeout, [this, id] { return entered_.count(id) != 0; });
+  }
+
+  bool waitRequested(JobId id, std::chrono::milliseconds timeout) const {
+    std::unique_lock lock(mtx_);
+    return cv_.wait_for(
+        lock, timeout, [this, id] { return requested_.count(id) != 0; });
+  }
+};
+
 /// Blocks until @p target jobs are concurrently active on the gated model or
 /// the timeout lapses.
 int waitForGatedActive(const RegistrationGatedTestModel& model, int target,
@@ -532,6 +612,7 @@ protected:
   std::unique_ptr<MockOutputCallback> callback_;
   std::unique_ptr<ConcurrentTestModel> model_;
   std::unique_ptr<RegistrationGatedTestModel> gatedModel_;
+  std::unique_ptr<DeferredCancelTestModel> deferredModel_;
   std::shared_ptr<OutputQueue> outputQueue_;
   std::unique_ptr<MultiJobScheduler> scheduler_;
 
@@ -595,6 +676,28 @@ protected:
     return gatedModel_.get();
   }
 
+  /// buildWithQueue with a DeferredCancelTestModel instead; returns it
+  /// (non-owning) so the test can observe requests and open release gates.
+  /// @p wholeModelCancel false wires cancel = nullptr, so cancelAll must
+  /// reach in-flight jobs via the (deferred) per-id fallback.
+  DeferredCancelTestModel* buildDeferredWithQueue(
+      unsigned maxConcurrency, unsigned queueCapacity,
+      bool wholeModelCancel = true) {
+    deferredModel_ = std::make_unique<DeferredCancelTestModel>();
+    callback_ = std::make_unique<MockOutputCallback>();
+    outputQueue_ = std::make_shared<OutputQueue>(*callback_, *deferredModel_);
+    scheduler_ = std::make_unique<MultiJobScheduler>(
+        deferredModel_.get(),
+        maxConcurrency,
+        wholeModelCancel
+            ? static_cast<model::IModelCancel*>(deferredModel_.get())
+            : nullptr,
+        deferredModel_.get(),
+        queueCapacity);
+    scheduler_->start(outputQueue_);
+    return deferredModel_.get();
+  }
+
   /// Build a scheduler whose model exposes no per-job cancellation (cancelById
   /// = nullptr), so cancel(id) for an in-flight job hits the unsupported path.
   void buildNoCancelById(
@@ -625,6 +728,7 @@ protected:
     outputQueue_.reset();
     model_.reset();
     gatedModel_.reset();
+    deferredModel_.reset();
     callback_.reset();
   }
 };
@@ -1695,6 +1799,105 @@ TEST_F(MultiJobSchedulerTest, PublicationThrowReleasesSlotOnce) {
 
   EXPECT_TRUE(scheduler_->runJob(std::string("follow-up")).has_value())
       << "admission wedged after a publication throw";
+}
+
+/// A model may apply a per-id cancel later than the cancelById() call (the
+/// llm-llamacpp continuous batch scheduler records it and tears the slot down
+/// on its own worker). cancel(id) must not return in that window: the caller
+/// treats its return as "the job is gone" (SingleJobScheduler waits via
+/// ProcessingSync::waitInactive), and an early return leaves activeJobs()
+/// still counting the cancelled job — a follow-up admission the consumer
+/// issues the moment its cancel resolves is then spuriously refused as busy.
+TEST_F(MultiJobSchedulerTest, CancelReturnsOnlyAfterSlotRelease) {
+  DeferredCancelTestModel* model = buildDeferredWithQueue(1, 0);
+
+  const std::optional<JobId> id = scheduler_->runJob(std::string("job"));
+  ASSERT_TRUE(id.has_value());
+  ASSERT_TRUE(model->waitEntered(*id, std::chrono::seconds{2}));
+
+  std::atomic_bool cancelReturned{false};
+  std::size_t activeAtReturn = 99;
+  std::thread canceller([&] {
+    scheduler_->cancel(*id);
+    activeAtReturn = scheduler_->activeJobs();
+    cancelReturned.store(true);
+  });
+
+  EXPECT_TRUE(model->waitRequested(*id, std::chrono::seconds{2}));
+  // The release gate is provably still closed, so the job still holds its
+  // slot: a trustworthy cancel must still be blocked. Watch long enough that
+  // an early return cannot slip past the check.
+  bool returnedWhileSlotHeld = false;
+  const std::chrono::steady_clock::time_point watchDeadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds{300};
+  while (std::chrono::steady_clock::now() < watchDeadline) {
+    if (cancelReturned.load()) {
+      returnedWhileSlotHeld = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{2});
+  }
+
+  // Apply the deferred teardown; only now may cancel(id) return.
+  model->release(*id);
+  canceller.join();
+
+  EXPECT_FALSE(returnedWhileSlotHeld)
+      << "cancel(id) returned while the cancelled job still held its slot";
+  EXPECT_EQ(activeAtReturn, 0u)
+      << "activeJobs() still counted the cancelled job when cancel returned";
+  EXPECT_TRUE(scheduler_->runJob(std::string("follow-up")).has_value())
+      << "admission right after a returned cancel refused as busy";
+
+  model->releaseAll();
+}
+
+/// Same guarantee for cancelAll() on a model with no whole-model cancel: the
+/// per-id fallback is just as deferred, so cancelAll must not return while
+/// any of the snapshotted in-flight jobs still holds its slot.
+TEST_F(MultiJobSchedulerTest, CancelAllReturnsOnlyAfterSlotsRelease) {
+  DeferredCancelTestModel* model =
+      buildDeferredWithQueue(2, 0, /*wholeModelCancel=*/false);
+
+  const std::optional<JobId> first = scheduler_->runJob(std::string("a"));
+  const std::optional<JobId> second = scheduler_->runJob(std::string("b"));
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  ASSERT_TRUE(model->waitEntered(*first, std::chrono::seconds{2}));
+  ASSERT_TRUE(model->waitEntered(*second, std::chrono::seconds{2}));
+
+  std::atomic_bool cancelReturned{false};
+  std::size_t activeAtReturn = 99;
+  std::thread canceller([&] {
+    scheduler_->cancelAll();
+    activeAtReturn = scheduler_->activeJobs();
+    cancelReturned.store(true);
+  });
+
+  EXPECT_TRUE(model->waitRequested(*first, std::chrono::seconds{2}));
+  EXPECT_TRUE(model->waitRequested(*second, std::chrono::seconds{2}));
+  // Release one of the two: cancelAll must keep blocking on the other.
+  model->release(*first);
+  bool returnedWhileSlotHeld = false;
+  const std::chrono::steady_clock::time_point watchDeadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds{300};
+  while (std::chrono::steady_clock::now() < watchDeadline) {
+    if (cancelReturned.load()) {
+      returnedWhileSlotHeld = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{2});
+  }
+
+  model->release(*second);
+  canceller.join();
+
+  EXPECT_FALSE(returnedWhileSlotHeld)
+      << "cancelAll() returned while a cancelled job still held its slot";
+  EXPECT_EQ(activeAtReturn, 0u)
+      << "activeJobs() still counted cancelled jobs when cancelAll returned";
+
+  model->releaseAll();
 }
 
 } // namespace qvac_lib_inference_addon_cpp

--- a/packages/inference-addon-cpp/vcpkg.json
+++ b/packages/inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## What problem does this PR solve?

`MultiJobScheduler`'s cancel entry points returned as soon as the cancel was *forwarded* to the model, not when the job was actually gone. A model that applies per-id cancels on its own worker — llm-llamacpp's continuous batch scheduler records the cancel and tears the slot down between decode steps — leaves a window where the cancel call has returned but the job still occupies its admission slot, so `activeJobs()` still counts it.

Consumers rely on the stronger contract: the JS `cancel()` promise is documented to resolve "when cancellation completes", and `SingleJobScheduler` guaranteed exactly that by blocking in `cancelImpl()` until the worker backed the job out (`ProcessingSync::waitInactive`). Under the multi-job scheduler that guarantee silently regressed, producing this spurious failure:

```js
await response.cancel()
model.run(prompt, { rejectWhenBusy: true }) // may throw RUN_BUSY — the cancelled job still holds its slot
```

## How does it solve it?

Test-first (red → green):

- **test**: a `DeferredCancelTestModel` whose `cancelById()` only records the request; the job ends when the test opens its release gate — the exact shape of llm-llamacpp's deferred teardown, with no timing assumptions. Two tests pin the contract: `CancelReturnsOnlyAfterSlotRelease` (targeted cancel + the follow-up-admission RUN_BUSY symptom) and `CancelAllReturnsOnlyAfterSlotsRelease` (per-id fallback keeps blocking until the *last* snapshotted job releases). Red before the fix: `cancel(id)` returned with `activeJobs() == 1`, `cancelAll()` with `activeJobs() == 2`.
- **fix**: after issuing the model-side cancel, `cancel(id)`, `cancelAll()` and the `cancelJobs()` no-`cancelById` fallback wait (`awaitJobsGone`) until the targeted ids have left both the queue and the in-flight set; the workers' two slot-release paths notify a new `jobsGoneCv_`. Ids are never reused, so the wait predicate can only flip once. Cancel paths that deliver no model-side cancel still return immediately (nothing to await), and scheduler teardown is unchanged — the destructor never waits for the model.
- **release prep**: version bump to 1.3.1 + changelog entry.

Full unit suite: 119/119 pass.

## Breaking changes

None. This strengthens cancel back to the documented single-job semantics. Two contract notes for model implementors: a model must eventually end a job it was told to cancel (otherwise the cancel call blocks, as it always did on the single-job path), and cancel entry points must not be invoked from a scheduler worker thread (the wait would depend on that worker releasing the slot).