### PR TITLE
QVAC-22691 infra: introduce qvac-addon CMake template and migrate classification-ggml

### DIFF
--- a/cmake/qvac-addon/qvac-addon.cmake
+++ b/cmake/qvac-addon/qvac-addon.cmake
@@ -1,0 +1,330 @@
+# qvac-addon.cmake — shared CMake helpers for QVAC native inference addons.
+#
+# See docs/architecture/ADDON-CMAKE-TEMPLATE.md for the design rationale, the
+# common-vs-addon-specific breakdown, and the migration plan.
+#
+# Addons include this module once, then call the helpers:
+#
+#   include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/qvac-addon/qvac-addon.cmake)
+#   qvac_addon_preproject()                 # BEFORE project()
+#   project(<name> LANGUAGES C CXX)
+#   qvac_addon_project_setup()              # AFTER project()
+#   qvac_addon_use_fabric()                 # sets qvac_fabric_target + BACKENDS_SUBDIR_VALUE
+#   add_bare_module(<name> EXPORTS)
+#   ...target_sources / target_include_directories...
+#   qvac_addon_link_fabric(${<name>} ${qvac_fabric_target})
+#   qvac_addon_finalize(${<name>} SUBDIR "${BACKENDS_SUBDIR_VALUE}")
+#
+# qvac_addon_preproject / _project_setup / _use_fabric are macros on purpose:
+# they set directory-scope state (VCPKG_MANIFEST_FEATURES, the vcpkg toolchain,
+# ANDROID_STL, CMAKE_CXX_STANDARD, the fabric target var, ...) that must land in
+# the addon's own scope, not a nested function scope.
+
+include_guard(GLOBAL)
+
+set(QVAC_ADDON_CMAKE_VERSION "0.1.0")
+
+# ---------------------------------------------------------------------------
+# qvac_addon_preproject()
+#
+# Pre-project() setup shared by every addon. Must run BEFORE project() so the
+# vcpkg toolchain, manifest features and Android STL are in effect when the
+# toolchain file loads.
+# ---------------------------------------------------------------------------
+macro(qvac_addon_preproject)
+  option(BUILD_TESTING "Build tests" OFF)
+  option(ENABLE_COVERAGE "Enable coverage instrumentation for unit tests" OFF)
+  if(BUILD_TESTING)
+    list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+  endif()
+
+  find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
+  find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
+
+  set(VCPKG_OVERLAY_TRIPLETS
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+
+  # Android STL configuration must be set before project().
+  if(DEFINED ENV{ANDROID_NDK} OR DEFINED ENV{ANDROID_NDK_HOME})
+    set(ANDROID_STL c++_shared)
+  endif()
+
+  message(STATUS "qvac-addon: template v${QVAC_ADDON_CMAKE_VERSION}")
+endmacro()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_project_setup([VALGRIND_SUPP] [PRE_COMMIT_HOOK])
+#
+# Post-project() setup: libc++ on Linux, lint-cpp config sync, the C++20 block,
+# and Windows lean-headers defines. `.clang-format` / `.clang-tidy` are always
+# synced from lint-cpp; the valgrind suppression file and the pre-commit hook
+# are opt-in (most addons want them; a few historically didn't).
+# ---------------------------------------------------------------------------
+macro(qvac_addon_project_setup)
+  cmake_parse_arguments(_QAPS "VALGRIND_SUPP;PRE_COMMIT_HOOK" "" "" ${ARGN})
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_compile_options(-stdlib=libc++)
+    add_link_options(-stdlib=libc++ -static-libstdc++)
+  endif()
+
+  find_path(VCPKG_INSTALLED_PATH share/lint-cpp/.clang-format REQUIRED)
+  configure_file(${VCPKG_INSTALLED_PATH}/share/lint-cpp/.clang-format
+                 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-format COPYONLY)
+  configure_file(${VCPKG_INSTALLED_PATH}/share/lint-cpp/.clang-tidy
+                 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy COPYONLY)
+  if(_QAPS_VALGRIND_SUPP)
+    configure_file(${VCPKG_INSTALLED_PATH}/share/lint-cpp/.valgrind.supp
+                   ${CMAKE_CURRENT_SOURCE_DIR}/.valgrind.supp COPYONLY)
+  endif()
+  if(_QAPS_PRE_COMMIT_HOOK)
+    configure_file(${VCPKG_INSTALLED_PATH}/tools/lint-cpp/hooks/pre-commit
+                   ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit COPYONLY)
+  endif()
+
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  if(WIN32)
+    add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -DNOGDI)
+  endif()
+endmacro()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_use_fabric()
+#
+# Consume the shared @qvac/fabric prebuilt ggml runtime. Sets, in the caller's
+# scope:
+#   qvac_fabric_target    — the fabric bare-module target (link its _module)
+#   BACKENDS_SUBDIR_VALUE  — "<host>/qvac__fabric": the subdir the addon appends
+#                            to the runtime-provided backendsDir before calling
+#                            ggml_backend_load_all_from_path().
+#
+# The ggml compute backends live in @qvac/fabric's own prebuilds and are loaded
+# once per process; the addon neither collects nor installs them.
+# ---------------------------------------------------------------------------
+macro(qvac_addon_use_fabric)
+  set(qvac-fabric_DIR
+      "${CMAKE_CURRENT_SOURCE_DIR}/node_modules/@qvac/fabric/prebuilds/share/qvac-fabric/cmake")
+  find_package(qvac-fabric CONFIG REQUIRED)
+  include_bare_module("@qvac/fabric" qvac_fabric_target PREBUILD)
+
+  bare_target(bare_target_value)
+  set(BACKENDS_SUBDIR_VALUE "${bare_target_value}/qvac__fabric")
+  message(STATUS "qvac-addon: BACKENDS_SUBDIR='${BACKENDS_SUBDIR_VALUE}'")
+endmacro()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_link_fabric(<addon_target> <fabric_target>)
+#
+# The two-target link split: compile the addon library against the ggml headers,
+# and give the .bare module a DT_NEEDED on the shared runtime.
+# ---------------------------------------------------------------------------
+function(qvac_addon_link_fabric addon_target fabric_target)
+  target_link_libraries(${addon_target} PRIVATE qvac-fabric::headers)
+  target_link_libraries(${addon_target}_module PRIVATE ${fabric_target}_module)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_finalize(<addon_target> [SUBDIR <value>])
+#
+# Apply the settings every addon module needs:
+#   * Linux symbol hygiene (--exclude-libs,ALL),
+#   * JS_LOGGER + BACKENDS_SUBDIR compile definitions,
+#   * platform-derived GGML_BACKEND_DL (Linux/Android load ggml backends as
+#     dlopen'd modules; macOS/Windows/iOS link them static into the runtime),
+#   * Android 16 KB page-size link flags,
+#   * Apple compiler-rt force_load for __isPlatformVersionAtLeast.
+#
+# The last two normalize fixes that had drifted across addons: they are applied
+# to every module so an addon can never silently miss them. They are no-ops on
+# platforms they don't target (guarded by ANDROID / APPLE).
+# ---------------------------------------------------------------------------
+function(qvac_addon_finalize addon_target)
+  cmake_parse_arguments(PARSE_ARGV 1 _QAF "" "SUBDIR" "")
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_options(${addon_target}_module PRIVATE -Wl,--exclude-libs,ALL)
+  endif()
+
+  target_compile_definitions(${addon_target} PRIVATE JS_LOGGER)
+  if(_QAF_SUBDIR)
+    target_compile_definitions(${addon_target} PRIVATE
+      BACKENDS_SUBDIR="${_QAF_SUBDIR}")
+  endif()
+
+  if((ANDROID OR UNIX) AND NOT APPLE)
+    target_compile_definitions(${addon_target} PRIVATE GGML_BACKEND_DL)
+  endif()
+
+  qvac_addon_android_page_size(${addon_target})
+  qvac_addon_apple_force_load_compiler_rt(${addon_target})
+endfunction()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_android_page_size(<addon_target>)
+#
+# Android 15+ on Pixel 9 / Pixel 9 Pro / Pixel 9 Pro XL ships with a 16 KB
+# page-size kernel (`getconf PAGE_SIZE` -> 16384). The dynamic loader on those
+# devices silently refuses .so files whose LOAD segments are aligned to the
+# older 4 KB max-page-size, which is what NDK r27 still emits by default (NDK
+# r28 flipped the default). Without this flag the addon never registers via
+# bare-kit's linker (Bare's resolver reports
+# `ADDON_NOT_FOUND: linked:libqvac__<addon>.*.so`) while the same APK loads
+# fine on 4 KB devices like the Samsung S25 Ultra. Drop once we move to NDK r28+.
+# ---------------------------------------------------------------------------
+function(qvac_addon_android_page_size addon_target)
+  if(ANDROID)
+    target_link_options(
+      ${addon_target}_module
+      PRIVATE
+        -Wl,-z,max-page-size=16384
+        -Wl,-z,common-page-size=16384
+    )
+  endif()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_apple_force_load_compiler_rt(<addon_target>)
+#
+# Force-load clang's compiler-rt builtins archive so `__isPlatformVersionAtLeast`
+# -- the symbol that lowers every Objective-C `@available(...)` runtime check --
+# resolves at link time.
+#
+# Why this is needed:
+#   Xcode 16 / iOS SDK 18 changed clang's `@available` lowering from a direct
+#   call to libSystem's `_availability_version_check` to a compiler-rt wrapper
+#   `__isPlatformVersionAtLeast` (clang commit D90367). cmake-bare links every
+#   Apple bare module with `-Wl,-undefined,dynamic_lookup`, so ld defers the
+#   symbol to dyld; but compiler-rt is a static archive dyld can't load, so the
+#   symbol binds to NULL and the first `@available` call jumps to PC=0 and the
+#   bare runtime aborts. `-Wl,-force_load,<archive>` is the only ld primitive
+#   that bypasses `-undefined,dynamic_lookup` and pulls the builtins in.
+#
+# We resolve the right libclang_rt.<variant>.a at configure time via Xcode's
+# clang (not ${CMAKE_C_COMPILER}, which may be Homebrew LLVM that only ships the
+# macOS variant). Long-term this belongs in cmake-bare itself.
+# ---------------------------------------------------------------------------
+function(qvac_addon_apple_force_load_compiler_rt addon_target)
+  if(NOT APPLE)
+    return()
+  endif()
+
+  # Map the active CMake target to (a) the xcrun SDK name and (b) clang's
+  # libclang_rt filename suffix. ld's search uses the exact filename, so picking
+  # the wrong variant silently leaves the symbol unresolved.
+  if(IOS)
+    if(CMAKE_OSX_SYSROOT MATCHES "Simulator")
+      set(_qvac_rtlib_variant "iossim")
+      set(_qvac_xcrun_sdk      "iphonesimulator")
+    else()
+      set(_qvac_rtlib_variant "ios")
+      set(_qvac_xcrun_sdk      "iphoneos")
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "tvOS")
+    if(CMAKE_OSX_SYSROOT MATCHES "Simulator")
+      set(_qvac_rtlib_variant "tvossim")
+      set(_qvac_xcrun_sdk      "appletvsimulator")
+    else()
+      set(_qvac_rtlib_variant "tvos")
+      set(_qvac_xcrun_sdk      "appletvos")
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "watchOS")
+    if(CMAKE_OSX_SYSROOT MATCHES "Simulator")
+      set(_qvac_rtlib_variant "watchossim")
+      set(_qvac_xcrun_sdk      "watchsimulator")
+    else()
+      set(_qvac_rtlib_variant "watchos")
+      set(_qvac_xcrun_sdk      "watchos")
+    endif()
+  else()
+    set(_qvac_rtlib_variant "osx")
+    set(_qvac_xcrun_sdk      "macosx")
+  endif()
+
+  execute_process(
+    COMMAND xcrun --sdk "${_qvac_xcrun_sdk}" clang -print-resource-dir
+    OUTPUT_VARIABLE _qvac_clang_resource_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _qvac_clang_resource_dir_result
+    ERROR_QUIET
+  )
+  if(NOT _qvac_clang_resource_dir_result EQUAL 0
+     OR NOT IS_DIRECTORY "${_qvac_clang_resource_dir}/lib/darwin")
+    message(FATAL_ERROR
+      "Apple bare-module link needs Xcode clang's compiler-rt for "
+      "__isPlatformVersionAtLeast (Xcode 16 / iOS SDK 18 @available "
+      "lowering). `xcrun --sdk ${_qvac_xcrun_sdk} clang -print-resource-dir`"
+      " returned '${_qvac_clang_resource_dir}' but lib/darwin/ doesn't "
+      "exist there. Verify Xcode + the ${_qvac_xcrun_sdk} SDK are "
+      "installed (`xcrun --sdk ${_qvac_xcrun_sdk} --show-sdk-path` "
+      "should resolve).")
+  endif()
+
+  set(_qvac_clang_rtlib
+    "${_qvac_clang_resource_dir}/lib/darwin/libclang_rt.${_qvac_rtlib_variant}.a")
+  if(NOT EXISTS "${_qvac_clang_rtlib}")
+    message(FATAL_ERROR
+      "Apple bare-module link expected compiler-rt at "
+      "'${_qvac_clang_rtlib}' but it doesn't exist. Toolchain layout "
+      "may have changed; pick the correct libclang_rt.<variant>.a "
+      "for ${CMAKE_SYSTEM_NAME} (sysroot: ${CMAKE_OSX_SYSROOT}).")
+  endif()
+  message(STATUS "${addon_target}: force-loading ${_qvac_clang_rtlib} "
+                 "to satisfy clang @available -> __isPlatformVersionAtLeast")
+
+  target_link_options(
+    ${addon_target}_module
+    PRIVATE
+      "SHELL:-Wl,-force_load,${_qvac_clang_rtlib}"
+  )
+endfunction()
+
+# ---------------------------------------------------------------------------
+# qvac_addon_stage_fabric_for_test(<test_target> <fabric_target>)
+#
+# Test-only wiring for a plain add_executable() that links the shared fabric
+# runtime (production .bare modules get this from add_bare_module()):
+#   * GGML_BACKEND_DL / GGML_BACKEND_DIR so backend_env.cpp preloads the ggml
+#     backend modules from the test binary dir,
+#   * copy qvac__fabric@0.bare next to the test binary,
+#   * stage @qvac/fabric's dlopen'd ggml backends (Linux/Android) alongside it,
+#   * $ORIGIN / @loader_path rpath so the copies resolve,
+#   * the Windows delay-load helper the imported module target doesn't carry.
+# ---------------------------------------------------------------------------
+function(qvac_addon_stage_fabric_for_test test_target fabric_target)
+  if((ANDROID OR UNIX) AND NOT APPLE)
+    target_compile_definitions(${test_target} PRIVATE GGML_BACKEND_DL)
+  endif()
+  target_compile_definitions(${test_target} PRIVATE
+    GGML_BACKEND_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+
+  if(WIN32)
+    target_link_libraries(${test_target} PRIVATE bare_delay_load)
+  endif()
+
+  add_custom_command(TARGET ${test_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:${fabric_target}_module>
+      ${CMAKE_CURRENT_BINARY_DIR}/qvac__fabric@0.bare
+    COMMENT "Copying qvac__fabric@0.bare to test directory")
+
+  bare_target(_qvac_host)
+  file(GLOB _qvac_fabric_test_backends
+    "${CMAKE_SOURCE_DIR}/node_modules/@qvac/fabric/prebuilds/${_qvac_host}/qvac__fabric/*.so")
+  if(_qvac_fabric_test_backends)
+    add_custom_command(TARGET ${test_target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${_qvac_fabric_test_backends}
+        ${CMAKE_CURRENT_BINARY_DIR}/
+      COMMENT "Staging @qvac/fabric ggml backends next to ${test_target}")
+  endif()
+
+  if(APPLE)
+    set_target_properties(${test_target} PROPERTIES BUILD_RPATH "@loader_path")
+  elseif(NOT WIN32)
+    set_target_properties(${test_target} PROPERTIES BUILD_RPATH "$ORIGIN")
+  endif()
+endfunction()

--- a/docs/architecture/ADDON-CMAKE-TEMPLATE.md
+++ b/docs/architecture/ADDON-CMAKE-TEMPLATE.md
@@ -7,9 +7,10 @@ boilerplate is extracted.
 Use it when refactoring an addon's build, migrating an addon to the shared
 `@qvac/fabric` runtime, or adding a new addon.
 
-> Status: **proposal / design**. Nothing here is implemented yet. The shared
-> module and CI guard described in "Proposed shared module" and "Keeping addons
-> in sync" do not exist at the time of writing.
+> Status: **partially implemented**. The shared module
+> (`cmake/qvac-addon/qvac-addon.cmake`) exists and `classification-ggml` is
+> migrated to it. The CI drift guard described in "Keeping addons in sync" is
+> not built yet, and no other addon is migrated.
 
 ## Background
 
@@ -89,7 +90,16 @@ New shared blocks introduced by the fabric form (also extract):
 - **Fixed `BACKENDS_SUBDIR = <host>/qvac__fabric`**.
 - **Platform-derived `GGML_BACKEND_DL`**.
 - **Test-harness staging**: copy `.bare` + glob fabric backends next to the test
-  exe, set rpath, win32 delay-load helper, limited-ASan + `ASAN_OPTIONS`.
+  exe, set rpath, win32 delay-load helper. This is **test-only** — the
+  production addon build stages no backends (see note below).
+
+> **The addon never packages ggml backends.** `add_bare_module(… EXPORTS)`
+> exports nothing. On desktop the runtime resolves backends from `@qvac/fabric`'s
+> own `node_modules` prebuilds (`resolveBackendsDir()` in `src/index.ts`); on
+> mobile the app/link bundling co-locates the `.bare` modules and their backends
+> (the addon's `__dirname/prebuilds` fallback just points at wherever that
+> bundling landed them). The only backend copying in the package is the
+> **test** harness staging backends next to the test binary.
 
 ### Addon-specific (keep as explicit customization points)
 
@@ -110,9 +120,22 @@ New shared blocks introduced by the fabric form (also extract):
 | Concern | Consequence if missing | Fix |
 |---|---|---|
 | `if(TARGET ggml::…)` backend guard | `add_bare_module` `get_target_property()` errors on some feature sets | Removed entirely by fabric form (no backend loop) |
-| Android 16 KB page-size link flags | addon fails to load on Pixel 9-class devices | Applied uniformly in `qvac_addon_finalize` |
-| Apple `compiler-rt` `force_load` (Xcode 16 `__isPlatformVersionAtLeast`) | module aborts at first `@available` call | Applied uniformly in `qvac_addon_finalize` |
-| lint-cpp `.valgrind.supp` / pre-commit hook | inconsistent local dev hooks | Applied uniformly in `qvac_addon_project_setup` |
+| Android 16 KB page-size link flags | addon fails to load on Pixel 9-class devices | Applied unconditionally in `qvac_addon_finalize` |
+| Apple `compiler-rt` `force_load` (Xcode 16 `__isPlatformVersionAtLeast`) | module aborts at first `@available` call | Applied unconditionally in `qvac_addon_finalize` |
+| lint-cpp `.valgrind.supp` / pre-commit hook | inconsistent local dev hooks | Opt-in flags on `qvac_addon_project_setup` |
+
+> **The Android page-size and Apple `compiler-rt` fixes are folded into
+> `qvac_addon_finalize` unconditionally** to normalize the drift: every migrated
+> addon gets them, so none can silently regress. They are platform-guarded
+> (`if(ANDROID)` / `if(APPLE)`), so they are no-ops where they don't apply. This
+> is a deliberate **behavior change** for addons (like `classification-ggml`)
+> that previously lacked them — that's the point. The Apple block resolves the
+> exact `libclang_rt.<variant>.a` via `xcrun` and `FATAL_ERROR`s with an
+> actionable message if Xcode's SDK is missing, matching the proven
+> parakeet/tts implementation. They live in dedicated helpers
+> (`qvac_addon_android_page_size` / `qvac_addon_apple_force_load_compiler_rt`)
+> that `finalize` calls, so a rare addon that must opt out can call the pieces
+> directly instead.
 
 ## Proposed shared module
 
@@ -130,26 +153,35 @@ cmake/qvac-addon/qvac-addon.cmake
 Included from an addon via `../../cmake/qvac-addon/qvac-addon.cmake` (consistent
 with the existing `../../vcpkg-overlays` relative path assumption).
 
-Function surface (plain functions/macros, so nothing is locked away):
+Function surface (plain functions/macros, so nothing is locked away). The
+pre-/post-`project()` helpers are **macros** because they must set directory-scope
+state (`VCPKG_MANIFEST_FEATURES`, the vcpkg toolchain, `ANDROID_STL`,
+`CMAKE_CXX_STANDARD`, the fabric target var) in the addon's own scope:
 
-- `qvac_addon_preproject([FEATURES <opt>…])` — pre-`project()` setup: options,
-  vcpkg feature mapping, `cmake-bare`/`cmake-vcpkg`, overlay triplets, Android
-  STL. Must run before `project()`.
-- `qvac_addon_project_setup()` — libc++ on Linux, lint-cpp sync, C++20 block,
-  WIN32 defs. Runs after `project()`.
-- `qvac_addon_use_fabric(OUT_TARGET <var> OUT_SUBDIR <var>)` — fabric discovery
-  (`set(qvac-fabric_DIR …)` + `find_package` + `include_bare_module`) and the
-  fixed `<host>/qvac__fabric` `BACKENDS_SUBDIR` value.
+- `qvac_addon_preproject()` (macro) — pre-`project()` setup: `BUILD_TESTING` /
+  `ENABLE_COVERAGE` options, `tests` vcpkg feature, `cmake-bare`/`cmake-vcpkg`,
+  overlay triplets, Android STL, version stamp. Addon-specific options / vcpkg
+  features are declared by the addon around this call (still before `project()`).
+- `qvac_addon_project_setup([VALGRIND_SUPP] [PRE_COMMIT_HOOK])` (macro) — libc++
+  on Linux, lint-cpp `.clang-format`/`.clang-tidy` sync (the `.valgrind.supp`
+  file and pre-commit hook are opt-in), C++20 block, WIN32 defs.
+- `qvac_addon_use_fabric()` (macro) — fabric discovery (`set(qvac-fabric_DIR …)`
+  + `find_package` + `include_bare_module`). Sets `qvac_fabric_target` and
+  `BACKENDS_SUBDIR_VALUE` (`<host>/qvac__fabric`) in the caller's scope.
 - `qvac_addon_link_fabric(<addon_target> <fabric_target>)` — the two-target link
   split (`qvac-fabric::headers` on the lib, `${fabric_target}_module` on the
   module).
-- `qvac_addon_finalize(<addon_target> SUBDIR <value>)` — everything applied to
-  every module: `--exclude-libs,ALL`, `JS_LOGGER`, `BACKENDS_SUBDIR` define,
-  platform-derived `GGML_BACKEND_DL`, Android page-size flags, Apple
-  `compiler-rt` `force_load`.
-- `qvac_addon_stage_fabric_for_test(<test_target>)` — copy `qvac__fabric@0.bare`
-  + glob fabric backends next to the test binary, set `$ORIGIN`/`@loader_path`
-  rpath, link `bare_delay_load` on win32, apply limited-ASan.
+- `qvac_addon_finalize(<addon_target> [SUBDIR <value>])` — everything applied to
+  every module: Linux `--exclude-libs,ALL`, `JS_LOGGER`, `BACKENDS_SUBDIR`
+  define, platform-derived `GGML_BACKEND_DL`, and (via dedicated helpers it
+  calls) the Android 16 KB page-size flags and Apple `compiler-rt` `force_load`.
+  The two platform fixes are also exposed as standalone helpers
+  (`qvac_addon_android_page_size` / `qvac_addon_apple_force_load_compiler_rt`)
+  for the rare addon that needs to opt out of `finalize` and wire them by hand.
+- `qvac_addon_stage_fabric_for_test(<test_target> <fabric_target>)` — test-only:
+  `GGML_BACKEND_DL`/`GGML_BACKEND_DIR`, copy `qvac__fabric@0.bare` + glob fabric
+  backends next to the test binary, set `$ORIGIN`/`@loader_path` rpath, link
+  `bare_delay_load` on win32. (ASan and coverage stay in the addon's test file.)
 
 ### Target template skeleton
 
@@ -166,8 +198,7 @@ find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS
   "inference-addon-cpp/JsInterface.hpp" REQUIRED)
 find_path(STB_INCLUDE_DIRS "stb_image.h" REQUIRED)          # addon-specific
 
-qvac_addon_use_fabric(OUT_TARGET qvac_fabric_target
-                      OUT_SUBDIR BACKENDS_SUBDIR_VALUE)
+qvac_addon_use_fabric()   # sets qvac_fabric_target + BACKENDS_SUBDIR_VALUE
 
 add_bare_module(classification-ggml EXPORTS)
 
@@ -186,7 +217,7 @@ if(BUILD_TESTING)
   find_package(GTest CONFIG REQUIRED)
   include(GoogleTest)
   enable_testing()
-  add_subdirectory(test/unit)   # calls qvac_addon_stage_fabric_for_test(addon-test)
+  add_subdirectory(test/unit)   # calls qvac_addon_stage_fabric_for_test(addon-test ${qvac_fabric_target})
 endif()
 ```
 
@@ -239,17 +270,22 @@ migration PR also be its template-adoption PR.
 
 1. Land `classification-ggml` fabric migration ([PR #3301][pr3301]) as the
    reference shape.
-2. Add `cmake/qvac-addon/qvac-addon.cmake` + the CI drift guard with no behavior
-   change, extracting only the blocks the reference already proves.
+2. Add `cmake/qvac-addon/qvac-addon.cmake` and migrate `classification-ggml`.
+   `finalize` folds in the Android page-size + Apple `compiler-rt` fixes
+   unconditionally — a deliberate behavior change that normalizes the drift, so
+   addons that lacked them now get them.
 3. Migrate + adopt per addon, starting with the direct-ggml consumers
    (`vla-ggml`, `ocr-ggml`, `translation-nmtcpp`), then the llama addons once
    fabric's llama packaging is ready.
 
 ## Open questions
 
-- Where the module lives long-term: repo-root `cmake/qvac-addon/` (recommended,
-  consistent with `vcpkg-overlays/`) vs. shipping it inside the `cmake-bare` /
-  `cmake-vcpkg` npm packages for consumption outside the monorepo.
-- Whether the mobile packaging path (which stages fabric backends into the
-  addon's own prebuilds as a fallback for `resolveBackendsDir()`) needs its own
-  helper or folds into `qvac_addon_finalize`.
+- Whether to ship the module inside the `cmake-bare` / `cmake-vcpkg` npm
+  packages later, for consumption outside the monorepo. (Location is decided:
+  repo-root `cmake/qvac-addon/`, consistent with `vcpkg-overlays/`.)
+- When parakeet / tts migrate, they must **drop their inline** Android
+  page-size + Apple `compiler-rt` blocks and rely on `finalize` (avoid
+  double-application). Their extra Apple `-Wl,-exported_symbol` flags and
+  `symbols.map` version-script stay addon-specific for now.
+- Building the CI drift guard (`scripts/check-addon-cmake.mjs`) before the second
+  addon migrates, so re-inlined boilerplate can't creep back.

--- a/docs/architecture/ADDON-CMAKE-TEMPLATE.md
+++ b/docs/architecture/ADDON-CMAKE-TEMPLATE.md
@@ -1,0 +1,255 @@
+# Addon CMake Template
+
+This document proposes a shared `CMakeLists.txt` template for the QVAC native
+inference addons and a strategy for keeping the addons in sync once the
+boilerplate is extracted.
+
+Use it when refactoring an addon's build, migrating an addon to the shared
+`@qvac/fabric` runtime, or adding a new addon.
+
+> Status: **proposal / design**. Nothing here is implemented yet. The shared
+> module and CI guard described in "Proposed shared module" and "Keeping addons
+> in sync" do not exist at the time of writing.
+
+## Background
+
+Each addon under `packages/` ships a Bare native module built on the shared
+`inference-addon-cpp` interface header via `cmake-bare` + `cmake-vcpkg`. The
+addons were developed as independent repos and merged into the monorepo, so
+their `CMakeLists.txt` files share a large boilerplate spine but have drifted in
+small, mostly accidental ways.
+
+Two forces make consolidation worthwhile now:
+
+1. The boilerplate is copy-pasted ~40–60 lines per file across ~12 files, and
+   several fixes (Android 16 KB page size, Apple `compiler-rt` `force_load`, the
+   `if(TARGET ggml::…)` backend guard) were applied unevenly — latent bugs, not
+   intentional differences.
+2. The **fabric migration** (see [PR #3301][pr3301]) changes how the ggml
+   runtime is linked. This removes the single largest drift-prone block (the
+   per-addon ggml backend collection loop) and replaces it with a smaller,
+   uniform "consume a shared prebuilt runtime" block. The template should be
+   built around the post-migration form, not the legacy static-ggml form.
+
+[pr3301]: https://github.com/tetherto/qvac/pull/3301
+
+## The fabric migration changes the build shape
+
+Legacy form: statically link ggml from the `qvac-fabric` vcpkg port and copy
+every ggml backend into each addon's `prebuilds/`.
+
+New form ([PR #3301][pr3301], `classification-ggml`): consume the `@qvac/fabric`
+npm prebuild and dynamically link one shared `.bare` module. The runtime and its
+backends ship **once** per process, not once per addon.
+
+Concretely, relative to the legacy `classification-ggml/CMakeLists.txt`:
+
+| Legacy | New |
+|---|---|
+| `find_package(ggml CONFIG REQUIRED)` | `set(qvac-fabric_DIR …/node_modules/@qvac/fabric/prebuilds/share/qvac-fabric/cmake)` + `find_package(qvac-fabric CONFIG REQUIRED)` + `include_bare_module("@qvac/fabric" qvac_fabric_target PREBUILD)` |
+| `foreach(_backend ${GGML_AVAILABLE_BACKENDS}) … INSTALL TARGET ggml::${_backend}` loop feeding `add_bare_module(… EXPORTS ${BACKEND_DL_LIBS})` | **deleted**; `add_bare_module(… EXPORTS)` (no exports) |
+| `BACKENDS_SUBDIR = ${bare_target_value}/${module_name}` (per-addon) | `BACKENDS_SUBDIR = ${bare_target_value}/qvac__fabric` (fixed, points at fabric's shared backend dir) |
+| `target_link_libraries(${tgt} PRIVATE ggml::ggml ggml::ggml-base)` + conditional `ggml::ggml-cpu` | `target_link_libraries(${tgt} PRIVATE qvac-fabric::headers)` (headers on lib target) **and** `target_link_libraries(${tgt}_module PRIVATE ${qvac_fabric_target}_module)` (dynamic link on module target) |
+| `if(GGML_BACKEND_DL)` (read from the ggml vcpkg var) | `if((ANDROID OR UNIX) AND NOT APPLE)` (platform-derived; the ggml var no longer exists) |
+| `vcpkg.json` depends on `qvac-fabric` | dependency removed; JS gains `resolveBackendsDir()` |
+| test links `ggml::*` | test links `qvac-fabric::headers` + `${qvac_fabric_target}_module`, stages the `.bare` + backends next to the test exe, sets `$ORIGIN`/`@loader_path` rpath, links `bare_delay_load` on win32, and runs limited-ASan with `ASAN_OPTIONS=alloc_dealloc_mismatch=0:detect_leaks=0` |
+
+Net effect on the template: the migration **shrinks** the common surface and
+removes most of the drift-prone code, while adding a small, uniform runtime-
+consumer block and a non-trivial test-harness staging block.
+
+## Common vs. addon-specific
+
+### Common spine (extract into shared helpers)
+
+Present, in the same order, in essentially every addon:
+
+- `cmake_minimum_required(VERSION 3.25)`.
+- Options + vcpkg feature mapping (`BUILD_TESTING` / `ENABLE_COVERAGE` →
+  `VCPKG_MANIFEST_FEATURES "tests"`).
+- `find_package(cmake-bare …)` + `find_package(cmake-vcpkg …)` from
+  `node_modules`.
+- `VCPKG_OVERLAY_TRIPLETS` prepend of `../../vcpkg-overlays/triplets`.
+- Android STL set before `project()`.
+- libc++ on Linux (`-stdlib=libc++`, `-static-libstdc++`).
+- lint-cpp sync (`configure_file` of `.clang-format` / `.clang-tidy` /
+  `.valgrind.supp` / pre-commit hook).
+- C++20 block (`CMAKE_CXX_STANDARD 20`, `EXTENSIONS OFF`, `PIC ON`).
+- `WIN32` → `-DNOMINMAX -DWIN32_LEAN_AND_MEAN -DNOGDI`.
+- `find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS …)`.
+- Linux `-Wl,--exclude-libs,ALL` symbol hygiene.
+- `JS_LOGGER` + `BACKENDS_SUBDIR` compile definitions.
+
+New shared blocks introduced by the fabric form (also extract):
+
+- **Runtime discovery**: `set(qvac-fabric_DIR …)` + `find_package(qvac-fabric)`
+  + `include_bare_module`.
+- **Two-target link split**: `::headers` on the lib target, `_module` on the
+  module target.
+- **Fixed `BACKENDS_SUBDIR = <host>/qvac__fabric`**.
+- **Platform-derived `GGML_BACKEND_DL`**.
+- **Test-harness staging**: copy `.bare` + glob fabric backends next to the test
+  exe, set rpath, win32 delay-load helper, limited-ASan + `ASAN_OPTIONS`.
+
+### Addon-specific (keep as explicit customization points)
+
+- Module name and `project()` languages.
+- Source file list (`target_sources`).
+- Extra upstream libs layered on top of fabric (e.g. `llama::llama` /
+  `llama::mtmd`, `bergamot-translator`, `sentencepiece`/`protobuf`) and extra
+  third-party deps (OpenCV, STB, picojson, nlohmann, concurrentqueue).
+- Addon-specific options and vcpkg features (`VK_PROFILING`, `USE_BERGAMOT`,
+  `USE_OPENCL`, `ENABLE_VULKAN`, …).
+- Mobile static-link fallback where applicable.
+- Genuinely exotic per-package logic (nmt's sentencepiece fallback chain,
+  parakeet's Android strip + `symbols.map`, etc.) — handled by adding CMake
+  after the shared calls, never hidden.
+
+### Accidental drift the template eliminates
+
+| Concern | Consequence if missing | Fix |
+|---|---|---|
+| `if(TARGET ggml::…)` backend guard | `add_bare_module` `get_target_property()` errors on some feature sets | Removed entirely by fabric form (no backend loop) |
+| Android 16 KB page-size link flags | addon fails to load on Pixel 9-class devices | Applied uniformly in `qvac_addon_finalize` |
+| Apple `compiler-rt` `force_load` (Xcode 16 `__isPlatformVersionAtLeast`) | module aborts at first `@available` call | Applied uniformly in `qvac_addon_finalize` |
+| lint-cpp `.valgrind.supp` / pre-commit hook | inconsistent local dev hooks | Applied uniformly in `qvac_addon_project_setup` |
+
+## Proposed shared module
+
+Precedent already exists in-repo: `.clang-format` / `.clang-tidy` are kept in
+sync by copying from a single `lint-cpp` source, and triplets are shared via
+`../../vcpkg-overlays/triplets`. Extend that model to the build logic.
+
+Location: a committed, versioned module at repo root, resolved the same way
+triplets are.
+
+```
+cmake/qvac-addon/qvac-addon.cmake
+```
+
+Included from an addon via `../../cmake/qvac-addon/qvac-addon.cmake` (consistent
+with the existing `../../vcpkg-overlays` relative path assumption).
+
+Function surface (plain functions/macros, so nothing is locked away):
+
+- `qvac_addon_preproject([FEATURES <opt>…])` — pre-`project()` setup: options,
+  vcpkg feature mapping, `cmake-bare`/`cmake-vcpkg`, overlay triplets, Android
+  STL. Must run before `project()`.
+- `qvac_addon_project_setup()` — libc++ on Linux, lint-cpp sync, C++20 block,
+  WIN32 defs. Runs after `project()`.
+- `qvac_addon_use_fabric(OUT_TARGET <var> OUT_SUBDIR <var>)` — fabric discovery
+  (`set(qvac-fabric_DIR …)` + `find_package` + `include_bare_module`) and the
+  fixed `<host>/qvac__fabric` `BACKENDS_SUBDIR` value.
+- `qvac_addon_link_fabric(<addon_target> <fabric_target>)` — the two-target link
+  split (`qvac-fabric::headers` on the lib, `${fabric_target}_module` on the
+  module).
+- `qvac_addon_finalize(<addon_target> SUBDIR <value>)` — everything applied to
+  every module: `--exclude-libs,ALL`, `JS_LOGGER`, `BACKENDS_SUBDIR` define,
+  platform-derived `GGML_BACKEND_DL`, Android page-size flags, Apple
+  `compiler-rt` `force_load`.
+- `qvac_addon_stage_fabric_for_test(<test_target>)` — copy `qvac__fabric@0.bare`
+  + glob fabric backends next to the test binary, set `$ORIGIN`/`@loader_path`
+  rpath, link `bare_delay_load` on win32, apply limited-ASan.
+
+### Target template skeleton
+
+```cmake
+cmake_minimum_required(VERSION 3.25)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/qvac-addon/qvac-addon.cmake)
+qvac_addon_preproject()
+
+project(classification-ggml LANGUAGES C CXX)
+qvac_addon_project_setup()
+
+find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS
+  "inference-addon-cpp/JsInterface.hpp" REQUIRED)
+find_path(STB_INCLUDE_DIRS "stb_image.h" REQUIRED)          # addon-specific
+
+qvac_addon_use_fabric(OUT_TARGET qvac_fabric_target
+                      OUT_SUBDIR BACKENDS_SUBDIR_VALUE)
+
+add_bare_module(classification-ggml EXPORTS)
+
+target_sources(${classification-ggml} PRIVATE ...)          # addon-specific
+target_include_directories(${classification-ggml} PRIVATE
+  ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS} ${STB_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/addon/src)
+
+qvac_addon_link_fabric(${classification-ggml} ${qvac_fabric_target})
+# addon-specific extra libs, if any:
+# target_link_libraries(${classification-ggml} PRIVATE llama::llama ...)
+
+qvac_addon_finalize(${classification-ggml} SUBDIR "${BACKENDS_SUBDIR_VALUE}")
+
+if(BUILD_TESTING)
+  find_package(GTest CONFIG REQUIRED)
+  include(GoogleTest)
+  enable_testing()
+  add_subdirectory(test/unit)   # calls qvac_addon_stage_fabric_for_test(addon-test)
+endif()
+```
+
+## Keeping addons in sync
+
+1. **Single source of truth + version stamp.** A `QVAC_ADDON_CMAKE_VERSION` in
+   the module, echoed via `message(STATUS)` in `qvac_addon_preproject`, so drift
+   is visible in build logs.
+2. **CI drift guard.** A script (e.g. `scripts/check-addon-cmake.mjs`, run in the
+   `on-pr-*` workflows) that asserts every migrated `packages/*/CMakeLists.txt`:
+   - includes the shared module and calls `qvac_addon_finalize`, and
+   - does **not** re-inline the extracted blocks — fail on sentinels like
+     `__isPlatformVersionAtLeast`, `max-page-size=16384`, `--exclude-libs,ALL`,
+     or a raw `GGML_AVAILABLE_BACKENDS` loop appearing outside
+     `cmake/qvac-addon/`.
+   This is the mechanism that actually prevents regression.
+3. **Reuse the lint-cpp precedent** for parts already synced (`.clang-format` /
+   `.clang-tidy`); the module just wraps the existing `configure_file` calls.
+4. **Template file + scaffolder.** A `cmake/qvac-addon/CMakeLists.template.txt`
+   (or a `qv-addon-*` skill) so new addons start from the canonical shape.
+5. **Optional golden test.** Render the template with a fixture and diff it, so
+   intentional template changes are reviewed deliberately.
+
+## Phase 1 scope and sequencing
+
+Phase 1 targets only the addons that build `qvac-fabric` from the vcpkg port
+today (the direct consumers migrating to the `@qvac/fabric` npm prebuild). Other
+ggml variants (whisper.cpp / parakeet / tts-cpp / stable-diffusion — separate
+vcpkg ports) and the ONNX addons (being phased out) are **out of scope**.
+
+Phase 1 packages (vcpkg.json depends on `qvac-fabric`):
+
+- `packages/classification-ggml` — reference, [PR #3301][pr3301].
+- `packages/vla-ggml`
+- `packages/ocr-ggml`
+- `packages/translation-nmtcpp`
+- `packages/llm-llamacpp`
+- `packages/embed-llamacpp`
+
+> The llama addons (`llm-llamacpp`, `embed-llamacpp`) consume `llama::*` targets
+> that also come from the `qvac-fabric` port. Their migration additionally
+> depends on `@qvac/fabric` exposing the llama layer with ggml linked
+> dynamically — a fabric-packaging question that may gate their order relative
+> to the direct-ggml addons.
+
+Sequencing principle: **template adoption == fabric migration**. Do not
+templatize the dying static-ggml backend loop and then delete it; build the
+shared module around the post-migration form and let each addon's fabric-
+migration PR also be its template-adoption PR.
+
+1. Land `classification-ggml` fabric migration ([PR #3301][pr3301]) as the
+   reference shape.
+2. Add `cmake/qvac-addon/qvac-addon.cmake` + the CI drift guard with no behavior
+   change, extracting only the blocks the reference already proves.
+3. Migrate + adopt per addon, starting with the direct-ggml consumers
+   (`vla-ggml`, `ocr-ggml`, `translation-nmtcpp`), then the llama addons once
+   fabric's llama packaging is ready.
+
+## Open questions
+
+- Where the module lives long-term: repo-root `cmake/qvac-addon/` (recommended,
+  consistent with `vcpkg-overlays/`) vs. shipping it inside the `cmake-bare` /
+  `cmake-vcpkg` npm packages for consumption outside the monorepo.
+- Whether the mobile packaging path (which stages fabric backends into the
+  addon's own prebuilds as a fallback for `resolveBackendsDir()`) needs its own
+  helper or folds into `qvac_addon_finalize`.

--- a/packages/classification-ggml/CMakeLists.txt
+++ b/packages/classification-ggml/CMakeLists.txt
@@ -1,70 +1,22 @@
 cmake_minimum_required(VERSION 3.25)
 
-option(BUILD_TESTING "Build tests" OFF)
-option(ENABLE_COVERAGE "Enable coverage instrumentation for unit tests" OFF)
-if(BUILD_TESTING)
-  list(APPEND VCPKG_MANIFEST_FEATURES "tests")
-endif()
-
-find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
-find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
-
-set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
-
-# Android STL configuration must be set before project()
-if(DEFINED ENV{ANDROID_NDK} OR DEFINED ENV{ANDROID_NDK_HOME})
-  set(ANDROID_STL c++_shared)
-endif()
+# Shared addon build helpers. See docs/architecture/ADDON-CMAKE-TEMPLATE.md.
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/qvac-addon/qvac-addon.cmake)
+qvac_addon_preproject()
 
 project(classification-ggml LANGUAGES C CXX)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  add_compile_options(-stdlib=libc++)
-  add_link_options(-stdlib=libc++ -static-libstdc++)
-endif()
-
-find_path(VCPKG_INSTALLED_PATH share/lint-cpp/.clang-format REQUIRED)
-configure_file(${VCPKG_INSTALLED_PATH}/share/lint-cpp/.clang-format
-               ${CMAKE_CURRENT_SOURCE_DIR}/.clang-format COPYONLY)
-configure_file(${VCPKG_INSTALLED_PATH}/share/lint-cpp/.clang-tidy
-               ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy COPYONLY)
-
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-if(WIN32)
-  add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -DNOGDI)
-endif()
+qvac_addon_project_setup()
 
 find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS
   "inference-addon-cpp/JsInterface.hpp" REQUIRED)
 find_path(STB_INCLUDE_DIRS "stb_image.h" REQUIRED)
 
-# The ggml runtime is provided by @qvac/fabric (npm dependency) instead of being
-# statically linked from the qvac-fabric vcpkg port. It ships the headers
-# (qvac-fabric::headers) and a single shared .bare module that this addon
-# dynamically links against, so the runtime is loaded once per process. All
-# platforms (desktop and mobile) use this dynamic-linking model.
-set(qvac-fabric_DIR "${CMAKE_CURRENT_SOURCE_DIR}/node_modules/@qvac/fabric/prebuilds/share/qvac-fabric/cmake")
-find_package(qvac-fabric CONFIG REQUIRED)
-
-include_bare_module("@qvac/fabric" qvac_fabric_target PREBUILD)
-
-bare_target(bare_target_value)
-# The ggml compute backends live under @qvac/fabric's own prebuilds subdir
-# (prebuilds/<host>/qvac__fabric), not a per-addon copy. BACKENDS_SUBDIR is the
-# "<host>/qvac__fabric" path the addon appends to the runtime-provided
-# backendsDir (see index.js) when calling ggml_backend_load_all_from_path().
-set(BACKENDS_SUBDIR_VALUE "${bare_target_value}/qvac__fabric")
-message(STATUS "Building classification-ggml with BACKENDS_SUBDIR='${BACKENDS_SUBDIR_VALUE}'")
+# ggml runtime is the shared @qvac/fabric prebuild (dynamically linked, loaded
+# once per process); sets qvac_fabric_target + BACKENDS_SUBDIR_VALUE.
+qvac_addon_use_fabric()
 
 add_bare_module(classification-ggml EXPORTS)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_options(${classification-ggml}_module PRIVATE -Wl,--exclude-libs,ALL)
-endif()
 
 set(ADDON_SOURCES
   ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
@@ -87,37 +39,9 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/addon/src
 )
 
-# Compile against the ggml headers...
-target_link_libraries(
-  ${classification-ggml}
-  PRIVATE
-    qvac-fabric::headers
-)
-# ...and dynamically link the shared runtime (DT_NEEDED qvac__fabric@0.bare).
-target_link_libraries(
-  ${classification-ggml}_module
-  PRIVATE
-    ${qvac_fabric_target}_module
-)
+qvac_addon_link_fabric(${classification-ggml} ${qvac_fabric_target})
 
-target_compile_definitions(
-  ${classification-ggml}
-  PRIVATE
-    JS_LOGGER
-    BACKENDS_SUBDIR="${BACKENDS_SUBDIR_VALUE}"
-)
-
-# On Linux and Android @qvac/fabric ships the ggml compute backends as separate
-# GGML_BACKEND_DL modules (CPU micro-arch variants, Vulkan) that must be dlopen'd
-# at runtime; tell the addon so load() loads them from backendsDir before
-# querying the backend registry. On macOS/Windows/iOS the backends are static
-# inside qvac__fabric@0.bare and self-register on load, so no dlopen is needed.
-# Either way load() acquires the CPU device via the generic registry API
-# (ggml_backend_dev_by_type); it never calls ggml_backend_cpu_init() directly,
-# which @qvac/fabric does not export from its Windows DLL.
-if((ANDROID OR UNIX) AND NOT APPLE)
-  target_compile_definitions(${classification-ggml} PRIVATE GGML_BACKEND_DL)
-endif()
+qvac_addon_finalize(${classification-ggml} SUBDIR "${BACKENDS_SUBDIR_VALUE}")
 
 if(BUILD_TESTING)
   find_package(GTest CONFIG REQUIRED)

--- a/packages/classification-ggml/scripts/run-cpp-tests.js
+++ b/packages/classification-ggml/scripts/run-cpp-tests.js
@@ -7,14 +7,35 @@ const { spawnSync } = require('child_process')
 const binary = os.platform() === 'win32' ? 'addon-test.exe' : './addon-test'
 const cwd = path.resolve(__dirname, '..', 'build', 'test', 'unit')
 
+// addon-test links AddressSanitizer but dynamically loads the non-ASan,
+// -static-libstdc++ @qvac/fabric prebuild. Objects that cross that module
+// boundary trip alloc-dealloc-mismatch, and fabric's long-lived runtime globals
+// plus its dlopen'd ggml backends look like leaks at exit -- both fire after
+// every test has already passed. Relax exactly those two checks, matching
+// .github/workflows/cpp-tests-classification.yml. An ASAN_OPTIONS already in
+// the environment wins, so CI and ad-hoc overrides stay authoritative.
+// See test/unit/CMakeLists.txt for the full rationale.
+const DEFAULT_ASAN_OPTIONS = 'alloc_dealloc_mismatch=0:detect_leaks=0:abort_on_error=1'
+
 const result = spawnSync(binary, ['--gtest_output=xml:cpp-test-results.xml'], {
   cwd,
   stdio: 'inherit',
-  shell: false
+  shell: false,
+  env: {
+    ...process.env,
+    ASAN_OPTIONS: process.env.ASAN_OPTIONS || DEFAULT_ASAN_OPTIONS
+  }
 })
 
 if (result.error) {
   throw result.error
 }
 
-process.exit(result.status || 0)
+// abort_on_error=1 makes a genuine sanitizer finding raise SIGABRT, which
+// leaves status null -- report those as a failure instead of exiting 0.
+if (result.signal) {
+  console.error(`addon-test terminated by signal ${result.signal}`)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 1)

--- a/packages/classification-ggml/test/unit/CMakeLists.txt
+++ b/packages/classification-ggml/test/unit/CMakeLists.txt
@@ -21,24 +21,6 @@ target_compile_features(addon-test PRIVATE cxx_std_20)
 target_compile_options(addon-test PRIVATE -Wall -Wextra -Wfatal-errors -g)
 target_compile_definitions(addon-test PRIVATE GTEST_HAS_POSIX_RE=0)
 
-# @qvac/fabric ships the ggml compute backends as GGML_BACKEND_DL modules on
-# Linux and Android (the CPU micro-arch variants and Vulkan). Compile the model
-# TU with GGML_BACKEND_DL there so it uses the registry API instead of the
-# statically-linked ggml_backend_cpu_init() (which lives inside a backend .so
-# and is not present in the shared runtime). On macOS/Windows the backends are
-# static inside qvac__fabric@0.bare and ggml_backend_cpu_init() links directly.
-if((ANDROID OR UNIX) AND NOT APPLE)
-  target_compile_definitions(addon-test PRIVATE GGML_BACKEND_DL)
-endif()
-
-# backend_env.cpp preloads the ggml DL backend modules from GGML_BACKEND_DIR
-# before any test runs. The staged @qvac/fabric backends are copied next to the
-# test binary (see below), so point the loader at the binary dir. On
-# macOS/Windows the dir has no backend .so files and the static backends inside
-# qvac__fabric@0.bare self-register on load.
-target_compile_definitions(
-  addon-test PRIVATE GGML_BACKEND_DIR="${CMAKE_CURRENT_BINARY_DIR}")
-
 # ClassificationModel.cpp references BACKENDS_SUBDIR on its DL load path. The
 # addon target defines it, but addon-test compiles that TU separately. The test
 # passes an empty backendsDir (backends are preloaded by backend_env), so the
@@ -66,16 +48,9 @@ target_link_libraries(
     GTest::gtest_main
 )
 
-if(WIN32)
-  # The fabric runtime is delay-loaded: the imported prebuilt module target
-  # propagates /DELAYLOAD:qvac__fabric@0.bare but not the delay-load helper.
-  # add_bare_module() attaches that helper (bare_delay_load -> delayimp, which
-  # provides __delayLoadHelper2) to real .bare modules, but this standalone test
-  # executable is a plain add_executable() and never goes through it, so it must
-  # link the helper itself. The parent CMakeLists defines bare_delay_load via its
-  # add_bare_module(classification-ggml) call before this subdirectory is added.
-  target_link_libraries(addon-test PRIVATE bare_delay_load)
-endif()
+# GGML_BACKEND_DL/DIR, copy qvac__fabric@0.bare + backends next to the binary,
+# rpath, and the win32 delay-load helper. See qvac-addon.cmake for the details.
+qvac_addon_stage_fabric_for_test(addon-test ${qvac_fabric_target})
 
 if(ENABLE_COVERAGE)
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
@@ -105,46 +80,6 @@ endif()
 # initializes before the fabric module loads.
 if(NOT WIN32)
   target_link_libraries(addon-test PRIVATE -fsanitize=address)
-endif()
-
-# Copy the shared @qvac/fabric runtime next to the test executable so it
-# resolves at runtime via the $ORIGIN/@loader_path rpath set below.
-add_custom_command(TARGET addon-test POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    $<TARGET_FILE:${qvac_fabric_target}_module>
-    ${CMAKE_CURRENT_BINARY_DIR}/qvac__fabric@0.bare
-  COMMENT "Copying qvac__fabric@0.bare to test directory"
-)
-
-# On Linux and Android @qvac/fabric builds its ggml compute backends as separate
-# shared libraries (GGML_BACKEND_DL): the runtime-dispatched CPU micro-arch
-# variants (and Vulkan) are dlopen'd at runtime via
-# ggml_backend_load_all_from_path(). backend_env.cpp loads them from
-# GGML_BACKEND_DIR (this binary dir), so stage them next to the executable,
-# mirroring the production install in the parent CMakeLists. Without them the
-# ggml backend registry is empty and every model-loading test fails with "no
-# backends are loaded". On macOS/Windows the backends are static inside
-# qvac__fabric@0.bare, so the glob is empty and the CPU backend self-registers
-# when the runtime loads.
-bare_target(host)
-file(GLOB _fabric_test_backends
-  "${CMAKE_SOURCE_DIR}/node_modules/@qvac/fabric/prebuilds/${host}/qvac__fabric/*.so")
-if(_fabric_test_backends)
-  add_custom_command(TARGET addon-test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      ${_fabric_test_backends}
-      ${CMAKE_CURRENT_BINARY_DIR}/
-    COMMENT "Staging @qvac/fabric ggml backends next to addon-test")
-endif()
-
-# The runtime is named qvac__fabric@0.bare (the module SONAME) only in the copy
-# beside the test binary, so point the executable's rpath at its own directory.
-# Unlike the .bare addon module (which cmake-bare gives an $ORIGIN rpath), this
-# plain test executable gets no such rpath by default.
-if(APPLE)
-  set_target_properties(addon-test PROPERTIES BUILD_RPATH "@loader_path")
-elseif(NOT WIN32)
-  set_target_properties(addon-test PROPERTIES BUILD_RPATH "$ORIGIN")
 endif()
 
 add_test(NAME ClassificationModelTests COMMAND addon-test)


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Addon `CMakeLists.txt` files share a large boilerplate spine (vcpkg/cmake-bare setup, fabric linking, platform link flags, test harness staging) that has drifted across packages — fixes like Android 16 KB page-size and Apple `compiler-rt` `force_load` were applied inconsistently.
- `classification-ggml` was the first post-fabric-migration reference shape; that logic lived inline and would be copy-pasted into every other `@qvac/fabric` consumer.

## 📝 How does it solve it?

- Add shared module `cmake/qvac-addon/qvac-addon.cmake` (`QVAC_ADDON_CMAKE_VERSION 0.1.0`) with helpers:
  - `qvac_addon_preproject()` / `qvac_addon_project_setup()` — common pre/post-`project()` boilerplate
  - `qvac_addon_use_fabric()` / `qvac_addon_link_fabric()` — `@qvac/fabric` discovery and two-target link split
  - `qvac_addon_finalize()` — `JS_LOGGER`, `BACKENDS_SUBDIR`, `GGML_BACKEND_DL`, Linux `--exclude-libs,ALL`, plus **unconditional** Android 16 KB page-size and Apple `compiler-rt` `force_load` (normalizes drift; deliberate behavior change for addons that lacked them)
  - `qvac_addon_stage_fabric_for_test()` — test-only fabric runtime + backend staging, rpath, win32 delay-load helper
- Migrate `packages/classification-ggml` production and unit-test `CMakeLists.txt` to the template (~128 → ~52 lines in the root file).
- Document the design, phase-1 scope, and sync strategy in `docs/architecture/ADDON-CMAKE-TEMPLATE.md`.
- Align local C++ test runs with CI in `scripts/run-cpp-tests.js`: default `ASAN_OPTIONS=alloc_dealloc_mismatch=0:detect_leaks=0:abort_on_error=1`, and treat SIGABRT from sanitizer findings as failure (fixes `status === null` exiting 0).

## 🧪 How was it tested?

- `bare-make generate && bare-make build` in `packages/classification-ggml` (Linux)
- `bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test`
- `npm run test:cpp` — 29/29 C++ tests pass, exit 0
- Verified `ASAN_OPTIONS` override still works when set explicitly in the environment
- CI green
