### PR TITLE
QVAC-22515 chore[mod]: deprecate all 19 ONNX OCR models in registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -1081,7 +1081,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "latin"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/easyocr/2026-05-14/latin_g2.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; use the GGUF equivalent with the ggml-ocr engine"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_512/detector_craft.onnx",
@@ -1092,7 +1095,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "detector", "craft"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/easyocr/2026-05-14/craft_mlt_25k.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; use the GGUF equivalent with the ggml-ocr engine"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/gguf/easyocr/2026-05-14/craft_mlt_25k.gguf",
@@ -2222,7 +2228,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "arabic"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_bengali.onnx",
@@ -2233,7 +2241,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "bengali"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_cyrillic.onnx",
@@ -2244,7 +2254,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "cyrillic"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_devanagari.onnx",
@@ -2255,7 +2267,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "devanagari"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_japanese.onnx",
@@ -2266,7 +2280,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "japanese"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_kannada.onnx",
@@ -2277,7 +2293,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "kannada"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_korean.onnx",
@@ -2288,7 +2306,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "korean"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_latin.onnx",
@@ -2299,7 +2319,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "latin"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/easyocr/2026-05-14/latin_g2.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; use the GGUF equivalent with the ggml-ocr engine"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_tamil.onnx",
@@ -2310,7 +2333,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "tamil"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_telugu.onnx",
@@ -2321,7 +2346,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "telugu"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_thai.onnx",
@@ -2332,7 +2359,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "thai"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_zh_sim.onnx",
@@ -2343,7 +2372,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "zh_sim"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_zh_tra.onnx",
@@ -2354,7 +2385,9 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "recognizer", "zh_tra"],
     "notes": "",
-    "link": "https://www.jaided.ai/easyocr/modelhub/"
+    "link": "https://www.jaided.ai/easyocr/modelhub/",
+    "deprecated": true,
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; no GGUF conversion published for this language yet"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/db_resnet50.onnx",
@@ -2365,7 +2398,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "doctr", "detector", "db_resnet50"],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15/db_mobilenet_v3_large.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; use the GGUF docTR detector (db_mobilenet_v3_large.gguf) with the ggml-ocr engine"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/db_mobilenet_v3_large.onnx",
@@ -2376,7 +2412,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "doctr", "detector", "db_mobilenet_v3_large"],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15/db_mobilenet_v3_large.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; use the GGUF equivalent with the ggml-ocr engine"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/parseq.onnx",
@@ -2387,7 +2426,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "doctr", "recognizer", "parseq"],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15/crnn_mobilenet_v3_small.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; PARSeq is not supported by ggml-ocr - use the GGUF docTR recognizer (crnn_mobilenet_v3_small.gguf)"
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/crnn_mobilenet_v3_small.onnx",
@@ -2398,7 +2440,10 @@
     "licenseId": "Apache-2.0",
     "tags": ["ocr", "doctr", "recognizer", "crnn_mobilenet_v3_small"],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": true,
+    "replacedBy": "s3:///qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15/crnn_mobilenet_v3_small.gguf",
+    "deprecationReason": "ONNX OCR engine (@qvac/ocr-onnx) removed in @qvac/sdk 0.15.0; use the GGUF equivalent with the ggml-ocr engine"
   },
   {
     "source": "s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen-mtl.gguf",


### PR DESCRIPTION
## Summary

The onnx-ocr plugin was removed in `@qvac/sdk` 0.15.0, but `modelRegistryList()` still returns 19 `.onnx` OCR artifacts whose engine (`@qvac/ocr-onnx`, surfaced as `ggml-ocr`) can never load them — the ggml-ocr loader only opens GGUF. This directly caused the 0.15.0 integrator confusion where the documented `ocr()` path appeared broken end to end.

This PR marks all 19 ONNX OCR entries `deprecated: true` in `models.prod.json`. The sync-on-merge process auto-sets `deprecatedAt`, and `findModels()` hides deprecated entries by default, so the registry stops advertising OCR models the engine cannot load. Model data is preserved per the registry's standard deprecation flow (no permanent deletion).

## Per-entry decisions (full audit of the 19)

**Direct GGUF replacement exists (`replacedBy` set):**

| ONNX entry | replacedBy |
|---|---|
| `rec_512/recognizer_latin.onnx` (OCR_LATIN_RECOGNIZER) | `gguf/easyocr/2026-05-14/latin_g2.gguf` (OCR_LATIN) |
| `rec_dyn/recognizer_latin.onnx` (OCR_LATIN_RECOGNIZER_1) | `gguf/easyocr/2026-05-14/latin_g2.gguf` (OCR_LATIN) |
| `rec_512/detector_craft.onnx` (OCR_CRAFT_DETECTOR) | `gguf/easyocr/2026-05-14/craft_mlt_25k.gguf` (OCR_CRAFT) |
| `doctr/db_mobilenet_v3_large.onnx` (OCR_DETECTOR_DB_MOBILENET_V3_LARGE) | `gguf/doctrf16/2026-05-15/db_mobilenet_v3_large.gguf` (OCR_DOCTR_1) |
| `doctr/crnn_mobilenet_v3_small.onnx` (OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL) | `gguf/doctrf16/2026-05-15/crnn_mobilenet_v3_small.gguf` (OCR_DOCTR) |
| `doctr/db_resnet50.onnx` (OCR_DETECTOR_DB_RESNET50) | functional replacement: `db_mobilenet_v3_large.gguf` (no resnet50 GGUF conversion published) |
| `doctr/parseq.onnx` (OCR_RECOGNIZER_PARSEQ) | functional replacement: `crnn_mobilenet_v3_small.gguf` (PARSeq has no ggml implementation) |

**No GGUF conversion published yet (deprecated without `replacedBy`):** the 12 per-language EasyOCR recognizers — arabic, bengali, cyrillic, devanagari, japanese, kannada, korean, tamil, telugu, thai, zh_sim, zh_tra. Note: the ocr-ggml engine already implements all of these language families (`easyocr/pipeline/lang.cpp` gen1/gen2 tables), so re-adding them later requires only converting the weights to GGUF and registering new entries — no code changes. Until then this is a documented capability gap (GGUF EasyOCR path is Latin-only).

**Kept (untouched, both working `ocr()` paths confirmed):** the 4 `@qvac/ocr-ggml` GGUF entries — `craft_mlt_25k.gguf` + `latin_g2.gguf` (EasyOCR default) and `db_mobilenet_v3_large.gguf` + `crnn_mobilenet_v3_small.gguf` (`pipelineType: "doctr"`), exactly the artifacts `resolve-config.ts` uses.

## Validation

- `node scripts/validate-models-json.js` — ✓ Valid: 745 model(s)
- JSON re-parsed: 745 models, exactly 19 deprecated, all `@qvac/ocr-onnx`

## Related

- QVAC-22515 (deprecate onnx-ocr end to end); follow-up to the 0.15.0 OCR load-failure triage
- Monorepo code removal + SDK/ai-sdk-provider cleanup lands separately; after this syncs, `update-models` regeneration drops the 19 entries from `contract/models.json` and ai-sdk-provider constants
