### PR TITLE
chore[notask|skiplog]: backmerge release openclaw-plugin 0.1.2

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.1.2]
+
+Release Date: 2026-07-27
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.2
+
+This patch keeps OpenClaw's existing tools when QVAC setup runs, and moves the plugin onto `@qvac/ai-sdk-provider` 0.4 and `@qvac/cli` 0.9 so local serves pick up the latest SDK and CLI fixes.
+
+### Fixed
+
+- **Preserve tools during QVAC setup.** Enabling the QVAC provider no longer clears tools already configured in OpenClaw.
+
+### Requirements
+
+- [`@qvac/ai-sdk-provider@^0.4.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the shared model catalog.
+- [`@qvac/cli@^0.9.0`](https://www.npmjs.com/package/@qvac/cli) so the local service can run `qvac serve` (SDK 0.16 runtime).
+- Node.js 22 or newer.
+- [`openclaw@>=2026.6.0`](https://www.npmjs.com/package/openclaw) as the host (optional peer).
+
 ## [0.1.1]
 
 Release Date: 2026-07-07

--- a/plugins/openclaw/changelog/0.1.2/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.1.2/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.1.2
+
+Release Date: 2026-07-27
+
+## Fixes
+
+- Preserve OpenClaw tools during QVAC setup so enabling the local QVAC provider no longer clears the agent's existing tool configuration. (see PR [#3320](https://github.com/tetherto/qvac/pull/3320))
+
+## Compatibility
+
+- Depends on `@qvac/ai-sdk-provider@^0.4.0` and `@qvac/cli@^0.9.0` so installs resolve the AI SDK 7 provider and the CLI 0.9 / SDK 0.16 serve runtime.
+- Requires Node.js 22 or newer (aligned with `@qvac/ai-sdk-provider` 0.4).

--- a/plugins/openclaw/changelog/0.1.2/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.1.2/CHANGELOG_LLM.md
@@ -1,0 +1,20 @@
+# QVAC OpenClaw Plugin v0.1.2 Release Notes
+
+Release Date: 2026-07-27
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.2
+
+This patch keeps OpenClaw's existing tools when QVAC setup runs, and moves the plugin onto `@qvac/ai-sdk-provider` 0.4 and `@qvac/cli` 0.9 so local serves pick up the latest SDK and CLI fixes.
+
+## Preserve Tools During QVAC Setup
+
+Enabling the QVAC provider no longer clears tools already configured in OpenClaw. Setup still registers the local QVAC provider and model catalog, but leaves the agent's tool configuration intact.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.4.0` for the shared model catalog (AI SDK 7 line)
+- `@qvac/cli@^0.9.0` for `qvac serve` (SDK 0.16 runtime)
+
+Node.js 22 or newer is required.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     "NOTICE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "qvac",
@@ -60,8 +60,8 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@qvac/ai-sdk-provider": "^0.3.0",
-    "@qvac/cli": "^0.8.0"
+    "@qvac/ai-sdk-provider": "^0.4.0",
+    "@qvac/cli": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Brings the `@qvac/openclaw-plugin` 0.1.2 version bump and changelog from [release PR #3482](https://github.com/tetherto/qvac/pull/3482) onto `main`.

## 📝 How does it solve it?

- Cherry-picks the release commit onto `main`:
  - `plugins/openclaw/package.json` version `0.1.2`, deps `@qvac/ai-sdk-provider@^0.4.0` / `@qvac/cli@^0.9.0`, engines Node 22+
  - `plugins/openclaw/changelog/0.1.2/` and prepended `CHANGELOG.md`
- Tagged `[skiplog]` so this backmerge does not generate another changelog entry.

## 🧪 How was it tested?

- Cherry-pick applied cleanly onto current `main`.
- Diff is limited to the expected openclaw-plugin release artifacts (same shape as prior openclaw backmerge #3099).