### PR TITLE
QVAC infra: don't persist PAT in mobile test-framework checkout

### DIFF
--- a/.github/actions/run-mobile-integration-tests/setup/action.yml
+++ b/.github/actions/run-mobile-integration-tests/setup/action.yml
@@ -115,6 +115,12 @@ runs:
         repository: tetherto/qvac-test-addon-mobile
         ref: ${{ inputs.test-framework-ref }}
         token: ${{ inputs.pat-token }}
+        # Do not persist the PAT into test-framework/.git/config: the build phase
+        # runs fork-controlled code (addon npm install, expo/gradle/xcode) in the
+        # same workspace and could otherwise read the credential from disk. The
+        # token is still used for the clone itself. Applies to every mobile addon
+        # that consumes this composite.
+        persist-credentials: false
         path: test-framework
         fetch-depth: 0
 


### PR DESCRIPTION
## What

Add `persist-credentials: false` to the **"Checkout mobile test framework"** step in the shared `run-mobile-integration-tests/setup` composite.

## Why

`actions/checkout` with the default `persist-credentials: true` writes the supplied `PAT_TOKEN` into `test-framework/.git/config` (as an `http.<host>.extraheader`). That checkout runs in the **build** phase, in the same workspace where fork-controlled code executes shortly after (addon `npm install`, `expo prebuild`, Gradle/xcodebuild). That fork code can read `test-framework/.git/config` and exfiltrate the PAT.

Setting `persist-credentials: false` keeps the token in-memory for the clone but never writes it to disk, closing the exfil path.

## Scope

This composite is consumed by **every** `integration-mobile-test-*.yml` workflow, so this one-line change hardens the whole mobile-addon fleet. It's raised as a standalone PR (rather than folded into a package PR) so it's easy to review in isolation.

## Safety

Nothing downstream needs `test-framework`'s git credentials — the build only uses the checked-out **files** (`npm install`/`npm pack`, expo, Gradle/xcode); no later step does a `git fetch`/`pull` in that repo. So dropping the persisted credential does not affect any build.

## Context

Flagged as a P1 in review of #3313 (inference-addon-cpp mobile CI). That PR closes the analogous leak on its own addon checkout; this PR fixes the shared sibling checkout for all addons.
