### PR TITLE
chore[notask|skiplog]: backmerge release opencode-plugin 0.1.1

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.1]
+
+Release Date: 2026-07-27
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.1.1
+
+This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.4 and `@qvac/cli` 0.9 so managed local serves pick up the AI SDK 7 provider and the latest CLI / SDK fixes.
+
+### Requirements
+
+- [`@qvac/ai-sdk-provider@^0.4.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for managed mode (AI SDK 7).
+- [`@qvac/cli@^0.9.0`](https://www.npmjs.com/package/@qvac/cli) so the host can run `qvac serve` (SDK 0.16 runtime).
+- `@ai-sdk/openai-compatible@^3.0.0` and `ai@^7.0.0`.
+- Node.js 22 or newer.
+
 ## [0.1.0]
 
 Release Date: 2026-06-16

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -124,7 +124,8 @@ running `opencode` from the terminal.
 
 ## Requirements
 
-- [`@qvac/ai-sdk-provider@^0.2.2`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)
-  for managed mode.
-- [`@qvac/cli@^0.7.0`](https://www.npmjs.com/package/@qvac/cli) available so the
-  host can run `qvac serve` (resolved by the provider's managed mode).
+- [`@qvac/ai-sdk-provider@^0.4.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)
+  for managed mode (AI SDK 7).
+- [`@qvac/cli@^0.9.0`](https://www.npmjs.com/package/@qvac/cli) available so the
+  host can run `qvac serve` (SDK 0.16 runtime).
+- Node.js 22 or newer.

--- a/plugins/opencode/changelog/0.1.1/CHANGELOG.md
+++ b/plugins/opencode/changelog/0.1.1/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog v0.1.1
+
+Release Date: 2026-07-27
+
+## Compatibility
+
+- Depends on `@qvac/ai-sdk-provider@^0.4.0` and `@qvac/cli@^0.9.0` so managed OpenCode installs resolve the AI SDK 7 provider and the CLI 0.9 / SDK 0.16 serve runtime.
+- Bumps direct `@ai-sdk/openai-compatible` to `^3.0.0` and `ai` to `^7.0.0` to match the provider peer graph.
+- Requires Node.js 22 or newer.

--- a/plugins/opencode/changelog/0.1.1/CHANGELOG_LLM.md
+++ b/plugins/opencode/changelog/0.1.1/CHANGELOG_LLM.md
@@ -1,0 +1,17 @@
+# QVAC OpenCode Plugin v0.1.1 Release Notes
+
+Release Date: 2026-07-27
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.1.1
+
+This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.4 and `@qvac/cli` 0.9 so managed local serves pick up the AI SDK 7 provider and the latest CLI / SDK fixes.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.4.0` for managed mode
+- `@qvac/cli@^0.9.0` for `qvac serve` (SDK 0.16 runtime)
+- `@ai-sdk/openai-compatible@^3.0.0` and `ai@^7.0.0` for the AI SDK 7 peer graph
+
+Node.js 22 or newer is required. Plugin behavior is unchanged: the host still starts managed QVAC serve, injects the OpenAI-compatible `qvac` provider, and keeps the existing compatibility shim.

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/opencode-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCode plugin that runs a local, managed QVAC serve so `opencode` works against on-device models with no second terminal",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     "NOTICE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "qvac",
@@ -57,10 +57,10 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^2.0.49",
-    "@qvac/ai-sdk-provider": "^0.2.2",
-    "@qvac/cli": "^0.7.0",
-    "ai": "^6.0.202"
+    "@ai-sdk/openai-compatible": "^3.0.0",
+    "@qvac/ai-sdk-provider": "^0.4.0",
+    "@qvac/cli": "^0.9.0",
+    "ai": "^7.0.0"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.16.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Brings the `@qvac/opencode-plugin` 0.1.1 version bump, dependency alignment, README, and changelog from [release PR #3484](https://github.com/tetherto/qvac/pull/3484) onto `main`.

## 📝 How does it solve it?

- Cherry-picks the release commit onto `main`:
  - `plugins/opencode/package.json` version `0.1.1`, deps for provider 0.4 / CLI 0.9 / AI SDK 7, engines Node 22+
  - README requirements update
  - `plugins/opencode/changelog/0.1.1/` and prepended `CHANGELOG.md`
- Tagged `[skiplog]` so this backmerge does not generate another changelog entry.

## 🧪 How was it tested?

- Cherry-pick applied cleanly onto current `main`.
- Diff is limited to the expected opencode-plugin release artifacts.