### PR TITLE
chore(embed-llamacpp): prepare 0.29.0 release

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.29.0] - 2026-07-24
+
+This release makes TypeScript the source of truth for the embed-llamacpp
+runtime wrapper and its public declarations.
+
+### Changed
+
+#### TypeScript-authored runtime wrapper and declarations
+
+The BERT wrapper, native-addon bridge, and logging wrapper are now authored in
+TypeScript. The published JavaScript entrypoints (`index.js`, `addon.js`,
+`addonLogging.js`) and their `.d.ts` declarations are generated from those
+sources and committed, guarded by a generated-output freshness check in CI. The
+CommonJS export shape, public API, and runtime behavior are unchanged for SDK
+and Bare consumers, while strict type checking and linting reduce the risk of
+the runtime drifting from the public types.
+
+### Pull Requests
+
+- [#3433](https://github.com/tetherto/qvac/pull/3433) - QVAC-22460 chore[notask]: migrate embed-llamacpp wrapper to TypeScript
+
 ## [0.28.0] - 2026-07-20
 
 ### Changed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
This PR bumps the embed-llamacpp package version to 0.29.0 and adds the corresponding CHANGELOG entry for the TypeScript migration (#3433).