### PR TITLE
doc[notask]: add Hermes Agent community quickstart

### DIFF
--- a/docs/website/content/docs/cli/http-server/connection.mdx
+++ b/docs/website/content/docs/cli/http-server/connection.mdx
@@ -11,6 +11,8 @@ For OpenCode, use the published [`@qvac/opencode-plugin`](https://www.npmjs.com/
 
 For OpenClaw, use the published [`@qvac/openclaw-plugin`](https://www.npmjs.com/package/@qvac/openclaw-plugin). The plugin registers the `qvac` provider, exposes the QVAC model catalog, and uses OpenClaw's `localService` support to start `qvac serve openai` when the local provider is used.
 
+For Hermes Agent, the community-maintained [Hermes + QVAC Quickstart](https://github.com/localhost41/hermes-qvac-quickstart) installs a standalone `qvac` provider and manages the same OpenAI-compatible QVAC server path. It reuses the official QVAC CLI, AI SDK provider, and model catalog, but is an independent community project rather than an official QVAC package.
+
 Manual HTTP-server setup is still available for other OpenAI-compatible tools, or for users who want to run `qvac serve openai` themselves. In that mode, the model name requested by the tool must match an alias declared in `serve.models`, and the tool's base URL must point to the running server (`http://localhost:11434/v1` by default).
 
 ## OpenCode quickstart
@@ -178,6 +180,25 @@ For example:
 
 Start `qvac serve openai` with that config, register an OpenClaw custom provider whose model id is `gemma4-2b`, and select `qvac/gemma4-2b` in OpenClaw. The raw SDK constant belongs in `qvac.config.json`; the OpenClaw-facing model name should use the alias.
 
+## Hermes Agent community quickstart
+
+If Hermes Agent is already installed and available as `hermes`, install the community quickstart and start the integration:
+
+```bash
+npm install -g @localhost41/hermes-qvac-provider@beta
+hermes-qvac start
+```
+
+The command checks local resources, asks before downloading models, installs the standalone Hermes provider, starts a managed `qvac serve openai` instance, waits for the selected models, launches Hermes, and cleans up its managed session when Hermes exits. The npm package includes the official QVAC CLI, so this path does not require a separate global `qvac` installation.
+
+The default profile uses Qwen3.5 9B for normal Hermes agent workflows. On smaller machines, an explicitly reduced fast profile uses Qwen3.5 4B, a 16K context, and Hermes' terminal toolset:
+
+```bash
+hermes-qvac start --fast
+```
+
+See the [Hermes + QVAC Quickstart README](https://github.com/localhost41/hermes-qvac-quickstart#readme) for requirements, model-download estimates, diagnostics, uninstall instructions, compatibility evidence, and current limitations. This integration is maintained independently and is not affiliated with or endorsed by QVAC or Hermes Agent.
+
 ## Compatible tools
 
 The following tools have been verified to work as drop-in replacements by pointing their base URL to the HTTP server:
@@ -193,6 +214,7 @@ The following tools have been verified to work as drop-in replacements by pointi
 | [Aider](https://aider.chat) | `/v1/chat/completions` (streaming) |
 | [OpenCode](https://opencode.ai) | `/v1/chat/completions` (streaming, tool calls) |
 | [OpenClaw](https://openclaw.ai) | `/v1/chat/completions` (streaming, tool calls), `/v1/models` |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | `/v1/chat/completions` (streaming, tool calls), `/v1/models` |
 
 ## Configure the HTTP server
 


### PR DESCRIPTION
## What problem does this PR solve?

- The HTTP-server connection guide documents dedicated OpenCode and OpenClaw paths but does not mention the tested community Hermes Agent integration.
- New Hermes users otherwise have to reconstruct the generic OpenAI-compatible setup manually.

## How does it solve it?

- Adds a clearly labeled community Hermes Agent quickstart using the published `@localhost41/hermes-qvac-provider@beta` package.
- Describes the integration boundary factually: it reuses the official QVAC CLI, AI SDK provider, model catalog, and `qvac serve openai` rather than replacing server behavior.
- Adds Hermes Agent to the existing compatible-tools table.
- Explicitly states that the package is independently maintained and is not affiliated with or endorsed by QVAC or Hermes Agent.

The package's [beta.3 release-readiness report](https://github.com/localhost41/hermes-qvac-quickstart/blob/main/docs/beta3-release-readiness.md) records validation against `@qvac/cli` 0.8.1, `@qvac/ai-sdk-provider` 0.3.0, Hermes 0.18.2 and 0.19.0, macOS live inference, Linux packed transport, Node 22/24/26, and Python 3.11/3.12/3.13. Its release workflow uses npm trusted publishing with provenance.

### Verification

- `npx vitest run --exclude '**/tsdoc-completeness*'` — 243 tests passed (the same exclusion used by Docs Website PR Checks).
- `npm run build` — static build completed for 144 pages and found 0 broken links.
- `npm test` additionally ran the warning-mode SDK TSDoc audit: 246 tests passed; the existing completeness check reported 89.8% against its 95% threshold. This PR does not change SDK source or that test.

### Review questions

1. Is the HTTP-server connection guide the right location for an independently maintained Hermes quickstart?
2. Are the stated QVAC package boundaries and Qwen3.5 9B/4B profile descriptions consistent with current QVAC guidance?

## Breaking changes

None. Documentation only.
