### PR TITLE
QVAC-19261 chore: release @qvac/tts-ggml v0.6.0 (Parler-TTS engine)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,13 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - 2026-07-21
-
-### Changed
-
-- Migrated the published JavaScript wrapper to generated TypeScript sources and added declarations for the supported `./text-chunker` and `./lib/textStreamAccumulator.js` subpath exports, while preserving the existing CommonJS runtime API.
-- Desktop linux-arm64 prebuilds now ship per-arch ggml CPU variants (`tts-cpp` >= 2026-07-13#2, pulling `ggml-speech` 2026-07-14): the previous armv8-a-baseline build compiled out the ARM dotprod/fp16 kernels (chatterbox q4 CPU mean RTF 2.70 -> 2.28 on ubuntu-24.04-arm).
-- Bumped the `tts-cpp` `version>=` floor from `2026-07-13#2` to `2026-07-13#3` (registry PR [tetherto/qvac-registry-vcpkg#253](https://github.com/tetherto/qvac-registry-vcpkg/pull/253)), which raises the `ggml-speech` floor to `2026-07-15` (`tetherto/qvac-ext-ggml` speech `d7e27ac7`, [#42](https://github.com/tetherto/qvac-ext-ggml/pull/42) — QVAC-21623 ggml-opencl Adreno FLASH_ATTN partial-KV NaN fix + q8_0 SOA `get_rows` + faster f16 GEMV/GEMM). `tts-cpp` source is unchanged (rebuild-only re-pin); the delta is OpenCL-only (non-Adreno / Vulkan / Metal / CPU byte-identical). Registry baseline unchanged.
+## [0.6.0] - 2026-07-24
 
 ### Added
 
@@ -49,6 +43,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tts-cpp` pin that ships the parler engine (qvac-ext-lib-whisper.cpp
   PR #92). New `examples/parler-tts.js`, integration/unit suites, C++
   config tests, and a `parler` model-download group (mini q8_0).
+
+## [0.5.1] - 2026-07-21
+
+### Changed
+
+- Migrated the published JavaScript wrapper to generated TypeScript sources and added declarations for the supported `./text-chunker` and `./lib/textStreamAccumulator.js` subpath exports, while preserving the existing CommonJS runtime API.
+- Desktop linux-arm64 prebuilds now ship per-arch ggml CPU variants (`tts-cpp` >= 2026-07-13#2, pulling `ggml-speech` 2026-07-14): the previous armv8-a-baseline build compiled out the ARM dotprod/fp16 kernels (chatterbox q4 CPU mean RTF 2.70 -> 2.28 on ubuntu-24.04-arm).
+- Bumped the `tts-cpp` `version>=` floor from `2026-07-13#2` to `2026-07-13#3` (registry PR [tetherto/qvac-registry-vcpkg#253](https://github.com/tetherto/qvac-registry-vcpkg/pull/253)), which raises the `ggml-speech` floor to `2026-07-15` (`tetherto/qvac-ext-ggml` speech `d7e27ac7`, [#42](https://github.com/tetherto/qvac-ext-ggml/pull/42) — QVAC-21623 ggml-opencl Adreno FLASH_ATTN partial-KV NaN fix + q8_0 SOA `get_rows` + faster f16 GEMV/GEMM). `tts-cpp` source is unchanged (rebuild-only re-pin); the delta is OpenCL-only (non-Adreno / Vulkan / Metal / CPU byte-identical). Registry baseline unchanged.
+
+### Added
+
 - **Chatterbox S3Gen classifier-free-guidance rate (`cfgRate`) (QVAC-21908).**
   New optional `cfgRate` knob for the Chatterbox engine, surfacing the S3Gen
   CFG rate that was previously fixed to the model's GGUF-baked value. The S3Gen

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The Parler-TTS engine (#3312) landed its CHANGELOG notes under the
  already-released `## [0.5.1]` section, and `@qvac/tts-ggml` is still pinned at
  `0.5.1` — so the new engine family has no release version of its own.

## 📝 How does it solve it?

- Adds a new `## [0.6.0] - 2026-07-24` CHANGELOG section and moves the four
  Parler bullets into it (engine mini/large/indic, Metal GPU, voice
  descriptions + emotion, sampling/generation knobs); `[0.5.1]` keeps only its
  own Chatterbox `cfgRate` / LavaSR / enhancer notes.
- Bumps `packages/tts-ggml/package.json` `version` `0.5.1` → `0.6.0` — a minor
  bump for a new, backward-compatible engine family.
- Release bookkeeping only: no source or behaviour change. Mirrors the earlier
  "Bump tts-ggml version to v0.5.1" (#3376).

## 🧪 How was it tested?

- No runtime change to exercise — the Parler engine itself was verified and
  merged in #3312 (CPU + Metal; unit + integration suites green).
- Confirmed the CHANGELOG split is well-formed (`[0.6.0]` holds the Parler
  entries, `[0.5.1]` otherwise unchanged) and that the `version` line is the
  only `package.json` delta.
