### PR TITLE
QVAC-22826 feat[api]: sync @qvac/inference with @qvac/sdk 0.16.0

### DIFF
--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/inference",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Bare-only in-process core of the QVAC SDK. Runs inference directly on the Bare runtime with explicit plugin assembly and no RPC, worker, or subprocess layer.",
   "license": "Apache-2.0",
   "repository": {
@@ -171,18 +171,18 @@
   },
   "peerDependencies": {
     "@qvac/bci-whispercpp": "^0.5.0",
-    "@qvac/classification-ggml": "^0.10.2",
+    "@qvac/classification-ggml": "^0.13.0",
     "@qvac/decoder-audio": "^0.5.0",
     "@qvac/diffusion-cpp": "^0.15.0",
-    "@qvac/embed-llamacpp": "^0.26.2",
+    "@qvac/embed-llamacpp": "^0.28.0",
     "@qvac/langdetect-text": "^0.1.2",
-    "@qvac/llm-llamacpp": "^0.36.3",
-    "@qvac/ocr-ggml": "^0.10.2",
+    "@qvac/llm-llamacpp": "^0.38.0",
+    "@qvac/ocr-ggml": "^0.12.1",
     "@qvac/transcription-parakeet": "^0.10.0",
     "@qvac/transcription-whispercpp": "^0.12.0",
-    "@qvac/translation-nmtcpp": "^7.2.2",
+    "@qvac/translation-nmtcpp": "^8.1.0",
     "@qvac/tts-ggml": "^0.5.0",
-    "@qvac/vla-ggml": "^0.11.2"
+    "@qvac/vla-ggml": "^0.14.0"
   },
   "peerDependenciesMeta": {
     "@qvac/bci-whispercpp": {
@@ -227,18 +227,18 @@
   },
   "devDependencies": {
     "@qvac/bci-whispercpp": "^0.5.0",
-    "@qvac/classification-ggml": "^0.10.2",
+    "@qvac/classification-ggml": "^0.13.0",
     "@qvac/decoder-audio": "^0.5.0",
     "@qvac/diffusion-cpp": "^0.15.0",
-    "@qvac/embed-llamacpp": "^0.26.2",
+    "@qvac/embed-llamacpp": "^0.28.0",
     "@qvac/langdetect-text": "^0.1.2",
-    "@qvac/llm-llamacpp": "^0.36.3",
-    "@qvac/ocr-ggml": "^0.10.2",
+    "@qvac/llm-llamacpp": "^0.38.0",
+    "@qvac/ocr-ggml": "^0.12.1",
     "@qvac/transcription-parakeet": "^0.10.0",
     "@qvac/transcription-whispercpp": "^0.12.0",
-    "@qvac/translation-nmtcpp": "^7.2.2",
+    "@qvac/translation-nmtcpp": "^8.1.0",
     "@qvac/tts-ggml": "^0.5.0",
-    "@qvac/vla-ggml": "^0.11.2",
+    "@qvac/vla-ggml": "^0.14.0",
     "@types/brittle": "^3.5.0",
     "bare": "*",
     "bare-console": "*",

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -62,6 +62,10 @@
       "types": "./dist/plugins/index.d.ts",
       "import": "./dist/plugins/index.js"
     },
+    "./plugin-registry": {
+      "types": "./dist/plugins/registry.d.ts",
+      "import": "./dist/plugins/registry.js"
+    },
     "./plugin-utils": {
       "types": "./dist/schemas/plugin.d.ts",
       "import": "./dist/schemas/plugin.js"

--- a/packages/inference/src/handlers/completion-orchestrate.ts
+++ b/packages/inference/src/handlers/completion-orchestrate.ts
@@ -1,0 +1,220 @@
+import type {
+  CompletionOrchestrateRequest,
+  CompletionOrchestrateResponse,
+  CompletionStreamRequest,
+  CompletionStreamResponse
+} from '../schemas/index.ts'
+import { toolCallbackResultSchema, type ToolCallbackResult } from '../schemas/completion-stream.ts'
+import { aggregateEvents } from '../utils/aggregate-events.ts'
+import { CompletionFailedError } from '../errors/index.ts'
+import { dispatchPluginStream } from './plugin-dispatch.ts'
+
+const DEFAULT_MAX_TOOL_TURNS = 8
+
+// Generous ceiling on one client-side tool execution: long enough for a slow
+// MCP round trip, short enough that a client that stopped reading can't pin a
+// model slot forever.
+const TOOL_RESULT_TIMEOUT_MS = 5 * 60 * 1000
+
+// A single tool result is small JSON; anything past this without a newline is a
+// malformed/hostile client trying to grow the buffer without bound. Fail loudly
+// instead of accumulating forever.
+const MAX_TOOL_RESULT_LINE_BYTES = 16 * 1024 * 1024
+
+/**
+ * Reads newline-delimited JSON tool results off the duplex request stream
+ * and resolves per-callId waiters. Chunk boundaries don't align with lines,
+ * so a partial tail is buffered until its newline arrives.
+ *
+ * The pump is torn down by `close()` (called from a `finally` when
+ * orchestration ends, however it ends) so the upstream iterator is returned
+ * and the reader stops holding the request stream open.
+ */
+export class ToolResultReader {
+  private buffer = ''
+  private readonly results = new Map<string, ToolCallbackResult>()
+  private readonly waiters = new Map<string, (result: ToolCallbackResult) => void>()
+  private failed: Error | undefined
+  private closed = false
+  private readonly iterator: AsyncIterator<Buffer>
+
+  constructor(inputStream: AsyncIterable<Buffer>) {
+    this.iterator = inputStream[Symbol.asyncIterator]()
+    void this.pump()
+  }
+
+  private async pump(): Promise<void> {
+    try {
+      while (!this.closed) {
+        const next = await this.iterator.next()
+        if (next.done) break
+        this.buffer += next.value.toString()
+        let nl: number
+        while ((nl = this.buffer.indexOf('\n')) !== -1) {
+          const line = this.buffer.slice(0, nl)
+          this.buffer = this.buffer.slice(nl + 1)
+          if (line.trim()) this.accept(line)
+        }
+        if (this.buffer.length > MAX_TOOL_RESULT_LINE_BYTES) {
+          throw new CompletionFailedError('tool result frame exceeds the maximum size')
+        }
+      }
+      if (!this.closed && this.buffer.trim()) this.accept(this.buffer)
+    } catch (error) {
+      this.failWaiters(error instanceof Error ? error : new Error(String(error)))
+    }
+  }
+
+  private failWaiters(error: Error): void {
+    this.failed = error
+    // Wake every waiter; each rethrows via waitFor's failure check.
+    for (const [callId, resolve] of this.waiters) {
+      this.waiters.delete(callId)
+      resolve({ callId, error: error.message })
+    }
+  }
+
+  private accept(line: string): void {
+    const parsed = toolCallbackResultSchema.parse(JSON.parse(line))
+    const waiter = this.waiters.get(parsed.callId)
+    if (waiter) {
+      this.waiters.delete(parsed.callId)
+      waiter(parsed)
+    } else {
+      this.results.set(parsed.callId, parsed)
+    }
+  }
+
+  async waitFor(callId: string, timeoutMs = TOOL_RESULT_TIMEOUT_MS): Promise<ToolCallbackResult> {
+    const buffered = this.results.get(callId)
+    if (buffered) {
+      this.results.delete(callId)
+      return buffered
+    }
+    if (this.failed) throw this.failed
+    return await new Promise<ToolCallbackResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters.delete(callId)
+        reject(new CompletionFailedError(`tool callback ${callId} timed out`))
+      }, timeoutMs)
+      this.waiters.set(callId, (result) => {
+        clearTimeout(timer)
+        resolve(result)
+      })
+    })
+  }
+
+  /**
+   * Stop the pump and release the upstream iterator. Idempotent. Pending
+   * waiters are failed so a caller blocked in `waitFor` can't hang after the
+   * stream is torn down.
+   */
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    this.buffer = ''
+    this.results.clear()
+    if (!this.failed) this.failWaiters(new CompletionFailedError('tool result stream closed'))
+    void this.iterator.return?.()
+  }
+}
+
+type RunTurn = (
+  request: CompletionStreamRequest
+) => AsyncGenerator<CompletionStreamResponse, void, unknown>
+
+/**
+ * The orchestration core, pure over its collaborators so it unit-tests
+ * without the plugin registry: runs completion turns, forwards their events
+ * downstream, and when a turn requests tool calls, emits `toolCallback`
+ * frames and blocks on the client's results before starting the next turn
+ * with the extended history.
+ */
+export async function* orchestrateCompletion(
+  request: CompletionOrchestrateRequest,
+  runTurn: RunTurn,
+  reader: Pick<ToolResultReader, 'waitFor'>
+): AsyncGenerator<CompletionOrchestrateResponse> {
+  // Pull the loop bound out of the per-turn base; everything else (including
+  // `requestId`) flows into each inner completionStream turn. Threading the
+  // orchestrate `requestId` down is what makes `cancel({ requestId })` reach
+  // the turn that's currently generating — the expensive part a Stop button
+  // targets. Turns run strictly sequentially: turn N's request-registry entry
+  // is disposed (on the `for await` break below) before turn N+1 calls
+  // `begin(...)`, so reusing the id can't collide in `entries`. A cancel that
+  // lands between turns (during a tool-result wait) is caught by the
+  // registry's cancel-before-begin tripwire and aborts the next turn's
+  // `begin(...)`. Each turn's `history` and `type` are set below.
+  const { maxToolTurns, ...turnBase } = request
+  const maxTurns = maxToolTurns ?? DEFAULT_MAX_TOOL_TURNS
+  let history = [...request.history]
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const turnEvents: CompletionStreamResponse['events'] = []
+    const innerRequest = {
+      ...turnBase,
+      history,
+      type: 'completionStream'
+    } as CompletionStreamRequest
+
+    for await (const response of runTurn(innerRequest)) {
+      turnEvents.push(...response.events)
+      yield { type: 'completionOrchestrate', turn, events: response.events }
+      if (response.done) break
+    }
+
+    const { toolCalls, rawFullText, contentText, error, cancelled } = aggregateEvents(turnEvents)
+
+    // Terminal turn: the model answered (or failed/was cancelled) without
+    // requesting tools — the client folds the forwarded events itself.
+    if (error || cancelled || toolCalls.length === 0) {
+      yield { type: 'completionOrchestrate', done: true }
+      return
+    }
+
+    // The assistant's tool-call turn goes back verbatim so the model sees
+    // its own call syntax; each result follows as a `tool` message.
+    history = [...history, { role: 'assistant', content: rawFullText ?? contentText }]
+    for (const call of toolCalls) {
+      yield {
+        type: 'completionOrchestrate',
+        turn,
+        toolCallback: { callId: call.id, name: call.name, arguments: call.arguments }
+      }
+      const result = await reader.waitFor(call.id)
+      const content =
+        result.error !== undefined
+          ? JSON.stringify({ error: result.error })
+          : JSON.stringify(result.result ?? null)
+      history = [...history, { role: 'tool', content }]
+    }
+  }
+
+  // Turn cap reached without a natural end. Emit a terminal done frame with a
+  // stopReason so the client can tell this was truncated (the model still
+  // wanted a tool) rather than a natural finish; the last turn's events carry
+  // whatever the model produced.
+  yield { type: 'completionOrchestrate', done: true, stopReason: 'maxToolTurns' }
+}
+
+export async function* handleCompletionOrchestrate(
+  request: CompletionOrchestrateRequest,
+  inputStream: AsyncIterable<Buffer>
+): AsyncGenerator<CompletionOrchestrateResponse> {
+  const reader = new ToolResultReader(inputStream)
+  const runTurn: RunTurn = async function* (innerRequest) {
+    yield* dispatchPluginStream<CompletionStreamRequest, CompletionStreamResponse>(
+      innerRequest.modelId,
+      'completionStream',
+      innerRequest
+    )
+  }
+  try {
+    yield* orchestrateCompletion(request, runTurn, reader)
+  } finally {
+    // Tear the reader down however orchestration ends -- natural finish, turn
+    // cap, error, or the client abandoning the stream -- so the pump stops and
+    // the request stream isn't held open.
+    reader.close()
+  }
+}

--- a/packages/inference/src/models/registry/models.ts
+++ b/packages/inference/src/models/registry/models.ts
@@ -453,23 +453,6 @@ export const models = [
     params: '4B'
   },
   {
-    name: 'QWEN3_4B_Q4_K_M',
-    registryPath:
-      'unsloth/Qwen3-4B-GGUF/resolve/9b5c4f3506ac99d74e59ecd9aa9abb05537b7f59/Qwen3-4B-Q4_K_M.gguf',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 296679,
-    blobBlockLength: 38106,
-    blobByteOffset: 19441407821,
-    modelId: 'Qwen3-4B-Q4_K_M.gguf',
-    addon: 'diffusion',
-    expectedSize: 2497281312,
-    sha256Checksum: 'f6f851777709861056efcdad3af01da38b31223a3ba26e61a4f8bf3a2195813a',
-    engine: 'sdcpp-generation',
-    quantization: 'Q4_K_M',
-    params: '4B'
-  },
-  {
     name: 'GTE_LARGE_FP16',
     registryPath:
       'ChristianAzinn/gte-large-gguf/blob/f9fa5479908e72c2a8b9d6ba112911cd1e51be53/gte-large_fp16.gguf',
@@ -734,6 +717,23 @@ export const models = [
     sha256Checksum: 'd453e776dac188abb702146b70e105ef5306212785f1b1f31c40831044b31ffc',
     engine: 'llamacpp-completion',
     quantization: 'q6_k',
+    params: '2B'
+  },
+  {
+    name: 'GEMMA4_2B_MULTIMODAL_Q8_0',
+    registryPath:
+      'bartowski/google_gemma-4-E2B-it-GGUF/resolve/b5e99bd964eaacc27ba484bb2eb3e9f6160b9143/google_gemma-4-E2B-it-Q8_0.gguf',
+    registrySource: 'hf',
+    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
+    blobBlockOffset: 4341686,
+    blobBlockLength: 75798,
+    blobByteOffset: 284524569674,
+    modelId: 'google_gemma-4-E2B-it-Q8_0.gguf',
+    addon: 'llm',
+    expectedSize: 4967495424,
+    sha256Checksum: 'f1a9243ad2da99b3c4706dd0d549b9dcb0a3f49c7e1a46e01f9f582f876265b0',
+    engine: 'llamacpp-completion',
+    quantization: 'q8_0',
     params: '2B'
   },
   {
@@ -2261,6 +2261,23 @@ export const models = [
     params: '1.7B'
   },
   {
+    name: 'QWEN3_4B_Q4_K_M',
+    registryPath:
+      'unsloth/Qwen3-4B-GGUF/resolve/9b5c4f3506ac99d74e59ecd9aa9abb05537b7f59/Qwen3-4B-Q4_K_M.gguf',
+    registrySource: 'hf',
+    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
+    blobBlockOffset: 296679,
+    blobBlockLength: 38106,
+    blobByteOffset: 19441407821,
+    modelId: 'Qwen3-4B-Q4_K_M.gguf',
+    addon: 'llm',
+    expectedSize: 2497281312,
+    sha256Checksum: 'f6f851777709861056efcdad3af01da38b31223a3ba26e61a4f8bf3a2195813a',
+    engine: 'llamacpp-completion',
+    quantization: 'q4_K_M',
+    params: '4B'
+  },
+  {
     name: 'MMPROJ_QWEN3_5_0_8B_MULTIMODAL_BF16',
     registryPath:
       'unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/mmproj-BF16.gguf',
@@ -2411,6 +2428,23 @@ export const models = [
     sha256Checksum: 'fc90339420b4298887aafb307a4291c55440b730133bbffe6ba9630503dcb548',
     engine: 'llamacpp-completion',
     quantization: 'q6_k',
+    params: '2B'
+  },
+  {
+    name: 'QWEN3_5_2B_MULTIMODAL_Q8_0',
+    registryPath:
+      'unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/Qwen3.5-2B-Q8_0.gguf',
+    registrySource: 'hf',
+    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
+    blobBlockOffset: 4417484,
+    blobBlockLength: 30701,
+    blobByteOffset: 289492065098,
+    modelId: 'Qwen3.5-2B-Q8_0.gguf',
+    addon: 'llm',
+    expectedSize: 2012012800,
+    sha256Checksum: '1b04acba824817554f4ce23639bc8495ff70453b8fcb047900c731521021f2c1',
+    engine: 'llamacpp-completion',
+    quantization: 'q8_0',
     params: '2B'
   },
   {
@@ -15786,276 +15820,6 @@ export const models = [
     params: ''
   },
   {
-    name: 'PARAKEET_EOU_DECODER_FP32',
-    registryPath:
-      'altunenes/parakeet-rs/resolve/0bd721ca2837b3aef5f98d1de5726d6796a80da4/realtime_eou_120m-v1-onnx/decoder_joint.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1133412,
-    blobBlockLength: 326,
-    blobByteOffset: 74269643751,
-    modelId: 'decoder_joint.onnx',
-    addon: 'parakeet',
-    expectedSize: 21347639,
-    sha256Checksum: '9d2553ac043c2fc5f69e970769b0fb8ab9103fbfdeb7d26a1ea9729d4bd2dddd',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '120M'
-  },
-  {
-    name: 'PARAKEET_EOU_ENCODER_FP32',
-    registryPath:
-      'altunenes/parakeet-rs/resolve/0bd721ca2837b3aef5f98d1de5726d6796a80da4/realtime_eou_120m-v1-onnx/encoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1133738,
-    blobBlockLength: 7009,
-    blobByteOffset: 74290991390,
-    modelId: 'encoder.onnx',
-    addon: 'parakeet',
-    expectedSize: 459341289,
-    sha256Checksum: 'd472887cc38a784a5bfc21c2dbe247639edc3b3f9992388d8ceceaec07256b5b',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '120M'
-  },
-  {
-    name: 'PARAKEET_EOU_TOKENIZER',
-    registryPath:
-      'altunenes/parakeet-rs/resolve/0bd721ca2837b3aef5f98d1de5726d6796a80da4/realtime_eou_120m-v1-onnx/tokenizer.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1140747,
-    blobBlockLength: 1,
-    blobByteOffset: 74750332679,
-    modelId: 'tokenizer.json',
-    addon: 'parakeet',
-    expectedSize: 20053,
-    sha256Checksum: 'f6b0ad8690559351fa478116fe0985a203b76f7c040f3a9381f485c99c0325f8',
-    engine: 'parakeet-transcription',
-    quantization: '',
-    params: '120M'
-  },
-  {
-    name: 'PARAKEET_SORTFORMER_FP32',
-    registryPath:
-      'cgus/diar_streaming_sortformer_4spk-v2-onnx/resolve/a3e0e6c8485b963cfdee82e4e961af1a9daca99d/diar_streaming_sortformer_4spk-v2.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1140748,
-    blobBlockLength: 7512,
-    blobByteOffset: 74750352732,
-    modelId: 'diar_streaming_sortformer_4spk-v2.onnx',
-    addon: 'parakeet',
-    expectedSize: 492242946,
-    sha256Checksum: '7dbfc7cba4615e07b679f7d65b5e0edd22a4b7b1ab69505a594f2f90421bd9c1',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '123M'
-  },
-  {
-    name: 'PARAKEET_TDT_DECODER_FP32',
-    registryPath:
-      'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/decoder_joint-model.onnx',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 37800,
-    blobBlockLength: 1107,
-    blobByteOffset: 2477191026,
-    modelId: 'decoder_joint-model.onnx',
-    addon: 'parakeet',
-    expectedSize: 72520893,
-    sha256Checksum: 'e978ddf6688527182c10fde2eb4b83068421648985ef23f7a86be732be8706c1',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_TDT_ENCODER_FP32',
-    registryPath:
-      'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/encoder-model.onnx',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 0,
-    blobBlockLength: 638,
-    blobByteOffset: 0,
-    modelId: 'encoder-model.onnx',
-    addon: 'parakeet',
-    expectedSize: 41770866,
-    sha256Checksum: '98a74b21b4cc0017c1e7030319a4a96f4a9506e50f0708f3a516d02a77c96bb1',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '0.6B',
-    companionSet: {
-      setKey: '58bc6ded7c93a073',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/encoder-model.onnx',
-          registrySource: 'hf',
-          targetName: 'encoder-model.onnx',
-          expectedSize: 41770866,
-          sha256Checksum: '98a74b21b4cc0017c1e7030319a4a96f4a9506e50f0708f3a516d02a77c96bb1',
-          blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-          blobBlockOffset: 0,
-          blobBlockLength: 638,
-          blobByteOffset: 0,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/encoder-model.onnx.data',
-          registrySource: 'hf',
-          targetName: 'encoder-model.onnx.data',
-          expectedSize: 2435420160,
-          sha256Checksum: '9a22d372c51455c34f13405da2520baefb7125bd16981397561423ed32d24f36',
-          blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-          blobBlockOffset: 638,
-          blobBlockLength: 37162,
-          blobByteOffset: 41770866
-        }
-      ]
-    }
-  },
-  {
-    name: 'PARAKEET_TDT_ENCODER_DATA_FP32',
-    registryPath:
-      'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/encoder-model.onnx.data',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 638,
-    blobBlockLength: 37162,
-    blobByteOffset: 41770866,
-    modelId: 'encoder-model.onnx.data',
-    addon: 'parakeet',
-    expectedSize: 2435420160,
-    sha256Checksum: '9a22d372c51455c34f13405da2520baefb7125bd16981397561423ed32d24f36',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_TDT_PREPROCESSOR_FP32',
-    registryPath:
-      'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/nemo128.onnx',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 38909,
-    blobBlockLength: 3,
-    blobByteOffset: 2549805858,
-    modelId: 'nemo128.onnx',
-    addon: 'parakeet',
-    expectedSize: 139764,
-    sha256Checksum: 'a9fde1486ebfcc08f328d75ad4610c67835fea58c73ba57e3209a6f6cf019e9f',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_TDT_VOCAB',
-    registryPath:
-      'istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/abd2878d52a678ce380088ef9d9b1d9664404565/vocab.txt',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 38907,
-    blobBlockLength: 2,
-    blobByteOffset: 2549711919,
-    modelId: 'vocab.txt',
-    addon: 'parakeet',
-    expectedSize: 93939,
-    sha256Checksum: 'd58544679ea4bc6ac563d1f545eb7d474bd6cfa467f0a6e2c1dc1c7d37e3c35d',
-    engine: 'parakeet-transcription',
-    quantization: '',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_CTC_FP32',
-    registryPath:
-      'onnx-community/parakeet-ctc-0.6b-ONNX/resolve/7df2cab7aed886b8b7f80d68a8214007e4847601/onnx/model.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1148260,
-    blobBlockLength: 14,
-    blobByteOffset: 75242595678,
-    modelId: 'model.onnx',
-    addon: 'parakeet',
-    expectedSize: 887486,
-    sha256Checksum: '5c459a949508ff0da5b36e8d94feb8ed1746fea9e732879117dd7c1f78a8a86c',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '0.6B',
-    companionSet: {
-      setKey: 'e224cc55eb5e3e4d',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/parakeet-ctc-0.6b-ONNX/resolve/7df2cab7aed886b8b7f80d68a8214007e4847601/onnx/model.onnx',
-          registrySource: 'hf',
-          targetName: 'model.onnx',
-          expectedSize: 887486,
-          sha256Checksum: '5c459a949508ff0da5b36e8d94feb8ed1746fea9e732879117dd7c1f78a8a86c',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 1148260,
-          blobBlockLength: 14,
-          blobByteOffset: 75242595678,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/parakeet-ctc-0.6b-ONNX/resolve/7df2cab7aed886b8b7f80d68a8214007e4847601/onnx/model.onnx_data',
-          registrySource: 'hf',
-          targetName: 'model.onnx_data',
-          expectedSize: 2435004420,
-          sha256Checksum: '8ebe1f7360dc705dfe8163fe72bc7a4d9b823d9ef6d426f1f1f8da18fffcc1ec',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 1148274,
-          blobBlockLength: 37156,
-          blobByteOffset: 75243483164
-        }
-      ]
-    }
-  },
-  {
-    name: 'PARAKEET_CTC_DATA_FP32',
-    registryPath:
-      'onnx-community/parakeet-ctc-0.6b-ONNX/resolve/7df2cab7aed886b8b7f80d68a8214007e4847601/onnx/model.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1148274,
-    blobBlockLength: 37156,
-    blobByteOffset: 75243483164,
-    modelId: 'model.onnx_data',
-    addon: 'parakeet',
-    expectedSize: 2435004420,
-    sha256Checksum: '8ebe1f7360dc705dfe8163fe72bc7a4d9b823d9ef6d426f1f1f8da18fffcc1ec',
-    engine: 'parakeet-transcription',
-    quantization: 'fp32',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_CTC_TOKENIZER',
-    registryPath:
-      'onnx-community/parakeet-ctc-0.6b-ONNX/resolve/7df2cab7aed886b8b7f80d68a8214007e4847601/tokenizer.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1185430,
-    blobBlockLength: 7,
-    blobByteOffset: 77678487584,
-    modelId: 'tokenizer.json',
-    addon: 'parakeet',
-    expectedSize: 412363,
-    sha256Checksum: 'f3f1dd45c3889ed2b5bf67180caf05f51d7d7e4948c20e5f24d8c24df9cc47aa',
-    engine: 'parakeet-transcription',
-    quantization: '',
-    params: '0.6B'
-  },
-  {
     name: 'PARAKEET_CTC_0_6B_Q8_0',
     registryPath: 'qvac_models_compiled/ggml/parakeet/2026-05-11/parakeet-ctc-0.6b.q8_0.gguf',
     registrySource: 's3',
@@ -16297,931 +16061,6 @@ export const models = [
     engine: 'parakeet-transcription',
     quantization: 'f16',
     params: '123M'
-  },
-  {
-    name: 'PARAKEET_TDT_DECODER_INT8',
-    registryPath:
-      'qvac_models_compiled/parakeet/parakeet-tdt-0.6b-v3-onnx-int8/2026-03-05/decoder_joint-model.onnx',
-    registrySource: 's3',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 100929,
-    blobBlockLength: 818,
-    blobByteOffset: 6612957534,
-    modelId: 'decoder_joint-model.onnx',
-    addon: 'parakeet',
-    expectedSize: 53592361,
-    sha256Checksum: 'f2ab8a752a7b356d18dcdd0eb18d0c57dec3c2fda8a35c95837bdc44fe9ea0f6',
-    engine: 'parakeet-transcription',
-    quantization: 'int8',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_TDT_ENCODER_INT8',
-    registryPath:
-      'qvac_models_compiled/parakeet/parakeet-tdt-0.6b-v3-onnx-int8/2026-03-05/encoder-model.onnx',
-    registrySource: 's3',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 90977,
-    blobBlockLength: 9952,
-    blobByteOffset: 5960773535,
-    modelId: 'encoder-model.onnx',
-    addon: 'parakeet',
-    expectedSize: 652183999,
-    sha256Checksum: '6139d2fa7e1b086097b277c7149725edbab89cc7c7ae64b23c741be4055aff09',
-    engine: 'parakeet-transcription',
-    quantization: 'int8',
-    params: '0.6B'
-  },
-  {
-    name: 'PARAKEET_TDT_PREPROCESSOR_INT8',
-    registryPath:
-      'qvac_models_compiled/parakeet/parakeet-tdt-0.6b-v3-onnx-int8/2026-03-05/preprocessor.onnx',
-    registrySource: 's3',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 101749,
-    blobBlockLength: 3,
-    blobByteOffset: 6666643834,
-    modelId: 'preprocessor.onnx',
-    addon: 'parakeet',
-    expectedSize: 140499,
-    sha256Checksum: '6f942bcff39cf304412a9877a30e52c3967fd92b6d1d4212af8f8a195efa78c9',
-    engine: 'parakeet-transcription',
-    quantization: 'int8',
-    params: '0.6B'
-  },
-  {
-    name: 'TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX_FP32',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/conditional_decoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944751,
-    blobBlockLength: 97,
-    blobByteOffset: 61906381774,
-    modelId: 'conditional_decoder.onnx',
-    addon: 'tts',
-    expectedSize: 6350448,
-    sha256Checksum: '1656d0d31332bae1854839959a3139300ebb67c178651dfa3f8c5fbfa5351351',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '24f5c81fe00112b1',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/conditional_decoder.onnx',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder.onnx',
-          expectedSize: 6350448,
-          sha256Checksum: '1656d0d31332bae1854839959a3139300ebb67c178651dfa3f8c5fbfa5351351',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 944751,
-          blobBlockLength: 97,
-          blobByteOffset: 61906381774,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/conditional_decoder.onnx_data',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder.onnx_data',
-          expectedSize: 533970816,
-          sha256Checksum: '51d58345a272747665ec9d5bb61e01835258a940e321a288582ac4c18cf01b5a',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 944848,
-          blobBlockLength: 8148,
-          blobByteOffset: 61912732222
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/conditional_decoder.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944848,
-    blobBlockLength: 8148,
-    blobByteOffset: 61912732222,
-    modelId: 'conditional_decoder.onnx_data',
-    addon: 'tts',
-    expectedSize: 533970816,
-    sha256Checksum: '51d58345a272747665ec9d5bb61e01835258a940e321a288582ac4c18cf01b5a',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX_FP32',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/embed_tokens.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 952996,
-    blobBlockLength: 1,
-    blobByteOffset: 62446703038,
-    modelId: 'embed_tokens.onnx',
-    addon: 'tts',
-    expectedSize: 13286,
-    sha256Checksum: 'f785819ca4f6271262d5bb8971d62796c3a909e3b031982c113dbe83a4c3b854',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: 'd9cd5615f97aa165',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/embed_tokens.onnx',
-          registrySource: 'hf',
-          targetName: 'embed_tokens.onnx',
-          expectedSize: 13286,
-          sha256Checksum: 'f785819ca4f6271262d5bb8971d62796c3a909e3b031982c113dbe83a4c3b854',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 952996,
-          blobBlockLength: 1,
-          blobByteOffset: 62446703038,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/embed_tokens.onnx_data',
-          registrySource: 'hf',
-          targetName: 'embed_tokens.onnx_data',
-          expectedSize: 68390912,
-          sha256Checksum: '2a15f7dd73b2ee47f6edf87740324011594b5a528ed6471ae55e327ed6cad68c',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 952997,
-          blobBlockLength: 1044,
-          blobByteOffset: 62446716324
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/embed_tokens.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 952997,
-    blobBlockLength: 1044,
-    blobByteOffset: 62446716324,
-    modelId: 'embed_tokens.onnx_data',
-    addon: 'tts',
-    expectedSize: 68390912,
-    sha256Checksum: '2a15f7dd73b2ee47f6edf87740324011594b5a528ed6471ae55e327ed6cad68c',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP16',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_fp16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 994834,
-    blobBlockLength: 3,
-    blobByteOffset: 65188370943,
-    modelId: 'language_model_fp16.onnx',
-    addon: 'tts',
-    expectedSize: 172657,
-    sha256Checksum: '0c36a5bbbc2a4ed8c345033896612cd320fd0971a0f5e6447ab4cdd2d7f22e36',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: '',
-    companionSet: {
-      setKey: '353bb697efea258c',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_fp16.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_fp16.onnx',
-          expectedSize: 172657,
-          sha256Checksum: '0c36a5bbbc2a4ed8c345033896612cd320fd0971a0f5e6447ab4cdd2d7f22e36',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 994834,
-          blobBlockLength: 3,
-          blobByteOffset: 65188370943,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_fp16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_fp16.onnx_data',
-          expectedSize: 1040316416,
-          sha256Checksum: '16dca11ae994e78427fa3090cc6faf347a15988ca40809c1bd9f2721f3b759a0',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 994837,
-          blobBlockLength: 15874,
-          blobByteOffset: 65188543600
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP16_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_fp16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 994837,
-    blobBlockLength: 15874,
-    blobByteOffset: 65188543600,
-    modelId: 'language_model_fp16.onnx_data',
-    addon: 'tts',
-    expectedSize: 1040316416,
-    sha256Checksum: '16dca11ae994e78427fa3090cc6faf347a15988ca40809c1bd9f2721f3b759a0',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: ''
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_Q4',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1010711,
-    blobBlockLength: 4,
-    blobByteOffset: 66228860016,
-    modelId: 'language_model_q4.onnx',
-    addon: 'tts',
-    expectedSize: 227911,
-    sha256Checksum: '7f8cdca83b2493536cbf3acf421199808a3d68736f55f4eabd20ef8a99da4313',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: '',
-    companionSet: {
-      setKey: '98c5d1550c77e389',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_q4.onnx',
-          expectedSize: 227911,
-          sha256Checksum: '7f8cdca83b2493536cbf3acf421199808a3d68736f55f4eabd20ef8a99da4313',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 1010711,
-          blobBlockLength: 4,
-          blobByteOffset: 66228860016,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_q4.onnx_data',
-          expectedSize: 353621248,
-          sha256Checksum: 'e79ab8784122a501718868b9631ff46e151c552d9b24e50f25d721f375e3526c',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 1010715,
-          blobBlockLength: 5396,
-          blobByteOffset: 66229087927
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_Q4_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1010715,
-    blobBlockLength: 5396,
-    blobByteOffset: 66229087927,
-    modelId: 'language_model_q4.onnx_data',
-    addon: 'tts',
-    expectedSize: 353621248,
-    sha256Checksum: 'e79ab8784122a501718868b9631ff46e151c552d9b24e50f25d721f375e3526c',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: ''
-  },
-  {
-    name: 'TTS_EN_ES_CHATTERBOX_Q4F16',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4f16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1016111,
-    blobBlockLength: 4,
-    blobByteOffset: 66582709175,
-    modelId: 'language_model_q4f16.onnx',
-    addon: 'tts',
-    expectedSize: 229388,
-    sha256Checksum: '3b78e9235be5e2e2a811e482399155cb30415f6d87c98c21d12bf48843fc928f',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: '',
-    companionSet: {
-      setKey: '91e42830d2e36b4b',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4f16.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_q4f16.onnx',
-          expectedSize: 229388,
-          sha256Checksum: '3b78e9235be5e2e2a811e482399155cb30415f6d87c98c21d12bf48843fc928f',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 1016111,
-          blobBlockLength: 4,
-          blobByteOffset: 66582709175,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4f16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_q4f16.onnx_data',
-          expectedSize: 304737408,
-          sha256Checksum: 'bdbc79504d20742b5d028074b4f1cdca8872e013fdfbbcea6b8b03154fe85a42',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 1016115,
-          blobBlockLength: 4650,
-          blobByteOffset: 66582938563
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_Q4F16_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model_q4f16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1016115,
-    blobBlockLength: 4650,
-    blobByteOffset: 66582938563,
-    modelId: 'language_model_q4f16.onnx_data',
-    addon: 'tts',
-    expectedSize: 304737408,
-    sha256Checksum: 'bdbc79504d20742b5d028074b4f1cdca8872e013fdfbbcea6b8b03154fe85a42',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: ''
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP32',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 963083,
-    blobBlockLength: 3,
-    blobByteOffset: 63107566724,
-    modelId: 'language_model.onnx',
-    addon: 'tts',
-    expectedSize: 171387,
-    sha256Checksum: '861a34585605e8ad671051788afc495dcbeaee833a41523a1b33aded9c3babc7',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: 'cf5a4b123e29d36d',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model.onnx',
-          expectedSize: 171387,
-          sha256Checksum: '861a34585605e8ad671051788afc495dcbeaee833a41523a1b33aded9c3babc7',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 963083,
-          blobBlockLength: 3,
-          blobByteOffset: 63107566724,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model.onnx_data',
-          expectedSize: 2080632832,
-          sha256Checksum: 'b3556d41085196c122b7197e4d44ec4475b6d7cfe0971a70faa95caa38ad787a',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 963086,
-          blobBlockLength: 31748,
-          blobByteOffset: 63107738111
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/language_model.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 963086,
-    blobBlockLength: 31748,
-    blobByteOffset: 63107738111,
-    modelId: 'language_model.onnx_data',
-    addon: 'tts',
-    expectedSize: 2080632832,
-    sha256Checksum: 'b3556d41085196c122b7197e4d44ec4475b6d7cfe0971a70faa95caa38ad787a',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX_FP32',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/speech_encoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 954041,
-    blobBlockLength: 19,
-    blobByteOffset: 62515107236,
-    modelId: 'speech_encoder.onnx',
-    addon: 'tts',
-    expectedSize: 1184608,
-    sha256Checksum: '8f1c8a0f89b77bf9cd5dd8f2e034eb2c79dc00fe70d41196b28c257643b00ccb',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: 'a4836655ee2c5b8c',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/speech_encoder.onnx',
-          registrySource: 'hf',
-          targetName: 'speech_encoder.onnx',
-          expectedSize: 1184608,
-          sha256Checksum: '8f1c8a0f89b77bf9cd5dd8f2e034eb2c79dc00fe70d41196b28c257643b00ccb',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 954041,
-          blobBlockLength: 19,
-          blobByteOffset: 62515107236,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/speech_encoder.onnx_data',
-          registrySource: 'hf',
-          targetName: 'speech_encoder.onnx_data',
-          expectedSize: 591274880,
-          sha256Checksum: '92f8f290fc9720e169bc2412c507209e20b03f6564bc3243739e25c56f7dfb8f',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 954060,
-          blobBlockLength: 9023,
-          blobByteOffset: 62516291844
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/onnx/speech_encoder.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 954060,
-    blobBlockLength: 9023,
-    blobByteOffset: 62516291844,
-    modelId: 'speech_encoder.onnx_data',
-    addon: 'tts',
-    expectedSize: 591274880,
-    sha256Checksum: '92f8f290fc9720e169bc2412c507209e20b03f6564bc3243739e25c56f7dfb8f',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX',
-    registryPath:
-      'onnx-community/chatterbox-multilingual-ONNX/resolve/452d3f434aa592098f1eedac9099f33642ab2da5/tokenizer.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 1020765,
-    blobBlockLength: 2,
-    blobByteOffset: 66887675971,
-    modelId: 'tokenizer.json',
-    addon: 'tts',
-    expectedSize: 71798,
-    sha256Checksum: '29d48c4a178f6af3ad5130097c34744639e9294847b38a7b912c8c68027cb819',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_LATENT_DENOISER_SUPERTONIC_FP32',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/latent_denoiser.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 941170,
-    blobBlockLength: 7,
-    blobByteOffset: 61671954279,
-    modelId: 'latent_denoiser.onnx',
-    addon: 'tts',
-    expectedSize: 398102,
-    sha256Checksum: '9a639a8c05c9be111848562c5cf10ea2697a589c6341830aac479d0ce7b75aa9',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '9ad174701f2dc744',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/latent_denoiser.onnx',
-          registrySource: 'hf',
-          targetName: 'latent_denoiser.onnx',
-          expectedSize: 398102,
-          sha256Checksum: '9a639a8c05c9be111848562c5cf10ea2697a589c6341830aac479d0ce7b75aa9',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 941170,
-          blobBlockLength: 7,
-          blobByteOffset: 61671954279,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/latent_denoiser.onnx_data',
-          registrySource: 'hf',
-          targetName: 'latent_denoiser.onnx_data',
-          expectedSize: 132098880,
-          sha256Checksum: 'cde4abf1136defce235bc446eaab4954a57721ae8d5a4754cdd337bf191b612f',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 941177,
-          blobBlockLength: 2016,
-          blobByteOffset: 61672352381
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_LATENT_DENOISER_SUPERTONIC_FP32_DATA',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/latent_denoiser.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 941177,
-    blobBlockLength: 2016,
-    blobByteOffset: 61672352381,
-    modelId: 'latent_denoiser.onnx_data',
-    addon: 'tts',
-    expectedSize: 132098880,
-    sha256Checksum: 'cde4abf1136defce235bc446eaab4954a57721ae8d5a4754cdd337bf191b612f',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_TEXT_ENCODER_SUPERTONIC_FP32',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/text_encoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 940729,
-    blobBlockLength: 7,
-    blobByteOffset: 61643094358,
-    modelId: 'text_encoder.onnx',
-    addon: 'tts',
-    expectedSize: 433169,
-    sha256Checksum: '50a03d29d5dc95918eeff578f542b814f3cf5a741f927116f5a8462a76ff6898',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '76d0aa8384649723',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/text_encoder.onnx',
-          registrySource: 'hf',
-          targetName: 'text_encoder.onnx',
-          expectedSize: 433169,
-          sha256Checksum: '50a03d29d5dc95918eeff578f542b814f3cf5a741f927116f5a8462a76ff6898',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 940729,
-          blobBlockLength: 7,
-          blobByteOffset: 61643094358,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/text_encoder.onnx_data',
-          registrySource: 'hf',
-          targetName: 'text_encoder.onnx_data',
-          expectedSize: 28426752,
-          sha256Checksum: '6415854f135a318909dc716e90f83a391d9a91bd9da09bdb6d6763d6b0a6c102',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 940736,
-          blobBlockLength: 434,
-          blobByteOffset: 61643527527
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_TEXT_ENCODER_SUPERTONIC_FP32_DATA',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/text_encoder.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 940736,
-    blobBlockLength: 434,
-    blobByteOffset: 61643527527,
-    modelId: 'text_encoder.onnx_data',
-    addon: 'tts',
-    expectedSize: 28426752,
-    sha256Checksum: '6415854f135a318909dc716e90f83a391d9a91bd9da09bdb6d6763d6b0a6c102',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_DECODER_SUPERTONIC_FP32',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/voice_decoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 943193,
-    blobBlockLength: 1,
-    blobByteOffset: 61804451261,
-    modelId: 'voice_decoder.onnx',
-    addon: 'tts',
-    expectedSize: 59921,
-    sha256Checksum: '83c104006dabcd6b568c0d5acb6fec18f65609d2391dd2c459e4440e85027669',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '19ca8337c16df8f7',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/voice_decoder.onnx',
-          registrySource: 'hf',
-          targetName: 'voice_decoder.onnx',
-          expectedSize: 59921,
-          sha256Checksum: '83c104006dabcd6b568c0d5acb6fec18f65609d2391dd2c459e4440e85027669',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 943193,
-          blobBlockLength: 1,
-          blobByteOffset: 61804451261,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/voice_decoder.onnx_data',
-          registrySource: 'hf',
-          targetName: 'voice_decoder.onnx_data',
-          expectedSize: 101353472,
-          sha256Checksum: 'ea52402c9ba5131ee2b3901a86db2f0b435b322169cd75157e053493d967d17f',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 943194,
-          blobBlockLength: 1547,
-          blobByteOffset: 61804511182
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_VOICE_DECODER_SUPERTONIC_FP32_DATA',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/onnx/voice_decoder.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 943194,
-    blobBlockLength: 1547,
-    blobByteOffset: 61804511182,
-    modelId: 'voice_decoder.onnx_data',
-    addon: 'tts',
-    expectedSize: 101353472,
-    sha256Checksum: 'ea52402c9ba5131ee2b3901a86db2f0b435b322169cd75157e053493d967d17f',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_TOKENIZER_SUPERTONIC',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 940728,
-    blobBlockLength: 1,
-    blobByteOffset: 61643092320,
-    modelId: 'tokenizer.json',
-    addon: 'tts',
-    expectedSize: 2038,
-    sha256Checksum: 'da6954f045585fc12c8ea9831b3c3eb1c5bffc8ef7ff6b6db7de781cd472ee01',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/F1.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944741,
-    blobBlockLength: 1,
-    blobByteOffset: 61905864654,
-    modelId: 'F1.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '5ef84e3421e4f80994a5a40a18ba39ba9fc48175c41ae6cf3e56418820872dbf',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_1',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/F2.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944742,
-    blobBlockLength: 1,
-    blobByteOffset: 61905916366,
-    modelId: 'F2.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '1949cf0e066c4278980d2b835cf334dab0f8f781704c9116bf48a072278f7c72',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_2',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/F3.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944743,
-    blobBlockLength: 1,
-    blobByteOffset: 61905968078,
-    modelId: 'F3.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '38ee1d62ad8a02877ab0d08b501742b76cf3586ed888514df1a7f27cc0f8d171',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_3',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/F4.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944744,
-    blobBlockLength: 1,
-    blobByteOffset: 61906019790,
-    modelId: 'F4.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '63890c361868a296c51f9aee114f51e0a9a92c3f46a91582539545f7ab408a72',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_4',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/F5.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944745,
-    blobBlockLength: 1,
-    blobByteOffset: 61906071502,
-    modelId: 'F5.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '793223d8d11e0ee49721842ebdc7bd46b4487579588f646953e75ad3fc8ffb9c',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_5',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/M1.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944746,
-    blobBlockLength: 1,
-    blobByteOffset: 61906123214,
-    modelId: 'M1.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '7d53fbaaccf39a358010dcc5f289fc1d5cb350fe5f518be35f62cc518d794892',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_6',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/M2.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944747,
-    blobBlockLength: 1,
-    blobByteOffset: 61906174926,
-    modelId: 'M2.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '2e02979a394f89002d920f0bcc006206d4cd8da90e8cc82d0532831a5bb20e79',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_7',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/M3.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944748,
-    blobBlockLength: 1,
-    blobByteOffset: 61906226638,
-    modelId: 'M3.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '470d2b6b77239628ce90ba879ca5366fb5e6103fdd7e7053954a7b6d5dc2142a',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_8',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/M4.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944749,
-    blobBlockLength: 1,
-    blobByteOffset: 61906278350,
-    modelId: 'M4.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: '4700e92c614fd34971a8ed9c8140c2f2162ab8ef3067f8e1e7ef67c3e6488fb7',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_VOICE_STYLE_SUPERTONIC_9',
-    registryPath:
-      'onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/voices/M5.bin',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 944750,
-    blobBlockLength: 1,
-    blobByteOffset: 61906330062,
-    modelId: 'M5.bin',
-    addon: 'tts',
-    expectedSize: 51712,
-    sha256Checksum: 'c40fbc4093d113ef261cbc7bfe3f080dd813d3168347d682c78b1ca71a07da1f',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
   },
   {
     name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX',
@@ -17735,6 +16574,150 @@ export const models = [
     params: ''
   },
   {
+    name: 'TTS_INDIC_MULTILINGUAL_PARLER_TTS_FP16',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-indic-f16.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2256396,
+    blobBlockLength: 40226,
+    blobByteOffset: 147858824578,
+    modelId: 'parler-indic-f16.gguf',
+    addon: 'tts',
+    expectedSize: 2636192608,
+    sha256Checksum: 'bdd113678a5e6b1fdc985a49e52576bc35cfd76164930557555ce4e46f1dbf1f',
+    engine: 'tts-ggml',
+    quantization: 'fp16',
+    params: '880M'
+  },
+  {
+    name: 'TTS_INDIC_MULTILINGUAL_PARLER_TTS_FP32',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-indic-f32.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2296622,
+    blobBlockLength: 55961,
+    blobByteOffset: 150495017186,
+    modelId: 'parler-indic-f32.gguf',
+    addon: 'tts',
+    expectedSize: 3667407712,
+    sha256Checksum: '8f5e8bd0e5b0c3f949ebff055269192bdd7ef7443bdc4e0ca46c6b49c55826a4',
+    engine: 'tts-ggml',
+    quantization: 'fp32',
+    params: '880M'
+  },
+  {
+    name: 'TTS_INDIC_MULTILINGUAL_PARLER_TTS_Q8_0',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-indic-q8_0.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2352583,
+    blobBlockLength: 19644,
+    blobByteOffset: 154162424898,
+    modelId: 'parler-indic-q8_0.gguf',
+    addon: 'tts',
+    expectedSize: 1287330656,
+    sha256Checksum: '3754448c805085b3d096f6c3070d9e9684d63b0c34adc5e81bb6acfe0bc16644',
+    engine: 'tts-ggml',
+    quantization: 'q8_0',
+    params: '880M'
+  },
+  {
+    name: 'TTS_LARGE_V1_EN_PARLER_TTS_FP16',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-large-v1-f16.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2372227,
+    blobBlockLength: 109723,
+    blobByteOffset: 155449755554,
+    modelId: 'parler-large-v1-f16.gguf',
+    addon: 'tts',
+    expectedSize: 7190761024,
+    sha256Checksum: 'a47d96e28b942b2589b940c10996240aa52fb4043cb32a49aec9530052674d32',
+    engine: 'tts-ggml',
+    quantization: 'fp16',
+    params: '2.3B'
+  },
+  {
+    name: 'TTS_LARGE_V1_EN_PARLER_TTS_FP32',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-large-v1-f32.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2481950,
+    blobBlockLength: 141043,
+    blobByteOffset: 162640516578,
+    modelId: 'parler-large-v1-f32.gguf',
+    addon: 'tts',
+    expectedSize: 9243376192,
+    sha256Checksum: 'd066480e6c329533f28485df5082eb09630d0e4d341e032225112ef0d17be8d4',
+    engine: 'tts-ggml',
+    quantization: 'fp32',
+    params: '2.3B'
+  },
+  {
+    name: 'TTS_LARGE_V1_EN_PARLER_TTS_Q8_0',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-large-v1-q8_0.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2622993,
+    blobBlockLength: 42282,
+    blobByteOffset: 171883892770,
+    modelId: 'parler-large-v1-q8_0.gguf',
+    addon: 'tts',
+    expectedSize: 2770947648,
+    sha256Checksum: 'ab71ac8744da28d93063446c5c834e48f6fd8ead2369f92527d038e6de470360',
+    engine: 'tts-ggml',
+    quantization: 'q8_0',
+    params: '2.3B'
+  },
+  {
+    name: 'TTS_MINI_V1_EN_PARLER_TTS_FP16',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-mini-v1-f16.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2665275,
+    blobBlockLength: 38322,
+    blobByteOffset: 174654840418,
+    modelId: 'parler-mini-v1-f16.gguf',
+    addon: 'tts',
+    expectedSize: 2511459808,
+    sha256Checksum: '84f636e1a9a11df6236e0e742db95065d4924af049f677e1ac3ffd6d1f0c98af',
+    engine: 'tts-ggml',
+    quantization: 'fp16',
+    params: '880M'
+  },
+  {
+    name: 'TTS_MINI_V1_EN_PARLER_TTS_FP32',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-mini-v1-f32.gguf',
+    registrySource: 's3',
+    blobCoreKey: '4035e66388340ff7c1f291e7c0101855f5d0b2c7085f3ff62213573a2cd5dd17',
+    blobBlockOffset: 2703597,
+    blobBlockLength: 52227,
+    blobByteOffset: 177166300226,
+    modelId: 'parler-mini-v1-f32.gguf',
+    addon: 'tts',
+    expectedSize: 3422690784,
+    sha256Checksum: 'd07b34918304d4b7e9ced3c59271a39d31e2693fe18a9c6c9dcaa9f7f7b87b6e',
+    engine: 'tts-ggml',
+    quantization: 'fp32',
+    params: '880M'
+  },
+  {
+    name: 'TTS_MINI_V1_EN_PARLER_TTS_Q8_0',
+    registryPath: 'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-mini-v1-q8_0.gguf',
+    registrySource: 's3',
+    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
+    blobBlockOffset: 4448185,
+    blobBlockLength: 17740,
+    blobByteOffset: 291504077898,
+    modelId: 'parler-mini-v1-q8_0.gguf',
+    addon: 'tts',
+    expectedSize: 1162597856,
+    sha256Checksum: 'b8a72142b73e540b8aa801519ce47bc235439330d6f2d41bf0e37ba059b3160f',
+    engine: 'tts-ggml',
+    quantization: 'q8_0',
+    params: '880M'
+  },
+  {
     name: 'TTS_EN_SUPERTONIC_Q4_0',
     registryPath: 'qvac_models_compiled/ggml/supertonic/2026-05-18/supertonic-q4_0.gguf',
     registrySource: 's3',
@@ -17863,2030 +16846,36 @@ export const models = [
     params: ''
   },
   {
-    name: 'TTS_DENOISER_LAVASR_FP32_1',
-    registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/denoiser_core_legacy_fixed63.onnx',
+    name: 'GROOT_Q5_VF16',
+    registryPath: 'qvac_models_compiled/vla/groot-n1.7-3b-libero/2026-07-14/groot-q5_vf16.gguf',
     registrySource: 's3',
     blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198918,
-    blobBlockLength: 28,
-    blobByteOffset: 144097399428,
-    modelId: 'denoiser_core_legacy_fixed63.onnx',
-    addon: 'tts',
-    expectedSize: 1815317,
-    sha256Checksum: '8afa7f4db9f356f7bfb575bb207d8673a728a7baf6773e0b10226a5e15687f2a',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
+    blobBlockOffset: 4651104,
+    blobBlockLength: 41801,
+    blobByteOffset: 304802373578,
+    modelId: 'groot-q5_vf16.gguf',
+    addon: 'vla',
+    expectedSize: 2739467616,
+    sha256Checksum: '5695a64ff37ca2d3a123bba6b32f1b05f2c185e37ba85d20a2f0df570cbbf8b7',
+    engine: 'ggml-vla',
+    quantization: 'q5_vf16',
+    params: 'groot-n1.7-3b-libero'
   },
   {
-    name: 'TTS_ENHANCER_BACKBONE_LAVASR_FP32',
-    registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_backbone.onnx',
+    name: 'GROOT_Q8_VF16',
+    registryPath: 'qvac_models_compiled/vla/groot-n1.7-3b-libero/2026-07-14/groot-q8_vf16.gguf',
     registrySource: 's3',
     blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198058,
-    blobBlockLength: 3,
-    blobByteOffset: 144041164373,
-    modelId: 'enhancer_backbone.onnx',
-    addon: 'tts',
-    expectedSize: 190195,
-    sha256Checksum: '841e96d261dffdf1dc974f3d29e2cfcf1b16fd0b358749c1ace0bbfa1d4c8ddd',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '240e4f609ef49d13',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_backbone.onnx',
-          registrySource: 's3',
-          targetName: 'enhancer_backbone.onnx',
-          expectedSize: 190195,
-          sha256Checksum: '841e96d261dffdf1dc974f3d29e2cfcf1b16fd0b358749c1ace0bbfa1d4c8ddd',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 2198058,
-          blobBlockLength: 3,
-          blobByteOffset: 144041164373,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_backbone.onnx.data',
-          registrySource: 's3',
-          targetName: 'enhancer_backbone.onnx.data',
-          expectedSize: 51773440,
-          sha256Checksum: 'a125a4ede7cfdd1073d906a3cadf2171a30be6a40f296ad28772e0ba258de8c5',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 2198061,
-          blobBlockLength: 790,
-          blobByteOffset: 144041354568
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_ENHANCER_BACKBONE_LAVASR_FP32_1',
-    registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_backbone.onnx.data',
-    registrySource: 's3',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198061,
-    blobBlockLength: 790,
-    blobByteOffset: 144041354568,
-    modelId: 'enhancer_backbone.onnx.data',
-    addon: 'tts',
-    expectedSize: 51773440,
-    sha256Checksum: 'a125a4ede7cfdd1073d906a3cadf2171a30be6a40f296ad28772e0ba258de8c5',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_ENHANCER_SPEC_HEAD_LAVASR_FP32',
-    registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_spec_head.onnx',
-    registrySource: 's3',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198851,
-    blobBlockLength: 1,
-    blobByteOffset: 144093128008,
-    modelId: 'enhancer_spec_head.onnx',
-    addon: 'tts',
-    expectedSize: 7484,
-    sha256Checksum: 'f66fd164c55fd1b07e5cea5e687c71522b192f452691128fd7ae4e6b26dbc683',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: 'b4c4d4008b8cd2b7',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_spec_head.onnx',
-          registrySource: 's3',
-          targetName: 'enhancer_spec_head.onnx',
-          expectedSize: 7484,
-          sha256Checksum: 'f66fd164c55fd1b07e5cea5e687c71522b192f452691128fd7ae4e6b26dbc683',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 2198851,
-          blobBlockLength: 1,
-          blobByteOffset: 144093128008,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_spec_head.onnx.data',
-          registrySource: 's3',
-          targetName: 'enhancer_spec_head.onnx.data',
-          expectedSize: 4263936,
-          sha256Checksum: 'b855e309b027af9aa75285b97b345571b6bd695a30fde434d06c979d83885fd6',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 2198852,
-          blobBlockLength: 66,
-          blobByteOffset: 144093135492
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_ENHANCER_SPEC_HEAD_LAVASR_FP32_1',
-    registryPath: 'qvac_models_compiled/onnx/lavasr/2026-04-03/enhancer_spec_head.onnx.data',
-    registrySource: 's3',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198852,
-    blobBlockLength: 66,
-    blobByteOffset: 144093135492,
-    modelId: 'enhancer_spec_head.onnx.data',
-    addon: 'tts',
-    expectedSize: 4263936,
-    sha256Checksum: 'b855e309b027af9aa75285b97b345571b6bd695a30fde434d06c979d83885fd6',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_fp16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 888458,
-    blobBlockLength: 33,
-    blobByteOffset: 58218557580,
-    modelId: 'conditional_decoder_fp16.onnx',
-    addon: 'tts',
-    expectedSize: 2104016,
-    sha256Checksum: 'cbdc0281548eb90a02fa2430647237df63fa0cb695e42b91c10b860b9b6d2230',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: '',
-    companionSet: {
-      setKey: '33f90b4f2c14ce8b',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_fp16.onnx',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_fp16.onnx',
-          expectedSize: 2104016,
-          sha256Checksum: 'cbdc0281548eb90a02fa2430647237df63fa0cb695e42b91c10b860b9b6d2230',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 888458,
-          blobBlockLength: 33,
-          blobByteOffset: 58218557580,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_fp16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_fp16.onnx_data',
-          expectedSize: 384019328,
-          sha256Checksum: 'c6c3e79e6ff86bc41f77381a3d67b8edaa16b13e43a2700ca8159d0894bd594a',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 888491,
-          blobBlockLength: 5860,
-          blobByteOffset: 58220661596
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_fp16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 888491,
-    blobBlockLength: 5860,
-    blobByteOffset: 58220661596,
-    modelId: 'conditional_decoder_fp16.onnx_data',
-    addon: 'tts',
-    expectedSize: 384019328,
-    sha256Checksum: 'c6c3e79e6ff86bc41f77381a3d67b8edaa16b13e43a2700ca8159d0894bd594a',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: ''
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 908135,
-    blobBlockLength: 34,
-    blobByteOffset: 59507802472,
-    modelId: 'conditional_decoder_q4.onnx',
-    addon: 'tts',
-    expectedSize: 2179022,
-    sha256Checksum: 'dccb7a6cea3472dc7f7d070eeb70ade18e6327fb4ec61a3d62cf211bfed90ea2',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: '',
-    companionSet: {
-      setKey: '71925140895dd0fb',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4.onnx',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_q4.onnx',
-          expectedSize: 2179022,
-          sha256Checksum: 'dccb7a6cea3472dc7f7d070eeb70ade18e6327fb4ec61a3d62cf211bfed90ea2',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 908135,
-          blobBlockLength: 34,
-          blobByteOffset: 59507802472,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4.onnx_data',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_q4.onnx_data',
-          expectedSize: 246397384,
-          sha256Checksum: 'b5c5317e0b79a1a19dd3d5e2b2091ea06b15716716ab801a54eaeb906c6971ec',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 908169,
-          blobBlockLength: 3760,
-          blobByteOffset: 59509981494
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 908169,
-    blobBlockLength: 3760,
-    blobByteOffset: 59509981494,
-    modelId: 'conditional_decoder_q4.onnx_data',
-    addon: 'tts',
-    expectedSize: 246397384,
-    sha256Checksum: 'b5c5317e0b79a1a19dd3d5e2b2091ea06b15716716ab801a54eaeb906c6971ec',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: ''
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4F16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4f16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 935390,
-    blobBlockLength: 37,
-    blobByteOffset: 61293443741,
-    modelId: 'conditional_decoder_q4f16.onnx',
-    addon: 'tts',
-    expectedSize: 2394210,
-    sha256Checksum: '17c9f7caef818605df2dc197c2f41682c0bda7fe437b8652dae8366de8b68b7e',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: '',
-    companionSet: {
-      setKey: '7f54ee2de8be85a6',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4f16.onnx',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_q4f16.onnx',
-          expectedSize: 2394210,
-          sha256Checksum: '17c9f7caef818605df2dc197c2f41682c0bda7fe437b8652dae8366de8b68b7e',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 935390,
-          blobBlockLength: 37,
-          blobByteOffset: 61293443741,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4f16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_q4f16.onnx_data',
-          expectedSize: 162996136,
-          sha256Checksum: '3e53cc7cc05e72957797c620e1bf0c6d6b909df937de4756c6e534d50854ca3e',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 935427,
-          blobBlockLength: 2488,
-          blobByteOffset: 61295837951
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4F16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_q4f16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 935427,
-    blobBlockLength: 2488,
-    blobByteOffset: 61295837951,
-    modelId: 'conditional_decoder_q4f16.onnx_data',
-    addon: 'tts',
-    expectedSize: 162996136,
-    sha256Checksum: '3e53cc7cc05e72957797c620e1bf0c6d6b909df937de4756c6e534d50854ca3e',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: ''
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_QUANTIZED',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_quantized.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 921513,
-    blobBlockLength: 34,
-    blobByteOffset: 60384292589,
-    modelId: 'conditional_decoder_quantized.onnx',
-    addon: 'tts',
-    expectedSize: 2202035,
-    sha256Checksum: '2af3b150196d9d559cd3c91e03da80eb27a466032369dc2b57ea729cddad3ebb',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: '',
-    companionSet: {
-      setKey: 'f73f7a3f68d0b2a8',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_quantized.onnx',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_quantized.onnx',
-          expectedSize: 2202035,
-          sha256Checksum: '2af3b150196d9d559cd3c91e03da80eb27a466032369dc2b57ea729cddad3ebb',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 921513,
-          blobBlockLength: 34,
-          blobByteOffset: 60384292589,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_quantized.onnx_data',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder_quantized.onnx_data',
-          expectedSize: 326548688,
-          sha256Checksum: '4918ca09e05e41d2b4aa1ace6201d1cd911ffc58a42801002bab177d495cfe0a',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 921547,
-          blobBlockLength: 4983,
-          blobByteOffset: 60386494624
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_QUANTIZED_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder_quantized.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 921547,
-    blobBlockLength: 4983,
-    blobByteOffset: 60386494624,
-    modelId: 'conditional_decoder_quantized.onnx_data',
-    addon: 'tts',
-    expectedSize: 326548688,
-    sha256Checksum: '4918ca09e05e41d2b4aa1ace6201d1cd911ffc58a42801002bab177d495cfe0a',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: ''
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP32',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 847555,
-    blobBlockLength: 29,
-    blobByteOffset: 55538237192,
-    modelId: 'conditional_decoder.onnx',
-    addon: 'tts',
-    expectedSize: 1889468,
-    sha256Checksum: '8c43f3a1d0ddb1a86e226a244d7cda5396c67f5c6412789c23900c646e3ffc50',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '551caf7c863ac598',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder.onnx',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder.onnx',
-          expectedSize: 1889468,
-          sha256Checksum: '8c43f3a1d0ddb1a86e226a244d7cda5396c67f5c6412789c23900c646e3ffc50',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 847555,
-          blobBlockLength: 29,
-          blobByteOffset: 55538237192,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder.onnx_data',
-          registrySource: 'hf',
-          targetName: 'conditional_decoder.onnx_data',
-          expectedSize: 768593792,
-          sha256Checksum: '05f162a519f3e9abaf0b7337ae037f4af8b2b30c4455d39b2c61ed3a9b2b5476',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 847584,
-          blobBlockLength: 11728,
-          blobByteOffset: 55540126660
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/conditional_decoder.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 847584,
-    blobBlockLength: 11728,
-    blobByteOffset: 55540126660,
-    modelId: 'conditional_decoder.onnx_data',
-    addon: 'tts',
-    expectedSize: 768593792,
-    sha256Checksum: '05f162a519f3e9abaf0b7337ae037f4af8b2b30c4455d39b2c61ed3a9b2b5476',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_FP16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_fp16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 886680,
-    blobBlockLength: 1,
-    blobByteOffset: 58102149554,
-    modelId: 'embed_tokens_fp16.onnx',
-    addon: 'tts',
-    expectedSize: 1754,
-    sha256Checksum: 'f7a7a83e91337e10add2fad054544421f9080e27b72af1aef27f339a1a66776c',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: '',
-    companionSet: {
-      setKey: 'b1bc9d091f52ca6a',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_fp16.onnx',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_fp16.onnx',
-          expectedSize: 1754,
-          sha256Checksum: 'f7a7a83e91337e10add2fad054544421f9080e27b72af1aef27f339a1a66776c',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 886680,
-          blobBlockLength: 1,
-          blobByteOffset: 58102149554,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_fp16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_fp16.onnx_data',
-          expectedSize: 116406272,
-          sha256Checksum: 'cdda886a9e58ad39059fe8f6cf5a3a628994a1a2dfc1a8b58502c252fec70327',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 886681,
-          blobBlockLength: 1777,
-          blobByteOffset: 58102151308
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_FP16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_fp16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 886681,
-    blobBlockLength: 1777,
-    blobByteOffset: 58102151308,
-    modelId: 'embed_tokens_fp16.onnx_data',
-    addon: 'tts',
-    expectedSize: 116406272,
-    sha256Checksum: 'cdda886a9e58ad39059fe8f6cf5a3a628994a1a2dfc1a8b58502c252fec70327',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: ''
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 907565,
-    blobBlockLength: 1,
-    blobByteOffset: 59470513244,
-    modelId: 'embed_tokens_q4.onnx',
-    addon: 'tts',
-    expectedSize: 2844,
-    sha256Checksum: 'fd6ba1d22902e8f539d3dd6d7c1c44b98ebb4c84ebbb5e47fcb826ddcf667561',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: '',
-    companionSet: {
-      setKey: 'f29a0a423cbcd2bc',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4.onnx',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_q4.onnx',
-          expectedSize: 2844,
-          sha256Checksum: 'fd6ba1d22902e8f539d3dd6d7c1c44b98ebb4c84ebbb5e47fcb826ddcf667561',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 907565,
-          blobBlockLength: 1,
-          blobByteOffset: 59470513244,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4.onnx_data',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_q4.onnx_data',
-          expectedSize: 37286384,
-          sha256Checksum: 'f54a51e234b509b64c3a03bb79e1149fba7e2eba6c2d9c222f18883379e1f5d8',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 907566,
-          blobBlockLength: 569,
-          blobByteOffset: 59470516088
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 907566,
-    blobBlockLength: 569,
-    blobByteOffset: 59470516088,
-    modelId: 'embed_tokens_q4.onnx_data',
-    addon: 'tts',
-    expectedSize: 37286384,
-    sha256Checksum: 'f54a51e234b509b64c3a03bb79e1149fba7e2eba6c2d9c222f18883379e1f5d8',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: ''
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4F16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4f16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 934875,
-    blobBlockLength: 1,
-    blobByteOffset: 61259792505,
-    modelId: 'embed_tokens_q4f16.onnx',
-    addon: 'tts',
-    expectedSize: 2548,
-    sha256Checksum: 'e5c9507c89e770e35d68bdd669e4ae44b34272232e84f010f2c97959feae79b3',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: '',
-    companionSet: {
-      setKey: '69d01d68e2a72bf8',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4f16.onnx',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_q4f16.onnx',
-          expectedSize: 2548,
-          sha256Checksum: 'e5c9507c89e770e35d68bdd669e4ae44b34272232e84f010f2c97959feae79b3',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 934875,
-          blobBlockLength: 1,
-          blobByteOffset: 61259792505,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4f16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_q4f16.onnx_data',
-          expectedSize: 33648688,
-          sha256Checksum: '37e96447b5f3ef46f46fb35cc599cfcb95b277e5528cc0c89bab78169da620ef',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 934876,
-          blobBlockLength: 514,
-          blobByteOffset: 61259795053
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4F16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_q4f16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 934876,
-    blobBlockLength: 514,
-    blobByteOffset: 61259795053,
-    modelId: 'embed_tokens_q4f16.onnx_data',
-    addon: 'tts',
-    expectedSize: 33648688,
-    sha256Checksum: '37e96447b5f3ef46f46fb35cc599cfcb95b277e5528cc0c89bab78169da620ef',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: ''
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_QUANTIZED',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_quantized.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 920485,
-    blobBlockLength: 1,
-    blobByteOffset: 60316992326,
-    modelId: 'embed_tokens_quantized.onnx',
-    addon: 'tts',
-    expectedSize: 2887,
-    sha256Checksum: '0efe1bc01c2c48a98425a74444fd9887924d887f922c2722a6ec961ebb9e1db6',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: '',
-    companionSet: {
-      setKey: 'd64517c10b1f2a5d',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_quantized.onnx',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_quantized.onnx',
-          expectedSize: 2887,
-          sha256Checksum: '0efe1bc01c2c48a98425a74444fd9887924d887f922c2722a6ec961ebb9e1db6',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 920485,
-          blobBlockLength: 1,
-          blobByteOffset: 60316992326,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_quantized.onnx_data',
-          registrySource: 'hf',
-          targetName: 'embed_tokens_quantized.onnx_data',
-          expectedSize: 67297376,
-          sha256Checksum: '9025d04c124899823124b1d7bb7069b1f535fb8a6c2d88f97520eb6fecced986',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 920486,
-          blobBlockLength: 1027,
-          blobByteOffset: 60316995213
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_QUANTIZED_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens_quantized.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 920486,
-    blobBlockLength: 1027,
-    blobByteOffset: 60316995213,
-    modelId: 'embed_tokens_quantized.onnx_data',
-    addon: 'tts',
-    expectedSize: 67297376,
-    sha256Checksum: '9025d04c124899823124b1d7bb7069b1f535fb8a6c2d88f97520eb6fecced986',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: ''
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_FP32',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 844001,
-    blobBlockLength: 1,
-    blobByteOffset: 55305422590,
-    modelId: 'embed_tokens.onnx',
-    addon: 'tts',
-    expectedSize: 2058,
-    sha256Checksum: '27796e8252f36b463b0421cafdcc35b5f1e670ab0d96c9182f37ac6571c2f4bc',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: 'd28edd54895b90f5',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens.onnx',
-          registrySource: 'hf',
-          targetName: 'embed_tokens.onnx',
-          expectedSize: 2058,
-          sha256Checksum: '27796e8252f36b463b0421cafdcc35b5f1e670ab0d96c9182f37ac6571c2f4bc',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 844001,
-          blobBlockLength: 1,
-          blobByteOffset: 55305422590,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens.onnx_data',
-          registrySource: 'hf',
-          targetName: 'embed_tokens.onnx_data',
-          expectedSize: 232812544,
-          sha256Checksum: 'a1c37edc6ec6adb655351f02e958da297221b50211c2c01b69312cb6f008a293',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 844002,
-          blobBlockLength: 3553,
-          blobByteOffset: 55305424648
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/embed_tokens.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 844002,
-    blobBlockLength: 3553,
-    blobByteOffset: 55305424648,
-    modelId: 'embed_tokens.onnx_data',
-    addon: 'tts',
-    expectedSize: 232812544,
-    sha256Checksum: 'a1c37edc6ec6adb655351f02e958da297221b50211c2c01b69312cb6f008a293',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_fp16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 894351,
-    blobBlockLength: 4,
-    blobByteOffset: 58604680924,
-    modelId: 'language_model_fp16.onnx',
-    addon: 'tts',
-    expectedSize: 209456,
-    sha256Checksum: '396b35570dd1dbc5f537ffc932c3e69130ab8a09bf1390469d92338c8eae7da4',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: '',
-    companionSet: {
-      setKey: '45d1ac921a78ac7c',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_fp16.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_fp16.onnx',
-          expectedSize: 209456,
-          sha256Checksum: '396b35570dd1dbc5f537ffc932c3e69130ab8a09bf1390469d92338c8eae7da4',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 894351,
-          blobBlockLength: 4,
-          blobByteOffset: 58604680924,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_fp16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_fp16.onnx_data',
-          expectedSize: 634862406,
-          sha256Checksum: 'd730d6437126d3e232747b26e2a7adece68844f22133277ca5012298ffe36f93',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 894355,
-          blobBlockLength: 9688,
-          blobByteOffset: 58604890380
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_fp16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 894355,
-    blobBlockLength: 9688,
-    blobByteOffset: 58604890380,
-    modelId: 'language_model_fp16.onnx_data',
-    addon: 'tts',
-    expectedSize: 634862406,
-    sha256Checksum: 'd730d6437126d3e232747b26e2a7adece68844f22133277ca5012298ffe36f93',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: ''
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 911929,
-    blobBlockLength: 5,
-    blobByteOffset: 59756378878,
-    modelId: 'language_model_q4.onnx',
-    addon: 'tts',
-    expectedSize: 274572,
-    sha256Checksum: 'b39d03d3f8b943b9e60c6fce3fb41191dbc1df4589f913291db1e214eef669b1',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: '',
-    companionSet: {
-      setKey: '3e9f08f1693434fb',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_q4.onnx',
-          expectedSize: 274572,
-          sha256Checksum: 'b39d03d3f8b943b9e60c6fce3fb41191dbc1df4589f913291db1e214eef669b1',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 911929,
-          blobBlockLength: 5,
-          blobByteOffset: 59756378878,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_q4.onnx_data',
-          expectedSize: 204456572,
-          sha256Checksum: '2c029dc0acf48752473d8c74c72b5ceaaad76b9886fe106eaf2022142d5b5d5e',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 911934,
-          blobBlockLength: 3120,
-          blobByteOffset: 59756653450
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 911934,
-    blobBlockLength: 3120,
-    blobByteOffset: 59756653450,
-    modelId: 'language_model_q4.onnx_data',
-    addon: 'tts',
-    expectedSize: 204456572,
-    sha256Checksum: '2c029dc0acf48752473d8c74c72b5ceaaad76b9886fe106eaf2022142d5b5d5e',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: ''
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4F16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4f16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 937915,
-    blobBlockLength: 5,
-    blobByteOffset: 61458834087,
-    modelId: 'language_model_q4f16.onnx',
-    addon: 'tts',
-    expectedSize: 276803,
-    sha256Checksum: '4c5d83674c52bb71683a1ea1f60e2608b80cda48aafce67e8f8c03162c474ad5',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: '',
-    companionSet: {
-      setKey: '90ef94e71680af09',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4f16.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_q4f16.onnx',
-          expectedSize: 276803,
-          sha256Checksum: '4c5d83674c52bb71683a1ea1f60e2608b80cda48aafce67e8f8c03162c474ad5',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 937915,
-          blobBlockLength: 5,
-          blobByteOffset: 61458834087,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4f16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_q4f16.onnx_data',
-          expectedSize: 183981430,
-          sha256Checksum: 'f084f21f977e365e76e622d2958c309ff894537f7b7133ac7fc5ce8fc055d6f9',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 937920,
-          blobBlockLength: 2808,
-          blobByteOffset: 61459110890
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4F16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_q4f16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 937920,
-    blobBlockLength: 2808,
-    blobByteOffset: 61459110890,
-    modelId: 'language_model_q4f16.onnx_data',
-    addon: 'tts',
-    expectedSize: 183981430,
-    sha256Checksum: 'f084f21f977e365e76e622d2958c309ff894537f7b7133ac7fc5ce8fc055d6f9',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: ''
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_QUANTIZED',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_quantized.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 926530,
-    blobBlockLength: 5,
-    blobByteOffset: 60713043312,
-    modelId: 'language_model_quantized.onnx',
-    addon: 'tts',
-    expectedSize: 279670,
-    sha256Checksum: '0b40581277e30b7034331ec8c3ad47ed71d321f015b387a95221e54e2fcbfde8',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: '',
-    companionSet: {
-      setKey: '24f3196f529d67af',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_quantized.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model_quantized.onnx',
-          expectedSize: 279670,
-          sha256Checksum: '0b40581277e30b7034331ec8c3ad47ed71d321f015b387a95221e54e2fcbfde8',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 926530,
-          blobBlockLength: 5,
-          blobByteOffset: 60713043312,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_quantized.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model_quantized.onnx_data',
-          expectedSize: 367962860,
-          sha256Checksum: 'ec9945df36cb5d131d46688f2609fd715fbfcb0b8ee9681af5c84118de2d55a2',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 926535,
-          blobBlockLength: 5615,
-          blobByteOffset: 60713322982
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_QUANTIZED_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model_quantized.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 926535,
-    blobBlockLength: 5615,
-    blobByteOffset: 60713322982,
-    modelId: 'language_model_quantized.onnx_data',
-    addon: 'tts',
-    expectedSize: 367962860,
-    sha256Checksum: 'ec9945df36cb5d131d46688f2609fd715fbfcb0b8ee9681af5c84118de2d55a2',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: ''
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP32',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 859312,
-    blobBlockLength: 4,
-    blobByteOffset: 56308720452,
-    modelId: 'language_model.onnx',
-    addon: 'tts',
-    expectedSize: 207266,
-    sha256Checksum: 'c12e31df78c74f9589b165c8d51e65171f5028b77b7fedb41900f55f7f410dc8',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: '8ee93fc7439a8e37',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model.onnx',
-          registrySource: 'hf',
-          targetName: 'language_model.onnx',
-          expectedSize: 207266,
-          sha256Checksum: 'c12e31df78c74f9589b165c8d51e65171f5028b77b7fedb41900f55f7f410dc8',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 859312,
-          blobBlockLength: 4,
-          blobByteOffset: 56308720452,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model.onnx_data',
-          registrySource: 'hf',
-          targetName: 'language_model.onnx_data',
-          expectedSize: 1269724812,
-          sha256Checksum: '67db106868f5354b2e425651f1791aef36ae3e6f00ac5e1d91e32c985cad6b39',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 859316,
-          blobBlockLength: 19375,
-          blobByteOffset: 56308927718
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/language_model.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 859316,
-    blobBlockLength: 19375,
-    blobByteOffset: 56308927718,
-    modelId: 'language_model.onnx_data',
-    addon: 'tts',
-    expectedSize: 1269724812,
-    sha256Checksum: '67db106868f5354b2e425651f1791aef36ae3e6f00ac5e1d91e32c985cad6b39',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_fp16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 878691,
-    blobBlockLength: 19,
-    blobByteOffset: 57578652530,
-    modelId: 'speech_encoder_fp16.onnx',
-    addon: 'tts',
-    expectedSize: 1189888,
-    sha256Checksum: '5544f87c3e1615a31f5dc3ccdf9ba52a9f5fb8f6018e72796235fc1cfd5ebc9f',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: '',
-    companionSet: {
-      setKey: 'ae62d0fa9f3988d9',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_fp16.onnx',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_fp16.onnx',
-          expectedSize: 1189888,
-          sha256Checksum: '5544f87c3e1615a31f5dc3ccdf9ba52a9f5fb8f6018e72796235fc1cfd5ebc9f',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 878691,
-          blobBlockLength: 19,
-          blobByteOffset: 57578652530,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_fp16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_fp16.onnx_data',
-          expectedSize: 522307136,
-          sha256Checksum: 'd24b817ff61489373ab13033cbdc28a5ba8347341248a00f9a63f10888e81d73',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 878710,
-          blobBlockLength: 7970,
-          blobByteOffset: 57579842418
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_fp16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 878710,
-    blobBlockLength: 7970,
-    blobByteOffset: 57579842418,
-    modelId: 'speech_encoder_fp16.onnx_data',
-    addon: 'tts',
-    expectedSize: 522307136,
-    sha256Checksum: 'd24b817ff61489373ab13033cbdc28a5ba8347341248a00f9a63f10888e81d73',
-    engine: 'tts-ggml',
-    quantization: 'fp16',
-    params: ''
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 904043,
-    blobBlockLength: 19,
-    blobByteOffset: 59239752786,
-    modelId: 'speech_encoder_q4.onnx',
-    addon: 'tts',
-    expectedSize: 1200346,
-    sha256Checksum: '37956c20b67bed85a0da4bc83509d67b5969a1b257d1c546516a5236a17ad71e',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: '',
-    companionSet: {
-      setKey: '51d47e9adf4cd869',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4.onnx',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_q4.onnx',
-          expectedSize: 1200346,
-          sha256Checksum: '37956c20b67bed85a0da4bc83509d67b5969a1b257d1c546516a5236a17ad71e',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 904043,
-          blobBlockLength: 19,
-          blobByteOffset: 59239752786,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4.onnx_data',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_q4.onnx_data',
-          expectedSize: 229560112,
-          sha256Checksum: '58956db217c6443e49c91bdd54d7cf76b4a243f225c748b7bf746459fc27bc7d',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 904062,
-          blobBlockLength: 3503,
-          blobByteOffset: 59240953132
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 904062,
-    blobBlockLength: 3503,
-    blobByteOffset: 59240953132,
-    modelId: 'speech_encoder_q4.onnx_data',
-    addon: 'tts',
-    expectedSize: 229560112,
-    sha256Checksum: '58956db217c6443e49c91bdd54d7cf76b4a243f225c748b7bf746459fc27bc7d',
-    engine: 'tts-ggml',
-    quantization: 'q4',
-    params: ''
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4F16',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4f16.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 932150,
-    blobBlockLength: 19,
-    blobByteOffset: 61081285842,
-    modelId: 'speech_encoder_q4f16.onnx',
-    addon: 'tts',
-    expectedSize: 1217655,
-    sha256Checksum: '004407d26127c1d8e974bd213ecff8dbe67611527ca7a1930e656b80d9c51125',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: '',
-    companionSet: {
-      setKey: 'f5c445135945fed5',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4f16.onnx',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_q4f16.onnx',
-          expectedSize: 1217655,
-          sha256Checksum: '004407d26127c1d8e974bd213ecff8dbe67611527ca7a1930e656b80d9c51125',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 932150,
-          blobBlockLength: 19,
-          blobByteOffset: 61081285842,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4f16.onnx_data',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_q4f16.onnx_data',
-          expectedSize: 177289008,
-          sha256Checksum: 'c017ab57887418e0609afdef52b0cbc17f43cb304e78af44300c0292cd2b2fa9',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 932169,
-          blobBlockLength: 2706,
-          blobByteOffset: 61082503497
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4F16_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_q4f16.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 932169,
-    blobBlockLength: 2706,
-    blobByteOffset: 61082503497,
-    modelId: 'speech_encoder_q4f16.onnx_data',
-    addon: 'tts',
-    expectedSize: 177289008,
-    sha256Checksum: 'c017ab57887418e0609afdef52b0cbc17f43cb304e78af44300c0292cd2b2fa9',
-    engine: 'tts-ggml',
-    quantization: 'q4f16',
-    params: ''
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_QUANTIZED',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_quantized.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 915054,
-    blobBlockLength: 19,
-    blobByteOffset: 59961110022,
-    modelId: 'speech_encoder_quantized.onnx',
-    addon: 'tts',
-    expectedSize: 1205728,
-    sha256Checksum: '5b6f15870a43cf97892df86fc550a0ef4763522d527cde72b2a4316f80a34de4',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: '',
-    companionSet: {
-      setKey: '00381b6db7f2b857',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_quantized.onnx',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_quantized.onnx',
-          expectedSize: 1205728,
-          sha256Checksum: '5b6f15870a43cf97892df86fc550a0ef4763522d527cde72b2a4316f80a34de4',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 915054,
-          blobBlockLength: 19,
-          blobByteOffset: 59961110022,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_quantized.onnx_data',
-          registrySource: 'hf',
-          targetName: 'speech_encoder_quantized.onnx_data',
-          expectedSize: 354676576,
-          sha256Checksum: 'd59861fb55e806fbeee731da9d4f8ff819fb5735de5d15e262d902594ee4dbb6',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 915073,
-          blobBlockLength: 5412,
-          blobByteOffset: 59962315750
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_QUANTIZED_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder_quantized.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 915073,
-    blobBlockLength: 5412,
-    blobByteOffset: 59962315750,
-    modelId: 'speech_encoder_quantized.onnx_data',
-    addon: 'tts',
-    expectedSize: 354676576,
-    sha256Checksum: 'd59861fb55e806fbeee731da9d4f8ff819fb5735de5d15e262d902594ee4dbb6',
-    engine: 'tts-ggml',
-    quantization: 'quantized',
-    params: ''
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP32',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 828041,
-    blobBlockLength: 18,
-    blobByteOffset: 54259537686,
-    modelId: 'speech_encoder.onnx',
-    addon: 'tts',
-    expectedSize: 1172072,
-    sha256Checksum: '4d66128037517dd51d370edc9b89ce36d42c75dcbd96e7216c7fb45dfae36045',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: '',
-    companionSet: {
-      setKey: 'c2ae8c52ce330071',
-      primaryKey: 'modelPath',
-      files: [
-        {
-          key: 'modelPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder.onnx',
-          registrySource: 'hf',
-          targetName: 'speech_encoder.onnx',
-          expectedSize: 1172072,
-          sha256Checksum: '4d66128037517dd51d370edc9b89ce36d42c75dcbd96e7216c7fb45dfae36045',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 828041,
-          blobBlockLength: 18,
-          blobByteOffset: 54259537686,
-          primary: true
-        },
-        {
-          key: 'dataPath',
-          registryPath:
-            'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder.onnx_data',
-          registrySource: 'hf',
-          targetName: 'speech_encoder.onnx_data',
-          expectedSize: 1044712832,
-          sha256Checksum: 'c9915ff6c529e7bb80983b525255e6744d6c39c7e35b12720925ba99ed0d0a2f',
-          blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-          blobBlockOffset: 828059,
-          blobBlockLength: 15942,
-          blobByteOffset: 54260709758
-        }
-      ]
-    }
-  },
-  {
-    name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP32_DATA',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/onnx/speech_encoder.onnx_data',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 828059,
-    blobBlockLength: 15942,
-    blobByteOffset: 54260709758,
-    modelId: 'speech_encoder.onnx_data',
-    addon: 'tts',
-    expectedSize: 1044712832,
-    sha256Checksum: 'c9915ff6c529e7bb80983b525255e6744d6c39c7e35b12720925ba99ed0d0a2f',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_TOKENIZER_EN_CHATTERBOX',
-    registryPath:
-      'ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/tokenizer.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 827986,
-    blobBlockLength: 55,
-    blobByteOffset: 54255975414,
-    modelId: 'tokenizer.json',
-    addon: 'tts',
-    expectedSize: 3562272,
-    sha256Checksum: '3f04e34bea22f9144d1a19151154095bc9ce0430bf421304f5797e716288a906',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/duration_predictor.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2193975,
-    blobBlockLength: 24,
-    blobByteOffset: 143774135142,
-    modelId: 'duration_predictor.onnx',
-    addon: 'tts',
-    expectedSize: 1521526,
-    sha256Checksum: '6d556b3691165c364be91dc0bd894656b5949f5acd2750d8ec2f954010845011',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/text_encoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2193999,
-    blobBlockLength: 419,
-    blobByteOffset: 143775656668,
-    modelId: 'text_encoder.onnx',
-    addon: 'tts',
-    expectedSize: 27431318,
-    sha256Checksum: 'dd5f535ed629f7df86071043e15f541ce1b2ab7f1bdbce4c7892b307bca79fa3',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_TTS_CONFIG_SUPERTONE',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/tts.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2193974,
-    blobBlockLength: 1,
-    blobByteOffset: 143774126443,
-    modelId: 'tts.json',
-    addon: 'tts',
-    expectedSize: 8699,
-    sha256Checksum: 'ee531d9af9b80438a2ed703e22155ee6c83b12595ab22fd3bb6de94c7502fe96',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_UNICODE_INDEXER_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/unicode_indexer.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198946,
-    blobBlockLength: 5,
-    blobByteOffset: 144099214745,
-    modelId: 'unicode_indexer.json',
-    addon: 'tts',
-    expectedSize: 262196,
-    sha256Checksum: 'b7662a73a0703f43b97c0f2e089f8e8325e26f5d841aca393b5a54c509c92df1',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/vector_estimator.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2194418,
-    blobBlockLength: 2022,
-    blobByteOffset: 143803087986,
-    modelId: 'vector_estimator.onnx',
-    addon: 'tts',
-    expectedSize: 132471364,
-    sha256Checksum: '105e9d66fd8756876b210a6b4aa03fc393b1eaca3a8dadcc8d9a3bc785c86a35',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOCODER_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/vocoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2196440,
-    blobBlockLength: 1548,
-    blobByteOffset: 143935559350,
-    modelId: 'vocoder.onnx',
-    addon: 'tts',
-    expectedSize: 101405066,
-    sha256Checksum: '19bd51f47a186069c752403518a40f7ea4c647455056d2511f7249691ecddf7c',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/F1.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2197988,
-    blobBlockLength: 7,
-    blobByteOffset: 144036964416,
-    modelId: 'F1.json',
-    addon: 'tts',
-    expectedSize: 420050,
-    sha256Checksum: '6106950ebeb8a5da29ea22075f605db659cd07dbc288a68292543d9129aa250f',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_1',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/F2.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2197995,
-    blobBlockLength: 7,
-    blobByteOffset: 144037384466,
-    modelId: 'F2.json',
-    addon: 'tts',
-    expectedSize: 420293,
-    sha256Checksum: '8b97feb16d79ac0447136796708feac5f83dbabe92a5be1168212653c38729ae',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_2',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/F3.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198002,
-    blobBlockLength: 7,
-    blobByteOffset: 144037804759,
-    modelId: 'F3.json',
-    addon: 'tts',
-    expectedSize: 419887,
-    sha256Checksum: '7eda5bccb4e6eb7f228fa182462d5fcf982d77628234603599027f0734d70c29',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_3',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/F4.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198009,
-    blobBlockLength: 7,
-    blobByteOffset: 144038224646,
-    modelId: 'F4.json',
-    addon: 'tts',
-    expectedSize: 419642,
-    sha256Checksum: 'e056fc2bee393edc8bff761eb28f33fb461e8dad828c3b05348a010ac1b7bb79',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_4',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/F5.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198016,
-    blobBlockLength: 7,
-    blobByteOffset: 144038644288,
-    modelId: 'F5.json',
-    addon: 'tts',
-    expectedSize: 419709,
-    sha256Checksum: 'ce7645ad7e3c13cca04e0d62bf890ef9ac401988005ba8f5e9c9b59257bc6931',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_5',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/M1.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198023,
-    blobBlockLength: 7,
-    blobByteOffset: 144039063997,
-    modelId: 'M1.json',
-    addon: 'tts',
-    expectedSize: 420510,
-    sha256Checksum: 'a04c823cbda6dd1c7de131ec68fea83bbb70d7f29d61623304eb871e3b83b5a1',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_6',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/M2.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198030,
-    blobBlockLength: 7,
-    blobByteOffset: 144039484507,
-    modelId: 'M2.json',
-    addon: 'tts',
-    expectedSize: 420285,
-    sha256Checksum: '7ddd07bf873a3fd67d09ef4e8293b486beb658158b47e371166198e4c6926072',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_7',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/M3.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198037,
-    blobBlockLength: 7,
-    blobByteOffset: 144039904792,
-    modelId: 'M3.json',
-    addon: 'tts',
-    expectedSize: 420005,
-    sha256Checksum: 'e8e77a56459e4dc8cdfeb88e6f778dc9a0adf22e1184414f4b0e82a5d1edbe72',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_8',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/M4.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198044,
-    blobBlockLength: 7,
-    blobByteOffset: 144040324797,
-    modelId: 'M4.json',
-    addon: 'tts',
-    expectedSize: 419957,
-    sha256Checksum: '95322725e4d25d9ed4e7dcccbf0f3726b0e9a2471d876b7942373218dbd30174',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_9',
-    registryPath:
-      'Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/M5.json',
-    registrySource: 'hf',
-    blobCoreKey: '6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963',
-    blobBlockOffset: 2198051,
-    blobBlockLength: 7,
-    blobByteOffset: 144040744754,
-    modelId: 'M5.json',
-    addon: 'tts',
-    expectedSize: 419619,
-    sha256Checksum: 'be52f82327da63ff18481ce2dd8060c7df432e0168d748745ef3e21b92d706a5',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/onnx/duration_predictor.onnx',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 707944,
-    blobBlockLength: 23,
-    blobByteOffset: 46393934781,
-    modelId: 'duration_predictor.onnx',
-    addon: 'tts',
-    expectedSize: 1500789,
-    sha256Checksum: 'b861580c56a0cba2a2b82aa697ecb3c5a163c3240c60a0ddfac369d21d054092',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/onnx/text_encoder.onnx',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 707526,
-    blobBlockLength: 418,
-    blobByteOffset: 46366586408,
-    modelId: 'text_encoder.onnx',
-    addon: 'tts',
-    expectedSize: 27348373,
-    sha256Checksum: 'ba0c8ea74aeb5df00d21a89b8d47c71317f47120232e3deef95024dba37dbd88',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_TTS_CONFIG_SUPERTONE',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/onnx/tts.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 707521,
-    blobBlockLength: 1,
-    blobByteOffset: 46366315629,
-    modelId: 'tts.json',
-    addon: 'tts',
-    expectedSize: 8645,
-    sha256Checksum: '4dac5f986698a3ace9a97ea2545d43f6c8ba120d25e005f8c905128281be9b6d',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_UNICODE_INDEXER_SUPERTONE',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/onnx/unicode_indexer.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 707522,
-    blobBlockLength: 4,
-    blobByteOffset: 46366324274,
-    modelId: 'unicode_indexer.json',
-    addon: 'tts',
-    expectedSize: 262134,
-    sha256Checksum: '0c3800ba4fb1fc760c9070eb43a0ad5a68279ec165742591a68ea3edca452978',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/onnx/vector_estimator.onnx',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 707967,
-    blobBlockLength: 2022,
-    blobByteOffset: 46395435570,
-    modelId: 'vector_estimator.onnx',
-    addon: 'tts',
-    expectedSize: 132471364,
-    sha256Checksum: 'b3f82ecd2e9decc4e2236048b03628a1c1d5f14a792ba274a59b7325107aa6a6',
-    engine: 'tts-ggml',
-    quantization: 'fp32',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/F1.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711537,
-    blobBlockLength: 7,
-    blobByteOffset: 46629312000,
-    modelId: 'F1.json',
-    addon: 'tts',
-    expectedSize: 420622,
-    sha256Checksum: '1450bcad84a2790eaf73f85e763dd5bae7c399f55d692c4835cf4f7686b5a10f',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_1',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/F2.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711544,
-    blobBlockLength: 7,
-    blobByteOffset: 46629732622,
-    modelId: 'F2.json',
-    addon: 'tts',
-    expectedSize: 420905,
-    sha256Checksum: '47c8d44445ef8ac8aae8ef5806feca21903483cbd4f1232e405184a40520a549',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_2',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/F3.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711551,
-    blobBlockLength: 7,
-    blobByteOffset: 46630153527,
-    modelId: 'F3.json',
-    addon: 'tts',
-    expectedSize: 420019,
-    sha256Checksum: '93d17bf5e967d11b9119877bab9e3c6a43350f9146a8db265abba102f29cdb36',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_3',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/F4.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711558,
-    blobBlockLength: 7,
-    blobByteOffset: 46630573546,
-    modelId: 'F4.json',
-    addon: 'tts',
-    expectedSize: 420646,
-    sha256Checksum: '325d8da46877089a67b7dfe1e59d04133d1f883754670af6b612a64b5ea697f2',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_4',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/F5.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711565,
-    blobBlockLength: 7,
-    blobByteOffset: 46630994192,
-    modelId: 'F5.json',
-    addon: 'tts',
-    expectedSize: 420080,
-    sha256Checksum: '72fd8e30dc65d2ad18a4bfdc48c925b5635219c1cb09a93096a81707bd2f695e',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_5',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/M1.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711572,
-    blobBlockLength: 7,
-    blobByteOffset: 46631414272,
-    modelId: 'M1.json',
-    addon: 'tts',
-    expectedSize: 421053,
-    sha256Checksum: '273c9ba6582d2e00383d8fbe2f5d660d86e8fba849c91ff695384d1a6e2e02f1',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_6',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/M2.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711579,
-    blobBlockLength: 7,
-    blobByteOffset: 46631835325,
-    modelId: 'M2.json',
-    addon: 'tts',
-    expectedSize: 421027,
-    sha256Checksum: '26898a9ec3de1b5bf8cc3f6cbf41930543ca0403f2201e12aad849691ff315dd',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_7',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/M3.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711586,
-    blobBlockLength: 7,
-    blobByteOffset: 46632256352,
-    modelId: 'M3.json',
-    addon: 'tts',
-    expectedSize: 420483,
-    sha256Checksum: '208b4f6d66ce68a1067602aa7e71b20d98d74a981ba14bdaa5df4df2c40e4068',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_8',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/M4.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711593,
-    blobBlockLength: 7,
-    blobByteOffset: 46632676835,
-    modelId: 'M4.json',
-    addon: 'tts',
-    expectedSize: 420577,
-    sha256Checksum: '733eec0e79cfd8e506368cdad0e863cf581d172caa31b9d412be613fd8649120',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
-  },
-  {
-    name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_9',
-    registryPath:
-      'Supertone/supertonic/resolve/b6856d033f622c63ea29441795be266a1133e227/voice_styles/M5.json',
-    registrySource: 'hf',
-    blobCoreKey: 'd90c0263033385abdb2290a69936d5cef030d5c63c87baa33c3a4a2d01b84ca8',
-    blobBlockOffset: 711600,
-    blobBlockLength: 7,
-    blobByteOffset: 46633097412,
-    modelId: 'M5.json',
-    addon: 'tts',
-    expectedSize: 420456,
-    sha256Checksum: 'f0c80d2f423f8a916cf3a92ee4356d63622265a9ab34ea79994eb7f751d2d245',
-    engine: 'tts-ggml',
-    quantization: '',
-    params: ''
+    blobBlockOffset: 4593738,
+    blobBlockLength: 57366,
+    blobByteOffset: 301042854506,
+    modelId: 'groot-q8_vf16.gguf',
+    addon: 'vla',
+    expectedSize: 3759519072,
+    sha256Checksum: '27b57d1d54122649e6fee6ed0bba07559bb61e7872cfcae5e9b13ce016391f7d',
+    engine: 'ggml-vla',
+    quantization: 'q8_vf16',
+    params: 'groot-n1.7-3b-libero'
   },
   {
     name: 'PI05_BASE_Q_AGGRESSIVE',
@@ -21000,8 +17989,8 @@ export const FLUX_2_KLEIN_4B_Q8_0 = {
   params: models[20].params
 } as const
 
-export const QWEN3_4B_Q4_K_M = {
-  name: 'QWEN3_4B_Q4_K_M',
+export const GTE_LARGE_FP16 = {
+  name: 'GTE_LARGE_FP16',
   src: `registry://${models[21].registrySource}/${models[21].registryPath}`,
   registryPath: models[21].registryPath,
   registrySource: models[21].registrySource,
@@ -21018,8 +18007,8 @@ export const QWEN3_4B_Q4_K_M = {
   params: models[21].params
 } as const
 
-export const GTE_LARGE_FP16 = {
-  name: 'GTE_LARGE_FP16',
+export const GTE_LARGE_335M_FP16_SHARD = {
+  name: 'GTE_LARGE_335M_FP16_SHARD',
   src: `registry://${models[22].registrySource}/${models[22].registryPath}`,
   registryPath: models[22].registryPath,
   registrySource: models[22].registrySource,
@@ -21036,8 +18025,8 @@ export const GTE_LARGE_FP16 = {
   params: models[22].params
 } as const
 
-export const GTE_LARGE_335M_FP16_SHARD = {
-  name: 'GTE_LARGE_335M_FP16_SHARD',
+export const GTE_LARGE_335M_FP16_TENSORS = {
+  name: 'GTE_LARGE_335M_FP16_TENSORS',
   src: `registry://${models[23].registrySource}/${models[23].registryPath}`,
   registryPath: models[23].registryPath,
   registrySource: models[23].registrySource,
@@ -21054,8 +18043,8 @@ export const GTE_LARGE_335M_FP16_SHARD = {
   params: models[23].params
 } as const
 
-export const GTE_LARGE_335M_FP16_TENSORS = {
-  name: 'GTE_LARGE_335M_FP16_TENSORS',
+export const EMBEDDINGGEMMA_300M_BF16 = {
+  name: 'EMBEDDINGGEMMA_300M_BF16',
   src: `registry://${models[24].registrySource}/${models[24].registryPath}`,
   registryPath: models[24].registryPath,
   registrySource: models[24].registrySource,
@@ -21072,8 +18061,8 @@ export const GTE_LARGE_335M_FP16_TENSORS = {
   params: models[24].params
 } as const
 
-export const EMBEDDINGGEMMA_300M_BF16 = {
-  name: 'EMBEDDINGGEMMA_300M_BF16',
+export const EMBEDDINGGEMMA_300M_F32 = {
+  name: 'EMBEDDINGGEMMA_300M_F32',
   src: `registry://${models[25].registrySource}/${models[25].registryPath}`,
   registryPath: models[25].registryPath,
   registrySource: models[25].registrySource,
@@ -21090,8 +18079,8 @@ export const EMBEDDINGGEMMA_300M_BF16 = {
   params: models[25].params
 } as const
 
-export const EMBEDDINGGEMMA_300M_F32 = {
-  name: 'EMBEDDINGGEMMA_300M_F32',
+export const EMBEDDINGGEMMA_300M_Q4_0 = {
+  name: 'EMBEDDINGGEMMA_300M_Q4_0',
   src: `registry://${models[26].registrySource}/${models[26].registryPath}`,
   registryPath: models[26].registryPath,
   registrySource: models[26].registrySource,
@@ -21108,8 +18097,8 @@ export const EMBEDDINGGEMMA_300M_F32 = {
   params: models[26].params
 } as const
 
-export const EMBEDDINGGEMMA_300M_Q4_0 = {
-  name: 'EMBEDDINGGEMMA_300M_Q4_0',
+export const EMBEDDINGGEMMA_300M_Q8_0 = {
+  name: 'EMBEDDINGGEMMA_300M_Q8_0',
   src: `registry://${models[27].registrySource}/${models[27].registryPath}`,
   registryPath: models[27].registryPath,
   registrySource: models[27].registrySource,
@@ -21126,8 +18115,8 @@ export const EMBEDDINGGEMMA_300M_Q4_0 = {
   params: models[27].params
 } as const
 
-export const EMBEDDINGGEMMA_300M_Q8_0 = {
-  name: 'EMBEDDINGGEMMA_300M_Q8_0',
+export const GEMMA4_31B_MULTIMODAL_Q4_K_M = {
+  name: 'GEMMA4_31B_MULTIMODAL_Q4_K_M',
   src: `registry://${models[28].registrySource}/${models[28].registryPath}`,
   registryPath: models[28].registryPath,
   registrySource: models[28].registrySource,
@@ -21144,8 +18133,8 @@ export const EMBEDDINGGEMMA_300M_Q8_0 = {
   params: models[28].params
 } as const
 
-export const GEMMA4_31B_MULTIMODAL_Q4_K_M = {
-  name: 'GEMMA4_31B_MULTIMODAL_Q4_K_M',
+export const GEMMA4_31B_MULTIMODAL_Q6_K = {
+  name: 'GEMMA4_31B_MULTIMODAL_Q6_K',
   src: `registry://${models[29].registrySource}/${models[29].registryPath}`,
   registryPath: models[29].registryPath,
   registrySource: models[29].registrySource,
@@ -21162,8 +18151,8 @@ export const GEMMA4_31B_MULTIMODAL_Q4_K_M = {
   params: models[29].params
 } as const
 
-export const GEMMA4_31B_MULTIMODAL_Q6_K = {
-  name: 'GEMMA4_31B_MULTIMODAL_Q6_K',
+export const MMPROJ_GEMMA4_31B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_GEMMA4_31B_MULTIMODAL_BF16',
   src: `registry://${models[30].registrySource}/${models[30].registryPath}`,
   registryPath: models[30].registryPath,
   registrySource: models[30].registrySource,
@@ -21180,8 +18169,8 @@ export const GEMMA4_31B_MULTIMODAL_Q6_K = {
   params: models[30].params
 } as const
 
-export const MMPROJ_GEMMA4_31B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_GEMMA4_31B_MULTIMODAL_BF16',
+export const MMPROJ_GEMMA4_31B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_GEMMA4_31B_MULTIMODAL_F16',
   src: `registry://${models[31].registrySource}/${models[31].registryPath}`,
   registryPath: models[31].registryPath,
   registrySource: models[31].registrySource,
@@ -21198,8 +18187,8 @@ export const MMPROJ_GEMMA4_31B_MULTIMODAL_BF16 = {
   params: models[31].params
 } as const
 
-export const MMPROJ_GEMMA4_31B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_GEMMA4_31B_MULTIMODAL_F16',
+export const GEMMA4_2B_MULTIMODAL_Q4_K_M = {
+  name: 'GEMMA4_2B_MULTIMODAL_Q4_K_M',
   src: `registry://${models[32].registrySource}/${models[32].registryPath}`,
   registryPath: models[32].registryPath,
   registrySource: models[32].registrySource,
@@ -21216,8 +18205,8 @@ export const MMPROJ_GEMMA4_31B_MULTIMODAL_F16 = {
   params: models[32].params
 } as const
 
-export const GEMMA4_2B_MULTIMODAL_Q4_K_M = {
-  name: 'GEMMA4_2B_MULTIMODAL_Q4_K_M',
+export const GEMMA4_2B_MULTIMODAL_Q6_K = {
+  name: 'GEMMA4_2B_MULTIMODAL_Q6_K',
   src: `registry://${models[33].registrySource}/${models[33].registryPath}`,
   registryPath: models[33].registryPath,
   registrySource: models[33].registrySource,
@@ -21234,8 +18223,8 @@ export const GEMMA4_2B_MULTIMODAL_Q4_K_M = {
   params: models[33].params
 } as const
 
-export const GEMMA4_2B_MULTIMODAL_Q6_K = {
-  name: 'GEMMA4_2B_MULTIMODAL_Q6_K',
+export const GEMMA4_2B_MULTIMODAL_Q8_0 = {
+  name: 'GEMMA4_2B_MULTIMODAL_Q8_0',
   src: `registry://${models[34].registrySource}/${models[34].registryPath}`,
   registryPath: models[34].registryPath,
   registrySource: models[34].registrySource,
@@ -22458,8 +19447,8 @@ export const QWEN3_1_7B_INST_Q4 = {
   params: models[101].params
 } as const
 
-export const MMPROJ_QWEN3_5_0_8B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_QWEN3_5_0_8B_MULTIMODAL_BF16',
+export const QWEN3_4B_Q4_K_M = {
+  name: 'QWEN3_4B_Q4_K_M',
   src: `registry://${models[102].registrySource}/${models[102].registryPath}`,
   registryPath: models[102].registryPath,
   registrySource: models[102].registrySource,
@@ -22476,8 +19465,8 @@ export const MMPROJ_QWEN3_5_0_8B_MULTIMODAL_BF16 = {
   params: models[102].params
 } as const
 
-export const MMPROJ_QWEN3_5_0_8B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_QWEN3_5_0_8B_MULTIMODAL_F16',
+export const MMPROJ_QWEN3_5_0_8B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_QWEN3_5_0_8B_MULTIMODAL_BF16',
   src: `registry://${models[103].registrySource}/${models[103].registryPath}`,
   registryPath: models[103].registryPath,
   registrySource: models[103].registrySource,
@@ -22494,8 +19483,8 @@ export const MMPROJ_QWEN3_5_0_8B_MULTIMODAL_F16 = {
   params: models[103].params
 } as const
 
-export const QWEN3_5_0_8B_MULTIMODAL_Q4_K_M = {
-  name: 'QWEN3_5_0_8B_MULTIMODAL_Q4_K_M',
+export const MMPROJ_QWEN3_5_0_8B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_QWEN3_5_0_8B_MULTIMODAL_F16',
   src: `registry://${models[104].registrySource}/${models[104].registryPath}`,
   registryPath: models[104].registryPath,
   registrySource: models[104].registrySource,
@@ -22512,8 +19501,8 @@ export const QWEN3_5_0_8B_MULTIMODAL_Q4_K_M = {
   params: models[104].params
 } as const
 
-export const QWEN3_5_0_8B_MULTIMODAL_Q6_K = {
-  name: 'QWEN3_5_0_8B_MULTIMODAL_Q6_K',
+export const QWEN3_5_0_8B_MULTIMODAL_Q4_K_M = {
+  name: 'QWEN3_5_0_8B_MULTIMODAL_Q4_K_M',
   src: `registry://${models[105].registrySource}/${models[105].registryPath}`,
   registryPath: models[105].registryPath,
   registrySource: models[105].registrySource,
@@ -22530,8 +19519,8 @@ export const QWEN3_5_0_8B_MULTIMODAL_Q6_K = {
   params: models[105].params
 } as const
 
-export const QWEN3_5_0_8B_MULTIMODAL_Q8_0 = {
-  name: 'QWEN3_5_0_8B_MULTIMODAL_Q8_0',
+export const QWEN3_5_0_8B_MULTIMODAL_Q6_K = {
+  name: 'QWEN3_5_0_8B_MULTIMODAL_Q6_K',
   src: `registry://${models[106].registrySource}/${models[106].registryPath}`,
   registryPath: models[106].registryPath,
   registrySource: models[106].registrySource,
@@ -22548,8 +19537,8 @@ export const QWEN3_5_0_8B_MULTIMODAL_Q8_0 = {
   params: models[106].params
 } as const
 
-export const MMPROJ_QWEN3_5_2B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_QWEN3_5_2B_MULTIMODAL_BF16',
+export const QWEN3_5_0_8B_MULTIMODAL_Q8_0 = {
+  name: 'QWEN3_5_0_8B_MULTIMODAL_Q8_0',
   src: `registry://${models[107].registrySource}/${models[107].registryPath}`,
   registryPath: models[107].registryPath,
   registrySource: models[107].registrySource,
@@ -22566,8 +19555,8 @@ export const MMPROJ_QWEN3_5_2B_MULTIMODAL_BF16 = {
   params: models[107].params
 } as const
 
-export const MMPROJ_QWEN3_5_2B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_QWEN3_5_2B_MULTIMODAL_F16',
+export const MMPROJ_QWEN3_5_2B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_QWEN3_5_2B_MULTIMODAL_BF16',
   src: `registry://${models[108].registrySource}/${models[108].registryPath}`,
   registryPath: models[108].registryPath,
   registrySource: models[108].registrySource,
@@ -22584,8 +19573,8 @@ export const MMPROJ_QWEN3_5_2B_MULTIMODAL_F16 = {
   params: models[108].params
 } as const
 
-export const QWEN3_5_2B_MULTIMODAL_Q4_K_M = {
-  name: 'QWEN3_5_2B_MULTIMODAL_Q4_K_M',
+export const MMPROJ_QWEN3_5_2B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_QWEN3_5_2B_MULTIMODAL_F16',
   src: `registry://${models[109].registrySource}/${models[109].registryPath}`,
   registryPath: models[109].registryPath,
   registrySource: models[109].registrySource,
@@ -22602,8 +19591,8 @@ export const QWEN3_5_2B_MULTIMODAL_Q4_K_M = {
   params: models[109].params
 } as const
 
-export const QWEN3_5_2B_MULTIMODAL_Q6_K = {
-  name: 'QWEN3_5_2B_MULTIMODAL_Q6_K',
+export const QWEN3_5_2B_MULTIMODAL_Q4_K_M = {
+  name: 'QWEN3_5_2B_MULTIMODAL_Q4_K_M',
   src: `registry://${models[110].registrySource}/${models[110].registryPath}`,
   registryPath: models[110].registryPath,
   registrySource: models[110].registrySource,
@@ -22620,8 +19609,8 @@ export const QWEN3_5_2B_MULTIMODAL_Q6_K = {
   params: models[110].params
 } as const
 
-export const MMPROJ_QWEN3_5_4B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_QWEN3_5_4B_MULTIMODAL_BF16',
+export const QWEN3_5_2B_MULTIMODAL_Q6_K = {
+  name: 'QWEN3_5_2B_MULTIMODAL_Q6_K',
   src: `registry://${models[111].registrySource}/${models[111].registryPath}`,
   registryPath: models[111].registryPath,
   registrySource: models[111].registrySource,
@@ -22638,8 +19627,8 @@ export const MMPROJ_QWEN3_5_4B_MULTIMODAL_BF16 = {
   params: models[111].params
 } as const
 
-export const MMPROJ_QWEN3_5_4B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_QWEN3_5_4B_MULTIMODAL_F16',
+export const QWEN3_5_2B_MULTIMODAL_Q8_0 = {
+  name: 'QWEN3_5_2B_MULTIMODAL_Q8_0',
   src: `registry://${models[112].registrySource}/${models[112].registryPath}`,
   registryPath: models[112].registryPath,
   registrySource: models[112].registrySource,
@@ -22656,8 +19645,8 @@ export const MMPROJ_QWEN3_5_4B_MULTIMODAL_F16 = {
   params: models[112].params
 } as const
 
-export const QWEN3_5_4B_MULTIMODAL_Q4_K_M = {
-  name: 'QWEN3_5_4B_MULTIMODAL_Q4_K_M',
+export const MMPROJ_QWEN3_5_4B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_QWEN3_5_4B_MULTIMODAL_BF16',
   src: `registry://${models[113].registrySource}/${models[113].registryPath}`,
   registryPath: models[113].registryPath,
   registrySource: models[113].registrySource,
@@ -22674,8 +19663,8 @@ export const QWEN3_5_4B_MULTIMODAL_Q4_K_M = {
   params: models[113].params
 } as const
 
-export const QWEN3_5_4B_MULTIMODAL_Q6_K = {
-  name: 'QWEN3_5_4B_MULTIMODAL_Q6_K',
+export const MMPROJ_QWEN3_5_4B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_QWEN3_5_4B_MULTIMODAL_F16',
   src: `registry://${models[114].registrySource}/${models[114].registryPath}`,
   registryPath: models[114].registryPath,
   registrySource: models[114].registrySource,
@@ -22692,8 +19681,8 @@ export const QWEN3_5_4B_MULTIMODAL_Q6_K = {
   params: models[114].params
 } as const
 
-export const MMPROJ_QWEN3_5_9B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_QWEN3_5_9B_MULTIMODAL_BF16',
+export const QWEN3_5_4B_MULTIMODAL_Q4_K_M = {
+  name: 'QWEN3_5_4B_MULTIMODAL_Q4_K_M',
   src: `registry://${models[115].registrySource}/${models[115].registryPath}`,
   registryPath: models[115].registryPath,
   registrySource: models[115].registrySource,
@@ -22710,8 +19699,8 @@ export const MMPROJ_QWEN3_5_9B_MULTIMODAL_BF16 = {
   params: models[115].params
 } as const
 
-export const MMPROJ_QWEN3_5_9B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_QWEN3_5_9B_MULTIMODAL_F16',
+export const QWEN3_5_4B_MULTIMODAL_Q6_K = {
+  name: 'QWEN3_5_4B_MULTIMODAL_Q6_K',
   src: `registry://${models[116].registrySource}/${models[116].registryPath}`,
   registryPath: models[116].registryPath,
   registrySource: models[116].registrySource,
@@ -22728,8 +19717,8 @@ export const MMPROJ_QWEN3_5_9B_MULTIMODAL_F16 = {
   params: models[116].params
 } as const
 
-export const QWEN3_5_9B_MULTIMODAL_Q4_K_M = {
-  name: 'QWEN3_5_9B_MULTIMODAL_Q4_K_M',
+export const MMPROJ_QWEN3_5_9B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_QWEN3_5_9B_MULTIMODAL_BF16',
   src: `registry://${models[117].registrySource}/${models[117].registryPath}`,
   registryPath: models[117].registryPath,
   registrySource: models[117].registrySource,
@@ -22746,8 +19735,8 @@ export const QWEN3_5_9B_MULTIMODAL_Q4_K_M = {
   params: models[117].params
 } as const
 
-export const QWEN3_5_9B_MULTIMODAL_Q6_K = {
-  name: 'QWEN3_5_9B_MULTIMODAL_Q6_K',
+export const MMPROJ_QWEN3_5_9B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_QWEN3_5_9B_MULTIMODAL_F16',
   src: `registry://${models[118].registrySource}/${models[118].registryPath}`,
   registryPath: models[118].registryPath,
   registrySource: models[118].registrySource,
@@ -22764,8 +19753,8 @@ export const QWEN3_5_9B_MULTIMODAL_Q6_K = {
   params: models[118].params
 } as const
 
-export const MMPROJ_QWEN3_6_27B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_QWEN3_6_27B_MULTIMODAL_BF16',
+export const QWEN3_5_9B_MULTIMODAL_Q4_K_M = {
+  name: 'QWEN3_5_9B_MULTIMODAL_Q4_K_M',
   src: `registry://${models[119].registrySource}/${models[119].registryPath}`,
   registryPath: models[119].registryPath,
   registrySource: models[119].registrySource,
@@ -22782,8 +19771,8 @@ export const MMPROJ_QWEN3_6_27B_MULTIMODAL_BF16 = {
   params: models[119].params
 } as const
 
-export const MMPROJ_QWEN3_6_27B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_QWEN3_6_27B_MULTIMODAL_F16',
+export const QWEN3_5_9B_MULTIMODAL_Q6_K = {
+  name: 'QWEN3_5_9B_MULTIMODAL_Q6_K',
   src: `registry://${models[120].registrySource}/${models[120].registryPath}`,
   registryPath: models[120].registryPath,
   registrySource: models[120].registrySource,
@@ -22800,8 +19789,8 @@ export const MMPROJ_QWEN3_6_27B_MULTIMODAL_F16 = {
   params: models[120].params
 } as const
 
-export const QWEN3_6_27B_MULTIMODAL_Q4_K_XL = {
-  name: 'QWEN3_6_27B_MULTIMODAL_Q4_K_XL',
+export const MMPROJ_QWEN3_6_27B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_QWEN3_6_27B_MULTIMODAL_BF16',
   src: `registry://${models[121].registrySource}/${models[121].registryPath}`,
   registryPath: models[121].registryPath,
   registrySource: models[121].registrySource,
@@ -22818,8 +19807,8 @@ export const QWEN3_6_27B_MULTIMODAL_Q4_K_XL = {
   params: models[121].params
 } as const
 
-export const QWEN3_6_27B_MULTIMODAL_Q6_K_XL = {
-  name: 'QWEN3_6_27B_MULTIMODAL_Q6_K_XL',
+export const MMPROJ_QWEN3_6_27B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_QWEN3_6_27B_MULTIMODAL_F16',
   src: `registry://${models[122].registrySource}/${models[122].registryPath}`,
   registryPath: models[122].registryPath,
   registrySource: models[122].registrySource,
@@ -22836,8 +19825,8 @@ export const QWEN3_6_27B_MULTIMODAL_Q6_K_XL = {
   params: models[122].params
 } as const
 
-export const MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_BF16 = {
-  name: 'MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_BF16',
+export const QWEN3_6_27B_MULTIMODAL_Q4_K_XL = {
+  name: 'QWEN3_6_27B_MULTIMODAL_Q4_K_XL',
   src: `registry://${models[123].registrySource}/${models[123].registryPath}`,
   registryPath: models[123].registryPath,
   registrySource: models[123].registrySource,
@@ -22854,8 +19843,8 @@ export const MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_BF16 = {
   params: models[123].params
 } as const
 
-export const MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_F16 = {
-  name: 'MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_F16',
+export const QWEN3_6_27B_MULTIMODAL_Q6_K_XL = {
+  name: 'QWEN3_6_27B_MULTIMODAL_Q6_K_XL',
   src: `registry://${models[124].registrySource}/${models[124].registryPath}`,
   registryPath: models[124].registryPath,
   registrySource: models[124].registrySource,
@@ -22872,8 +19861,8 @@ export const MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_F16 = {
   params: models[124].params
 } as const
 
-export const QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M = {
-  name: 'QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M',
+export const MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_BF16 = {
+  name: 'MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_BF16',
   src: `registry://${models[125].registrySource}/${models[125].registryPath}`,
   registryPath: models[125].registryPath,
   registrySource: models[125].registrySource,
@@ -22890,8 +19879,8 @@ export const QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M = {
   params: models[125].params
 } as const
 
-export const QWEN3_6_35B_A3B_MULTIMODAL_Q6_K_XL = {
-  name: 'QWEN3_6_35B_A3B_MULTIMODAL_Q6_K_XL',
+export const MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_F16 = {
+  name: 'MMPROJ_QWEN3_6_35B_A3B_MULTIMODAL_F16',
   src: `registry://${models[126].registrySource}/${models[126].registryPath}`,
   registryPath: models[126].registryPath,
   registrySource: models[126].registrySource,
@@ -22908,1844 +19897,1862 @@ export const QWEN3_6_35B_A3B_MULTIMODAL_Q6_K_XL = {
   params: models[126].params
 } as const
 
+export const QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M = {
+  name: 'QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M',
+  src: `registry://${models[127].registrySource}/${models[127].registryPath}`,
+  registryPath: models[127].registryPath,
+  registrySource: models[127].registrySource,
+  blobCoreKey: models[127].blobCoreKey,
+  blobBlockOffset: models[127].blobBlockOffset,
+  blobBlockLength: models[127].blobBlockLength,
+  blobByteOffset: models[127].blobByteOffset,
+  modelId: models[127].modelId,
+  expectedSize: models[127].expectedSize,
+  sha256Checksum: models[127].sha256Checksum,
+  addon: models[127].addon,
+  engine: models[127].engine,
+  quantization: models[127].quantization,
+  params: models[127].params
+} as const
+
+export const QWEN3_6_35B_A3B_MULTIMODAL_Q6_K_XL = {
+  name: 'QWEN3_6_35B_A3B_MULTIMODAL_Q6_K_XL',
+  src: `registry://${models[128].registrySource}/${models[128].registryPath}`,
+  registryPath: models[128].registryPath,
+  registrySource: models[128].registrySource,
+  blobCoreKey: models[128].blobCoreKey,
+  blobBlockOffset: models[128].blobBlockOffset,
+  blobBlockLength: models[128].blobBlockLength,
+  blobByteOffset: models[128].blobByteOffset,
+  modelId: models[128].modelId,
+  expectedSize: models[128].expectedSize,
+  sha256Checksum: models[128].sha256Checksum,
+  addon: models[128].addon,
+  engine: models[128].engine,
+  quantization: models[128].quantization,
+  params: models[128].params
+} as const
+
 export const BERGAMOT_AR_EN = {
   name: 'BERGAMOT_AR_EN',
-  src: `registry://${models[129].registrySource}/${models[129].registryPath}`,
-  registryPath: models[129].registryPath,
-  registrySource: models[129].registrySource,
-  blobCoreKey: models[129].blobCoreKey,
-  blobBlockOffset: models[129].blobBlockOffset,
-  blobBlockLength: models[129].blobBlockLength,
-  blobByteOffset: models[129].blobByteOffset,
-  modelId: models[129].modelId,
-  expectedSize: models[129].expectedSize,
-  sha256Checksum: models[129].sha256Checksum,
-  addon: models[129].addon,
-  engine: models[129].engine,
-  quantization: models[129].quantization,
-  params: models[129].params
+  src: `registry://${models[131].registrySource}/${models[131].registryPath}`,
+  registryPath: models[131].registryPath,
+  registrySource: models[131].registrySource,
+  blobCoreKey: models[131].blobCoreKey,
+  blobBlockOffset: models[131].blobBlockOffset,
+  blobBlockLength: models[131].blobBlockLength,
+  blobByteOffset: models[131].blobByteOffset,
+  modelId: models[131].modelId,
+  expectedSize: models[131].expectedSize,
+  sha256Checksum: models[131].sha256Checksum,
+  addon: models[131].addon,
+  engine: models[131].engine,
+  quantization: models[131].quantization,
+  params: models[131].params
 } as const
 
 export const BERGAMOT_AZ_EN = {
   name: 'BERGAMOT_AZ_EN',
-  src: `registry://${models[133].registrySource}/${models[133].registryPath}`,
-  registryPath: models[133].registryPath,
-  registrySource: models[133].registrySource,
-  blobCoreKey: models[133].blobCoreKey,
-  blobBlockOffset: models[133].blobBlockOffset,
-  blobBlockLength: models[133].blobBlockLength,
-  blobByteOffset: models[133].blobByteOffset,
-  modelId: models[133].modelId,
-  expectedSize: models[133].expectedSize,
-  sha256Checksum: models[133].sha256Checksum,
-  addon: models[133].addon,
-  engine: models[133].engine,
-  quantization: models[133].quantization,
-  params: models[133].params
+  src: `registry://${models[135].registrySource}/${models[135].registryPath}`,
+  registryPath: models[135].registryPath,
+  registrySource: models[135].registrySource,
+  blobCoreKey: models[135].blobCoreKey,
+  blobBlockOffset: models[135].blobBlockOffset,
+  blobBlockLength: models[135].blobBlockLength,
+  blobByteOffset: models[135].blobByteOffset,
+  modelId: models[135].modelId,
+  expectedSize: models[135].expectedSize,
+  sha256Checksum: models[135].sha256Checksum,
+  addon: models[135].addon,
+  engine: models[135].engine,
+  quantization: models[135].quantization,
+  params: models[135].params
 } as const
 
 export const BERGAMOT_BE_EN = {
   name: 'BERGAMOT_BE_EN',
-  src: `registry://${models[137].registrySource}/${models[137].registryPath}`,
-  registryPath: models[137].registryPath,
-  registrySource: models[137].registrySource,
-  blobCoreKey: models[137].blobCoreKey,
-  blobBlockOffset: models[137].blobBlockOffset,
-  blobBlockLength: models[137].blobBlockLength,
-  blobByteOffset: models[137].blobByteOffset,
-  modelId: models[137].modelId,
-  expectedSize: models[137].expectedSize,
-  sha256Checksum: models[137].sha256Checksum,
-  addon: models[137].addon,
-  engine: models[137].engine,
-  quantization: models[137].quantization,
-  params: models[137].params
+  src: `registry://${models[139].registrySource}/${models[139].registryPath}`,
+  registryPath: models[139].registryPath,
+  registrySource: models[139].registrySource,
+  blobCoreKey: models[139].blobCoreKey,
+  blobBlockOffset: models[139].blobBlockOffset,
+  blobBlockLength: models[139].blobBlockLength,
+  blobByteOffset: models[139].blobByteOffset,
+  modelId: models[139].modelId,
+  expectedSize: models[139].expectedSize,
+  sha256Checksum: models[139].sha256Checksum,
+  addon: models[139].addon,
+  engine: models[139].engine,
+  quantization: models[139].quantization,
+  params: models[139].params
 } as const
 
 export const BERGAMOT_BG_EN = {
   name: 'BERGAMOT_BG_EN',
-  src: `registry://${models[141].registrySource}/${models[141].registryPath}`,
-  registryPath: models[141].registryPath,
-  registrySource: models[141].registrySource,
-  blobCoreKey: models[141].blobCoreKey,
-  blobBlockOffset: models[141].blobBlockOffset,
-  blobBlockLength: models[141].blobBlockLength,
-  blobByteOffset: models[141].blobByteOffset,
-  modelId: models[141].modelId,
-  expectedSize: models[141].expectedSize,
-  sha256Checksum: models[141].sha256Checksum,
-  addon: models[141].addon,
-  engine: models[141].engine,
-  quantization: models[141].quantization,
-  params: models[141].params
+  src: `registry://${models[143].registrySource}/${models[143].registryPath}`,
+  registryPath: models[143].registryPath,
+  registrySource: models[143].registrySource,
+  blobCoreKey: models[143].blobCoreKey,
+  blobBlockOffset: models[143].blobBlockOffset,
+  blobBlockLength: models[143].blobBlockLength,
+  blobByteOffset: models[143].blobByteOffset,
+  modelId: models[143].modelId,
+  expectedSize: models[143].expectedSize,
+  sha256Checksum: models[143].sha256Checksum,
+  addon: models[143].addon,
+  engine: models[143].engine,
+  quantization: models[143].quantization,
+  params: models[143].params
 } as const
 
 export const BERGAMOT_BN_EN = {
   name: 'BERGAMOT_BN_EN',
-  src: `registry://${models[145].registrySource}/${models[145].registryPath}`,
-  registryPath: models[145].registryPath,
-  registrySource: models[145].registrySource,
-  blobCoreKey: models[145].blobCoreKey,
-  blobBlockOffset: models[145].blobBlockOffset,
-  blobBlockLength: models[145].blobBlockLength,
-  blobByteOffset: models[145].blobByteOffset,
-  modelId: models[145].modelId,
-  expectedSize: models[145].expectedSize,
-  sha256Checksum: models[145].sha256Checksum,
-  addon: models[145].addon,
-  engine: models[145].engine,
-  quantization: models[145].quantization,
-  params: models[145].params
+  src: `registry://${models[147].registrySource}/${models[147].registryPath}`,
+  registryPath: models[147].registryPath,
+  registrySource: models[147].registrySource,
+  blobCoreKey: models[147].blobCoreKey,
+  blobBlockOffset: models[147].blobBlockOffset,
+  blobBlockLength: models[147].blobBlockLength,
+  blobByteOffset: models[147].blobByteOffset,
+  modelId: models[147].modelId,
+  expectedSize: models[147].expectedSize,
+  sha256Checksum: models[147].sha256Checksum,
+  addon: models[147].addon,
+  engine: models[147].engine,
+  quantization: models[147].quantization,
+  params: models[147].params
 } as const
 
 export const BERGAMOT_BS_EN = {
   name: 'BERGAMOT_BS_EN',
-  src: `registry://${models[149].registrySource}/${models[149].registryPath}`,
-  registryPath: models[149].registryPath,
-  registrySource: models[149].registrySource,
-  blobCoreKey: models[149].blobCoreKey,
-  blobBlockOffset: models[149].blobBlockOffset,
-  blobBlockLength: models[149].blobBlockLength,
-  blobByteOffset: models[149].blobByteOffset,
-  modelId: models[149].modelId,
-  expectedSize: models[149].expectedSize,
-  sha256Checksum: models[149].sha256Checksum,
-  addon: models[149].addon,
-  engine: models[149].engine,
-  quantization: models[149].quantization,
-  params: models[149].params
+  src: `registry://${models[151].registrySource}/${models[151].registryPath}`,
+  registryPath: models[151].registryPath,
+  registrySource: models[151].registrySource,
+  blobCoreKey: models[151].blobCoreKey,
+  blobBlockOffset: models[151].blobBlockOffset,
+  blobBlockLength: models[151].blobBlockLength,
+  blobByteOffset: models[151].blobByteOffset,
+  modelId: models[151].modelId,
+  expectedSize: models[151].expectedSize,
+  sha256Checksum: models[151].sha256Checksum,
+  addon: models[151].addon,
+  engine: models[151].engine,
+  quantization: models[151].quantization,
+  params: models[151].params
 } as const
 
 export const BERGAMOT_CA_EN = {
   name: 'BERGAMOT_CA_EN',
-  src: `registry://${models[153].registrySource}/${models[153].registryPath}`,
-  registryPath: models[153].registryPath,
-  registrySource: models[153].registrySource,
-  blobCoreKey: models[153].blobCoreKey,
-  blobBlockOffset: models[153].blobBlockOffset,
-  blobBlockLength: models[153].blobBlockLength,
-  blobByteOffset: models[153].blobByteOffset,
-  modelId: models[153].modelId,
-  expectedSize: models[153].expectedSize,
-  sha256Checksum: models[153].sha256Checksum,
-  addon: models[153].addon,
-  engine: models[153].engine,
-  quantization: models[153].quantization,
-  params: models[153].params
+  src: `registry://${models[155].registrySource}/${models[155].registryPath}`,
+  registryPath: models[155].registryPath,
+  registrySource: models[155].registrySource,
+  blobCoreKey: models[155].blobCoreKey,
+  blobBlockOffset: models[155].blobBlockOffset,
+  blobBlockLength: models[155].blobBlockLength,
+  blobByteOffset: models[155].blobByteOffset,
+  modelId: models[155].modelId,
+  expectedSize: models[155].expectedSize,
+  sha256Checksum: models[155].sha256Checksum,
+  addon: models[155].addon,
+  engine: models[155].engine,
+  quantization: models[155].quantization,
+  params: models[155].params
 } as const
 
 export const BERGAMOT_CS_EN = {
   name: 'BERGAMOT_CS_EN',
-  src: `registry://${models[157].registrySource}/${models[157].registryPath}`,
-  registryPath: models[157].registryPath,
-  registrySource: models[157].registrySource,
-  blobCoreKey: models[157].blobCoreKey,
-  blobBlockOffset: models[157].blobBlockOffset,
-  blobBlockLength: models[157].blobBlockLength,
-  blobByteOffset: models[157].blobByteOffset,
-  modelId: models[157].modelId,
-  expectedSize: models[157].expectedSize,
-  sha256Checksum: models[157].sha256Checksum,
-  addon: models[157].addon,
-  engine: models[157].engine,
-  quantization: models[157].quantization,
-  params: models[157].params
+  src: `registry://${models[159].registrySource}/${models[159].registryPath}`,
+  registryPath: models[159].registryPath,
+  registrySource: models[159].registrySource,
+  blobCoreKey: models[159].blobCoreKey,
+  blobBlockOffset: models[159].blobBlockOffset,
+  blobBlockLength: models[159].blobBlockLength,
+  blobByteOffset: models[159].blobByteOffset,
+  modelId: models[159].modelId,
+  expectedSize: models[159].expectedSize,
+  sha256Checksum: models[159].sha256Checksum,
+  addon: models[159].addon,
+  engine: models[159].engine,
+  quantization: models[159].quantization,
+  params: models[159].params
 } as const
 
 export const BERGAMOT_DA_EN = {
   name: 'BERGAMOT_DA_EN',
-  src: `registry://${models[161].registrySource}/${models[161].registryPath}`,
-  registryPath: models[161].registryPath,
-  registrySource: models[161].registrySource,
-  blobCoreKey: models[161].blobCoreKey,
-  blobBlockOffset: models[161].blobBlockOffset,
-  blobBlockLength: models[161].blobBlockLength,
-  blobByteOffset: models[161].blobByteOffset,
-  modelId: models[161].modelId,
-  expectedSize: models[161].expectedSize,
-  sha256Checksum: models[161].sha256Checksum,
-  addon: models[161].addon,
-  engine: models[161].engine,
-  quantization: models[161].quantization,
-  params: models[161].params
+  src: `registry://${models[163].registrySource}/${models[163].registryPath}`,
+  registryPath: models[163].registryPath,
+  registrySource: models[163].registrySource,
+  blobCoreKey: models[163].blobCoreKey,
+  blobBlockOffset: models[163].blobBlockOffset,
+  blobBlockLength: models[163].blobBlockLength,
+  blobByteOffset: models[163].blobByteOffset,
+  modelId: models[163].modelId,
+  expectedSize: models[163].expectedSize,
+  sha256Checksum: models[163].sha256Checksum,
+  addon: models[163].addon,
+  engine: models[163].engine,
+  quantization: models[163].quantization,
+  params: models[163].params
 } as const
 
 export const BERGAMOT_DE_EN = {
   name: 'BERGAMOT_DE_EN',
-  src: `registry://${models[165].registrySource}/${models[165].registryPath}`,
-  registryPath: models[165].registryPath,
-  registrySource: models[165].registrySource,
-  blobCoreKey: models[165].blobCoreKey,
-  blobBlockOffset: models[165].blobBlockOffset,
-  blobBlockLength: models[165].blobBlockLength,
-  blobByteOffset: models[165].blobByteOffset,
-  modelId: models[165].modelId,
-  expectedSize: models[165].expectedSize,
-  sha256Checksum: models[165].sha256Checksum,
-  addon: models[165].addon,
-  engine: models[165].engine,
-  quantization: models[165].quantization,
-  params: models[165].params
+  src: `registry://${models[167].registrySource}/${models[167].registryPath}`,
+  registryPath: models[167].registryPath,
+  registrySource: models[167].registrySource,
+  blobCoreKey: models[167].blobCoreKey,
+  blobBlockOffset: models[167].blobBlockOffset,
+  blobBlockLength: models[167].blobBlockLength,
+  blobByteOffset: models[167].blobByteOffset,
+  modelId: models[167].modelId,
+  expectedSize: models[167].expectedSize,
+  sha256Checksum: models[167].sha256Checksum,
+  addon: models[167].addon,
+  engine: models[167].engine,
+  quantization: models[167].quantization,
+  params: models[167].params
 } as const
 
 export const BERGAMOT_EL_EN = {
   name: 'BERGAMOT_EL_EN',
-  src: `registry://${models[169].registrySource}/${models[169].registryPath}`,
-  registryPath: models[169].registryPath,
-  registrySource: models[169].registrySource,
-  blobCoreKey: models[169].blobCoreKey,
-  blobBlockOffset: models[169].blobBlockOffset,
-  blobBlockLength: models[169].blobBlockLength,
-  blobByteOffset: models[169].blobByteOffset,
-  modelId: models[169].modelId,
-  expectedSize: models[169].expectedSize,
-  sha256Checksum: models[169].sha256Checksum,
-  addon: models[169].addon,
-  engine: models[169].engine,
-  quantization: models[169].quantization,
-  params: models[169].params
+  src: `registry://${models[171].registrySource}/${models[171].registryPath}`,
+  registryPath: models[171].registryPath,
+  registrySource: models[171].registrySource,
+  blobCoreKey: models[171].blobCoreKey,
+  blobBlockOffset: models[171].blobBlockOffset,
+  blobBlockLength: models[171].blobBlockLength,
+  blobByteOffset: models[171].blobByteOffset,
+  modelId: models[171].modelId,
+  expectedSize: models[171].expectedSize,
+  sha256Checksum: models[171].sha256Checksum,
+  addon: models[171].addon,
+  engine: models[171].engine,
+  quantization: models[171].quantization,
+  params: models[171].params
 } as const
 
 export const BERGAMOT_EN_AR = {
   name: 'BERGAMOT_EN_AR',
-  src: `registry://${models[173].registrySource}/${models[173].registryPath}`,
-  registryPath: models[173].registryPath,
-  registrySource: models[173].registrySource,
-  blobCoreKey: models[173].blobCoreKey,
-  blobBlockOffset: models[173].blobBlockOffset,
-  blobBlockLength: models[173].blobBlockLength,
-  blobByteOffset: models[173].blobByteOffset,
-  modelId: models[173].modelId,
-  expectedSize: models[173].expectedSize,
-  sha256Checksum: models[173].sha256Checksum,
-  addon: models[173].addon,
-  engine: models[173].engine,
-  quantization: models[173].quantization,
-  params: models[173].params
+  src: `registry://${models[175].registrySource}/${models[175].registryPath}`,
+  registryPath: models[175].registryPath,
+  registrySource: models[175].registrySource,
+  blobCoreKey: models[175].blobCoreKey,
+  blobBlockOffset: models[175].blobBlockOffset,
+  blobBlockLength: models[175].blobBlockLength,
+  blobByteOffset: models[175].blobByteOffset,
+  modelId: models[175].modelId,
+  expectedSize: models[175].expectedSize,
+  sha256Checksum: models[175].sha256Checksum,
+  addon: models[175].addon,
+  engine: models[175].engine,
+  quantization: models[175].quantization,
+  params: models[175].params
 } as const
 
 export const BERGAMOT_EN_AZ = {
   name: 'BERGAMOT_EN_AZ',
-  src: `registry://${models[177].registrySource}/${models[177].registryPath}`,
-  registryPath: models[177].registryPath,
-  registrySource: models[177].registrySource,
-  blobCoreKey: models[177].blobCoreKey,
-  blobBlockOffset: models[177].blobBlockOffset,
-  blobBlockLength: models[177].blobBlockLength,
-  blobByteOffset: models[177].blobByteOffset,
-  modelId: models[177].modelId,
-  expectedSize: models[177].expectedSize,
-  sha256Checksum: models[177].sha256Checksum,
-  addon: models[177].addon,
-  engine: models[177].engine,
-  quantization: models[177].quantization,
-  params: models[177].params
+  src: `registry://${models[179].registrySource}/${models[179].registryPath}`,
+  registryPath: models[179].registryPath,
+  registrySource: models[179].registrySource,
+  blobCoreKey: models[179].blobCoreKey,
+  blobBlockOffset: models[179].blobBlockOffset,
+  blobBlockLength: models[179].blobBlockLength,
+  blobByteOffset: models[179].blobByteOffset,
+  modelId: models[179].modelId,
+  expectedSize: models[179].expectedSize,
+  sha256Checksum: models[179].sha256Checksum,
+  addon: models[179].addon,
+  engine: models[179].engine,
+  quantization: models[179].quantization,
+  params: models[179].params
 } as const
 
 export const BERGAMOT_EN_BG = {
   name: 'BERGAMOT_EN_BG',
-  src: `registry://${models[181].registrySource}/${models[181].registryPath}`,
-  registryPath: models[181].registryPath,
-  registrySource: models[181].registrySource,
-  blobCoreKey: models[181].blobCoreKey,
-  blobBlockOffset: models[181].blobBlockOffset,
-  blobBlockLength: models[181].blobBlockLength,
-  blobByteOffset: models[181].blobByteOffset,
-  modelId: models[181].modelId,
-  expectedSize: models[181].expectedSize,
-  sha256Checksum: models[181].sha256Checksum,
-  addon: models[181].addon,
-  engine: models[181].engine,
-  quantization: models[181].quantization,
-  params: models[181].params
+  src: `registry://${models[183].registrySource}/${models[183].registryPath}`,
+  registryPath: models[183].registryPath,
+  registrySource: models[183].registrySource,
+  blobCoreKey: models[183].blobCoreKey,
+  blobBlockOffset: models[183].blobBlockOffset,
+  blobBlockLength: models[183].blobBlockLength,
+  blobByteOffset: models[183].blobByteOffset,
+  modelId: models[183].modelId,
+  expectedSize: models[183].expectedSize,
+  sha256Checksum: models[183].sha256Checksum,
+  addon: models[183].addon,
+  engine: models[183].engine,
+  quantization: models[183].quantization,
+  params: models[183].params
 } as const
 
 export const BERGAMOT_EN_BN = {
   name: 'BERGAMOT_EN_BN',
-  src: `registry://${models[185].registrySource}/${models[185].registryPath}`,
-  registryPath: models[185].registryPath,
-  registrySource: models[185].registrySource,
-  blobCoreKey: models[185].blobCoreKey,
-  blobBlockOffset: models[185].blobBlockOffset,
-  blobBlockLength: models[185].blobBlockLength,
-  blobByteOffset: models[185].blobByteOffset,
-  modelId: models[185].modelId,
-  expectedSize: models[185].expectedSize,
-  sha256Checksum: models[185].sha256Checksum,
-  addon: models[185].addon,
-  engine: models[185].engine,
-  quantization: models[185].quantization,
-  params: models[185].params
+  src: `registry://${models[187].registrySource}/${models[187].registryPath}`,
+  registryPath: models[187].registryPath,
+  registrySource: models[187].registrySource,
+  blobCoreKey: models[187].blobCoreKey,
+  blobBlockOffset: models[187].blobBlockOffset,
+  blobBlockLength: models[187].blobBlockLength,
+  blobByteOffset: models[187].blobByteOffset,
+  modelId: models[187].modelId,
+  expectedSize: models[187].expectedSize,
+  sha256Checksum: models[187].sha256Checksum,
+  addon: models[187].addon,
+  engine: models[187].engine,
+  quantization: models[187].quantization,
+  params: models[187].params
 } as const
 
 export const BERGAMOT_EN_BS = {
   name: 'BERGAMOT_EN_BS',
-  src: `registry://${models[189].registrySource}/${models[189].registryPath}`,
-  registryPath: models[189].registryPath,
-  registrySource: models[189].registrySource,
-  blobCoreKey: models[189].blobCoreKey,
-  blobBlockOffset: models[189].blobBlockOffset,
-  blobBlockLength: models[189].blobBlockLength,
-  blobByteOffset: models[189].blobByteOffset,
-  modelId: models[189].modelId,
-  expectedSize: models[189].expectedSize,
-  sha256Checksum: models[189].sha256Checksum,
-  addon: models[189].addon,
-  engine: models[189].engine,
-  quantization: models[189].quantization,
-  params: models[189].params
+  src: `registry://${models[191].registrySource}/${models[191].registryPath}`,
+  registryPath: models[191].registryPath,
+  registrySource: models[191].registrySource,
+  blobCoreKey: models[191].blobCoreKey,
+  blobBlockOffset: models[191].blobBlockOffset,
+  blobBlockLength: models[191].blobBlockLength,
+  blobByteOffset: models[191].blobByteOffset,
+  modelId: models[191].modelId,
+  expectedSize: models[191].expectedSize,
+  sha256Checksum: models[191].sha256Checksum,
+  addon: models[191].addon,
+  engine: models[191].engine,
+  quantization: models[191].quantization,
+  params: models[191].params
 } as const
 
 export const BERGAMOT_EN_CA = {
   name: 'BERGAMOT_EN_CA',
-  src: `registry://${models[193].registrySource}/${models[193].registryPath}`,
-  registryPath: models[193].registryPath,
-  registrySource: models[193].registrySource,
-  blobCoreKey: models[193].blobCoreKey,
-  blobBlockOffset: models[193].blobBlockOffset,
-  blobBlockLength: models[193].blobBlockLength,
-  blobByteOffset: models[193].blobByteOffset,
-  modelId: models[193].modelId,
-  expectedSize: models[193].expectedSize,
-  sha256Checksum: models[193].sha256Checksum,
-  addon: models[193].addon,
-  engine: models[193].engine,
-  quantization: models[193].quantization,
-  params: models[193].params
+  src: `registry://${models[195].registrySource}/${models[195].registryPath}`,
+  registryPath: models[195].registryPath,
+  registrySource: models[195].registrySource,
+  blobCoreKey: models[195].blobCoreKey,
+  blobBlockOffset: models[195].blobBlockOffset,
+  blobBlockLength: models[195].blobBlockLength,
+  blobByteOffset: models[195].blobByteOffset,
+  modelId: models[195].modelId,
+  expectedSize: models[195].expectedSize,
+  sha256Checksum: models[195].sha256Checksum,
+  addon: models[195].addon,
+  engine: models[195].engine,
+  quantization: models[195].quantization,
+  params: models[195].params
 } as const
 
 export const BERGAMOT_EN_CS = {
   name: 'BERGAMOT_EN_CS',
-  src: `registry://${models[197].registrySource}/${models[197].registryPath}`,
-  registryPath: models[197].registryPath,
-  registrySource: models[197].registrySource,
-  blobCoreKey: models[197].blobCoreKey,
-  blobBlockOffset: models[197].blobBlockOffset,
-  blobBlockLength: models[197].blobBlockLength,
-  blobByteOffset: models[197].blobByteOffset,
-  modelId: models[197].modelId,
-  expectedSize: models[197].expectedSize,
-  sha256Checksum: models[197].sha256Checksum,
-  addon: models[197].addon,
-  engine: models[197].engine,
-  quantization: models[197].quantization,
-  params: models[197].params
+  src: `registry://${models[199].registrySource}/${models[199].registryPath}`,
+  registryPath: models[199].registryPath,
+  registrySource: models[199].registrySource,
+  blobCoreKey: models[199].blobCoreKey,
+  blobBlockOffset: models[199].blobBlockOffset,
+  blobBlockLength: models[199].blobBlockLength,
+  blobByteOffset: models[199].blobByteOffset,
+  modelId: models[199].modelId,
+  expectedSize: models[199].expectedSize,
+  sha256Checksum: models[199].sha256Checksum,
+  addon: models[199].addon,
+  engine: models[199].engine,
+  quantization: models[199].quantization,
+  params: models[199].params
 } as const
 
 export const BERGAMOT_EN_DA = {
   name: 'BERGAMOT_EN_DA',
-  src: `registry://${models[201].registrySource}/${models[201].registryPath}`,
-  registryPath: models[201].registryPath,
-  registrySource: models[201].registrySource,
-  blobCoreKey: models[201].blobCoreKey,
-  blobBlockOffset: models[201].blobBlockOffset,
-  blobBlockLength: models[201].blobBlockLength,
-  blobByteOffset: models[201].blobByteOffset,
-  modelId: models[201].modelId,
-  expectedSize: models[201].expectedSize,
-  sha256Checksum: models[201].sha256Checksum,
-  addon: models[201].addon,
-  engine: models[201].engine,
-  quantization: models[201].quantization,
-  params: models[201].params
+  src: `registry://${models[203].registrySource}/${models[203].registryPath}`,
+  registryPath: models[203].registryPath,
+  registrySource: models[203].registrySource,
+  blobCoreKey: models[203].blobCoreKey,
+  blobBlockOffset: models[203].blobBlockOffset,
+  blobBlockLength: models[203].blobBlockLength,
+  blobByteOffset: models[203].blobByteOffset,
+  modelId: models[203].modelId,
+  expectedSize: models[203].expectedSize,
+  sha256Checksum: models[203].sha256Checksum,
+  addon: models[203].addon,
+  engine: models[203].engine,
+  quantization: models[203].quantization,
+  params: models[203].params
 } as const
 
 export const BERGAMOT_EN_DE = {
   name: 'BERGAMOT_EN_DE',
-  src: `registry://${models[205].registrySource}/${models[205].registryPath}`,
-  registryPath: models[205].registryPath,
-  registrySource: models[205].registrySource,
-  blobCoreKey: models[205].blobCoreKey,
-  blobBlockOffset: models[205].blobBlockOffset,
-  blobBlockLength: models[205].blobBlockLength,
-  blobByteOffset: models[205].blobByteOffset,
-  modelId: models[205].modelId,
-  expectedSize: models[205].expectedSize,
-  sha256Checksum: models[205].sha256Checksum,
-  addon: models[205].addon,
-  engine: models[205].engine,
-  quantization: models[205].quantization,
-  params: models[205].params
+  src: `registry://${models[207].registrySource}/${models[207].registryPath}`,
+  registryPath: models[207].registryPath,
+  registrySource: models[207].registrySource,
+  blobCoreKey: models[207].blobCoreKey,
+  blobBlockOffset: models[207].blobBlockOffset,
+  blobBlockLength: models[207].blobBlockLength,
+  blobByteOffset: models[207].blobByteOffset,
+  modelId: models[207].modelId,
+  expectedSize: models[207].expectedSize,
+  sha256Checksum: models[207].sha256Checksum,
+  addon: models[207].addon,
+  engine: models[207].engine,
+  quantization: models[207].quantization,
+  params: models[207].params
 } as const
 
 export const BERGAMOT_EN_EL = {
   name: 'BERGAMOT_EN_EL',
-  src: `registry://${models[209].registrySource}/${models[209].registryPath}`,
-  registryPath: models[209].registryPath,
-  registrySource: models[209].registrySource,
-  blobCoreKey: models[209].blobCoreKey,
-  blobBlockOffset: models[209].blobBlockOffset,
-  blobBlockLength: models[209].blobBlockLength,
-  blobByteOffset: models[209].blobByteOffset,
-  modelId: models[209].modelId,
-  expectedSize: models[209].expectedSize,
-  sha256Checksum: models[209].sha256Checksum,
-  addon: models[209].addon,
-  engine: models[209].engine,
-  quantization: models[209].quantization,
-  params: models[209].params
+  src: `registry://${models[211].registrySource}/${models[211].registryPath}`,
+  registryPath: models[211].registryPath,
+  registrySource: models[211].registrySource,
+  blobCoreKey: models[211].blobCoreKey,
+  blobBlockOffset: models[211].blobBlockOffset,
+  blobBlockLength: models[211].blobBlockLength,
+  blobByteOffset: models[211].blobByteOffset,
+  modelId: models[211].modelId,
+  expectedSize: models[211].expectedSize,
+  sha256Checksum: models[211].sha256Checksum,
+  addon: models[211].addon,
+  engine: models[211].engine,
+  quantization: models[211].quantization,
+  params: models[211].params
 } as const
 
 export const BERGAMOT_EN_ES = {
   name: 'BERGAMOT_EN_ES',
-  src: `registry://${models[213].registrySource}/${models[213].registryPath}`,
-  registryPath: models[213].registryPath,
-  registrySource: models[213].registrySource,
-  blobCoreKey: models[213].blobCoreKey,
-  blobBlockOffset: models[213].blobBlockOffset,
-  blobBlockLength: models[213].blobBlockLength,
-  blobByteOffset: models[213].blobByteOffset,
-  modelId: models[213].modelId,
-  expectedSize: models[213].expectedSize,
-  sha256Checksum: models[213].sha256Checksum,
-  addon: models[213].addon,
-  engine: models[213].engine,
-  quantization: models[213].quantization,
-  params: models[213].params
+  src: `registry://${models[215].registrySource}/${models[215].registryPath}`,
+  registryPath: models[215].registryPath,
+  registrySource: models[215].registrySource,
+  blobCoreKey: models[215].blobCoreKey,
+  blobBlockOffset: models[215].blobBlockOffset,
+  blobBlockLength: models[215].blobBlockLength,
+  blobByteOffset: models[215].blobByteOffset,
+  modelId: models[215].modelId,
+  expectedSize: models[215].expectedSize,
+  sha256Checksum: models[215].sha256Checksum,
+  addon: models[215].addon,
+  engine: models[215].engine,
+  quantization: models[215].quantization,
+  params: models[215].params
 } as const
 
 export const BERGAMOT_EN_ET = {
   name: 'BERGAMOT_EN_ET',
-  src: `registry://${models[217].registrySource}/${models[217].registryPath}`,
-  registryPath: models[217].registryPath,
-  registrySource: models[217].registrySource,
-  blobCoreKey: models[217].blobCoreKey,
-  blobBlockOffset: models[217].blobBlockOffset,
-  blobBlockLength: models[217].blobBlockLength,
-  blobByteOffset: models[217].blobByteOffset,
-  modelId: models[217].modelId,
-  expectedSize: models[217].expectedSize,
-  sha256Checksum: models[217].sha256Checksum,
-  addon: models[217].addon,
-  engine: models[217].engine,
-  quantization: models[217].quantization,
-  params: models[217].params
+  src: `registry://${models[219].registrySource}/${models[219].registryPath}`,
+  registryPath: models[219].registryPath,
+  registrySource: models[219].registrySource,
+  blobCoreKey: models[219].blobCoreKey,
+  blobBlockOffset: models[219].blobBlockOffset,
+  blobBlockLength: models[219].blobBlockLength,
+  blobByteOffset: models[219].blobByteOffset,
+  modelId: models[219].modelId,
+  expectedSize: models[219].expectedSize,
+  sha256Checksum: models[219].sha256Checksum,
+  addon: models[219].addon,
+  engine: models[219].engine,
+  quantization: models[219].quantization,
+  params: models[219].params
 } as const
 
 export const BERGAMOT_EN_FA = {
   name: 'BERGAMOT_EN_FA',
-  src: `registry://${models[221].registrySource}/${models[221].registryPath}`,
-  registryPath: models[221].registryPath,
-  registrySource: models[221].registrySource,
-  blobCoreKey: models[221].blobCoreKey,
-  blobBlockOffset: models[221].blobBlockOffset,
-  blobBlockLength: models[221].blobBlockLength,
-  blobByteOffset: models[221].blobByteOffset,
-  modelId: models[221].modelId,
-  expectedSize: models[221].expectedSize,
-  sha256Checksum: models[221].sha256Checksum,
-  addon: models[221].addon,
-  engine: models[221].engine,
-  quantization: models[221].quantization,
-  params: models[221].params
+  src: `registry://${models[223].registrySource}/${models[223].registryPath}`,
+  registryPath: models[223].registryPath,
+  registrySource: models[223].registrySource,
+  blobCoreKey: models[223].blobCoreKey,
+  blobBlockOffset: models[223].blobBlockOffset,
+  blobBlockLength: models[223].blobBlockLength,
+  blobByteOffset: models[223].blobByteOffset,
+  modelId: models[223].modelId,
+  expectedSize: models[223].expectedSize,
+  sha256Checksum: models[223].sha256Checksum,
+  addon: models[223].addon,
+  engine: models[223].engine,
+  quantization: models[223].quantization,
+  params: models[223].params
 } as const
 
 export const BERGAMOT_EN_FI = {
   name: 'BERGAMOT_EN_FI',
-  src: `registry://${models[225].registrySource}/${models[225].registryPath}`,
-  registryPath: models[225].registryPath,
-  registrySource: models[225].registrySource,
-  blobCoreKey: models[225].blobCoreKey,
-  blobBlockOffset: models[225].blobBlockOffset,
-  blobBlockLength: models[225].blobBlockLength,
-  blobByteOffset: models[225].blobByteOffset,
-  modelId: models[225].modelId,
-  expectedSize: models[225].expectedSize,
-  sha256Checksum: models[225].sha256Checksum,
-  addon: models[225].addon,
-  engine: models[225].engine,
-  quantization: models[225].quantization,
-  params: models[225].params
+  src: `registry://${models[227].registrySource}/${models[227].registryPath}`,
+  registryPath: models[227].registryPath,
+  registrySource: models[227].registrySource,
+  blobCoreKey: models[227].blobCoreKey,
+  blobBlockOffset: models[227].blobBlockOffset,
+  blobBlockLength: models[227].blobBlockLength,
+  blobByteOffset: models[227].blobByteOffset,
+  modelId: models[227].modelId,
+  expectedSize: models[227].expectedSize,
+  sha256Checksum: models[227].sha256Checksum,
+  addon: models[227].addon,
+  engine: models[227].engine,
+  quantization: models[227].quantization,
+  params: models[227].params
 } as const
 
 export const BERGAMOT_EN_FR = {
   name: 'BERGAMOT_EN_FR',
-  src: `registry://${models[229].registrySource}/${models[229].registryPath}`,
-  registryPath: models[229].registryPath,
-  registrySource: models[229].registrySource,
-  blobCoreKey: models[229].blobCoreKey,
-  blobBlockOffset: models[229].blobBlockOffset,
-  blobBlockLength: models[229].blobBlockLength,
-  blobByteOffset: models[229].blobByteOffset,
-  modelId: models[229].modelId,
-  expectedSize: models[229].expectedSize,
-  sha256Checksum: models[229].sha256Checksum,
-  addon: models[229].addon,
-  engine: models[229].engine,
-  quantization: models[229].quantization,
-  params: models[229].params
+  src: `registry://${models[231].registrySource}/${models[231].registryPath}`,
+  registryPath: models[231].registryPath,
+  registrySource: models[231].registrySource,
+  blobCoreKey: models[231].blobCoreKey,
+  blobBlockOffset: models[231].blobBlockOffset,
+  blobBlockLength: models[231].blobBlockLength,
+  blobByteOffset: models[231].blobByteOffset,
+  modelId: models[231].modelId,
+  expectedSize: models[231].expectedSize,
+  sha256Checksum: models[231].sha256Checksum,
+  addon: models[231].addon,
+  engine: models[231].engine,
+  quantization: models[231].quantization,
+  params: models[231].params
 } as const
 
 export const BERGAMOT_EN_GU = {
   name: 'BERGAMOT_EN_GU',
-  src: `registry://${models[233].registrySource}/${models[233].registryPath}`,
-  registryPath: models[233].registryPath,
-  registrySource: models[233].registrySource,
-  blobCoreKey: models[233].blobCoreKey,
-  blobBlockOffset: models[233].blobBlockOffset,
-  blobBlockLength: models[233].blobBlockLength,
-  blobByteOffset: models[233].blobByteOffset,
-  modelId: models[233].modelId,
-  expectedSize: models[233].expectedSize,
-  sha256Checksum: models[233].sha256Checksum,
-  addon: models[233].addon,
-  engine: models[233].engine,
-  quantization: models[233].quantization,
-  params: models[233].params
+  src: `registry://${models[235].registrySource}/${models[235].registryPath}`,
+  registryPath: models[235].registryPath,
+  registrySource: models[235].registrySource,
+  blobCoreKey: models[235].blobCoreKey,
+  blobBlockOffset: models[235].blobBlockOffset,
+  blobBlockLength: models[235].blobBlockLength,
+  blobByteOffset: models[235].blobByteOffset,
+  modelId: models[235].modelId,
+  expectedSize: models[235].expectedSize,
+  sha256Checksum: models[235].sha256Checksum,
+  addon: models[235].addon,
+  engine: models[235].engine,
+  quantization: models[235].quantization,
+  params: models[235].params
 } as const
 
 export const BERGAMOT_EN_HE = {
   name: 'BERGAMOT_EN_HE',
-  src: `registry://${models[237].registrySource}/${models[237].registryPath}`,
-  registryPath: models[237].registryPath,
-  registrySource: models[237].registrySource,
-  blobCoreKey: models[237].blobCoreKey,
-  blobBlockOffset: models[237].blobBlockOffset,
-  blobBlockLength: models[237].blobBlockLength,
-  blobByteOffset: models[237].blobByteOffset,
-  modelId: models[237].modelId,
-  expectedSize: models[237].expectedSize,
-  sha256Checksum: models[237].sha256Checksum,
-  addon: models[237].addon,
-  engine: models[237].engine,
-  quantization: models[237].quantization,
-  params: models[237].params
+  src: `registry://${models[239].registrySource}/${models[239].registryPath}`,
+  registryPath: models[239].registryPath,
+  registrySource: models[239].registrySource,
+  blobCoreKey: models[239].blobCoreKey,
+  blobBlockOffset: models[239].blobBlockOffset,
+  blobBlockLength: models[239].blobBlockLength,
+  blobByteOffset: models[239].blobByteOffset,
+  modelId: models[239].modelId,
+  expectedSize: models[239].expectedSize,
+  sha256Checksum: models[239].sha256Checksum,
+  addon: models[239].addon,
+  engine: models[239].engine,
+  quantization: models[239].quantization,
+  params: models[239].params
 } as const
 
 export const BERGAMOT_EN_HI = {
   name: 'BERGAMOT_EN_HI',
-  src: `registry://${models[241].registrySource}/${models[241].registryPath}`,
-  registryPath: models[241].registryPath,
-  registrySource: models[241].registrySource,
-  blobCoreKey: models[241].blobCoreKey,
-  blobBlockOffset: models[241].blobBlockOffset,
-  blobBlockLength: models[241].blobBlockLength,
-  blobByteOffset: models[241].blobByteOffset,
-  modelId: models[241].modelId,
-  expectedSize: models[241].expectedSize,
-  sha256Checksum: models[241].sha256Checksum,
-  addon: models[241].addon,
-  engine: models[241].engine,
-  quantization: models[241].quantization,
-  params: models[241].params
+  src: `registry://${models[243].registrySource}/${models[243].registryPath}`,
+  registryPath: models[243].registryPath,
+  registrySource: models[243].registrySource,
+  blobCoreKey: models[243].blobCoreKey,
+  blobBlockOffset: models[243].blobBlockOffset,
+  blobBlockLength: models[243].blobBlockLength,
+  blobByteOffset: models[243].blobByteOffset,
+  modelId: models[243].modelId,
+  expectedSize: models[243].expectedSize,
+  sha256Checksum: models[243].sha256Checksum,
+  addon: models[243].addon,
+  engine: models[243].engine,
+  quantization: models[243].quantization,
+  params: models[243].params
 } as const
 
 export const BERGAMOT_EN_HR = {
   name: 'BERGAMOT_EN_HR',
-  src: `registry://${models[245].registrySource}/${models[245].registryPath}`,
-  registryPath: models[245].registryPath,
-  registrySource: models[245].registrySource,
-  blobCoreKey: models[245].blobCoreKey,
-  blobBlockOffset: models[245].blobBlockOffset,
-  blobBlockLength: models[245].blobBlockLength,
-  blobByteOffset: models[245].blobByteOffset,
-  modelId: models[245].modelId,
-  expectedSize: models[245].expectedSize,
-  sha256Checksum: models[245].sha256Checksum,
-  addon: models[245].addon,
-  engine: models[245].engine,
-  quantization: models[245].quantization,
-  params: models[245].params
+  src: `registry://${models[247].registrySource}/${models[247].registryPath}`,
+  registryPath: models[247].registryPath,
+  registrySource: models[247].registrySource,
+  blobCoreKey: models[247].blobCoreKey,
+  blobBlockOffset: models[247].blobBlockOffset,
+  blobBlockLength: models[247].blobBlockLength,
+  blobByteOffset: models[247].blobByteOffset,
+  modelId: models[247].modelId,
+  expectedSize: models[247].expectedSize,
+  sha256Checksum: models[247].sha256Checksum,
+  addon: models[247].addon,
+  engine: models[247].engine,
+  quantization: models[247].quantization,
+  params: models[247].params
 } as const
 
 export const BERGAMOT_EN_HU = {
   name: 'BERGAMOT_EN_HU',
-  src: `registry://${models[249].registrySource}/${models[249].registryPath}`,
-  registryPath: models[249].registryPath,
-  registrySource: models[249].registrySource,
-  blobCoreKey: models[249].blobCoreKey,
-  blobBlockOffset: models[249].blobBlockOffset,
-  blobBlockLength: models[249].blobBlockLength,
-  blobByteOffset: models[249].blobByteOffset,
-  modelId: models[249].modelId,
-  expectedSize: models[249].expectedSize,
-  sha256Checksum: models[249].sha256Checksum,
-  addon: models[249].addon,
-  engine: models[249].engine,
-  quantization: models[249].quantization,
-  params: models[249].params
+  src: `registry://${models[251].registrySource}/${models[251].registryPath}`,
+  registryPath: models[251].registryPath,
+  registrySource: models[251].registrySource,
+  blobCoreKey: models[251].blobCoreKey,
+  blobBlockOffset: models[251].blobBlockOffset,
+  blobBlockLength: models[251].blobBlockLength,
+  blobByteOffset: models[251].blobByteOffset,
+  modelId: models[251].modelId,
+  expectedSize: models[251].expectedSize,
+  sha256Checksum: models[251].sha256Checksum,
+  addon: models[251].addon,
+  engine: models[251].engine,
+  quantization: models[251].quantization,
+  params: models[251].params
 } as const
 
 export const BERGAMOT_EN_ID = {
   name: 'BERGAMOT_EN_ID',
-  src: `registry://${models[253].registrySource}/${models[253].registryPath}`,
-  registryPath: models[253].registryPath,
-  registrySource: models[253].registrySource,
-  blobCoreKey: models[253].blobCoreKey,
-  blobBlockOffset: models[253].blobBlockOffset,
-  blobBlockLength: models[253].blobBlockLength,
-  blobByteOffset: models[253].blobByteOffset,
-  modelId: models[253].modelId,
-  expectedSize: models[253].expectedSize,
-  sha256Checksum: models[253].sha256Checksum,
-  addon: models[253].addon,
-  engine: models[253].engine,
-  quantization: models[253].quantization,
-  params: models[253].params
+  src: `registry://${models[255].registrySource}/${models[255].registryPath}`,
+  registryPath: models[255].registryPath,
+  registrySource: models[255].registrySource,
+  blobCoreKey: models[255].blobCoreKey,
+  blobBlockOffset: models[255].blobBlockOffset,
+  blobBlockLength: models[255].blobBlockLength,
+  blobByteOffset: models[255].blobByteOffset,
+  modelId: models[255].modelId,
+  expectedSize: models[255].expectedSize,
+  sha256Checksum: models[255].sha256Checksum,
+  addon: models[255].addon,
+  engine: models[255].engine,
+  quantization: models[255].quantization,
+  params: models[255].params
 } as const
 
 export const BERGAMOT_EN_IS = {
   name: 'BERGAMOT_EN_IS',
-  src: `registry://${models[257].registrySource}/${models[257].registryPath}`,
-  registryPath: models[257].registryPath,
-  registrySource: models[257].registrySource,
-  blobCoreKey: models[257].blobCoreKey,
-  blobBlockOffset: models[257].blobBlockOffset,
-  blobBlockLength: models[257].blobBlockLength,
-  blobByteOffset: models[257].blobByteOffset,
-  modelId: models[257].modelId,
-  expectedSize: models[257].expectedSize,
-  sha256Checksum: models[257].sha256Checksum,
-  addon: models[257].addon,
-  engine: models[257].engine,
-  quantization: models[257].quantization,
-  params: models[257].params
+  src: `registry://${models[259].registrySource}/${models[259].registryPath}`,
+  registryPath: models[259].registryPath,
+  registrySource: models[259].registrySource,
+  blobCoreKey: models[259].blobCoreKey,
+  blobBlockOffset: models[259].blobBlockOffset,
+  blobBlockLength: models[259].blobBlockLength,
+  blobByteOffset: models[259].blobByteOffset,
+  modelId: models[259].modelId,
+  expectedSize: models[259].expectedSize,
+  sha256Checksum: models[259].sha256Checksum,
+  addon: models[259].addon,
+  engine: models[259].engine,
+  quantization: models[259].quantization,
+  params: models[259].params
 } as const
 
 export const BERGAMOT_EN_IT = {
   name: 'BERGAMOT_EN_IT',
-  src: `registry://${models[261].registrySource}/${models[261].registryPath}`,
-  registryPath: models[261].registryPath,
-  registrySource: models[261].registrySource,
-  blobCoreKey: models[261].blobCoreKey,
-  blobBlockOffset: models[261].blobBlockOffset,
-  blobBlockLength: models[261].blobBlockLength,
-  blobByteOffset: models[261].blobByteOffset,
-  modelId: models[261].modelId,
-  expectedSize: models[261].expectedSize,
-  sha256Checksum: models[261].sha256Checksum,
-  addon: models[261].addon,
-  engine: models[261].engine,
-  quantization: models[261].quantization,
-  params: models[261].params
+  src: `registry://${models[263].registrySource}/${models[263].registryPath}`,
+  registryPath: models[263].registryPath,
+  registrySource: models[263].registrySource,
+  blobCoreKey: models[263].blobCoreKey,
+  blobBlockOffset: models[263].blobBlockOffset,
+  blobBlockLength: models[263].blobBlockLength,
+  blobByteOffset: models[263].blobByteOffset,
+  modelId: models[263].modelId,
+  expectedSize: models[263].expectedSize,
+  sha256Checksum: models[263].sha256Checksum,
+  addon: models[263].addon,
+  engine: models[263].engine,
+  quantization: models[263].quantization,
+  params: models[263].params
 } as const
 
 export const BERGAMOT_EN_JA = {
   name: 'BERGAMOT_EN_JA',
-  src: `registry://${models[265].registrySource}/${models[265].registryPath}`,
-  registryPath: models[265].registryPath,
-  registrySource: models[265].registrySource,
-  blobCoreKey: models[265].blobCoreKey,
-  blobBlockOffset: models[265].blobBlockOffset,
-  blobBlockLength: models[265].blobBlockLength,
-  blobByteOffset: models[265].blobByteOffset,
-  modelId: models[265].modelId,
-  expectedSize: models[265].expectedSize,
-  sha256Checksum: models[265].sha256Checksum,
-  addon: models[265].addon,
-  engine: models[265].engine,
-  quantization: models[265].quantization,
-  params: models[265].params
+  src: `registry://${models[267].registrySource}/${models[267].registryPath}`,
+  registryPath: models[267].registryPath,
+  registrySource: models[267].registrySource,
+  blobCoreKey: models[267].blobCoreKey,
+  blobBlockOffset: models[267].blobBlockOffset,
+  blobBlockLength: models[267].blobBlockLength,
+  blobByteOffset: models[267].blobByteOffset,
+  modelId: models[267].modelId,
+  expectedSize: models[267].expectedSize,
+  sha256Checksum: models[267].sha256Checksum,
+  addon: models[267].addon,
+  engine: models[267].engine,
+  quantization: models[267].quantization,
+  params: models[267].params
 } as const
 
 export const BERGAMOT_EN_KN = {
   name: 'BERGAMOT_EN_KN',
-  src: `registry://${models[270].registrySource}/${models[270].registryPath}`,
-  registryPath: models[270].registryPath,
-  registrySource: models[270].registrySource,
-  blobCoreKey: models[270].blobCoreKey,
-  blobBlockOffset: models[270].blobBlockOffset,
-  blobBlockLength: models[270].blobBlockLength,
-  blobByteOffset: models[270].blobByteOffset,
-  modelId: models[270].modelId,
-  expectedSize: models[270].expectedSize,
-  sha256Checksum: models[270].sha256Checksum,
-  addon: models[270].addon,
-  engine: models[270].engine,
-  quantization: models[270].quantization,
-  params: models[270].params
+  src: `registry://${models[272].registrySource}/${models[272].registryPath}`,
+  registryPath: models[272].registryPath,
+  registrySource: models[272].registrySource,
+  blobCoreKey: models[272].blobCoreKey,
+  blobBlockOffset: models[272].blobBlockOffset,
+  blobBlockLength: models[272].blobBlockLength,
+  blobByteOffset: models[272].blobByteOffset,
+  modelId: models[272].modelId,
+  expectedSize: models[272].expectedSize,
+  sha256Checksum: models[272].sha256Checksum,
+  addon: models[272].addon,
+  engine: models[272].engine,
+  quantization: models[272].quantization,
+  params: models[272].params
 } as const
 
 export const BERGAMOT_EN_KO = {
   name: 'BERGAMOT_EN_KO',
-  src: `registry://${models[274].registrySource}/${models[274].registryPath}`,
-  registryPath: models[274].registryPath,
-  registrySource: models[274].registrySource,
-  blobCoreKey: models[274].blobCoreKey,
-  blobBlockOffset: models[274].blobBlockOffset,
-  blobBlockLength: models[274].blobBlockLength,
-  blobByteOffset: models[274].blobByteOffset,
-  modelId: models[274].modelId,
-  expectedSize: models[274].expectedSize,
-  sha256Checksum: models[274].sha256Checksum,
-  addon: models[274].addon,
-  engine: models[274].engine,
-  quantization: models[274].quantization,
-  params: models[274].params
+  src: `registry://${models[276].registrySource}/${models[276].registryPath}`,
+  registryPath: models[276].registryPath,
+  registrySource: models[276].registrySource,
+  blobCoreKey: models[276].blobCoreKey,
+  blobBlockOffset: models[276].blobBlockOffset,
+  blobBlockLength: models[276].blobBlockLength,
+  blobByteOffset: models[276].blobByteOffset,
+  modelId: models[276].modelId,
+  expectedSize: models[276].expectedSize,
+  sha256Checksum: models[276].sha256Checksum,
+  addon: models[276].addon,
+  engine: models[276].engine,
+  quantization: models[276].quantization,
+  params: models[276].params
 } as const
 
 export const BERGAMOT_EN_LT = {
   name: 'BERGAMOT_EN_LT',
-  src: `registry://${models[279].registrySource}/${models[279].registryPath}`,
-  registryPath: models[279].registryPath,
-  registrySource: models[279].registrySource,
-  blobCoreKey: models[279].blobCoreKey,
-  blobBlockOffset: models[279].blobBlockOffset,
-  blobBlockLength: models[279].blobBlockLength,
-  blobByteOffset: models[279].blobByteOffset,
-  modelId: models[279].modelId,
-  expectedSize: models[279].expectedSize,
-  sha256Checksum: models[279].sha256Checksum,
-  addon: models[279].addon,
-  engine: models[279].engine,
-  quantization: models[279].quantization,
-  params: models[279].params
+  src: `registry://${models[281].registrySource}/${models[281].registryPath}`,
+  registryPath: models[281].registryPath,
+  registrySource: models[281].registrySource,
+  blobCoreKey: models[281].blobCoreKey,
+  blobBlockOffset: models[281].blobBlockOffset,
+  blobBlockLength: models[281].blobBlockLength,
+  blobByteOffset: models[281].blobByteOffset,
+  modelId: models[281].modelId,
+  expectedSize: models[281].expectedSize,
+  sha256Checksum: models[281].sha256Checksum,
+  addon: models[281].addon,
+  engine: models[281].engine,
+  quantization: models[281].quantization,
+  params: models[281].params
 } as const
 
 export const BERGAMOT_EN_LV = {
   name: 'BERGAMOT_EN_LV',
-  src: `registry://${models[283].registrySource}/${models[283].registryPath}`,
-  registryPath: models[283].registryPath,
-  registrySource: models[283].registrySource,
-  blobCoreKey: models[283].blobCoreKey,
-  blobBlockOffset: models[283].blobBlockOffset,
-  blobBlockLength: models[283].blobBlockLength,
-  blobByteOffset: models[283].blobByteOffset,
-  modelId: models[283].modelId,
-  expectedSize: models[283].expectedSize,
-  sha256Checksum: models[283].sha256Checksum,
-  addon: models[283].addon,
-  engine: models[283].engine,
-  quantization: models[283].quantization,
-  params: models[283].params
+  src: `registry://${models[285].registrySource}/${models[285].registryPath}`,
+  registryPath: models[285].registryPath,
+  registrySource: models[285].registrySource,
+  blobCoreKey: models[285].blobCoreKey,
+  blobBlockOffset: models[285].blobBlockOffset,
+  blobBlockLength: models[285].blobBlockLength,
+  blobByteOffset: models[285].blobByteOffset,
+  modelId: models[285].modelId,
+  expectedSize: models[285].expectedSize,
+  sha256Checksum: models[285].sha256Checksum,
+  addon: models[285].addon,
+  engine: models[285].engine,
+  quantization: models[285].quantization,
+  params: models[285].params
 } as const
 
 export const BERGAMOT_EN_ML = {
   name: 'BERGAMOT_EN_ML',
-  src: `registry://${models[287].registrySource}/${models[287].registryPath}`,
-  registryPath: models[287].registryPath,
-  registrySource: models[287].registrySource,
-  blobCoreKey: models[287].blobCoreKey,
-  blobBlockOffset: models[287].blobBlockOffset,
-  blobBlockLength: models[287].blobBlockLength,
-  blobByteOffset: models[287].blobByteOffset,
-  modelId: models[287].modelId,
-  expectedSize: models[287].expectedSize,
-  sha256Checksum: models[287].sha256Checksum,
-  addon: models[287].addon,
-  engine: models[287].engine,
-  quantization: models[287].quantization,
-  params: models[287].params
+  src: `registry://${models[289].registrySource}/${models[289].registryPath}`,
+  registryPath: models[289].registryPath,
+  registrySource: models[289].registrySource,
+  blobCoreKey: models[289].blobCoreKey,
+  blobBlockOffset: models[289].blobBlockOffset,
+  blobBlockLength: models[289].blobBlockLength,
+  blobByteOffset: models[289].blobByteOffset,
+  modelId: models[289].modelId,
+  expectedSize: models[289].expectedSize,
+  sha256Checksum: models[289].sha256Checksum,
+  addon: models[289].addon,
+  engine: models[289].engine,
+  quantization: models[289].quantization,
+  params: models[289].params
 } as const
 
 export const BERGAMOT_EN_MS = {
   name: 'BERGAMOT_EN_MS',
-  src: `registry://${models[291].registrySource}/${models[291].registryPath}`,
-  registryPath: models[291].registryPath,
-  registrySource: models[291].registrySource,
-  blobCoreKey: models[291].blobCoreKey,
-  blobBlockOffset: models[291].blobBlockOffset,
-  blobBlockLength: models[291].blobBlockLength,
-  blobByteOffset: models[291].blobByteOffset,
-  modelId: models[291].modelId,
-  expectedSize: models[291].expectedSize,
-  sha256Checksum: models[291].sha256Checksum,
-  addon: models[291].addon,
-  engine: models[291].engine,
-  quantization: models[291].quantization,
-  params: models[291].params
+  src: `registry://${models[293].registrySource}/${models[293].registryPath}`,
+  registryPath: models[293].registryPath,
+  registrySource: models[293].registrySource,
+  blobCoreKey: models[293].blobCoreKey,
+  blobBlockOffset: models[293].blobBlockOffset,
+  blobBlockLength: models[293].blobBlockLength,
+  blobByteOffset: models[293].blobByteOffset,
+  modelId: models[293].modelId,
+  expectedSize: models[293].expectedSize,
+  sha256Checksum: models[293].sha256Checksum,
+  addon: models[293].addon,
+  engine: models[293].engine,
+  quantization: models[293].quantization,
+  params: models[293].params
 } as const
 
 export const BERGAMOT_EN_NB = {
   name: 'BERGAMOT_EN_NB',
-  src: `registry://${models[295].registrySource}/${models[295].registryPath}`,
-  registryPath: models[295].registryPath,
-  registrySource: models[295].registrySource,
-  blobCoreKey: models[295].blobCoreKey,
-  blobBlockOffset: models[295].blobBlockOffset,
-  blobBlockLength: models[295].blobBlockLength,
-  blobByteOffset: models[295].blobByteOffset,
-  modelId: models[295].modelId,
-  expectedSize: models[295].expectedSize,
-  sha256Checksum: models[295].sha256Checksum,
-  addon: models[295].addon,
-  engine: models[295].engine,
-  quantization: models[295].quantization,
-  params: models[295].params
+  src: `registry://${models[297].registrySource}/${models[297].registryPath}`,
+  registryPath: models[297].registryPath,
+  registrySource: models[297].registrySource,
+  blobCoreKey: models[297].blobCoreKey,
+  blobBlockOffset: models[297].blobBlockOffset,
+  blobBlockLength: models[297].blobBlockLength,
+  blobByteOffset: models[297].blobByteOffset,
+  modelId: models[297].modelId,
+  expectedSize: models[297].expectedSize,
+  sha256Checksum: models[297].sha256Checksum,
+  addon: models[297].addon,
+  engine: models[297].engine,
+  quantization: models[297].quantization,
+  params: models[297].params
 } as const
 
 export const BERGAMOT_EN_NL = {
   name: 'BERGAMOT_EN_NL',
-  src: `registry://${models[299].registrySource}/${models[299].registryPath}`,
-  registryPath: models[299].registryPath,
-  registrySource: models[299].registrySource,
-  blobCoreKey: models[299].blobCoreKey,
-  blobBlockOffset: models[299].blobBlockOffset,
-  blobBlockLength: models[299].blobBlockLength,
-  blobByteOffset: models[299].blobByteOffset,
-  modelId: models[299].modelId,
-  expectedSize: models[299].expectedSize,
-  sha256Checksum: models[299].sha256Checksum,
-  addon: models[299].addon,
-  engine: models[299].engine,
-  quantization: models[299].quantization,
-  params: models[299].params
+  src: `registry://${models[301].registrySource}/${models[301].registryPath}`,
+  registryPath: models[301].registryPath,
+  registrySource: models[301].registrySource,
+  blobCoreKey: models[301].blobCoreKey,
+  blobBlockOffset: models[301].blobBlockOffset,
+  blobBlockLength: models[301].blobBlockLength,
+  blobByteOffset: models[301].blobByteOffset,
+  modelId: models[301].modelId,
+  expectedSize: models[301].expectedSize,
+  sha256Checksum: models[301].sha256Checksum,
+  addon: models[301].addon,
+  engine: models[301].engine,
+  quantization: models[301].quantization,
+  params: models[301].params
 } as const
 
 export const BERGAMOT_EN_NO = {
   name: 'BERGAMOT_EN_NO',
-  src: `registry://${models[303].registrySource}/${models[303].registryPath}`,
-  registryPath: models[303].registryPath,
-  registrySource: models[303].registrySource,
-  blobCoreKey: models[303].blobCoreKey,
-  blobBlockOffset: models[303].blobBlockOffset,
-  blobBlockLength: models[303].blobBlockLength,
-  blobByteOffset: models[303].blobByteOffset,
-  modelId: models[303].modelId,
-  expectedSize: models[303].expectedSize,
-  sha256Checksum: models[303].sha256Checksum,
-  addon: models[303].addon,
-  engine: models[303].engine,
-  quantization: models[303].quantization,
-  params: models[303].params
+  src: `registry://${models[305].registrySource}/${models[305].registryPath}`,
+  registryPath: models[305].registryPath,
+  registrySource: models[305].registrySource,
+  blobCoreKey: models[305].blobCoreKey,
+  blobBlockOffset: models[305].blobBlockOffset,
+  blobBlockLength: models[305].blobBlockLength,
+  blobByteOffset: models[305].blobByteOffset,
+  modelId: models[305].modelId,
+  expectedSize: models[305].expectedSize,
+  sha256Checksum: models[305].sha256Checksum,
+  addon: models[305].addon,
+  engine: models[305].engine,
+  quantization: models[305].quantization,
+  params: models[305].params
 } as const
 
 export const BERGAMOT_EN_PL = {
   name: 'BERGAMOT_EN_PL',
-  src: `registry://${models[307].registrySource}/${models[307].registryPath}`,
-  registryPath: models[307].registryPath,
-  registrySource: models[307].registrySource,
-  blobCoreKey: models[307].blobCoreKey,
-  blobBlockOffset: models[307].blobBlockOffset,
-  blobBlockLength: models[307].blobBlockLength,
-  blobByteOffset: models[307].blobByteOffset,
-  modelId: models[307].modelId,
-  expectedSize: models[307].expectedSize,
-  sha256Checksum: models[307].sha256Checksum,
-  addon: models[307].addon,
-  engine: models[307].engine,
-  quantization: models[307].quantization,
-  params: models[307].params
+  src: `registry://${models[309].registrySource}/${models[309].registryPath}`,
+  registryPath: models[309].registryPath,
+  registrySource: models[309].registrySource,
+  blobCoreKey: models[309].blobCoreKey,
+  blobBlockOffset: models[309].blobBlockOffset,
+  blobBlockLength: models[309].blobBlockLength,
+  blobByteOffset: models[309].blobByteOffset,
+  modelId: models[309].modelId,
+  expectedSize: models[309].expectedSize,
+  sha256Checksum: models[309].sha256Checksum,
+  addon: models[309].addon,
+  engine: models[309].engine,
+  quantization: models[309].quantization,
+  params: models[309].params
 } as const
 
 export const BERGAMOT_EN_PT = {
   name: 'BERGAMOT_EN_PT',
-  src: `registry://${models[311].registrySource}/${models[311].registryPath}`,
-  registryPath: models[311].registryPath,
-  registrySource: models[311].registrySource,
-  blobCoreKey: models[311].blobCoreKey,
-  blobBlockOffset: models[311].blobBlockOffset,
-  blobBlockLength: models[311].blobBlockLength,
-  blobByteOffset: models[311].blobByteOffset,
-  modelId: models[311].modelId,
-  expectedSize: models[311].expectedSize,
-  sha256Checksum: models[311].sha256Checksum,
-  addon: models[311].addon,
-  engine: models[311].engine,
-  quantization: models[311].quantization,
-  params: models[311].params
+  src: `registry://${models[313].registrySource}/${models[313].registryPath}`,
+  registryPath: models[313].registryPath,
+  registrySource: models[313].registrySource,
+  blobCoreKey: models[313].blobCoreKey,
+  blobBlockOffset: models[313].blobBlockOffset,
+  blobBlockLength: models[313].blobBlockLength,
+  blobByteOffset: models[313].blobByteOffset,
+  modelId: models[313].modelId,
+  expectedSize: models[313].expectedSize,
+  sha256Checksum: models[313].sha256Checksum,
+  addon: models[313].addon,
+  engine: models[313].engine,
+  quantization: models[313].quantization,
+  params: models[313].params
 } as const
 
 export const BERGAMOT_EN_RO = {
   name: 'BERGAMOT_EN_RO',
-  src: `registry://${models[315].registrySource}/${models[315].registryPath}`,
-  registryPath: models[315].registryPath,
-  registrySource: models[315].registrySource,
-  blobCoreKey: models[315].blobCoreKey,
-  blobBlockOffset: models[315].blobBlockOffset,
-  blobBlockLength: models[315].blobBlockLength,
-  blobByteOffset: models[315].blobByteOffset,
-  modelId: models[315].modelId,
-  expectedSize: models[315].expectedSize,
-  sha256Checksum: models[315].sha256Checksum,
-  addon: models[315].addon,
-  engine: models[315].engine,
-  quantization: models[315].quantization,
-  params: models[315].params
+  src: `registry://${models[317].registrySource}/${models[317].registryPath}`,
+  registryPath: models[317].registryPath,
+  registrySource: models[317].registrySource,
+  blobCoreKey: models[317].blobCoreKey,
+  blobBlockOffset: models[317].blobBlockOffset,
+  blobBlockLength: models[317].blobBlockLength,
+  blobByteOffset: models[317].blobByteOffset,
+  modelId: models[317].modelId,
+  expectedSize: models[317].expectedSize,
+  sha256Checksum: models[317].sha256Checksum,
+  addon: models[317].addon,
+  engine: models[317].engine,
+  quantization: models[317].quantization,
+  params: models[317].params
 } as const
 
 export const BERGAMOT_EN_RU = {
   name: 'BERGAMOT_EN_RU',
-  src: `registry://${models[319].registrySource}/${models[319].registryPath}`,
-  registryPath: models[319].registryPath,
-  registrySource: models[319].registrySource,
-  blobCoreKey: models[319].blobCoreKey,
-  blobBlockOffset: models[319].blobBlockOffset,
-  blobBlockLength: models[319].blobBlockLength,
-  blobByteOffset: models[319].blobByteOffset,
-  modelId: models[319].modelId,
-  expectedSize: models[319].expectedSize,
-  sha256Checksum: models[319].sha256Checksum,
-  addon: models[319].addon,
-  engine: models[319].engine,
-  quantization: models[319].quantization,
-  params: models[319].params
+  src: `registry://${models[321].registrySource}/${models[321].registryPath}`,
+  registryPath: models[321].registryPath,
+  registrySource: models[321].registrySource,
+  blobCoreKey: models[321].blobCoreKey,
+  blobBlockOffset: models[321].blobBlockOffset,
+  blobBlockLength: models[321].blobBlockLength,
+  blobByteOffset: models[321].blobByteOffset,
+  modelId: models[321].modelId,
+  expectedSize: models[321].expectedSize,
+  sha256Checksum: models[321].sha256Checksum,
+  addon: models[321].addon,
+  engine: models[321].engine,
+  quantization: models[321].quantization,
+  params: models[321].params
 } as const
 
 export const BERGAMOT_EN_SK = {
   name: 'BERGAMOT_EN_SK',
-  src: `registry://${models[323].registrySource}/${models[323].registryPath}`,
-  registryPath: models[323].registryPath,
-  registrySource: models[323].registrySource,
-  blobCoreKey: models[323].blobCoreKey,
-  blobBlockOffset: models[323].blobBlockOffset,
-  blobBlockLength: models[323].blobBlockLength,
-  blobByteOffset: models[323].blobByteOffset,
-  modelId: models[323].modelId,
-  expectedSize: models[323].expectedSize,
-  sha256Checksum: models[323].sha256Checksum,
-  addon: models[323].addon,
-  engine: models[323].engine,
-  quantization: models[323].quantization,
-  params: models[323].params
+  src: `registry://${models[325].registrySource}/${models[325].registryPath}`,
+  registryPath: models[325].registryPath,
+  registrySource: models[325].registrySource,
+  blobCoreKey: models[325].blobCoreKey,
+  blobBlockOffset: models[325].blobBlockOffset,
+  blobBlockLength: models[325].blobBlockLength,
+  blobByteOffset: models[325].blobByteOffset,
+  modelId: models[325].modelId,
+  expectedSize: models[325].expectedSize,
+  sha256Checksum: models[325].sha256Checksum,
+  addon: models[325].addon,
+  engine: models[325].engine,
+  quantization: models[325].quantization,
+  params: models[325].params
 } as const
 
 export const BERGAMOT_EN_SL = {
   name: 'BERGAMOT_EN_SL',
-  src: `registry://${models[327].registrySource}/${models[327].registryPath}`,
-  registryPath: models[327].registryPath,
-  registrySource: models[327].registrySource,
-  blobCoreKey: models[327].blobCoreKey,
-  blobBlockOffset: models[327].blobBlockOffset,
-  blobBlockLength: models[327].blobBlockLength,
-  blobByteOffset: models[327].blobByteOffset,
-  modelId: models[327].modelId,
-  expectedSize: models[327].expectedSize,
-  sha256Checksum: models[327].sha256Checksum,
-  addon: models[327].addon,
-  engine: models[327].engine,
-  quantization: models[327].quantization,
-  params: models[327].params
+  src: `registry://${models[329].registrySource}/${models[329].registryPath}`,
+  registryPath: models[329].registryPath,
+  registrySource: models[329].registrySource,
+  blobCoreKey: models[329].blobCoreKey,
+  blobBlockOffset: models[329].blobBlockOffset,
+  blobBlockLength: models[329].blobBlockLength,
+  blobByteOffset: models[329].blobByteOffset,
+  modelId: models[329].modelId,
+  expectedSize: models[329].expectedSize,
+  sha256Checksum: models[329].sha256Checksum,
+  addon: models[329].addon,
+  engine: models[329].engine,
+  quantization: models[329].quantization,
+  params: models[329].params
 } as const
 
 export const BERGAMOT_EN_SQ = {
   name: 'BERGAMOT_EN_SQ',
-  src: `registry://${models[331].registrySource}/${models[331].registryPath}`,
-  registryPath: models[331].registryPath,
-  registrySource: models[331].registrySource,
-  blobCoreKey: models[331].blobCoreKey,
-  blobBlockOffset: models[331].blobBlockOffset,
-  blobBlockLength: models[331].blobBlockLength,
-  blobByteOffset: models[331].blobByteOffset,
-  modelId: models[331].modelId,
-  expectedSize: models[331].expectedSize,
-  sha256Checksum: models[331].sha256Checksum,
-  addon: models[331].addon,
-  engine: models[331].engine,
-  quantization: models[331].quantization,
-  params: models[331].params
+  src: `registry://${models[333].registrySource}/${models[333].registryPath}`,
+  registryPath: models[333].registryPath,
+  registrySource: models[333].registrySource,
+  blobCoreKey: models[333].blobCoreKey,
+  blobBlockOffset: models[333].blobBlockOffset,
+  blobBlockLength: models[333].blobBlockLength,
+  blobByteOffset: models[333].blobByteOffset,
+  modelId: models[333].modelId,
+  expectedSize: models[333].expectedSize,
+  sha256Checksum: models[333].sha256Checksum,
+  addon: models[333].addon,
+  engine: models[333].engine,
+  quantization: models[333].quantization,
+  params: models[333].params
 } as const
 
 export const BERGAMOT_EN_SR = {
   name: 'BERGAMOT_EN_SR',
-  src: `registry://${models[335].registrySource}/${models[335].registryPath}`,
-  registryPath: models[335].registryPath,
-  registrySource: models[335].registrySource,
-  blobCoreKey: models[335].blobCoreKey,
-  blobBlockOffset: models[335].blobBlockOffset,
-  blobBlockLength: models[335].blobBlockLength,
-  blobByteOffset: models[335].blobByteOffset,
-  modelId: models[335].modelId,
-  expectedSize: models[335].expectedSize,
-  sha256Checksum: models[335].sha256Checksum,
-  addon: models[335].addon,
-  engine: models[335].engine,
-  quantization: models[335].quantization,
-  params: models[335].params
+  src: `registry://${models[337].registrySource}/${models[337].registryPath}`,
+  registryPath: models[337].registryPath,
+  registrySource: models[337].registrySource,
+  blobCoreKey: models[337].blobCoreKey,
+  blobBlockOffset: models[337].blobBlockOffset,
+  blobBlockLength: models[337].blobBlockLength,
+  blobByteOffset: models[337].blobByteOffset,
+  modelId: models[337].modelId,
+  expectedSize: models[337].expectedSize,
+  sha256Checksum: models[337].sha256Checksum,
+  addon: models[337].addon,
+  engine: models[337].engine,
+  quantization: models[337].quantization,
+  params: models[337].params
 } as const
 
 export const BERGAMOT_EN_SV = {
   name: 'BERGAMOT_EN_SV',
-  src: `registry://${models[339].registrySource}/${models[339].registryPath}`,
-  registryPath: models[339].registryPath,
-  registrySource: models[339].registrySource,
-  blobCoreKey: models[339].blobCoreKey,
-  blobBlockOffset: models[339].blobBlockOffset,
-  blobBlockLength: models[339].blobBlockLength,
-  blobByteOffset: models[339].blobByteOffset,
-  modelId: models[339].modelId,
-  expectedSize: models[339].expectedSize,
-  sha256Checksum: models[339].sha256Checksum,
-  addon: models[339].addon,
-  engine: models[339].engine,
-  quantization: models[339].quantization,
-  params: models[339].params
+  src: `registry://${models[341].registrySource}/${models[341].registryPath}`,
+  registryPath: models[341].registryPath,
+  registrySource: models[341].registrySource,
+  blobCoreKey: models[341].blobCoreKey,
+  blobBlockOffset: models[341].blobBlockOffset,
+  blobBlockLength: models[341].blobBlockLength,
+  blobByteOffset: models[341].blobByteOffset,
+  modelId: models[341].modelId,
+  expectedSize: models[341].expectedSize,
+  sha256Checksum: models[341].sha256Checksum,
+  addon: models[341].addon,
+  engine: models[341].engine,
+  quantization: models[341].quantization,
+  params: models[341].params
 } as const
 
 export const BERGAMOT_EN_TA = {
   name: 'BERGAMOT_EN_TA',
-  src: `registry://${models[343].registrySource}/${models[343].registryPath}`,
-  registryPath: models[343].registryPath,
-  registrySource: models[343].registrySource,
-  blobCoreKey: models[343].blobCoreKey,
-  blobBlockOffset: models[343].blobBlockOffset,
-  blobBlockLength: models[343].blobBlockLength,
-  blobByteOffset: models[343].blobByteOffset,
-  modelId: models[343].modelId,
-  expectedSize: models[343].expectedSize,
-  sha256Checksum: models[343].sha256Checksum,
-  addon: models[343].addon,
-  engine: models[343].engine,
-  quantization: models[343].quantization,
-  params: models[343].params
+  src: `registry://${models[345].registrySource}/${models[345].registryPath}`,
+  registryPath: models[345].registryPath,
+  registrySource: models[345].registrySource,
+  blobCoreKey: models[345].blobCoreKey,
+  blobBlockOffset: models[345].blobBlockOffset,
+  blobBlockLength: models[345].blobBlockLength,
+  blobByteOffset: models[345].blobByteOffset,
+  modelId: models[345].modelId,
+  expectedSize: models[345].expectedSize,
+  sha256Checksum: models[345].sha256Checksum,
+  addon: models[345].addon,
+  engine: models[345].engine,
+  quantization: models[345].quantization,
+  params: models[345].params
 } as const
 
 export const BERGAMOT_EN_TE = {
   name: 'BERGAMOT_EN_TE',
-  src: `registry://${models[347].registrySource}/${models[347].registryPath}`,
-  registryPath: models[347].registryPath,
-  registrySource: models[347].registrySource,
-  blobCoreKey: models[347].blobCoreKey,
-  blobBlockOffset: models[347].blobBlockOffset,
-  blobBlockLength: models[347].blobBlockLength,
-  blobByteOffset: models[347].blobByteOffset,
-  modelId: models[347].modelId,
-  expectedSize: models[347].expectedSize,
-  sha256Checksum: models[347].sha256Checksum,
-  addon: models[347].addon,
-  engine: models[347].engine,
-  quantization: models[347].quantization,
-  params: models[347].params
+  src: `registry://${models[349].registrySource}/${models[349].registryPath}`,
+  registryPath: models[349].registryPath,
+  registrySource: models[349].registrySource,
+  blobCoreKey: models[349].blobCoreKey,
+  blobBlockOffset: models[349].blobBlockOffset,
+  blobBlockLength: models[349].blobBlockLength,
+  blobByteOffset: models[349].blobByteOffset,
+  modelId: models[349].modelId,
+  expectedSize: models[349].expectedSize,
+  sha256Checksum: models[349].sha256Checksum,
+  addon: models[349].addon,
+  engine: models[349].engine,
+  quantization: models[349].quantization,
+  params: models[349].params
 } as const
 
 export const BERGAMOT_EN_TH = {
   name: 'BERGAMOT_EN_TH',
-  src: `registry://${models[351].registrySource}/${models[351].registryPath}`,
-  registryPath: models[351].registryPath,
-  registrySource: models[351].registrySource,
-  blobCoreKey: models[351].blobCoreKey,
-  blobBlockOffset: models[351].blobBlockOffset,
-  blobBlockLength: models[351].blobBlockLength,
-  blobByteOffset: models[351].blobByteOffset,
-  modelId: models[351].modelId,
-  expectedSize: models[351].expectedSize,
-  sha256Checksum: models[351].sha256Checksum,
-  addon: models[351].addon,
-  engine: models[351].engine,
-  quantization: models[351].quantization,
-  params: models[351].params
+  src: `registry://${models[353].registrySource}/${models[353].registryPath}`,
+  registryPath: models[353].registryPath,
+  registrySource: models[353].registrySource,
+  blobCoreKey: models[353].blobCoreKey,
+  blobBlockOffset: models[353].blobBlockOffset,
+  blobBlockLength: models[353].blobBlockLength,
+  blobByteOffset: models[353].blobByteOffset,
+  modelId: models[353].modelId,
+  expectedSize: models[353].expectedSize,
+  sha256Checksum: models[353].sha256Checksum,
+  addon: models[353].addon,
+  engine: models[353].engine,
+  quantization: models[353].quantization,
+  params: models[353].params
 } as const
 
 export const BERGAMOT_EN_TR = {
   name: 'BERGAMOT_EN_TR',
-  src: `registry://${models[355].registrySource}/${models[355].registryPath}`,
-  registryPath: models[355].registryPath,
-  registrySource: models[355].registrySource,
-  blobCoreKey: models[355].blobCoreKey,
-  blobBlockOffset: models[355].blobBlockOffset,
-  blobBlockLength: models[355].blobBlockLength,
-  blobByteOffset: models[355].blobByteOffset,
-  modelId: models[355].modelId,
-  expectedSize: models[355].expectedSize,
-  sha256Checksum: models[355].sha256Checksum,
-  addon: models[355].addon,
-  engine: models[355].engine,
-  quantization: models[355].quantization,
-  params: models[355].params
+  src: `registry://${models[357].registrySource}/${models[357].registryPath}`,
+  registryPath: models[357].registryPath,
+  registrySource: models[357].registrySource,
+  blobCoreKey: models[357].blobCoreKey,
+  blobBlockOffset: models[357].blobBlockOffset,
+  blobBlockLength: models[357].blobBlockLength,
+  blobByteOffset: models[357].blobByteOffset,
+  modelId: models[357].modelId,
+  expectedSize: models[357].expectedSize,
+  sha256Checksum: models[357].sha256Checksum,
+  addon: models[357].addon,
+  engine: models[357].engine,
+  quantization: models[357].quantization,
+  params: models[357].params
 } as const
 
 export const BERGAMOT_EN_UK = {
   name: 'BERGAMOT_EN_UK',
-  src: `registry://${models[359].registrySource}/${models[359].registryPath}`,
-  registryPath: models[359].registryPath,
-  registrySource: models[359].registrySource,
-  blobCoreKey: models[359].blobCoreKey,
-  blobBlockOffset: models[359].blobBlockOffset,
-  blobBlockLength: models[359].blobBlockLength,
-  blobByteOffset: models[359].blobByteOffset,
-  modelId: models[359].modelId,
-  expectedSize: models[359].expectedSize,
-  sha256Checksum: models[359].sha256Checksum,
-  addon: models[359].addon,
-  engine: models[359].engine,
-  quantization: models[359].quantization,
-  params: models[359].params
+  src: `registry://${models[361].registrySource}/${models[361].registryPath}`,
+  registryPath: models[361].registryPath,
+  registrySource: models[361].registrySource,
+  blobCoreKey: models[361].blobCoreKey,
+  blobBlockOffset: models[361].blobBlockOffset,
+  blobBlockLength: models[361].blobBlockLength,
+  blobByteOffset: models[361].blobByteOffset,
+  modelId: models[361].modelId,
+  expectedSize: models[361].expectedSize,
+  sha256Checksum: models[361].sha256Checksum,
+  addon: models[361].addon,
+  engine: models[361].engine,
+  quantization: models[361].quantization,
+  params: models[361].params
 } as const
 
 export const BERGAMOT_EN_VI = {
   name: 'BERGAMOT_EN_VI',
-  src: `registry://${models[363].registrySource}/${models[363].registryPath}`,
-  registryPath: models[363].registryPath,
-  registrySource: models[363].registrySource,
-  blobCoreKey: models[363].blobCoreKey,
-  blobBlockOffset: models[363].blobBlockOffset,
-  blobBlockLength: models[363].blobBlockLength,
-  blobByteOffset: models[363].blobByteOffset,
-  modelId: models[363].modelId,
-  expectedSize: models[363].expectedSize,
-  sha256Checksum: models[363].sha256Checksum,
-  addon: models[363].addon,
-  engine: models[363].engine,
-  quantization: models[363].quantization,
-  params: models[363].params
+  src: `registry://${models[365].registrySource}/${models[365].registryPath}`,
+  registryPath: models[365].registryPath,
+  registrySource: models[365].registrySource,
+  blobCoreKey: models[365].blobCoreKey,
+  blobBlockOffset: models[365].blobBlockOffset,
+  blobBlockLength: models[365].blobBlockLength,
+  blobByteOffset: models[365].blobByteOffset,
+  modelId: models[365].modelId,
+  expectedSize: models[365].expectedSize,
+  sha256Checksum: models[365].sha256Checksum,
+  addon: models[365].addon,
+  engine: models[365].engine,
+  quantization: models[365].quantization,
+  params: models[365].params
 } as const
 
 export const BERGAMOT_EN_ZH = {
   name: 'BERGAMOT_EN_ZH',
-  src: `registry://${models[367].registrySource}/${models[367].registryPath}`,
-  registryPath: models[367].registryPath,
-  registrySource: models[367].registrySource,
-  blobCoreKey: models[367].blobCoreKey,
-  blobBlockOffset: models[367].blobBlockOffset,
-  blobBlockLength: models[367].blobBlockLength,
-  blobByteOffset: models[367].blobByteOffset,
-  modelId: models[367].modelId,
-  expectedSize: models[367].expectedSize,
-  sha256Checksum: models[367].sha256Checksum,
-  addon: models[367].addon,
-  engine: models[367].engine,
-  quantization: models[367].quantization,
-  params: models[367].params
+  src: `registry://${models[369].registrySource}/${models[369].registryPath}`,
+  registryPath: models[369].registryPath,
+  registrySource: models[369].registrySource,
+  blobCoreKey: models[369].blobCoreKey,
+  blobBlockOffset: models[369].blobBlockOffset,
+  blobBlockLength: models[369].blobBlockLength,
+  blobByteOffset: models[369].blobByteOffset,
+  modelId: models[369].modelId,
+  expectedSize: models[369].expectedSize,
+  sha256Checksum: models[369].sha256Checksum,
+  addon: models[369].addon,
+  engine: models[369].engine,
+  quantization: models[369].quantization,
+  params: models[369].params
 } as const
 
 export const BERGAMOT_ES_EN = {
   name: 'BERGAMOT_ES_EN',
-  src: `registry://${models[372].registrySource}/${models[372].registryPath}`,
-  registryPath: models[372].registryPath,
-  registrySource: models[372].registrySource,
-  blobCoreKey: models[372].blobCoreKey,
-  blobBlockOffset: models[372].blobBlockOffset,
-  blobBlockLength: models[372].blobBlockLength,
-  blobByteOffset: models[372].blobByteOffset,
-  modelId: models[372].modelId,
-  expectedSize: models[372].expectedSize,
-  sha256Checksum: models[372].sha256Checksum,
-  addon: models[372].addon,
-  engine: models[372].engine,
-  quantization: models[372].quantization,
-  params: models[372].params
+  src: `registry://${models[374].registrySource}/${models[374].registryPath}`,
+  registryPath: models[374].registryPath,
+  registrySource: models[374].registrySource,
+  blobCoreKey: models[374].blobCoreKey,
+  blobBlockOffset: models[374].blobBlockOffset,
+  blobBlockLength: models[374].blobBlockLength,
+  blobByteOffset: models[374].blobByteOffset,
+  modelId: models[374].modelId,
+  expectedSize: models[374].expectedSize,
+  sha256Checksum: models[374].sha256Checksum,
+  addon: models[374].addon,
+  engine: models[374].engine,
+  quantization: models[374].quantization,
+  params: models[374].params
 } as const
 
 export const BERGAMOT_ET_EN = {
   name: 'BERGAMOT_ET_EN',
-  src: `registry://${models[376].registrySource}/${models[376].registryPath}`,
-  registryPath: models[376].registryPath,
-  registrySource: models[376].registrySource,
-  blobCoreKey: models[376].blobCoreKey,
-  blobBlockOffset: models[376].blobBlockOffset,
-  blobBlockLength: models[376].blobBlockLength,
-  blobByteOffset: models[376].blobByteOffset,
-  modelId: models[376].modelId,
-  expectedSize: models[376].expectedSize,
-  sha256Checksum: models[376].sha256Checksum,
-  addon: models[376].addon,
-  engine: models[376].engine,
-  quantization: models[376].quantization,
-  params: models[376].params
+  src: `registry://${models[378].registrySource}/${models[378].registryPath}`,
+  registryPath: models[378].registryPath,
+  registrySource: models[378].registrySource,
+  blobCoreKey: models[378].blobCoreKey,
+  blobBlockOffset: models[378].blobBlockOffset,
+  blobBlockLength: models[378].blobBlockLength,
+  blobByteOffset: models[378].blobByteOffset,
+  modelId: models[378].modelId,
+  expectedSize: models[378].expectedSize,
+  sha256Checksum: models[378].sha256Checksum,
+  addon: models[378].addon,
+  engine: models[378].engine,
+  quantization: models[378].quantization,
+  params: models[378].params
 } as const
 
 export const BERGAMOT_FA_EN = {
   name: 'BERGAMOT_FA_EN',
-  src: `registry://${models[380].registrySource}/${models[380].registryPath}`,
-  registryPath: models[380].registryPath,
-  registrySource: models[380].registrySource,
-  blobCoreKey: models[380].blobCoreKey,
-  blobBlockOffset: models[380].blobBlockOffset,
-  blobBlockLength: models[380].blobBlockLength,
-  blobByteOffset: models[380].blobByteOffset,
-  modelId: models[380].modelId,
-  expectedSize: models[380].expectedSize,
-  sha256Checksum: models[380].sha256Checksum,
-  addon: models[380].addon,
-  engine: models[380].engine,
-  quantization: models[380].quantization,
-  params: models[380].params
+  src: `registry://${models[382].registrySource}/${models[382].registryPath}`,
+  registryPath: models[382].registryPath,
+  registrySource: models[382].registrySource,
+  blobCoreKey: models[382].blobCoreKey,
+  blobBlockOffset: models[382].blobBlockOffset,
+  blobBlockLength: models[382].blobBlockLength,
+  blobByteOffset: models[382].blobByteOffset,
+  modelId: models[382].modelId,
+  expectedSize: models[382].expectedSize,
+  sha256Checksum: models[382].sha256Checksum,
+  addon: models[382].addon,
+  engine: models[382].engine,
+  quantization: models[382].quantization,
+  params: models[382].params
 } as const
 
 export const BERGAMOT_FI_EN = {
   name: 'BERGAMOT_FI_EN',
-  src: `registry://${models[384].registrySource}/${models[384].registryPath}`,
-  registryPath: models[384].registryPath,
-  registrySource: models[384].registrySource,
-  blobCoreKey: models[384].blobCoreKey,
-  blobBlockOffset: models[384].blobBlockOffset,
-  blobBlockLength: models[384].blobBlockLength,
-  blobByteOffset: models[384].blobByteOffset,
-  modelId: models[384].modelId,
-  expectedSize: models[384].expectedSize,
-  sha256Checksum: models[384].sha256Checksum,
-  addon: models[384].addon,
-  engine: models[384].engine,
-  quantization: models[384].quantization,
-  params: models[384].params
+  src: `registry://${models[386].registrySource}/${models[386].registryPath}`,
+  registryPath: models[386].registryPath,
+  registrySource: models[386].registrySource,
+  blobCoreKey: models[386].blobCoreKey,
+  blobBlockOffset: models[386].blobBlockOffset,
+  blobBlockLength: models[386].blobBlockLength,
+  blobByteOffset: models[386].blobByteOffset,
+  modelId: models[386].modelId,
+  expectedSize: models[386].expectedSize,
+  sha256Checksum: models[386].sha256Checksum,
+  addon: models[386].addon,
+  engine: models[386].engine,
+  quantization: models[386].quantization,
+  params: models[386].params
 } as const
 
 export const BERGAMOT_FR_EN = {
   name: 'BERGAMOT_FR_EN',
-  src: `registry://${models[388].registrySource}/${models[388].registryPath}`,
-  registryPath: models[388].registryPath,
-  registrySource: models[388].registrySource,
-  blobCoreKey: models[388].blobCoreKey,
-  blobBlockOffset: models[388].blobBlockOffset,
-  blobBlockLength: models[388].blobBlockLength,
-  blobByteOffset: models[388].blobByteOffset,
-  modelId: models[388].modelId,
-  expectedSize: models[388].expectedSize,
-  sha256Checksum: models[388].sha256Checksum,
-  addon: models[388].addon,
-  engine: models[388].engine,
-  quantization: models[388].quantization,
-  params: models[388].params
+  src: `registry://${models[390].registrySource}/${models[390].registryPath}`,
+  registryPath: models[390].registryPath,
+  registrySource: models[390].registrySource,
+  blobCoreKey: models[390].blobCoreKey,
+  blobBlockOffset: models[390].blobBlockOffset,
+  blobBlockLength: models[390].blobBlockLength,
+  blobByteOffset: models[390].blobByteOffset,
+  modelId: models[390].modelId,
+  expectedSize: models[390].expectedSize,
+  sha256Checksum: models[390].sha256Checksum,
+  addon: models[390].addon,
+  engine: models[390].engine,
+  quantization: models[390].quantization,
+  params: models[390].params
 } as const
 
 export const BERGAMOT_GU_EN = {
   name: 'BERGAMOT_GU_EN',
-  src: `registry://${models[392].registrySource}/${models[392].registryPath}`,
-  registryPath: models[392].registryPath,
-  registrySource: models[392].registrySource,
-  blobCoreKey: models[392].blobCoreKey,
-  blobBlockOffset: models[392].blobBlockOffset,
-  blobBlockLength: models[392].blobBlockLength,
-  blobByteOffset: models[392].blobByteOffset,
-  modelId: models[392].modelId,
-  expectedSize: models[392].expectedSize,
-  sha256Checksum: models[392].sha256Checksum,
-  addon: models[392].addon,
-  engine: models[392].engine,
-  quantization: models[392].quantization,
-  params: models[392].params
+  src: `registry://${models[394].registrySource}/${models[394].registryPath}`,
+  registryPath: models[394].registryPath,
+  registrySource: models[394].registrySource,
+  blobCoreKey: models[394].blobCoreKey,
+  blobBlockOffset: models[394].blobBlockOffset,
+  blobBlockLength: models[394].blobBlockLength,
+  blobByteOffset: models[394].blobByteOffset,
+  modelId: models[394].modelId,
+  expectedSize: models[394].expectedSize,
+  sha256Checksum: models[394].sha256Checksum,
+  addon: models[394].addon,
+  engine: models[394].engine,
+  quantization: models[394].quantization,
+  params: models[394].params
 } as const
 
 export const BERGAMOT = {
   name: 'BERGAMOT',
-  src: `registry://${models[396].registrySource}/${models[396].registryPath}`,
-  registryPath: models[396].registryPath,
-  registrySource: models[396].registrySource,
-  blobCoreKey: models[396].blobCoreKey,
-  blobBlockOffset: models[396].blobBlockOffset,
-  blobBlockLength: models[396].blobBlockLength,
-  blobByteOffset: models[396].blobByteOffset,
-  modelId: models[396].modelId,
-  expectedSize: models[396].expectedSize,
-  sha256Checksum: models[396].sha256Checksum,
-  addon: models[396].addon,
-  engine: models[396].engine,
-  quantization: models[396].quantization,
-  params: models[396].params
+  src: `registry://${models[398].registrySource}/${models[398].registryPath}`,
+  registryPath: models[398].registryPath,
+  registrySource: models[398].registrySource,
+  blobCoreKey: models[398].blobCoreKey,
+  blobBlockOffset: models[398].blobBlockOffset,
+  blobBlockLength: models[398].blobBlockLength,
+  blobByteOffset: models[398].blobByteOffset,
+  modelId: models[398].modelId,
+  expectedSize: models[398].expectedSize,
+  sha256Checksum: models[398].sha256Checksum,
+  addon: models[398].addon,
+  engine: models[398].engine,
+  quantization: models[398].quantization,
+  params: models[398].params
 } as const
 
 export const BERGAMOT_HE_EN = {
   name: 'BERGAMOT_HE_EN',
-  src: `registry://${models[400].registrySource}/${models[400].registryPath}`,
-  registryPath: models[400].registryPath,
-  registrySource: models[400].registrySource,
-  blobCoreKey: models[400].blobCoreKey,
-  blobBlockOffset: models[400].blobBlockOffset,
-  blobBlockLength: models[400].blobBlockLength,
-  blobByteOffset: models[400].blobByteOffset,
-  modelId: models[400].modelId,
-  expectedSize: models[400].expectedSize,
-  sha256Checksum: models[400].sha256Checksum,
-  addon: models[400].addon,
-  engine: models[400].engine,
-  quantization: models[400].quantization,
-  params: models[400].params
+  src: `registry://${models[402].registrySource}/${models[402].registryPath}`,
+  registryPath: models[402].registryPath,
+  registrySource: models[402].registrySource,
+  blobCoreKey: models[402].blobCoreKey,
+  blobBlockOffset: models[402].blobBlockOffset,
+  blobBlockLength: models[402].blobBlockLength,
+  blobByteOffset: models[402].blobByteOffset,
+  modelId: models[402].modelId,
+  expectedSize: models[402].expectedSize,
+  sha256Checksum: models[402].sha256Checksum,
+  addon: models[402].addon,
+  engine: models[402].engine,
+  quantization: models[402].quantization,
+  params: models[402].params
 } as const
 
 export const BERGAMOT_HI_EN = {
   name: 'BERGAMOT_HI_EN',
-  src: `registry://${models[404].registrySource}/${models[404].registryPath}`,
-  registryPath: models[404].registryPath,
-  registrySource: models[404].registrySource,
-  blobCoreKey: models[404].blobCoreKey,
-  blobBlockOffset: models[404].blobBlockOffset,
-  blobBlockLength: models[404].blobBlockLength,
-  blobByteOffset: models[404].blobByteOffset,
-  modelId: models[404].modelId,
-  expectedSize: models[404].expectedSize,
-  sha256Checksum: models[404].sha256Checksum,
-  addon: models[404].addon,
-  engine: models[404].engine,
-  quantization: models[404].quantization,
-  params: models[404].params
+  src: `registry://${models[406].registrySource}/${models[406].registryPath}`,
+  registryPath: models[406].registryPath,
+  registrySource: models[406].registrySource,
+  blobCoreKey: models[406].blobCoreKey,
+  blobBlockOffset: models[406].blobBlockOffset,
+  blobBlockLength: models[406].blobBlockLength,
+  blobByteOffset: models[406].blobByteOffset,
+  modelId: models[406].modelId,
+  expectedSize: models[406].expectedSize,
+  sha256Checksum: models[406].sha256Checksum,
+  addon: models[406].addon,
+  engine: models[406].engine,
+  quantization: models[406].quantization,
+  params: models[406].params
 } as const
 
 export const BERGAMOT_HR_EN = {
   name: 'BERGAMOT_HR_EN',
-  src: `registry://${models[408].registrySource}/${models[408].registryPath}`,
-  registryPath: models[408].registryPath,
-  registrySource: models[408].registrySource,
-  blobCoreKey: models[408].blobCoreKey,
-  blobBlockOffset: models[408].blobBlockOffset,
-  blobBlockLength: models[408].blobBlockLength,
-  blobByteOffset: models[408].blobByteOffset,
-  modelId: models[408].modelId,
-  expectedSize: models[408].expectedSize,
-  sha256Checksum: models[408].sha256Checksum,
-  addon: models[408].addon,
-  engine: models[408].engine,
-  quantization: models[408].quantization,
-  params: models[408].params
+  src: `registry://${models[410].registrySource}/${models[410].registryPath}`,
+  registryPath: models[410].registryPath,
+  registrySource: models[410].registrySource,
+  blobCoreKey: models[410].blobCoreKey,
+  blobBlockOffset: models[410].blobBlockOffset,
+  blobBlockLength: models[410].blobBlockLength,
+  blobByteOffset: models[410].blobByteOffset,
+  modelId: models[410].modelId,
+  expectedSize: models[410].expectedSize,
+  sha256Checksum: models[410].sha256Checksum,
+  addon: models[410].addon,
+  engine: models[410].engine,
+  quantization: models[410].quantization,
+  params: models[410].params
 } as const
 
 export const BERGAMOT_HU_EN = {
   name: 'BERGAMOT_HU_EN',
-  src: `registry://${models[412].registrySource}/${models[412].registryPath}`,
-  registryPath: models[412].registryPath,
-  registrySource: models[412].registrySource,
-  blobCoreKey: models[412].blobCoreKey,
-  blobBlockOffset: models[412].blobBlockOffset,
-  blobBlockLength: models[412].blobBlockLength,
-  blobByteOffset: models[412].blobByteOffset,
-  modelId: models[412].modelId,
-  expectedSize: models[412].expectedSize,
-  sha256Checksum: models[412].sha256Checksum,
-  addon: models[412].addon,
-  engine: models[412].engine,
-  quantization: models[412].quantization,
-  params: models[412].params
+  src: `registry://${models[414].registrySource}/${models[414].registryPath}`,
+  registryPath: models[414].registryPath,
+  registrySource: models[414].registrySource,
+  blobCoreKey: models[414].blobCoreKey,
+  blobBlockOffset: models[414].blobBlockOffset,
+  blobBlockLength: models[414].blobBlockLength,
+  blobByteOffset: models[414].blobByteOffset,
+  modelId: models[414].modelId,
+  expectedSize: models[414].expectedSize,
+  sha256Checksum: models[414].sha256Checksum,
+  addon: models[414].addon,
+  engine: models[414].engine,
+  quantization: models[414].quantization,
+  params: models[414].params
 } as const
 
 export const BERGAMOT_ID_EN = {
   name: 'BERGAMOT_ID_EN',
-  src: `registry://${models[416].registrySource}/${models[416].registryPath}`,
-  registryPath: models[416].registryPath,
-  registrySource: models[416].registrySource,
-  blobCoreKey: models[416].blobCoreKey,
-  blobBlockOffset: models[416].blobBlockOffset,
-  blobBlockLength: models[416].blobBlockLength,
-  blobByteOffset: models[416].blobByteOffset,
-  modelId: models[416].modelId,
-  expectedSize: models[416].expectedSize,
-  sha256Checksum: models[416].sha256Checksum,
-  addon: models[416].addon,
-  engine: models[416].engine,
-  quantization: models[416].quantization,
-  params: models[416].params
+  src: `registry://${models[418].registrySource}/${models[418].registryPath}`,
+  registryPath: models[418].registryPath,
+  registrySource: models[418].registrySource,
+  blobCoreKey: models[418].blobCoreKey,
+  blobBlockOffset: models[418].blobBlockOffset,
+  blobBlockLength: models[418].blobBlockLength,
+  blobByteOffset: models[418].blobByteOffset,
+  modelId: models[418].modelId,
+  expectedSize: models[418].expectedSize,
+  sha256Checksum: models[418].sha256Checksum,
+  addon: models[418].addon,
+  engine: models[418].engine,
+  quantization: models[418].quantization,
+  params: models[418].params
 } as const
 
 export const BERGAMOT_IS_EN = {
   name: 'BERGAMOT_IS_EN',
-  src: `registry://${models[420].registrySource}/${models[420].registryPath}`,
-  registryPath: models[420].registryPath,
-  registrySource: models[420].registrySource,
-  blobCoreKey: models[420].blobCoreKey,
-  blobBlockOffset: models[420].blobBlockOffset,
-  blobBlockLength: models[420].blobBlockLength,
-  blobByteOffset: models[420].blobByteOffset,
-  modelId: models[420].modelId,
-  expectedSize: models[420].expectedSize,
-  sha256Checksum: models[420].sha256Checksum,
-  addon: models[420].addon,
-  engine: models[420].engine,
-  quantization: models[420].quantization,
-  params: models[420].params
+  src: `registry://${models[422].registrySource}/${models[422].registryPath}`,
+  registryPath: models[422].registryPath,
+  registrySource: models[422].registrySource,
+  blobCoreKey: models[422].blobCoreKey,
+  blobBlockOffset: models[422].blobBlockOffset,
+  blobBlockLength: models[422].blobBlockLength,
+  blobByteOffset: models[422].blobByteOffset,
+  modelId: models[422].modelId,
+  expectedSize: models[422].expectedSize,
+  sha256Checksum: models[422].sha256Checksum,
+  addon: models[422].addon,
+  engine: models[422].engine,
+  quantization: models[422].quantization,
+  params: models[422].params
 } as const
 
 export const BERGAMOT_IT_EN = {
   name: 'BERGAMOT_IT_EN',
-  src: `registry://${models[424].registrySource}/${models[424].registryPath}`,
-  registryPath: models[424].registryPath,
-  registrySource: models[424].registrySource,
-  blobCoreKey: models[424].blobCoreKey,
-  blobBlockOffset: models[424].blobBlockOffset,
-  blobBlockLength: models[424].blobBlockLength,
-  blobByteOffset: models[424].blobByteOffset,
-  modelId: models[424].modelId,
-  expectedSize: models[424].expectedSize,
-  sha256Checksum: models[424].sha256Checksum,
-  addon: models[424].addon,
-  engine: models[424].engine,
-  quantization: models[424].quantization,
-  params: models[424].params
+  src: `registry://${models[426].registrySource}/${models[426].registryPath}`,
+  registryPath: models[426].registryPath,
+  registrySource: models[426].registrySource,
+  blobCoreKey: models[426].blobCoreKey,
+  blobBlockOffset: models[426].blobBlockOffset,
+  blobBlockLength: models[426].blobBlockLength,
+  blobByteOffset: models[426].blobByteOffset,
+  modelId: models[426].modelId,
+  expectedSize: models[426].expectedSize,
+  sha256Checksum: models[426].sha256Checksum,
+  addon: models[426].addon,
+  engine: models[426].engine,
+  quantization: models[426].quantization,
+  params: models[426].params
 } as const
 
 export const BERGAMOT_JA_EN = {
   name: 'BERGAMOT_JA_EN',
-  src: `registry://${models[428].registrySource}/${models[428].registryPath}`,
-  registryPath: models[428].registryPath,
-  registrySource: models[428].registrySource,
-  blobCoreKey: models[428].blobCoreKey,
-  blobBlockOffset: models[428].blobBlockOffset,
-  blobBlockLength: models[428].blobBlockLength,
-  blobByteOffset: models[428].blobByteOffset,
-  modelId: models[428].modelId,
-  expectedSize: models[428].expectedSize,
-  sha256Checksum: models[428].sha256Checksum,
-  addon: models[428].addon,
-  engine: models[428].engine,
-  quantization: models[428].quantization,
-  params: models[428].params
+  src: `registry://${models[430].registrySource}/${models[430].registryPath}`,
+  registryPath: models[430].registryPath,
+  registrySource: models[430].registrySource,
+  blobCoreKey: models[430].blobCoreKey,
+  blobBlockOffset: models[430].blobBlockOffset,
+  blobBlockLength: models[430].blobBlockLength,
+  blobByteOffset: models[430].blobByteOffset,
+  modelId: models[430].modelId,
+  expectedSize: models[430].expectedSize,
+  sha256Checksum: models[430].sha256Checksum,
+  addon: models[430].addon,
+  engine: models[430].engine,
+  quantization: models[430].quantization,
+  params: models[430].params
 } as const
 
 export const BERGAMOT_KN_EN = {
   name: 'BERGAMOT_KN_EN',
-  src: `registry://${models[432].registrySource}/${models[432].registryPath}`,
-  registryPath: models[432].registryPath,
-  registrySource: models[432].registrySource,
-  blobCoreKey: models[432].blobCoreKey,
-  blobBlockOffset: models[432].blobBlockOffset,
-  blobBlockLength: models[432].blobBlockLength,
-  blobByteOffset: models[432].blobByteOffset,
-  modelId: models[432].modelId,
-  expectedSize: models[432].expectedSize,
-  sha256Checksum: models[432].sha256Checksum,
-  addon: models[432].addon,
-  engine: models[432].engine,
-  quantization: models[432].quantization,
-  params: models[432].params
+  src: `registry://${models[434].registrySource}/${models[434].registryPath}`,
+  registryPath: models[434].registryPath,
+  registrySource: models[434].registrySource,
+  blobCoreKey: models[434].blobCoreKey,
+  blobBlockOffset: models[434].blobBlockOffset,
+  blobBlockLength: models[434].blobBlockLength,
+  blobByteOffset: models[434].blobByteOffset,
+  modelId: models[434].modelId,
+  expectedSize: models[434].expectedSize,
+  sha256Checksum: models[434].sha256Checksum,
+  addon: models[434].addon,
+  engine: models[434].engine,
+  quantization: models[434].quantization,
+  params: models[434].params
 } as const
 
 export const BERGAMOT_KO_EN = {
   name: 'BERGAMOT_KO_EN',
-  src: `registry://${models[436].registrySource}/${models[436].registryPath}`,
-  registryPath: models[436].registryPath,
-  registrySource: models[436].registrySource,
-  blobCoreKey: models[436].blobCoreKey,
-  blobBlockOffset: models[436].blobBlockOffset,
-  blobBlockLength: models[436].blobBlockLength,
-  blobByteOffset: models[436].blobByteOffset,
-  modelId: models[436].modelId,
-  expectedSize: models[436].expectedSize,
-  sha256Checksum: models[436].sha256Checksum,
-  addon: models[436].addon,
-  engine: models[436].engine,
-  quantization: models[436].quantization,
-  params: models[436].params
+  src: `registry://${models[438].registrySource}/${models[438].registryPath}`,
+  registryPath: models[438].registryPath,
+  registrySource: models[438].registrySource,
+  blobCoreKey: models[438].blobCoreKey,
+  blobBlockOffset: models[438].blobBlockOffset,
+  blobBlockLength: models[438].blobBlockLength,
+  blobByteOffset: models[438].blobByteOffset,
+  modelId: models[438].modelId,
+  expectedSize: models[438].expectedSize,
+  sha256Checksum: models[438].sha256Checksum,
+  addon: models[438].addon,
+  engine: models[438].engine,
+  quantization: models[438].quantization,
+  params: models[438].params
 } as const
 
 export const BERGAMOT_LT_EN = {
   name: 'BERGAMOT_LT_EN',
-  src: `registry://${models[440].registrySource}/${models[440].registryPath}`,
-  registryPath: models[440].registryPath,
-  registrySource: models[440].registrySource,
-  blobCoreKey: models[440].blobCoreKey,
-  blobBlockOffset: models[440].blobBlockOffset,
-  blobBlockLength: models[440].blobBlockLength,
-  blobByteOffset: models[440].blobByteOffset,
-  modelId: models[440].modelId,
-  expectedSize: models[440].expectedSize,
-  sha256Checksum: models[440].sha256Checksum,
-  addon: models[440].addon,
-  engine: models[440].engine,
-  quantization: models[440].quantization,
-  params: models[440].params
+  src: `registry://${models[442].registrySource}/${models[442].registryPath}`,
+  registryPath: models[442].registryPath,
+  registrySource: models[442].registrySource,
+  blobCoreKey: models[442].blobCoreKey,
+  blobBlockOffset: models[442].blobBlockOffset,
+  blobBlockLength: models[442].blobBlockLength,
+  blobByteOffset: models[442].blobByteOffset,
+  modelId: models[442].modelId,
+  expectedSize: models[442].expectedSize,
+  sha256Checksum: models[442].sha256Checksum,
+  addon: models[442].addon,
+  engine: models[442].engine,
+  quantization: models[442].quantization,
+  params: models[442].params
 } as const
 
 export const BERGAMOT_LV_EN = {
   name: 'BERGAMOT_LV_EN',
-  src: `registry://${models[444].registrySource}/${models[444].registryPath}`,
-  registryPath: models[444].registryPath,
-  registrySource: models[444].registrySource,
-  blobCoreKey: models[444].blobCoreKey,
-  blobBlockOffset: models[444].blobBlockOffset,
-  blobBlockLength: models[444].blobBlockLength,
-  blobByteOffset: models[444].blobByteOffset,
-  modelId: models[444].modelId,
-  expectedSize: models[444].expectedSize,
-  sha256Checksum: models[444].sha256Checksum,
-  addon: models[444].addon,
-  engine: models[444].engine,
-  quantization: models[444].quantization,
-  params: models[444].params
+  src: `registry://${models[446].registrySource}/${models[446].registryPath}`,
+  registryPath: models[446].registryPath,
+  registrySource: models[446].registrySource,
+  blobCoreKey: models[446].blobCoreKey,
+  blobBlockOffset: models[446].blobBlockOffset,
+  blobBlockLength: models[446].blobBlockLength,
+  blobByteOffset: models[446].blobByteOffset,
+  modelId: models[446].modelId,
+  expectedSize: models[446].expectedSize,
+  sha256Checksum: models[446].sha256Checksum,
+  addon: models[446].addon,
+  engine: models[446].engine,
+  quantization: models[446].quantization,
+  params: models[446].params
 } as const
 
 export const BERGAMOT_ML_EN = {
   name: 'BERGAMOT_ML_EN',
-  src: `registry://${models[448].registrySource}/${models[448].registryPath}`,
-  registryPath: models[448].registryPath,
-  registrySource: models[448].registrySource,
-  blobCoreKey: models[448].blobCoreKey,
-  blobBlockOffset: models[448].blobBlockOffset,
-  blobBlockLength: models[448].blobBlockLength,
-  blobByteOffset: models[448].blobByteOffset,
-  modelId: models[448].modelId,
-  expectedSize: models[448].expectedSize,
-  sha256Checksum: models[448].sha256Checksum,
-  addon: models[448].addon,
-  engine: models[448].engine,
-  quantization: models[448].quantization,
-  params: models[448].params
+  src: `registry://${models[450].registrySource}/${models[450].registryPath}`,
+  registryPath: models[450].registryPath,
+  registrySource: models[450].registrySource,
+  blobCoreKey: models[450].blobCoreKey,
+  blobBlockOffset: models[450].blobBlockOffset,
+  blobBlockLength: models[450].blobBlockLength,
+  blobByteOffset: models[450].blobByteOffset,
+  modelId: models[450].modelId,
+  expectedSize: models[450].expectedSize,
+  sha256Checksum: models[450].sha256Checksum,
+  addon: models[450].addon,
+  engine: models[450].engine,
+  quantization: models[450].quantization,
+  params: models[450].params
 } as const
 
 export const BERGAMOT_MS_EN = {
   name: 'BERGAMOT_MS_EN',
-  src: `registry://${models[452].registrySource}/${models[452].registryPath}`,
-  registryPath: models[452].registryPath,
-  registrySource: models[452].registrySource,
-  blobCoreKey: models[452].blobCoreKey,
-  blobBlockOffset: models[452].blobBlockOffset,
-  blobBlockLength: models[452].blobBlockLength,
-  blobByteOffset: models[452].blobByteOffset,
-  modelId: models[452].modelId,
-  expectedSize: models[452].expectedSize,
-  sha256Checksum: models[452].sha256Checksum,
-  addon: models[452].addon,
-  engine: models[452].engine,
-  quantization: models[452].quantization,
-  params: models[452].params
+  src: `registry://${models[454].registrySource}/${models[454].registryPath}`,
+  registryPath: models[454].registryPath,
+  registrySource: models[454].registrySource,
+  blobCoreKey: models[454].blobCoreKey,
+  blobBlockOffset: models[454].blobBlockOffset,
+  blobBlockLength: models[454].blobBlockLength,
+  blobByteOffset: models[454].blobByteOffset,
+  modelId: models[454].modelId,
+  expectedSize: models[454].expectedSize,
+  sha256Checksum: models[454].sha256Checksum,
+  addon: models[454].addon,
+  engine: models[454].engine,
+  quantization: models[454].quantization,
+  params: models[454].params
 } as const
 
 export const BERGAMOT_MT_EN = {
   name: 'BERGAMOT_MT_EN',
-  src: `registry://${models[456].registrySource}/${models[456].registryPath}`,
-  registryPath: models[456].registryPath,
-  registrySource: models[456].registrySource,
-  blobCoreKey: models[456].blobCoreKey,
-  blobBlockOffset: models[456].blobBlockOffset,
-  blobBlockLength: models[456].blobBlockLength,
-  blobByteOffset: models[456].blobByteOffset,
-  modelId: models[456].modelId,
-  expectedSize: models[456].expectedSize,
-  sha256Checksum: models[456].sha256Checksum,
-  addon: models[456].addon,
-  engine: models[456].engine,
-  quantization: models[456].quantization,
-  params: models[456].params
+  src: `registry://${models[458].registrySource}/${models[458].registryPath}`,
+  registryPath: models[458].registryPath,
+  registrySource: models[458].registrySource,
+  blobCoreKey: models[458].blobCoreKey,
+  blobBlockOffset: models[458].blobBlockOffset,
+  blobBlockLength: models[458].blobBlockLength,
+  blobByteOffset: models[458].blobByteOffset,
+  modelId: models[458].modelId,
+  expectedSize: models[458].expectedSize,
+  sha256Checksum: models[458].sha256Checksum,
+  addon: models[458].addon,
+  engine: models[458].engine,
+  quantization: models[458].quantization,
+  params: models[458].params
 } as const
 
 export const BERGAMOT_NB_EN = {
   name: 'BERGAMOT_NB_EN',
-  src: `registry://${models[460].registrySource}/${models[460].registryPath}`,
-  registryPath: models[460].registryPath,
-  registrySource: models[460].registrySource,
-  blobCoreKey: models[460].blobCoreKey,
-  blobBlockOffset: models[460].blobBlockOffset,
-  blobBlockLength: models[460].blobBlockLength,
-  blobByteOffset: models[460].blobByteOffset,
-  modelId: models[460].modelId,
-  expectedSize: models[460].expectedSize,
-  sha256Checksum: models[460].sha256Checksum,
-  addon: models[460].addon,
-  engine: models[460].engine,
-  quantization: models[460].quantization,
-  params: models[460].params
+  src: `registry://${models[462].registrySource}/${models[462].registryPath}`,
+  registryPath: models[462].registryPath,
+  registrySource: models[462].registrySource,
+  blobCoreKey: models[462].blobCoreKey,
+  blobBlockOffset: models[462].blobBlockOffset,
+  blobBlockLength: models[462].blobBlockLength,
+  blobByteOffset: models[462].blobByteOffset,
+  modelId: models[462].modelId,
+  expectedSize: models[462].expectedSize,
+  sha256Checksum: models[462].sha256Checksum,
+  addon: models[462].addon,
+  engine: models[462].engine,
+  quantization: models[462].quantization,
+  params: models[462].params
 } as const
 
 export const BERGAMOT_NL_EN = {
   name: 'BERGAMOT_NL_EN',
-  src: `registry://${models[464].registrySource}/${models[464].registryPath}`,
-  registryPath: models[464].registryPath,
-  registrySource: models[464].registrySource,
-  blobCoreKey: models[464].blobCoreKey,
-  blobBlockOffset: models[464].blobBlockOffset,
-  blobBlockLength: models[464].blobBlockLength,
-  blobByteOffset: models[464].blobByteOffset,
-  modelId: models[464].modelId,
-  expectedSize: models[464].expectedSize,
-  sha256Checksum: models[464].sha256Checksum,
-  addon: models[464].addon,
-  engine: models[464].engine,
-  quantization: models[464].quantization,
-  params: models[464].params
+  src: `registry://${models[466].registrySource}/${models[466].registryPath}`,
+  registryPath: models[466].registryPath,
+  registrySource: models[466].registrySource,
+  blobCoreKey: models[466].blobCoreKey,
+  blobBlockOffset: models[466].blobBlockOffset,
+  blobBlockLength: models[466].blobBlockLength,
+  blobByteOffset: models[466].blobByteOffset,
+  modelId: models[466].modelId,
+  expectedSize: models[466].expectedSize,
+  sha256Checksum: models[466].sha256Checksum,
+  addon: models[466].addon,
+  engine: models[466].engine,
+  quantization: models[466].quantization,
+  params: models[466].params
 } as const
 
 export const BERGAMOT_NN_EN = {
   name: 'BERGAMOT_NN_EN',
-  src: `registry://${models[468].registrySource}/${models[468].registryPath}`,
-  registryPath: models[468].registryPath,
-  registrySource: models[468].registrySource,
-  blobCoreKey: models[468].blobCoreKey,
-  blobBlockOffset: models[468].blobBlockOffset,
-  blobBlockLength: models[468].blobBlockLength,
-  blobByteOffset: models[468].blobByteOffset,
-  modelId: models[468].modelId,
-  expectedSize: models[468].expectedSize,
-  sha256Checksum: models[468].sha256Checksum,
-  addon: models[468].addon,
-  engine: models[468].engine,
-  quantization: models[468].quantization,
-  params: models[468].params
+  src: `registry://${models[470].registrySource}/${models[470].registryPath}`,
+  registryPath: models[470].registryPath,
+  registrySource: models[470].registrySource,
+  blobCoreKey: models[470].blobCoreKey,
+  blobBlockOffset: models[470].blobBlockOffset,
+  blobBlockLength: models[470].blobBlockLength,
+  blobByteOffset: models[470].blobByteOffset,
+  modelId: models[470].modelId,
+  expectedSize: models[470].expectedSize,
+  sha256Checksum: models[470].sha256Checksum,
+  addon: models[470].addon,
+  engine: models[470].engine,
+  quantization: models[470].quantization,
+  params: models[470].params
 } as const
 
 export const BERGAMOT_NO_EN = {
   name: 'BERGAMOT_NO_EN',
-  src: `registry://${models[472].registrySource}/${models[472].registryPath}`,
-  registryPath: models[472].registryPath,
-  registrySource: models[472].registrySource,
-  blobCoreKey: models[472].blobCoreKey,
-  blobBlockOffset: models[472].blobBlockOffset,
-  blobBlockLength: models[472].blobBlockLength,
-  blobByteOffset: models[472].blobByteOffset,
-  modelId: models[472].modelId,
-  expectedSize: models[472].expectedSize,
-  sha256Checksum: models[472].sha256Checksum,
-  addon: models[472].addon,
-  engine: models[472].engine,
-  quantization: models[472].quantization,
-  params: models[472].params
+  src: `registry://${models[474].registrySource}/${models[474].registryPath}`,
+  registryPath: models[474].registryPath,
+  registrySource: models[474].registrySource,
+  blobCoreKey: models[474].blobCoreKey,
+  blobBlockOffset: models[474].blobBlockOffset,
+  blobBlockLength: models[474].blobBlockLength,
+  blobByteOffset: models[474].blobByteOffset,
+  modelId: models[474].modelId,
+  expectedSize: models[474].expectedSize,
+  sha256Checksum: models[474].sha256Checksum,
+  addon: models[474].addon,
+  engine: models[474].engine,
+  quantization: models[474].quantization,
+  params: models[474].params
 } as const
 
 export const BERGAMOT_PL_EN = {
   name: 'BERGAMOT_PL_EN',
-  src: `registry://${models[476].registrySource}/${models[476].registryPath}`,
-  registryPath: models[476].registryPath,
-  registrySource: models[476].registrySource,
-  blobCoreKey: models[476].blobCoreKey,
-  blobBlockOffset: models[476].blobBlockOffset,
-  blobBlockLength: models[476].blobBlockLength,
-  blobByteOffset: models[476].blobByteOffset,
-  modelId: models[476].modelId,
-  expectedSize: models[476].expectedSize,
-  sha256Checksum: models[476].sha256Checksum,
-  addon: models[476].addon,
-  engine: models[476].engine,
-  quantization: models[476].quantization,
-  params: models[476].params
+  src: `registry://${models[478].registrySource}/${models[478].registryPath}`,
+  registryPath: models[478].registryPath,
+  registrySource: models[478].registrySource,
+  blobCoreKey: models[478].blobCoreKey,
+  blobBlockOffset: models[478].blobBlockOffset,
+  blobBlockLength: models[478].blobBlockLength,
+  blobByteOffset: models[478].blobByteOffset,
+  modelId: models[478].modelId,
+  expectedSize: models[478].expectedSize,
+  sha256Checksum: models[478].sha256Checksum,
+  addon: models[478].addon,
+  engine: models[478].engine,
+  quantization: models[478].quantization,
+  params: models[478].params
 } as const
 
 export const BERGAMOT_PT_EN = {
   name: 'BERGAMOT_PT_EN',
-  src: `registry://${models[480].registrySource}/${models[480].registryPath}`,
-  registryPath: models[480].registryPath,
-  registrySource: models[480].registrySource,
-  blobCoreKey: models[480].blobCoreKey,
-  blobBlockOffset: models[480].blobBlockOffset,
-  blobBlockLength: models[480].blobBlockLength,
-  blobByteOffset: models[480].blobByteOffset,
-  modelId: models[480].modelId,
-  expectedSize: models[480].expectedSize,
-  sha256Checksum: models[480].sha256Checksum,
-  addon: models[480].addon,
-  engine: models[480].engine,
-  quantization: models[480].quantization,
-  params: models[480].params
+  src: `registry://${models[482].registrySource}/${models[482].registryPath}`,
+  registryPath: models[482].registryPath,
+  registrySource: models[482].registrySource,
+  blobCoreKey: models[482].blobCoreKey,
+  blobBlockOffset: models[482].blobBlockOffset,
+  blobBlockLength: models[482].blobBlockLength,
+  blobByteOffset: models[482].blobByteOffset,
+  modelId: models[482].modelId,
+  expectedSize: models[482].expectedSize,
+  sha256Checksum: models[482].sha256Checksum,
+  addon: models[482].addon,
+  engine: models[482].engine,
+  quantization: models[482].quantization,
+  params: models[482].params
 } as const
 
 export const BERGAMOT_RO_EN = {
   name: 'BERGAMOT_RO_EN',
-  src: `registry://${models[484].registrySource}/${models[484].registryPath}`,
-  registryPath: models[484].registryPath,
-  registrySource: models[484].registrySource,
-  blobCoreKey: models[484].blobCoreKey,
-  blobBlockOffset: models[484].blobBlockOffset,
-  blobBlockLength: models[484].blobBlockLength,
-  blobByteOffset: models[484].blobByteOffset,
-  modelId: models[484].modelId,
-  expectedSize: models[484].expectedSize,
-  sha256Checksum: models[484].sha256Checksum,
-  addon: models[484].addon,
-  engine: models[484].engine,
-  quantization: models[484].quantization,
-  params: models[484].params
+  src: `registry://${models[486].registrySource}/${models[486].registryPath}`,
+  registryPath: models[486].registryPath,
+  registrySource: models[486].registrySource,
+  blobCoreKey: models[486].blobCoreKey,
+  blobBlockOffset: models[486].blobBlockOffset,
+  blobBlockLength: models[486].blobBlockLength,
+  blobByteOffset: models[486].blobByteOffset,
+  modelId: models[486].modelId,
+  expectedSize: models[486].expectedSize,
+  sha256Checksum: models[486].sha256Checksum,
+  addon: models[486].addon,
+  engine: models[486].engine,
+  quantization: models[486].quantization,
+  params: models[486].params
 } as const
 
 export const BERGAMOT_RU_EN = {
   name: 'BERGAMOT_RU_EN',
-  src: `registry://${models[488].registrySource}/${models[488].registryPath}`,
-  registryPath: models[488].registryPath,
-  registrySource: models[488].registrySource,
-  blobCoreKey: models[488].blobCoreKey,
-  blobBlockOffset: models[488].blobBlockOffset,
-  blobBlockLength: models[488].blobBlockLength,
-  blobByteOffset: models[488].blobByteOffset,
-  modelId: models[488].modelId,
-  expectedSize: models[488].expectedSize,
-  sha256Checksum: models[488].sha256Checksum,
-  addon: models[488].addon,
-  engine: models[488].engine,
-  quantization: models[488].quantization,
-  params: models[488].params
+  src: `registry://${models[490].registrySource}/${models[490].registryPath}`,
+  registryPath: models[490].registryPath,
+  registrySource: models[490].registrySource,
+  blobCoreKey: models[490].blobCoreKey,
+  blobBlockOffset: models[490].blobBlockOffset,
+  blobBlockLength: models[490].blobBlockLength,
+  blobByteOffset: models[490].blobByteOffset,
+  modelId: models[490].modelId,
+  expectedSize: models[490].expectedSize,
+  sha256Checksum: models[490].sha256Checksum,
+  addon: models[490].addon,
+  engine: models[490].engine,
+  quantization: models[490].quantization,
+  params: models[490].params
 } as const
 
 export const BERGAMOT_SK_EN = {
   name: 'BERGAMOT_SK_EN',
-  src: `registry://${models[492].registrySource}/${models[492].registryPath}`,
-  registryPath: models[492].registryPath,
-  registrySource: models[492].registrySource,
-  blobCoreKey: models[492].blobCoreKey,
-  blobBlockOffset: models[492].blobBlockOffset,
-  blobBlockLength: models[492].blobBlockLength,
-  blobByteOffset: models[492].blobByteOffset,
-  modelId: models[492].modelId,
-  expectedSize: models[492].expectedSize,
-  sha256Checksum: models[492].sha256Checksum,
-  addon: models[492].addon,
-  engine: models[492].engine,
-  quantization: models[492].quantization,
-  params: models[492].params
+  src: `registry://${models[494].registrySource}/${models[494].registryPath}`,
+  registryPath: models[494].registryPath,
+  registrySource: models[494].registrySource,
+  blobCoreKey: models[494].blobCoreKey,
+  blobBlockOffset: models[494].blobBlockOffset,
+  blobBlockLength: models[494].blobBlockLength,
+  blobByteOffset: models[494].blobByteOffset,
+  modelId: models[494].modelId,
+  expectedSize: models[494].expectedSize,
+  sha256Checksum: models[494].sha256Checksum,
+  addon: models[494].addon,
+  engine: models[494].engine,
+  quantization: models[494].quantization,
+  params: models[494].params
 } as const
 
 export const BERGAMOT_SL_EN = {
   name: 'BERGAMOT_SL_EN',
-  src: `registry://${models[496].registrySource}/${models[496].registryPath}`,
-  registryPath: models[496].registryPath,
-  registrySource: models[496].registrySource,
-  blobCoreKey: models[496].blobCoreKey,
-  blobBlockOffset: models[496].blobBlockOffset,
-  blobBlockLength: models[496].blobBlockLength,
-  blobByteOffset: models[496].blobByteOffset,
-  modelId: models[496].modelId,
-  expectedSize: models[496].expectedSize,
-  sha256Checksum: models[496].sha256Checksum,
-  addon: models[496].addon,
-  engine: models[496].engine,
-  quantization: models[496].quantization,
-  params: models[496].params
+  src: `registry://${models[498].registrySource}/${models[498].registryPath}`,
+  registryPath: models[498].registryPath,
+  registrySource: models[498].registrySource,
+  blobCoreKey: models[498].blobCoreKey,
+  blobBlockOffset: models[498].blobBlockOffset,
+  blobBlockLength: models[498].blobBlockLength,
+  blobByteOffset: models[498].blobByteOffset,
+  modelId: models[498].modelId,
+  expectedSize: models[498].expectedSize,
+  sha256Checksum: models[498].sha256Checksum,
+  addon: models[498].addon,
+  engine: models[498].engine,
+  quantization: models[498].quantization,
+  params: models[498].params
 } as const
 
 export const BERGAMOT_SQ_EN = {
   name: 'BERGAMOT_SQ_EN',
-  src: `registry://${models[500].registrySource}/${models[500].registryPath}`,
-  registryPath: models[500].registryPath,
-  registrySource: models[500].registrySource,
-  blobCoreKey: models[500].blobCoreKey,
-  blobBlockOffset: models[500].blobBlockOffset,
-  blobBlockLength: models[500].blobBlockLength,
-  blobByteOffset: models[500].blobByteOffset,
-  modelId: models[500].modelId,
-  expectedSize: models[500].expectedSize,
-  sha256Checksum: models[500].sha256Checksum,
-  addon: models[500].addon,
-  engine: models[500].engine,
-  quantization: models[500].quantization,
-  params: models[500].params
+  src: `registry://${models[502].registrySource}/${models[502].registryPath}`,
+  registryPath: models[502].registryPath,
+  registrySource: models[502].registrySource,
+  blobCoreKey: models[502].blobCoreKey,
+  blobBlockOffset: models[502].blobBlockOffset,
+  blobBlockLength: models[502].blobBlockLength,
+  blobByteOffset: models[502].blobByteOffset,
+  modelId: models[502].modelId,
+  expectedSize: models[502].expectedSize,
+  sha256Checksum: models[502].sha256Checksum,
+  addon: models[502].addon,
+  engine: models[502].engine,
+  quantization: models[502].quantization,
+  params: models[502].params
 } as const
 
 export const BERGAMOT_SR_EN = {
   name: 'BERGAMOT_SR_EN',
-  src: `registry://${models[504].registrySource}/${models[504].registryPath}`,
-  registryPath: models[504].registryPath,
-  registrySource: models[504].registrySource,
-  blobCoreKey: models[504].blobCoreKey,
-  blobBlockOffset: models[504].blobBlockOffset,
-  blobBlockLength: models[504].blobBlockLength,
-  blobByteOffset: models[504].blobByteOffset,
-  modelId: models[504].modelId,
-  expectedSize: models[504].expectedSize,
-  sha256Checksum: models[504].sha256Checksum,
-  addon: models[504].addon,
-  engine: models[504].engine,
-  quantization: models[504].quantization,
-  params: models[504].params
+  src: `registry://${models[506].registrySource}/${models[506].registryPath}`,
+  registryPath: models[506].registryPath,
+  registrySource: models[506].registrySource,
+  blobCoreKey: models[506].blobCoreKey,
+  blobBlockOffset: models[506].blobBlockOffset,
+  blobBlockLength: models[506].blobBlockLength,
+  blobByteOffset: models[506].blobByteOffset,
+  modelId: models[506].modelId,
+  expectedSize: models[506].expectedSize,
+  sha256Checksum: models[506].sha256Checksum,
+  addon: models[506].addon,
+  engine: models[506].engine,
+  quantization: models[506].quantization,
+  params: models[506].params
 } as const
 
 export const BERGAMOT_SV_EN = {
   name: 'BERGAMOT_SV_EN',
-  src: `registry://${models[508].registrySource}/${models[508].registryPath}`,
-  registryPath: models[508].registryPath,
-  registrySource: models[508].registrySource,
-  blobCoreKey: models[508].blobCoreKey,
-  blobBlockOffset: models[508].blobBlockOffset,
-  blobBlockLength: models[508].blobBlockLength,
-  blobByteOffset: models[508].blobByteOffset,
-  modelId: models[508].modelId,
-  expectedSize: models[508].expectedSize,
-  sha256Checksum: models[508].sha256Checksum,
-  addon: models[508].addon,
-  engine: models[508].engine,
-  quantization: models[508].quantization,
-  params: models[508].params
+  src: `registry://${models[510].registrySource}/${models[510].registryPath}`,
+  registryPath: models[510].registryPath,
+  registrySource: models[510].registrySource,
+  blobCoreKey: models[510].blobCoreKey,
+  blobBlockOffset: models[510].blobBlockOffset,
+  blobBlockLength: models[510].blobBlockLength,
+  blobByteOffset: models[510].blobByteOffset,
+  modelId: models[510].modelId,
+  expectedSize: models[510].expectedSize,
+  sha256Checksum: models[510].sha256Checksum,
+  addon: models[510].addon,
+  engine: models[510].engine,
+  quantization: models[510].quantization,
+  params: models[510].params
 } as const
 
 export const BERGAMOT_TA_EN = {
   name: 'BERGAMOT_TA_EN',
-  src: `registry://${models[512].registrySource}/${models[512].registryPath}`,
-  registryPath: models[512].registryPath,
-  registrySource: models[512].registrySource,
-  blobCoreKey: models[512].blobCoreKey,
-  blobBlockOffset: models[512].blobBlockOffset,
-  blobBlockLength: models[512].blobBlockLength,
-  blobByteOffset: models[512].blobByteOffset,
-  modelId: models[512].modelId,
-  expectedSize: models[512].expectedSize,
-  sha256Checksum: models[512].sha256Checksum,
-  addon: models[512].addon,
-  engine: models[512].engine,
-  quantization: models[512].quantization,
-  params: models[512].params
+  src: `registry://${models[514].registrySource}/${models[514].registryPath}`,
+  registryPath: models[514].registryPath,
+  registrySource: models[514].registrySource,
+  blobCoreKey: models[514].blobCoreKey,
+  blobBlockOffset: models[514].blobBlockOffset,
+  blobBlockLength: models[514].blobBlockLength,
+  blobByteOffset: models[514].blobByteOffset,
+  modelId: models[514].modelId,
+  expectedSize: models[514].expectedSize,
+  sha256Checksum: models[514].sha256Checksum,
+  addon: models[514].addon,
+  engine: models[514].engine,
+  quantization: models[514].quantization,
+  params: models[514].params
 } as const
 
 export const BERGAMOT_TE_EN = {
   name: 'BERGAMOT_TE_EN',
-  src: `registry://${models[516].registrySource}/${models[516].registryPath}`,
-  registryPath: models[516].registryPath,
-  registrySource: models[516].registrySource,
-  blobCoreKey: models[516].blobCoreKey,
-  blobBlockOffset: models[516].blobBlockOffset,
-  blobBlockLength: models[516].blobBlockLength,
-  blobByteOffset: models[516].blobByteOffset,
-  modelId: models[516].modelId,
-  expectedSize: models[516].expectedSize,
-  sha256Checksum: models[516].sha256Checksum,
-  addon: models[516].addon,
-  engine: models[516].engine,
-  quantization: models[516].quantization,
-  params: models[516].params
+  src: `registry://${models[518].registrySource}/${models[518].registryPath}`,
+  registryPath: models[518].registryPath,
+  registrySource: models[518].registrySource,
+  blobCoreKey: models[518].blobCoreKey,
+  blobBlockOffset: models[518].blobBlockOffset,
+  blobBlockLength: models[518].blobBlockLength,
+  blobByteOffset: models[518].blobByteOffset,
+  modelId: models[518].modelId,
+  expectedSize: models[518].expectedSize,
+  sha256Checksum: models[518].sha256Checksum,
+  addon: models[518].addon,
+  engine: models[518].engine,
+  quantization: models[518].quantization,
+  params: models[518].params
 } as const
 
 export const BERGAMOT_TH_EN = {
   name: 'BERGAMOT_TH_EN',
-  src: `registry://${models[520].registrySource}/${models[520].registryPath}`,
-  registryPath: models[520].registryPath,
-  registrySource: models[520].registrySource,
-  blobCoreKey: models[520].blobCoreKey,
-  blobBlockOffset: models[520].blobBlockOffset,
-  blobBlockLength: models[520].blobBlockLength,
-  blobByteOffset: models[520].blobByteOffset,
-  modelId: models[520].modelId,
-  expectedSize: models[520].expectedSize,
-  sha256Checksum: models[520].sha256Checksum,
-  addon: models[520].addon,
-  engine: models[520].engine,
-  quantization: models[520].quantization,
-  params: models[520].params
+  src: `registry://${models[522].registrySource}/${models[522].registryPath}`,
+  registryPath: models[522].registryPath,
+  registrySource: models[522].registrySource,
+  blobCoreKey: models[522].blobCoreKey,
+  blobBlockOffset: models[522].blobBlockOffset,
+  blobBlockLength: models[522].blobBlockLength,
+  blobByteOffset: models[522].blobByteOffset,
+  modelId: models[522].modelId,
+  expectedSize: models[522].expectedSize,
+  sha256Checksum: models[522].sha256Checksum,
+  addon: models[522].addon,
+  engine: models[522].engine,
+  quantization: models[522].quantization,
+  params: models[522].params
 } as const
 
 export const BERGAMOT_TR_EN = {
   name: 'BERGAMOT_TR_EN',
-  src: `registry://${models[524].registrySource}/${models[524].registryPath}`,
-  registryPath: models[524].registryPath,
-  registrySource: models[524].registrySource,
-  blobCoreKey: models[524].blobCoreKey,
-  blobBlockOffset: models[524].blobBlockOffset,
-  blobBlockLength: models[524].blobBlockLength,
-  blobByteOffset: models[524].blobByteOffset,
-  modelId: models[524].modelId,
-  expectedSize: models[524].expectedSize,
-  sha256Checksum: models[524].sha256Checksum,
-  addon: models[524].addon,
-  engine: models[524].engine,
-  quantization: models[524].quantization,
-  params: models[524].params
+  src: `registry://${models[526].registrySource}/${models[526].registryPath}`,
+  registryPath: models[526].registryPath,
+  registrySource: models[526].registrySource,
+  blobCoreKey: models[526].blobCoreKey,
+  blobBlockOffset: models[526].blobBlockOffset,
+  blobBlockLength: models[526].blobBlockLength,
+  blobByteOffset: models[526].blobByteOffset,
+  modelId: models[526].modelId,
+  expectedSize: models[526].expectedSize,
+  sha256Checksum: models[526].sha256Checksum,
+  addon: models[526].addon,
+  engine: models[526].engine,
+  quantization: models[526].quantization,
+  params: models[526].params
 } as const
 
 export const BERGAMOT_UK_EN = {
   name: 'BERGAMOT_UK_EN',
-  src: `registry://${models[528].registrySource}/${models[528].registryPath}`,
-  registryPath: models[528].registryPath,
-  registrySource: models[528].registrySource,
-  blobCoreKey: models[528].blobCoreKey,
-  blobBlockOffset: models[528].blobBlockOffset,
-  blobBlockLength: models[528].blobBlockLength,
-  blobByteOffset: models[528].blobByteOffset,
-  modelId: models[528].modelId,
-  expectedSize: models[528].expectedSize,
-  sha256Checksum: models[528].sha256Checksum,
-  addon: models[528].addon,
-  engine: models[528].engine,
-  quantization: models[528].quantization,
-  params: models[528].params
+  src: `registry://${models[530].registrySource}/${models[530].registryPath}`,
+  registryPath: models[530].registryPath,
+  registrySource: models[530].registrySource,
+  blobCoreKey: models[530].blobCoreKey,
+  blobBlockOffset: models[530].blobBlockOffset,
+  blobBlockLength: models[530].blobBlockLength,
+  blobByteOffset: models[530].blobByteOffset,
+  modelId: models[530].modelId,
+  expectedSize: models[530].expectedSize,
+  sha256Checksum: models[530].sha256Checksum,
+  addon: models[530].addon,
+  engine: models[530].engine,
+  quantization: models[530].quantization,
+  params: models[530].params
 } as const
 
 export const BERGAMOT_VI_EN = {
   name: 'BERGAMOT_VI_EN',
-  src: `registry://${models[532].registrySource}/${models[532].registryPath}`,
-  registryPath: models[532].registryPath,
-  registrySource: models[532].registrySource,
-  blobCoreKey: models[532].blobCoreKey,
-  blobBlockOffset: models[532].blobBlockOffset,
-  blobBlockLength: models[532].blobBlockLength,
-  blobByteOffset: models[532].blobByteOffset,
-  modelId: models[532].modelId,
-  expectedSize: models[532].expectedSize,
-  sha256Checksum: models[532].sha256Checksum,
-  addon: models[532].addon,
-  engine: models[532].engine,
-  quantization: models[532].quantization,
-  params: models[532].params
+  src: `registry://${models[534].registrySource}/${models[534].registryPath}`,
+  registryPath: models[534].registryPath,
+  registrySource: models[534].registrySource,
+  blobCoreKey: models[534].blobCoreKey,
+  blobBlockOffset: models[534].blobBlockOffset,
+  blobBlockLength: models[534].blobBlockLength,
+  blobByteOffset: models[534].blobByteOffset,
+  modelId: models[534].modelId,
+  expectedSize: models[534].expectedSize,
+  sha256Checksum: models[534].sha256Checksum,
+  addon: models[534].addon,
+  engine: models[534].engine,
+  quantization: models[534].quantization,
+  params: models[534].params
 } as const
 
 export const BERGAMOT_ZH_EN = {
   name: 'BERGAMOT_ZH_EN',
-  src: `registry://${models[536].registrySource}/${models[536].registryPath}`,
-  registryPath: models[536].registryPath,
-  registrySource: models[536].registrySource,
-  blobCoreKey: models[536].blobCoreKey,
-  blobBlockOffset: models[536].blobBlockOffset,
-  blobBlockLength: models[536].blobBlockLength,
-  blobByteOffset: models[536].blobByteOffset,
-  modelId: models[536].modelId,
-  expectedSize: models[536].expectedSize,
-  sha256Checksum: models[536].sha256Checksum,
-  addon: models[536].addon,
-  engine: models[536].engine,
-  quantization: models[536].quantization,
-  params: models[536].params
-} as const
-
-export const MARIAN_EN_HI_INDIC_1B_F16 = {
-  name: 'MARIAN_EN_HI_INDIC_1B_F16',
   src: `registry://${models[538].registrySource}/${models[538].registryPath}`,
   registryPath: models[538].registryPath,
   registrySource: models[538].registrySource,
@@ -24762,26 +21769,8 @@ export const MARIAN_EN_HI_INDIC_1B_F16 = {
   params: models[538].params
 } as const
 
-export const MARIAN_EN_HI_INDIC_200M_F16 = {
-  name: 'MARIAN_EN_HI_INDIC_200M_F16',
-  src: `registry://${models[539].registrySource}/${models[539].registryPath}`,
-  registryPath: models[539].registryPath,
-  registrySource: models[539].registrySource,
-  blobCoreKey: models[539].blobCoreKey,
-  blobBlockOffset: models[539].blobBlockOffset,
-  blobBlockLength: models[539].blobBlockLength,
-  blobByteOffset: models[539].blobByteOffset,
-  modelId: models[539].modelId,
-  expectedSize: models[539].expectedSize,
-  sha256Checksum: models[539].sha256Checksum,
-  addon: models[539].addon,
-  engine: models[539].engine,
-  quantization: models[539].quantization,
-  params: models[539].params
-} as const
-
-export const MARIAN_HI_EN_INDIC_1B_F16 = {
-  name: 'MARIAN_HI_EN_INDIC_1B_F16',
+export const MARIAN_EN_HI_INDIC_1B_F16 = {
+  name: 'MARIAN_EN_HI_INDIC_1B_F16',
   src: `registry://${models[540].registrySource}/${models[540].registryPath}`,
   registryPath: models[540].registryPath,
   registrySource: models[540].registrySource,
@@ -24798,8 +21787,8 @@ export const MARIAN_HI_EN_INDIC_1B_F16 = {
   params: models[540].params
 } as const
 
-export const MARIAN_HI_EN_INDIC_200M_F16 = {
-  name: 'MARIAN_HI_EN_INDIC_200M_F16',
+export const MARIAN_EN_HI_INDIC_200M_F16 = {
+  name: 'MARIAN_EN_HI_INDIC_200M_F16',
   src: `registry://${models[541].registrySource}/${models[541].registryPath}`,
   registryPath: models[541].registryPath,
   registrySource: models[541].registrySource,
@@ -24816,8 +21805,8 @@ export const MARIAN_HI_EN_INDIC_200M_F16 = {
   params: models[541].params
 } as const
 
-export const MARIAN_HI_HI_INDIC_1B_F16 = {
-  name: 'MARIAN_HI_HI_INDIC_1B_F16',
+export const MARIAN_HI_EN_INDIC_1B_F16 = {
+  name: 'MARIAN_HI_EN_INDIC_1B_F16',
   src: `registry://${models[542].registrySource}/${models[542].registryPath}`,
   registryPath: models[542].registryPath,
   registrySource: models[542].registrySource,
@@ -24834,8 +21823,8 @@ export const MARIAN_HI_HI_INDIC_1B_F16 = {
   params: models[542].params
 } as const
 
-export const MARIAN_HI_HI_INDIC_320M_F16 = {
-  name: 'MARIAN_HI_HI_INDIC_320M_F16',
+export const MARIAN_HI_EN_INDIC_200M_F16 = {
+  name: 'MARIAN_HI_EN_INDIC_200M_F16',
   src: `registry://${models[543].registrySource}/${models[543].registryPath}`,
   registryPath: models[543].registryPath,
   registrySource: models[543].registrySource,
@@ -24852,8 +21841,8 @@ export const MARIAN_HI_HI_INDIC_320M_F16 = {
   params: models[543].params
 } as const
 
-export const MARIAN_EN_HI_INDIC_1B_Q4_0 = {
-  name: 'MARIAN_EN_HI_INDIC_1B_Q4_0',
+export const MARIAN_HI_HI_INDIC_1B_F16 = {
+  name: 'MARIAN_HI_HI_INDIC_1B_F16',
   src: `registry://${models[544].registrySource}/${models[544].registryPath}`,
   registryPath: models[544].registryPath,
   registrySource: models[544].registrySource,
@@ -24870,8 +21859,8 @@ export const MARIAN_EN_HI_INDIC_1B_Q4_0 = {
   params: models[544].params
 } as const
 
-export const MARIAN_EN_HI_INDIC_200M_Q4_0 = {
-  name: 'MARIAN_EN_HI_INDIC_200M_Q4_0',
+export const MARIAN_HI_HI_INDIC_320M_F16 = {
+  name: 'MARIAN_HI_HI_INDIC_320M_F16',
   src: `registry://${models[545].registrySource}/${models[545].registryPath}`,
   registryPath: models[545].registryPath,
   registrySource: models[545].registrySource,
@@ -24888,8 +21877,8 @@ export const MARIAN_EN_HI_INDIC_200M_Q4_0 = {
   params: models[545].params
 } as const
 
-export const MARIAN_HI_EN_INDIC_1B_Q4_0 = {
-  name: 'MARIAN_HI_EN_INDIC_1B_Q4_0',
+export const MARIAN_EN_HI_INDIC_1B_Q4_0 = {
+  name: 'MARIAN_EN_HI_INDIC_1B_Q4_0',
   src: `registry://${models[546].registrySource}/${models[546].registryPath}`,
   registryPath: models[546].registryPath,
   registrySource: models[546].registrySource,
@@ -24906,8 +21895,8 @@ export const MARIAN_HI_EN_INDIC_1B_Q4_0 = {
   params: models[546].params
 } as const
 
-export const MARIAN_HI_EN_INDIC_200M_Q4_0 = {
-  name: 'MARIAN_HI_EN_INDIC_200M_Q4_0',
+export const MARIAN_EN_HI_INDIC_200M_Q4_0 = {
+  name: 'MARIAN_EN_HI_INDIC_200M_Q4_0',
   src: `registry://${models[547].registrySource}/${models[547].registryPath}`,
   registryPath: models[547].registryPath,
   registrySource: models[547].registrySource,
@@ -24924,8 +21913,8 @@ export const MARIAN_HI_EN_INDIC_200M_Q4_0 = {
   params: models[547].params
 } as const
 
-export const MARIAN_HI_HI_INDIC_1B_Q4_0 = {
-  name: 'MARIAN_HI_HI_INDIC_1B_Q4_0',
+export const MARIAN_HI_EN_INDIC_1B_Q4_0 = {
+  name: 'MARIAN_HI_EN_INDIC_1B_Q4_0',
   src: `registry://${models[548].registrySource}/${models[548].registryPath}`,
   registryPath: models[548].registryPath,
   registrySource: models[548].registrySource,
@@ -24942,8 +21931,8 @@ export const MARIAN_HI_HI_INDIC_1B_Q4_0 = {
   params: models[548].params
 } as const
 
-export const MARIAN_HI_HI_INDIC_320M_Q4_0 = {
-  name: 'MARIAN_HI_HI_INDIC_320M_Q4_0',
+export const MARIAN_HI_EN_INDIC_200M_Q4_0 = {
+  name: 'MARIAN_HI_EN_INDIC_200M_Q4_0',
   src: `registry://${models[549].registrySource}/${models[549].registryPath}`,
   registryPath: models[549].registryPath,
   registrySource: models[549].registrySource,
@@ -24960,8 +21949,8 @@ export const MARIAN_HI_HI_INDIC_320M_Q4_0 = {
   params: models[549].params
 } as const
 
-export const OCR_CRAFT_DETECTOR = {
-  name: 'OCR_CRAFT_DETECTOR',
+export const MARIAN_HI_HI_INDIC_1B_Q4_0 = {
+  name: 'MARIAN_HI_HI_INDIC_1B_Q4_0',
   src: `registry://${models[550].registrySource}/${models[550].registryPath}`,
   registryPath: models[550].registryPath,
   registrySource: models[550].registrySource,
@@ -24978,8 +21967,8 @@ export const OCR_CRAFT_DETECTOR = {
   params: models[550].params
 } as const
 
-export const OCR_LATIN_RECOGNIZER = {
-  name: 'OCR_LATIN_RECOGNIZER',
+export const MARIAN_HI_HI_INDIC_320M_Q4_0 = {
+  name: 'MARIAN_HI_HI_INDIC_320M_Q4_0',
   src: `registry://${models[551].registrySource}/${models[551].registryPath}`,
   registryPath: models[551].registryPath,
   registrySource: models[551].registrySource,
@@ -24996,8 +21985,8 @@ export const OCR_LATIN_RECOGNIZER = {
   params: models[551].params
 } as const
 
-export const OCR_ARABIC_RECOGNIZER = {
-  name: 'OCR_ARABIC_RECOGNIZER',
+export const OCR_CRAFT_DETECTOR = {
+  name: 'OCR_CRAFT_DETECTOR',
   src: `registry://${models[552].registrySource}/${models[552].registryPath}`,
   registryPath: models[552].registryPath,
   registrySource: models[552].registrySource,
@@ -25014,8 +22003,8 @@ export const OCR_ARABIC_RECOGNIZER = {
   params: models[552].params
 } as const
 
-export const OCR_BENGALI_RECOGNIZER = {
-  name: 'OCR_BENGALI_RECOGNIZER',
+export const OCR_LATIN_RECOGNIZER = {
+  name: 'OCR_LATIN_RECOGNIZER',
   src: `registry://${models[553].registrySource}/${models[553].registryPath}`,
   registryPath: models[553].registryPath,
   registrySource: models[553].registrySource,
@@ -25032,8 +22021,8 @@ export const OCR_BENGALI_RECOGNIZER = {
   params: models[553].params
 } as const
 
-export const OCR_CYRILLIC_RECOGNIZER = {
-  name: 'OCR_CYRILLIC_RECOGNIZER',
+export const OCR_ARABIC_RECOGNIZER = {
+  name: 'OCR_ARABIC_RECOGNIZER',
   src: `registry://${models[554].registrySource}/${models[554].registryPath}`,
   registryPath: models[554].registryPath,
   registrySource: models[554].registrySource,
@@ -25050,8 +22039,8 @@ export const OCR_CYRILLIC_RECOGNIZER = {
   params: models[554].params
 } as const
 
-export const OCR_DEVANAGARI_RECOGNIZER = {
-  name: 'OCR_DEVANAGARI_RECOGNIZER',
+export const OCR_BENGALI_RECOGNIZER = {
+  name: 'OCR_BENGALI_RECOGNIZER',
   src: `registry://${models[555].registrySource}/${models[555].registryPath}`,
   registryPath: models[555].registryPath,
   registrySource: models[555].registrySource,
@@ -25068,8 +22057,8 @@ export const OCR_DEVANAGARI_RECOGNIZER = {
   params: models[555].params
 } as const
 
-export const OCR_JAPANESE_RECOGNIZER = {
-  name: 'OCR_JAPANESE_RECOGNIZER',
+export const OCR_CYRILLIC_RECOGNIZER = {
+  name: 'OCR_CYRILLIC_RECOGNIZER',
   src: `registry://${models[556].registrySource}/${models[556].registryPath}`,
   registryPath: models[556].registryPath,
   registrySource: models[556].registrySource,
@@ -25086,8 +22075,8 @@ export const OCR_JAPANESE_RECOGNIZER = {
   params: models[556].params
 } as const
 
-export const OCR_KANNADA_RECOGNIZER = {
-  name: 'OCR_KANNADA_RECOGNIZER',
+export const OCR_DEVANAGARI_RECOGNIZER = {
+  name: 'OCR_DEVANAGARI_RECOGNIZER',
   src: `registry://${models[557].registrySource}/${models[557].registryPath}`,
   registryPath: models[557].registryPath,
   registrySource: models[557].registrySource,
@@ -25104,8 +22093,8 @@ export const OCR_KANNADA_RECOGNIZER = {
   params: models[557].params
 } as const
 
-export const OCR_KOREAN_RECOGNIZER = {
-  name: 'OCR_KOREAN_RECOGNIZER',
+export const OCR_JAPANESE_RECOGNIZER = {
+  name: 'OCR_JAPANESE_RECOGNIZER',
   src: `registry://${models[558].registrySource}/${models[558].registryPath}`,
   registryPath: models[558].registryPath,
   registrySource: models[558].registrySource,
@@ -25122,8 +22111,8 @@ export const OCR_KOREAN_RECOGNIZER = {
   params: models[558].params
 } as const
 
-export const OCR_LATIN_RECOGNIZER_1 = {
-  name: 'OCR_LATIN_RECOGNIZER_1',
+export const OCR_KANNADA_RECOGNIZER = {
+  name: 'OCR_KANNADA_RECOGNIZER',
   src: `registry://${models[559].registrySource}/${models[559].registryPath}`,
   registryPath: models[559].registryPath,
   registrySource: models[559].registrySource,
@@ -25140,8 +22129,8 @@ export const OCR_LATIN_RECOGNIZER_1 = {
   params: models[559].params
 } as const
 
-export const OCR_TAMIL_RECOGNIZER = {
-  name: 'OCR_TAMIL_RECOGNIZER',
+export const OCR_KOREAN_RECOGNIZER = {
+  name: 'OCR_KOREAN_RECOGNIZER',
   src: `registry://${models[560].registrySource}/${models[560].registryPath}`,
   registryPath: models[560].registryPath,
   registrySource: models[560].registrySource,
@@ -25158,8 +22147,8 @@ export const OCR_TAMIL_RECOGNIZER = {
   params: models[560].params
 } as const
 
-export const OCR_TELUGU_RECOGNIZER = {
-  name: 'OCR_TELUGU_RECOGNIZER',
+export const OCR_LATIN_RECOGNIZER_1 = {
+  name: 'OCR_LATIN_RECOGNIZER_1',
   src: `registry://${models[561].registrySource}/${models[561].registryPath}`,
   registryPath: models[561].registryPath,
   registrySource: models[561].registrySource,
@@ -25176,8 +22165,8 @@ export const OCR_TELUGU_RECOGNIZER = {
   params: models[561].params
 } as const
 
-export const OCR_THAI_RECOGNIZER = {
-  name: 'OCR_THAI_RECOGNIZER',
+export const OCR_TAMIL_RECOGNIZER = {
+  name: 'OCR_TAMIL_RECOGNIZER',
   src: `registry://${models[562].registrySource}/${models[562].registryPath}`,
   registryPath: models[562].registryPath,
   registrySource: models[562].registrySource,
@@ -25194,8 +22183,8 @@ export const OCR_THAI_RECOGNIZER = {
   params: models[562].params
 } as const
 
-export const OCR_ZH_SIM_RECOGNIZER = {
-  name: 'OCR_ZH_SIM_RECOGNIZER',
+export const OCR_TELUGU_RECOGNIZER = {
+  name: 'OCR_TELUGU_RECOGNIZER',
   src: `registry://${models[563].registrySource}/${models[563].registryPath}`,
   registryPath: models[563].registryPath,
   registrySource: models[563].registrySource,
@@ -25212,8 +22201,8 @@ export const OCR_ZH_SIM_RECOGNIZER = {
   params: models[563].params
 } as const
 
-export const OCR_ZH_TRA_RECOGNIZER = {
-  name: 'OCR_ZH_TRA_RECOGNIZER',
+export const OCR_THAI_RECOGNIZER = {
+  name: 'OCR_THAI_RECOGNIZER',
   src: `registry://${models[564].registrySource}/${models[564].registryPath}`,
   registryPath: models[564].registryPath,
   registrySource: models[564].registrySource,
@@ -25230,8 +22219,8 @@ export const OCR_ZH_TRA_RECOGNIZER = {
   params: models[564].params
 } as const
 
-export const OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL = {
-  name: 'OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL',
+export const OCR_ZH_SIM_RECOGNIZER = {
+  name: 'OCR_ZH_SIM_RECOGNIZER',
   src: `registry://${models[565].registrySource}/${models[565].registryPath}`,
   registryPath: models[565].registryPath,
   registrySource: models[565].registrySource,
@@ -25248,8 +22237,8 @@ export const OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL = {
   params: models[565].params
 } as const
 
-export const OCR_DETECTOR_DB_MOBILENET_V3_LARGE = {
-  name: 'OCR_DETECTOR_DB_MOBILENET_V3_LARGE',
+export const OCR_ZH_TRA_RECOGNIZER = {
+  name: 'OCR_ZH_TRA_RECOGNIZER',
   src: `registry://${models[566].registrySource}/${models[566].registryPath}`,
   registryPath: models[566].registryPath,
   registrySource: models[566].registrySource,
@@ -25266,8 +22255,8 @@ export const OCR_DETECTOR_DB_MOBILENET_V3_LARGE = {
   params: models[566].params
 } as const
 
-export const OCR_DETECTOR_DB_RESNET50 = {
-  name: 'OCR_DETECTOR_DB_RESNET50',
+export const OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL = {
+  name: 'OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL',
   src: `registry://${models[567].registrySource}/${models[567].registryPath}`,
   registryPath: models[567].registryPath,
   registrySource: models[567].registrySource,
@@ -25284,8 +22273,8 @@ export const OCR_DETECTOR_DB_RESNET50 = {
   params: models[567].params
 } as const
 
-export const OCR_RECOGNIZER_PARSEQ = {
-  name: 'OCR_RECOGNIZER_PARSEQ',
+export const OCR_DETECTOR_DB_MOBILENET_V3_LARGE = {
+  name: 'OCR_DETECTOR_DB_MOBILENET_V3_LARGE',
   src: `registry://${models[568].registrySource}/${models[568].registryPath}`,
   registryPath: models[568].registryPath,
   registrySource: models[568].registrySource,
@@ -25302,8 +22291,8 @@ export const OCR_RECOGNIZER_PARSEQ = {
   params: models[568].params
 } as const
 
-export const OCR_DOCTR = {
-  name: 'OCR_DOCTR',
+export const OCR_DETECTOR_DB_RESNET50 = {
+  name: 'OCR_DETECTOR_DB_RESNET50',
   src: `registry://${models[569].registrySource}/${models[569].registryPath}`,
   registryPath: models[569].registryPath,
   registrySource: models[569].registrySource,
@@ -25320,8 +22309,8 @@ export const OCR_DOCTR = {
   params: models[569].params
 } as const
 
-export const OCR_DOCTR_1 = {
-  name: 'OCR_DOCTR_1',
+export const OCR_RECOGNIZER_PARSEQ = {
+  name: 'OCR_RECOGNIZER_PARSEQ',
   src: `registry://${models[570].registrySource}/${models[570].registryPath}`,
   registryPath: models[570].registryPath,
   registrySource: models[570].registrySource,
@@ -25338,8 +22327,8 @@ export const OCR_DOCTR_1 = {
   params: models[570].params
 } as const
 
-export const OCR_CRAFT = {
-  name: 'OCR_CRAFT',
+export const OCR_DOCTR = {
+  name: 'OCR_DOCTR',
   src: `registry://${models[571].registrySource}/${models[571].registryPath}`,
   registryPath: models[571].registryPath,
   registrySource: models[571].registrySource,
@@ -25356,8 +22345,8 @@ export const OCR_CRAFT = {
   params: models[571].params
 } as const
 
-export const OCR_LATIN = {
-  name: 'OCR_LATIN',
+export const OCR_DOCTR_1 = {
+  name: 'OCR_DOCTR_1',
   src: `registry://${models[572].registrySource}/${models[572].registryPath}`,
   registryPath: models[572].registryPath,
   registrySource: models[572].registrySource,
@@ -25374,8 +22363,8 @@ export const OCR_LATIN = {
   params: models[572].params
 } as const
 
-export const PARAKEET_EOU_DECODER_FP32 = {
-  name: 'PARAKEET_EOU_DECODER_FP32',
+export const OCR_CRAFT = {
+  name: 'OCR_CRAFT',
   src: `registry://${models[573].registrySource}/${models[573].registryPath}`,
   registryPath: models[573].registryPath,
   registrySource: models[573].registrySource,
@@ -25392,8 +22381,8 @@ export const PARAKEET_EOU_DECODER_FP32 = {
   params: models[573].params
 } as const
 
-export const PARAKEET_EOU_ENCODER_FP32 = {
-  name: 'PARAKEET_EOU_ENCODER_FP32',
+export const OCR_LATIN = {
+  name: 'OCR_LATIN',
   src: `registry://${models[574].registrySource}/${models[574].registryPath}`,
   registryPath: models[574].registryPath,
   registrySource: models[574].registrySource,
@@ -25410,8 +22399,8 @@ export const PARAKEET_EOU_ENCODER_FP32 = {
   params: models[574].params
 } as const
 
-export const PARAKEET_EOU_TOKENIZER = {
-  name: 'PARAKEET_EOU_TOKENIZER',
+export const PARAKEET_CTC_0_6B_Q8_0 = {
+  name: 'PARAKEET_CTC_0_6B_Q8_0',
   src: `registry://${models[575].registrySource}/${models[575].registryPath}`,
   registryPath: models[575].registryPath,
   registrySource: models[575].registrySource,
@@ -25428,8 +22417,8 @@ export const PARAKEET_EOU_TOKENIZER = {
   params: models[575].params
 } as const
 
-export const PARAKEET_SORTFORMER_FP32 = {
-  name: 'PARAKEET_SORTFORMER_FP32',
+export const PARAKEET_EOU_120M_V1_Q8_0 = {
+  name: 'PARAKEET_EOU_120M_V1_Q8_0',
   src: `registry://${models[576].registrySource}/${models[576].registryPath}`,
   registryPath: models[576].registryPath,
   registrySource: models[576].registrySource,
@@ -25446,8 +22435,8 @@ export const PARAKEET_SORTFORMER_FP32 = {
   params: models[576].params
 } as const
 
-export const PARAKEET_TDT_DECODER_FP32 = {
-  name: 'PARAKEET_TDT_DECODER_FP32',
+export const PARAKEET_TDT_0_6B_V3_Q8_0 = {
+  name: 'PARAKEET_TDT_0_6B_V3_Q8_0',
   src: `registry://${models[577].registrySource}/${models[577].registryPath}`,
   registryPath: models[577].registryPath,
   registrySource: models[577].registrySource,
@@ -25464,8 +22453,8 @@ export const PARAKEET_TDT_DECODER_FP32 = {
   params: models[577].params
 } as const
 
-export const PARAKEET_TDT_ENCODER_FP32 = {
-  name: 'PARAKEET_TDT_ENCODER_FP32',
+export const PARAKEET_SORTFORMER_4SPK_V1_Q8_0 = {
+  name: 'PARAKEET_SORTFORMER_4SPK_V1_Q8_0',
   src: `registry://${models[578].registrySource}/${models[578].registryPath}`,
   registryPath: models[578].registryPath,
   registrySource: models[578].registrySource,
@@ -25482,8 +22471,26 @@ export const PARAKEET_TDT_ENCODER_FP32 = {
   params: models[578].params
 } as const
 
-export const PARAKEET_TDT_PREPROCESSOR_FP32 = {
-  name: 'PARAKEET_TDT_PREPROCESSOR_FP32',
+export const PARAKEET_SORTFORMER_4SPK_V2_1_F16 = {
+  name: 'PARAKEET_SORTFORMER_4SPK_V2_1_F16',
+  src: `registry://${models[579].registrySource}/${models[579].registryPath}`,
+  registryPath: models[579].registryPath,
+  registrySource: models[579].registrySource,
+  blobCoreKey: models[579].blobCoreKey,
+  blobBlockOffset: models[579].blobBlockOffset,
+  blobBlockLength: models[579].blobBlockLength,
+  blobByteOffset: models[579].blobByteOffset,
+  modelId: models[579].modelId,
+  expectedSize: models[579].expectedSize,
+  sha256Checksum: models[579].sha256Checksum,
+  addon: models[579].addon,
+  engine: models[579].engine,
+  quantization: models[579].quantization,
+  params: models[579].params
+} as const
+
+export const PARAKEET_SORTFORMER_4SPK_V2_1_Q4_0 = {
+  name: 'PARAKEET_SORTFORMER_4SPK_V2_1_Q4_0',
   src: `registry://${models[580].registrySource}/${models[580].registryPath}`,
   registryPath: models[580].registryPath,
   registrySource: models[580].registrySource,
@@ -25500,8 +22507,8 @@ export const PARAKEET_TDT_PREPROCESSOR_FP32 = {
   params: models[580].params
 } as const
 
-export const PARAKEET_TDT_VOCAB = {
-  name: 'PARAKEET_TDT_VOCAB',
+export const PARAKEET_SORTFORMER_4SPK_V2_1_Q8_0 = {
+  name: 'PARAKEET_SORTFORMER_4SPK_V2_1_Q8_0',
   src: `registry://${models[581].registrySource}/${models[581].registryPath}`,
   registryPath: models[581].registryPath,
   registrySource: models[581].registrySource,
@@ -25518,8 +22525,8 @@ export const PARAKEET_TDT_VOCAB = {
   params: models[581].params
 } as const
 
-export const PARAKEET_CTC_FP32 = {
-  name: 'PARAKEET_CTC_FP32',
+export const PARAKEET_EOU_120M_V1_Q4_0 = {
+  name: 'PARAKEET_EOU_120M_V1_Q4_0',
   src: `registry://${models[582].registrySource}/${models[582].registryPath}`,
   registryPath: models[582].registryPath,
   registrySource: models[582].registrySource,
@@ -25536,8 +22543,26 @@ export const PARAKEET_CTC_FP32 = {
   params: models[582].params
 } as const
 
-export const PARAKEET_CTC_TOKENIZER = {
-  name: 'PARAKEET_CTC_TOKENIZER',
+export const PARAKEET_TDT_0_6B_V3_Q4_0 = {
+  name: 'PARAKEET_TDT_0_6B_V3_Q4_0',
+  src: `registry://${models[583].registrySource}/${models[583].registryPath}`,
+  registryPath: models[583].registryPath,
+  registrySource: models[583].registrySource,
+  blobCoreKey: models[583].blobCoreKey,
+  blobBlockOffset: models[583].blobBlockOffset,
+  blobBlockLength: models[583].blobBlockLength,
+  blobByteOffset: models[583].blobByteOffset,
+  modelId: models[583].modelId,
+  expectedSize: models[583].expectedSize,
+  sha256Checksum: models[583].sha256Checksum,
+  addon: models[583].addon,
+  engine: models[583].engine,
+  quantization: models[583].quantization,
+  params: models[583].params
+} as const
+
+export const PARAKEET_SORTFORMER_4SPK_V1_Q4_0 = {
+  name: 'PARAKEET_SORTFORMER_4SPK_V1_Q4_0',
   src: `registry://${models[584].registrySource}/${models[584].registryPath}`,
   registryPath: models[584].registryPath,
   registrySource: models[584].registrySource,
@@ -25554,8 +22579,8 @@ export const PARAKEET_CTC_TOKENIZER = {
   params: models[584].params
 } as const
 
-export const PARAKEET_CTC_0_6B_Q8_0 = {
-  name: 'PARAKEET_CTC_0_6B_Q8_0',
+export const PARAKEET_CTC_0_6B_F16 = {
+  name: 'PARAKEET_CTC_0_6B_F16',
   src: `registry://${models[585].registrySource}/${models[585].registryPath}`,
   registryPath: models[585].registryPath,
   registrySource: models[585].registrySource,
@@ -25572,8 +22597,8 @@ export const PARAKEET_CTC_0_6B_Q8_0 = {
   params: models[585].params
 } as const
 
-export const PARAKEET_EOU_120M_V1_Q8_0 = {
-  name: 'PARAKEET_EOU_120M_V1_Q8_0',
+export const PARAKEET_CTC_0_6B_Q4_0 = {
+  name: 'PARAKEET_CTC_0_6B_Q4_0',
   src: `registry://${models[586].registrySource}/${models[586].registryPath}`,
   registryPath: models[586].registryPath,
   registrySource: models[586].registrySource,
@@ -25590,8 +22615,8 @@ export const PARAKEET_EOU_120M_V1_Q8_0 = {
   params: models[586].params
 } as const
 
-export const PARAKEET_TDT_0_6B_V3_Q8_0 = {
-  name: 'PARAKEET_TDT_0_6B_V3_Q8_0',
+export const PARAKEET_EOU_120M_V1_F16 = {
+  name: 'PARAKEET_EOU_120M_V1_F16',
   src: `registry://${models[587].registrySource}/${models[587].registryPath}`,
   registryPath: models[587].registryPath,
   registrySource: models[587].registrySource,
@@ -25608,8 +22633,8 @@ export const PARAKEET_TDT_0_6B_V3_Q8_0 = {
   params: models[587].params
 } as const
 
-export const PARAKEET_SORTFORMER_4SPK_V1_Q8_0 = {
-  name: 'PARAKEET_SORTFORMER_4SPK_V1_Q8_0',
+export const PARAKEET_TDT_0_6B_V3_F16 = {
+  name: 'PARAKEET_TDT_0_6B_V3_F16',
   src: `registry://${models[588].registrySource}/${models[588].registryPath}`,
   registryPath: models[588].registryPath,
   registrySource: models[588].registrySource,
@@ -25626,8 +22651,8 @@ export const PARAKEET_SORTFORMER_4SPK_V1_Q8_0 = {
   params: models[588].params
 } as const
 
-export const PARAKEET_SORTFORMER_4SPK_V2_1_F16 = {
-  name: 'PARAKEET_SORTFORMER_4SPK_V2_1_F16',
+export const PARAKEET_SORTFORMER_4SPK_V1_F16 = {
+  name: 'PARAKEET_SORTFORMER_4SPK_V1_F16',
   src: `registry://${models[589].registrySource}/${models[589].registryPath}`,
   registryPath: models[589].registryPath,
   registrySource: models[589].registrySource,
@@ -25644,8 +22669,8 @@ export const PARAKEET_SORTFORMER_4SPK_V2_1_F16 = {
   params: models[589].params
 } as const
 
-export const PARAKEET_SORTFORMER_4SPK_V2_1_Q4_0 = {
-  name: 'PARAKEET_SORTFORMER_4SPK_V2_1_Q4_0',
+export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX = {
+  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX',
   src: `registry://${models[590].registrySource}/${models[590].registryPath}`,
   registryPath: models[590].registryPath,
   registrySource: models[590].registrySource,
@@ -25662,8 +22687,8 @@ export const PARAKEET_SORTFORMER_4SPK_V2_1_Q4_0 = {
   params: models[590].params
 } as const
 
-export const PARAKEET_SORTFORMER_4SPK_V2_1_Q8_0 = {
-  name: 'PARAKEET_SORTFORMER_4SPK_V2_1_Q8_0',
+export const TTS_S3GEN_EN_CHATTERBOX = {
+  name: 'TTS_S3GEN_EN_CHATTERBOX',
   src: `registry://${models[591].registrySource}/${models[591].registryPath}`,
   registryPath: models[591].registryPath,
   registrySource: models[591].registrySource,
@@ -25680,8 +22705,8 @@ export const PARAKEET_SORTFORMER_4SPK_V2_1_Q8_0 = {
   params: models[591].params
 } as const
 
-export const PARAKEET_EOU_120M_V1_Q4_0 = {
-  name: 'PARAKEET_EOU_120M_V1_Q4_0',
+export const TTS_T3_MULTILINGUAL_CHATTERBOX_FP16 = {
+  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_FP16',
   src: `registry://${models[592].registrySource}/${models[592].registryPath}`,
   registryPath: models[592].registryPath,
   registrySource: models[592].registrySource,
@@ -25698,8 +22723,8 @@ export const PARAKEET_EOU_120M_V1_Q4_0 = {
   params: models[592].params
 } as const
 
-export const PARAKEET_TDT_0_6B_V3_Q4_0 = {
-  name: 'PARAKEET_TDT_0_6B_V3_Q4_0',
+export const TTS_T3_TURBO_EN_CHATTERBOX_FP16 = {
+  name: 'TTS_T3_TURBO_EN_CHATTERBOX_FP16',
   src: `registry://${models[593].registrySource}/${models[593].registryPath}`,
   registryPath: models[593].registryPath,
   registrySource: models[593].registrySource,
@@ -25716,8 +22741,8 @@ export const PARAKEET_TDT_0_6B_V3_Q4_0 = {
   params: models[593].params
 } as const
 
-export const PARAKEET_SORTFORMER_4SPK_V1_Q4_0 = {
-  name: 'PARAKEET_SORTFORMER_4SPK_V1_Q4_0',
+export const TTS_MECAB_IPADIC_CHATTERBOX = {
+  name: 'TTS_MECAB_IPADIC_CHATTERBOX',
   src: `registry://${models[594].registrySource}/${models[594].registryPath}`,
   registryPath: models[594].registryPath,
   registrySource: models[594].registrySource,
@@ -25734,98 +22759,8 @@ export const PARAKEET_SORTFORMER_4SPK_V1_Q4_0 = {
   params: models[594].params
 } as const
 
-export const PARAKEET_CTC_0_6B_F16 = {
-  name: 'PARAKEET_CTC_0_6B_F16',
-  src: `registry://${models[595].registrySource}/${models[595].registryPath}`,
-  registryPath: models[595].registryPath,
-  registrySource: models[595].registrySource,
-  blobCoreKey: models[595].blobCoreKey,
-  blobBlockOffset: models[595].blobBlockOffset,
-  blobBlockLength: models[595].blobBlockLength,
-  blobByteOffset: models[595].blobByteOffset,
-  modelId: models[595].modelId,
-  expectedSize: models[595].expectedSize,
-  sha256Checksum: models[595].sha256Checksum,
-  addon: models[595].addon,
-  engine: models[595].engine,
-  quantization: models[595].quantization,
-  params: models[595].params
-} as const
-
-export const PARAKEET_CTC_0_6B_Q4_0 = {
-  name: 'PARAKEET_CTC_0_6B_Q4_0',
-  src: `registry://${models[596].registrySource}/${models[596].registryPath}`,
-  registryPath: models[596].registryPath,
-  registrySource: models[596].registrySource,
-  blobCoreKey: models[596].blobCoreKey,
-  blobBlockOffset: models[596].blobBlockOffset,
-  blobBlockLength: models[596].blobBlockLength,
-  blobByteOffset: models[596].blobByteOffset,
-  modelId: models[596].modelId,
-  expectedSize: models[596].expectedSize,
-  sha256Checksum: models[596].sha256Checksum,
-  addon: models[596].addon,
-  engine: models[596].engine,
-  quantization: models[596].quantization,
-  params: models[596].params
-} as const
-
-export const PARAKEET_EOU_120M_V1_F16 = {
-  name: 'PARAKEET_EOU_120M_V1_F16',
-  src: `registry://${models[597].registrySource}/${models[597].registryPath}`,
-  registryPath: models[597].registryPath,
-  registrySource: models[597].registrySource,
-  blobCoreKey: models[597].blobCoreKey,
-  blobBlockOffset: models[597].blobBlockOffset,
-  blobBlockLength: models[597].blobBlockLength,
-  blobByteOffset: models[597].blobByteOffset,
-  modelId: models[597].modelId,
-  expectedSize: models[597].expectedSize,
-  sha256Checksum: models[597].sha256Checksum,
-  addon: models[597].addon,
-  engine: models[597].engine,
-  quantization: models[597].quantization,
-  params: models[597].params
-} as const
-
-export const PARAKEET_TDT_0_6B_V3_F16 = {
-  name: 'PARAKEET_TDT_0_6B_V3_F16',
-  src: `registry://${models[598].registrySource}/${models[598].registryPath}`,
-  registryPath: models[598].registryPath,
-  registrySource: models[598].registrySource,
-  blobCoreKey: models[598].blobCoreKey,
-  blobBlockOffset: models[598].blobBlockOffset,
-  blobBlockLength: models[598].blobBlockLength,
-  blobByteOffset: models[598].blobByteOffset,
-  modelId: models[598].modelId,
-  expectedSize: models[598].expectedSize,
-  sha256Checksum: models[598].sha256Checksum,
-  addon: models[598].addon,
-  engine: models[598].engine,
-  quantization: models[598].quantization,
-  params: models[598].params
-} as const
-
-export const PARAKEET_SORTFORMER_4SPK_V1_F16 = {
-  name: 'PARAKEET_SORTFORMER_4SPK_V1_F16',
-  src: `registry://${models[599].registrySource}/${models[599].registryPath}`,
-  registryPath: models[599].registryPath,
-  registrySource: models[599].registrySource,
-  blobCoreKey: models[599].blobCoreKey,
-  blobBlockOffset: models[599].blobBlockOffset,
-  blobBlockLength: models[599].blobBlockLength,
-  blobByteOffset: models[599].blobByteOffset,
-  modelId: models[599].modelId,
-  expectedSize: models[599].expectedSize,
-  sha256Checksum: models[599].sha256Checksum,
-  addon: models[599].addon,
-  engine: models[599].engine,
-  quantization: models[599].quantization,
-  params: models[599].params
-} as const
-
-export const PARAKEET_TDT_DECODER_INT8 = {
-  name: 'PARAKEET_TDT_DECODER_INT8',
+export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0 = {
+  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0',
   src: `registry://${models[600].registrySource}/${models[600].registryPath}`,
   registryPath: models[600].registryPath,
   registrySource: models[600].registrySource,
@@ -25842,8 +22777,8 @@ export const PARAKEET_TDT_DECODER_INT8 = {
   params: models[600].params
 } as const
 
-export const PARAKEET_TDT_ENCODER_INT8 = {
-  name: 'PARAKEET_TDT_ENCODER_INT8',
+export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q8_0 = {
+  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_Q8_0',
   src: `registry://${models[601].registrySource}/${models[601].registryPath}`,
   registryPath: models[601].registryPath,
   registrySource: models[601].registrySource,
@@ -25860,8 +22795,8 @@ export const PARAKEET_TDT_ENCODER_INT8 = {
   params: models[601].params
 } as const
 
-export const PARAKEET_TDT_PREPROCESSOR_INT8 = {
-  name: 'PARAKEET_TDT_PREPROCESSOR_INT8',
+export const TTS_T3_TURBO_EN_CHATTERBOX_Q4_0 = {
+  name: 'TTS_T3_TURBO_EN_CHATTERBOX_Q4_0',
   src: `registry://${models[602].registrySource}/${models[602].registryPath}`,
   registryPath: models[602].registryPath,
   registrySource: models[602].registrySource,
@@ -25878,8 +22813,8 @@ export const PARAKEET_TDT_PREPROCESSOR_INT8 = {
   params: models[602].params
 } as const
 
-export const TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX_FP32 = {
-  name: 'TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX_FP32',
+export const TTS_T3_TURBO_EN_CHATTERBOX_Q8_0 = {
+  name: 'TTS_T3_TURBO_EN_CHATTERBOX_Q8_0',
   src: `registry://${models[603].registrySource}/${models[603].registryPath}`,
   registryPath: models[603].registryPath,
   registrySource: models[603].registrySource,
@@ -25896,8 +22831,26 @@ export const TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX_FP32 = {
   params: models[603].params
 } as const
 
-export const TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX_FP32 = {
-  name: 'TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX_FP32',
+export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0 = {
+  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0',
+  src: `registry://${models[604].registrySource}/${models[604].registryPath}`,
+  registryPath: models[604].registryPath,
+  registrySource: models[604].registrySource,
+  blobCoreKey: models[604].blobCoreKey,
+  blobBlockOffset: models[604].blobBlockOffset,
+  blobBlockLength: models[604].blobBlockLength,
+  blobByteOffset: models[604].blobByteOffset,
+  modelId: models[604].modelId,
+  expectedSize: models[604].expectedSize,
+  sha256Checksum: models[604].sha256Checksum,
+  addon: models[604].addon,
+  engine: models[604].engine,
+  quantization: models[604].quantization,
+  params: models[604].params
+} as const
+
+export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q5_0 = {
+  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q5_0',
   src: `registry://${models[605].registrySource}/${models[605].registryPath}`,
   registryPath: models[605].registryPath,
   registrySource: models[605].registrySource,
@@ -25914,8 +22867,26 @@ export const TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX_FP32 = {
   params: models[605].params
 } as const
 
-export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP16 = {
-  name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP16',
+export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q8_0 = {
+  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q8_0',
+  src: `registry://${models[606].registrySource}/${models[606].registryPath}`,
+  registryPath: models[606].registryPath,
+  registrySource: models[606].registrySource,
+  blobCoreKey: models[606].blobCoreKey,
+  blobBlockOffset: models[606].blobBlockOffset,
+  blobBlockLength: models[606].blobBlockLength,
+  blobByteOffset: models[606].blobByteOffset,
+  modelId: models[606].modelId,
+  expectedSize: models[606].expectedSize,
+  sha256Checksum: models[606].sha256Checksum,
+  addon: models[606].addon,
+  engine: models[606].engine,
+  quantization: models[606].quantization,
+  params: models[606].params
+} as const
+
+export const TTS_S3GEN_EN_CHATTERBOX_Q4_0 = {
+  name: 'TTS_S3GEN_EN_CHATTERBOX_Q4_0',
   src: `registry://${models[607].registrySource}/${models[607].registryPath}`,
   registryPath: models[607].registryPath,
   registrySource: models[607].registrySource,
@@ -25932,8 +22903,26 @@ export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP16 = {
   params: models[607].params
 } as const
 
-export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_Q4 = {
-  name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_Q4',
+export const TTS_S3GEN_EN_CHATTERBOX_Q5_0 = {
+  name: 'TTS_S3GEN_EN_CHATTERBOX_Q5_0',
+  src: `registry://${models[608].registrySource}/${models[608].registryPath}`,
+  registryPath: models[608].registryPath,
+  registrySource: models[608].registrySource,
+  blobCoreKey: models[608].blobCoreKey,
+  blobBlockOffset: models[608].blobBlockOffset,
+  blobBlockLength: models[608].blobBlockLength,
+  blobByteOffset: models[608].blobByteOffset,
+  modelId: models[608].modelId,
+  expectedSize: models[608].expectedSize,
+  sha256Checksum: models[608].sha256Checksum,
+  addon: models[608].addon,
+  engine: models[608].engine,
+  quantization: models[608].quantization,
+  params: models[608].params
+} as const
+
+export const TTS_S3GEN_EN_CHATTERBOX_Q8_0 = {
+  name: 'TTS_S3GEN_EN_CHATTERBOX_Q8_0',
   src: `registry://${models[609].registrySource}/${models[609].registryPath}`,
   registryPath: models[609].registryPath,
   registrySource: models[609].registrySource,
@@ -25950,8 +22939,26 @@ export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_Q4 = {
   params: models[609].params
 } as const
 
-export const TTS_EN_ES_CHATTERBOX_Q4F16 = {
-  name: 'TTS_EN_ES_CHATTERBOX_Q4F16',
+export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q5_0 = {
+  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_Q5_0',
+  src: `registry://${models[610].registrySource}/${models[610].registryPath}`,
+  registryPath: models[610].registryPath,
+  registrySource: models[610].registrySource,
+  blobCoreKey: models[610].blobCoreKey,
+  blobBlockOffset: models[610].blobBlockOffset,
+  blobBlockLength: models[610].blobBlockLength,
+  blobByteOffset: models[610].blobByteOffset,
+  modelId: models[610].modelId,
+  expectedSize: models[610].expectedSize,
+  sha256Checksum: models[610].sha256Checksum,
+  addon: models[610].addon,
+  engine: models[610].engine,
+  quantization: models[610].quantization,
+  params: models[610].params
+} as const
+
+export const TTS_T3_TURBO_EN_CHATTERBOX_Q5_0 = {
+  name: 'TTS_T3_TURBO_EN_CHATTERBOX_Q5_0',
   src: `registry://${models[611].registrySource}/${models[611].registryPath}`,
   registryPath: models[611].registryPath,
   registrySource: models[611].registrySource,
@@ -25968,8 +22975,26 @@ export const TTS_EN_ES_CHATTERBOX_Q4F16 = {
   params: models[611].params
 } as const
 
-export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP32 = {
-  name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP32',
+export const TTS_CANGJIE_ZH_CHATTERBOX = {
+  name: 'TTS_CANGJIE_ZH_CHATTERBOX',
+  src: `registry://${models[612].registrySource}/${models[612].registryPath}`,
+  registryPath: models[612].registryPath,
+  registrySource: models[612].registrySource,
+  blobCoreKey: models[612].blobCoreKey,
+  blobBlockOffset: models[612].blobBlockOffset,
+  blobBlockLength: models[612].blobBlockLength,
+  blobByteOffset: models[612].blobByteOffset,
+  modelId: models[612].modelId,
+  expectedSize: models[612].expectedSize,
+  sha256Checksum: models[612].sha256Checksum,
+  addon: models[612].addon,
+  engine: models[612].engine,
+  quantization: models[612].quantization,
+  params: models[612].params
+} as const
+
+export const TTS_ENHANCER_LAVASR_FP16 = {
+  name: 'TTS_ENHANCER_LAVASR_FP16',
   src: `registry://${models[613].registrySource}/${models[613].registryPath}`,
   registryPath: models[613].registryPath,
   registrySource: models[613].registrySource,
@@ -25986,8 +23011,26 @@ export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX_FP32 = {
   params: models[613].params
 } as const
 
-export const TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX_FP32 = {
-  name: 'TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX_FP32',
+export const TTS_ENHANCER_LAVASR_FP32 = {
+  name: 'TTS_ENHANCER_LAVASR_FP32',
+  src: `registry://${models[614].registrySource}/${models[614].registryPath}`,
+  registryPath: models[614].registryPath,
+  registrySource: models[614].registrySource,
+  blobCoreKey: models[614].blobCoreKey,
+  blobBlockOffset: models[614].blobBlockOffset,
+  blobBlockLength: models[614].blobBlockLength,
+  blobByteOffset: models[614].blobByteOffset,
+  modelId: models[614].modelId,
+  expectedSize: models[614].expectedSize,
+  sha256Checksum: models[614].sha256Checksum,
+  addon: models[614].addon,
+  engine: models[614].engine,
+  quantization: models[614].quantization,
+  params: models[614].params
+} as const
+
+export const TTS_DENOISER_LAVASR_FP16 = {
+  name: 'TTS_DENOISER_LAVASR_FP16',
   src: `registry://${models[615].registrySource}/${models[615].registryPath}`,
   registryPath: models[615].registryPath,
   registrySource: models[615].registrySource,
@@ -26004,8 +23047,26 @@ export const TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX_FP32 = {
   params: models[615].params
 } as const
 
-export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX = {
-  name: 'TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX',
+export const TTS_DENOISER_LAVASR_FP32 = {
+  name: 'TTS_DENOISER_LAVASR_FP32',
+  src: `registry://${models[616].registrySource}/${models[616].registryPath}`,
+  registryPath: models[616].registryPath,
+  registrySource: models[616].registrySource,
+  blobCoreKey: models[616].blobCoreKey,
+  blobBlockOffset: models[616].blobBlockOffset,
+  blobBlockLength: models[616].blobBlockLength,
+  blobByteOffset: models[616].blobByteOffset,
+  modelId: models[616].modelId,
+  expectedSize: models[616].expectedSize,
+  sha256Checksum: models[616].sha256Checksum,
+  addon: models[616].addon,
+  engine: models[616].engine,
+  quantization: models[616].quantization,
+  params: models[616].params
+} as const
+
+export const TTS_INDIC_MULTILINGUAL_PARLER_TTS_FP16 = {
+  name: 'TTS_INDIC_MULTILINGUAL_PARLER_TTS_FP16',
   src: `registry://${models[617].registrySource}/${models[617].registryPath}`,
   registryPath: models[617].registryPath,
   registrySource: models[617].registrySource,
@@ -26022,8 +23083,8 @@ export const TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX = {
   params: models[617].params
 } as const
 
-export const TTS_LATENT_DENOISER_SUPERTONIC_FP32 = {
-  name: 'TTS_LATENT_DENOISER_SUPERTONIC_FP32',
+export const TTS_INDIC_MULTILINGUAL_PARLER_TTS_FP32 = {
+  name: 'TTS_INDIC_MULTILINGUAL_PARLER_TTS_FP32',
   src: `registry://${models[618].registrySource}/${models[618].registryPath}`,
   registryPath: models[618].registryPath,
   registrySource: models[618].registrySource,
@@ -26040,8 +23101,26 @@ export const TTS_LATENT_DENOISER_SUPERTONIC_FP32 = {
   params: models[618].params
 } as const
 
-export const TTS_TEXT_ENCODER_SUPERTONIC_FP32 = {
-  name: 'TTS_TEXT_ENCODER_SUPERTONIC_FP32',
+export const TTS_INDIC_MULTILINGUAL_PARLER_TTS_Q8_0 = {
+  name: 'TTS_INDIC_MULTILINGUAL_PARLER_TTS_Q8_0',
+  src: `registry://${models[619].registrySource}/${models[619].registryPath}`,
+  registryPath: models[619].registryPath,
+  registrySource: models[619].registrySource,
+  blobCoreKey: models[619].blobCoreKey,
+  blobBlockOffset: models[619].blobBlockOffset,
+  blobBlockLength: models[619].blobBlockLength,
+  blobByteOffset: models[619].blobByteOffset,
+  modelId: models[619].modelId,
+  expectedSize: models[619].expectedSize,
+  sha256Checksum: models[619].sha256Checksum,
+  addon: models[619].addon,
+  engine: models[619].engine,
+  quantization: models[619].quantization,
+  params: models[619].params
+} as const
+
+export const TTS_LARGE_V1_EN_PARLER_TTS_FP16 = {
+  name: 'TTS_LARGE_V1_EN_PARLER_TTS_FP16',
   src: `registry://${models[620].registrySource}/${models[620].registryPath}`,
   registryPath: models[620].registryPath,
   registrySource: models[620].registrySource,
@@ -26058,8 +23137,26 @@ export const TTS_TEXT_ENCODER_SUPERTONIC_FP32 = {
   params: models[620].params
 } as const
 
-export const TTS_VOICE_DECODER_SUPERTONIC_FP32 = {
-  name: 'TTS_VOICE_DECODER_SUPERTONIC_FP32',
+export const TTS_LARGE_V1_EN_PARLER_TTS_FP32 = {
+  name: 'TTS_LARGE_V1_EN_PARLER_TTS_FP32',
+  src: `registry://${models[621].registrySource}/${models[621].registryPath}`,
+  registryPath: models[621].registryPath,
+  registrySource: models[621].registrySource,
+  blobCoreKey: models[621].blobCoreKey,
+  blobBlockOffset: models[621].blobBlockOffset,
+  blobBlockLength: models[621].blobBlockLength,
+  blobByteOffset: models[621].blobByteOffset,
+  modelId: models[621].modelId,
+  expectedSize: models[621].expectedSize,
+  sha256Checksum: models[621].sha256Checksum,
+  addon: models[621].addon,
+  engine: models[621].engine,
+  quantization: models[621].quantization,
+  params: models[621].params
+} as const
+
+export const TTS_LARGE_V1_EN_PARLER_TTS_Q8_0 = {
+  name: 'TTS_LARGE_V1_EN_PARLER_TTS_Q8_0',
   src: `registry://${models[622].registrySource}/${models[622].registryPath}`,
   registryPath: models[622].registryPath,
   registrySource: models[622].registrySource,
@@ -26076,8 +23173,26 @@ export const TTS_VOICE_DECODER_SUPERTONIC_FP32 = {
   params: models[622].params
 } as const
 
-export const TTS_TOKENIZER_SUPERTONIC = {
-  name: 'TTS_TOKENIZER_SUPERTONIC',
+export const TTS_MINI_V1_EN_PARLER_TTS_FP16 = {
+  name: 'TTS_MINI_V1_EN_PARLER_TTS_FP16',
+  src: `registry://${models[623].registrySource}/${models[623].registryPath}`,
+  registryPath: models[623].registryPath,
+  registrySource: models[623].registrySource,
+  blobCoreKey: models[623].blobCoreKey,
+  blobBlockOffset: models[623].blobBlockOffset,
+  blobBlockLength: models[623].blobBlockLength,
+  blobByteOffset: models[623].blobByteOffset,
+  modelId: models[623].modelId,
+  expectedSize: models[623].expectedSize,
+  sha256Checksum: models[623].sha256Checksum,
+  addon: models[623].addon,
+  engine: models[623].engine,
+  quantization: models[623].quantization,
+  params: models[623].params
+} as const
+
+export const TTS_MINI_V1_EN_PARLER_TTS_FP32 = {
+  name: 'TTS_MINI_V1_EN_PARLER_TTS_FP32',
   src: `registry://${models[624].registrySource}/${models[624].registryPath}`,
   registryPath: models[624].registryPath,
   registrySource: models[624].registrySource,
@@ -26094,8 +23209,8 @@ export const TTS_TOKENIZER_SUPERTONIC = {
   params: models[624].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC',
+export const TTS_MINI_V1_EN_PARLER_TTS_Q8_0 = {
+  name: 'TTS_MINI_V1_EN_PARLER_TTS_Q8_0',
   src: `registry://${models[625].registrySource}/${models[625].registryPath}`,
   registryPath: models[625].registryPath,
   registrySource: models[625].registrySource,
@@ -26112,8 +23227,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC = {
   params: models[625].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_1 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_1',
+export const TTS_EN_SUPERTONIC_Q4_0 = {
+  name: 'TTS_EN_SUPERTONIC_Q4_0',
   src: `registry://${models[626].registrySource}/${models[626].registryPath}`,
   registryPath: models[626].registryPath,
   registrySource: models[626].registrySource,
@@ -26130,8 +23245,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_1 = {
   params: models[626].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_2 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_2',
+export const TTS_EN_SUPERTONIC_Q8_0 = {
+  name: 'TTS_EN_SUPERTONIC_Q8_0',
   src: `registry://${models[627].registrySource}/${models[627].registryPath}`,
   registryPath: models[627].registryPath,
   registrySource: models[627].registrySource,
@@ -26148,8 +23263,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_2 = {
   params: models[627].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_3 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_3',
+export const TTS_MULTILINGUAL_SUPERTONIC2_Q4_0 = {
+  name: 'TTS_MULTILINGUAL_SUPERTONIC2_Q4_0',
   src: `registry://${models[628].registrySource}/${models[628].registryPath}`,
   registryPath: models[628].registryPath,
   registrySource: models[628].registrySource,
@@ -26166,8 +23281,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_3 = {
   params: models[628].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_4 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_4',
+export const TTS_MULTILINGUAL_SUPERTONIC2_Q8_0 = {
+  name: 'TTS_MULTILINGUAL_SUPERTONIC2_Q8_0',
   src: `registry://${models[629].registrySource}/${models[629].registryPath}`,
   registryPath: models[629].registryPath,
   registrySource: models[629].registrySource,
@@ -26184,8 +23299,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_4 = {
   params: models[629].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_5 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_5',
+export const TTS_MULTILINGUAL_SUPERTONIC3_FP16 = {
+  name: 'TTS_MULTILINGUAL_SUPERTONIC3_FP16',
   src: `registry://${models[630].registrySource}/${models[630].registryPath}`,
   registryPath: models[630].registryPath,
   registrySource: models[630].registrySource,
@@ -26202,8 +23317,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_5 = {
   params: models[630].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_6 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_6',
+export const TTS_MULTILINGUAL_SUPERTONIC3_FP32 = {
+  name: 'TTS_MULTILINGUAL_SUPERTONIC3_FP32',
   src: `registry://${models[631].registrySource}/${models[631].registryPath}`,
   registryPath: models[631].registryPath,
   registrySource: models[631].registrySource,
@@ -26220,8 +23335,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_6 = {
   params: models[631].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_7 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_7',
+export const TTS_MULTILINGUAL_SUPERTONIC3_Q8_0 = {
+  name: 'TTS_MULTILINGUAL_SUPERTONIC3_Q8_0',
   src: `registry://${models[632].registrySource}/${models[632].registryPath}`,
   registryPath: models[632].registryPath,
   registrySource: models[632].registrySource,
@@ -26238,8 +23353,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_7 = {
   params: models[632].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_8 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_8',
+export const TTS_MULTILINGUAL_SUPERTONIC3_Q4_0 = {
+  name: 'TTS_MULTILINGUAL_SUPERTONIC3_Q4_0',
   src: `registry://${models[633].registrySource}/${models[633].registryPath}`,
   registryPath: models[633].registryPath,
   registrySource: models[633].registrySource,
@@ -26256,8 +23371,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_8 = {
   params: models[633].params
 } as const
 
-export const TTS_VOICE_STYLE_SUPERTONIC_9 = {
-  name: 'TTS_VOICE_STYLE_SUPERTONIC_9',
+export const GROOT_Q5_VF16 = {
+  name: 'GROOT_Q5_VF16',
   src: `registry://${models[634].registrySource}/${models[634].registryPath}`,
   registryPath: models[634].registryPath,
   registrySource: models[634].registrySource,
@@ -26274,8 +23389,8 @@ export const TTS_VOICE_STYLE_SUPERTONIC_9 = {
   params: models[634].params
 } as const
 
-export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX = {
-  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX',
+export const GROOT_Q8_VF16 = {
+  name: 'GROOT_Q8_VF16',
   src: `registry://${models[635].registrySource}/${models[635].registryPath}`,
   registryPath: models[635].registryPath,
   registrySource: models[635].registrySource,
@@ -26292,8 +23407,8 @@ export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX = {
   params: models[635].params
 } as const
 
-export const TTS_S3GEN_EN_CHATTERBOX = {
-  name: 'TTS_S3GEN_EN_CHATTERBOX',
+export const PI05_BASE_Q_AGGRESSIVE = {
+  name: 'PI05_BASE_Q_AGGRESSIVE',
   src: `registry://${models[636].registrySource}/${models[636].registryPath}`,
   registryPath: models[636].registryPath,
   registrySource: models[636].registrySource,
@@ -26310,8 +23425,8 @@ export const TTS_S3GEN_EN_CHATTERBOX = {
   params: models[636].params
 } as const
 
-export const TTS_T3_MULTILINGUAL_CHATTERBOX_FP16 = {
-  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_FP16',
+export const SMOLVLA_LIBERO_VISION_Q8 = {
+  name: 'SMOLVLA_LIBERO_VISION_Q8',
   src: `registry://${models[637].registrySource}/${models[637].registryPath}`,
   registryPath: models[637].registryPath,
   registrySource: models[637].registrySource,
@@ -26328,8 +23443,8 @@ export const TTS_T3_MULTILINGUAL_CHATTERBOX_FP16 = {
   params: models[637].params
 } as const
 
-export const TTS_T3_TURBO_EN_CHATTERBOX_FP16 = {
-  name: 'TTS_T3_TURBO_EN_CHATTERBOX_FP16',
+export const WHISPER_BASE_Q8_0 = {
+  name: 'WHISPER_BASE_Q8_0',
   src: `registry://${models[638].registrySource}/${models[638].registryPath}`,
   registryPath: models[638].registryPath,
   registrySource: models[638].registrySource,
@@ -26346,8 +23461,8 @@ export const TTS_T3_TURBO_EN_CHATTERBOX_FP16 = {
   params: models[638].params
 } as const
 
-export const TTS_MECAB_IPADIC_CHATTERBOX = {
-  name: 'TTS_MECAB_IPADIC_CHATTERBOX',
+export const WHISPER_BASE_Q0F16 = {
+  name: 'WHISPER_BASE_Q0F16',
   src: `registry://${models[639].registrySource}/${models[639].registryPath}`,
   registryPath: models[639].registryPath,
   registrySource: models[639].registrySource,
@@ -26364,8 +23479,98 @@ export const TTS_MECAB_IPADIC_CHATTERBOX = {
   params: models[639].params
 } as const
 
-export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0 = {
-  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0',
+export const WHISPER_EN_BASE_Q8_0 = {
+  name: 'WHISPER_EN_BASE_Q8_0',
+  src: `registry://${models[640].registrySource}/${models[640].registryPath}`,
+  registryPath: models[640].registryPath,
+  registrySource: models[640].registrySource,
+  blobCoreKey: models[640].blobCoreKey,
+  blobBlockOffset: models[640].blobBlockOffset,
+  blobBlockLength: models[640].blobBlockLength,
+  blobByteOffset: models[640].blobByteOffset,
+  modelId: models[640].modelId,
+  expectedSize: models[640].expectedSize,
+  sha256Checksum: models[640].sha256Checksum,
+  addon: models[640].addon,
+  engine: models[640].engine,
+  quantization: models[640].quantization,
+  params: models[640].params
+} as const
+
+export const WHISPER_EN_BASE_Q0F16 = {
+  name: 'WHISPER_EN_BASE_Q0F16',
+  src: `registry://${models[641].registrySource}/${models[641].registryPath}`,
+  registryPath: models[641].registryPath,
+  registrySource: models[641].registrySource,
+  blobCoreKey: models[641].blobCoreKey,
+  blobBlockOffset: models[641].blobBlockOffset,
+  blobBlockLength: models[641].blobBlockLength,
+  blobByteOffset: models[641].blobByteOffset,
+  modelId: models[641].modelId,
+  expectedSize: models[641].expectedSize,
+  sha256Checksum: models[641].sha256Checksum,
+  addon: models[641].addon,
+  engine: models[641].engine,
+  quantization: models[641].quantization,
+  params: models[641].params
+} as const
+
+export const WHISPER_LARGE_V3_TURBO = {
+  name: 'WHISPER_LARGE_V3_TURBO',
+  src: `registry://${models[642].registrySource}/${models[642].registryPath}`,
+  registryPath: models[642].registryPath,
+  registrySource: models[642].registrySource,
+  blobCoreKey: models[642].blobCoreKey,
+  blobBlockOffset: models[642].blobBlockOffset,
+  blobBlockLength: models[642].blobBlockLength,
+  blobByteOffset: models[642].blobByteOffset,
+  modelId: models[642].modelId,
+  expectedSize: models[642].expectedSize,
+  sha256Checksum: models[642].sha256Checksum,
+  addon: models[642].addon,
+  engine: models[642].engine,
+  quantization: models[642].quantization,
+  params: models[642].params
+} as const
+
+export const WHISPER_SMALL_Q8_0 = {
+  name: 'WHISPER_SMALL_Q8_0',
+  src: `registry://${models[643].registrySource}/${models[643].registryPath}`,
+  registryPath: models[643].registryPath,
+  registrySource: models[643].registrySource,
+  blobCoreKey: models[643].blobCoreKey,
+  blobBlockOffset: models[643].blobBlockOffset,
+  blobBlockLength: models[643].blobBlockLength,
+  blobByteOffset: models[643].blobByteOffset,
+  modelId: models[643].modelId,
+  expectedSize: models[643].expectedSize,
+  sha256Checksum: models[643].sha256Checksum,
+  addon: models[643].addon,
+  engine: models[643].engine,
+  quantization: models[643].quantization,
+  params: models[643].params
+} as const
+
+export const WHISPER_SMALL_Q0F16 = {
+  name: 'WHISPER_SMALL_Q0F16',
+  src: `registry://${models[644].registrySource}/${models[644].registryPath}`,
+  registryPath: models[644].registryPath,
+  registrySource: models[644].registrySource,
+  blobCoreKey: models[644].blobCoreKey,
+  blobBlockOffset: models[644].blobBlockOffset,
+  blobBlockLength: models[644].blobBlockLength,
+  blobByteOffset: models[644].blobByteOffset,
+  modelId: models[644].modelId,
+  expectedSize: models[644].expectedSize,
+  sha256Checksum: models[644].sha256Checksum,
+  addon: models[644].addon,
+  engine: models[644].engine,
+  quantization: models[644].quantization,
+  params: models[644].params
+} as const
+
+export const WHISPER_EN_SMALL_Q8_0 = {
+  name: 'WHISPER_EN_SMALL_Q8_0',
   src: `registry://${models[645].registrySource}/${models[645].registryPath}`,
   registryPath: models[645].registryPath,
   registrySource: models[645].registrySource,
@@ -26382,8 +23587,8 @@ export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0 = {
   params: models[645].params
 } as const
 
-export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q8_0 = {
-  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_Q8_0',
+export const WHISPER_EN_SMALL_Q0F16 = {
+  name: 'WHISPER_EN_SMALL_Q0F16',
   src: `registry://${models[646].registrySource}/${models[646].registryPath}`,
   registryPath: models[646].registryPath,
   registrySource: models[646].registrySource,
@@ -26400,8 +23605,8 @@ export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q8_0 = {
   params: models[646].params
 } as const
 
-export const TTS_T3_TURBO_EN_CHATTERBOX_Q4_0 = {
-  name: 'TTS_T3_TURBO_EN_CHATTERBOX_Q4_0',
+export const WHISPER_TINY_Q8_0 = {
+  name: 'WHISPER_TINY_Q8_0',
   src: `registry://${models[647].registrySource}/${models[647].registryPath}`,
   registryPath: models[647].registryPath,
   registrySource: models[647].registrySource,
@@ -26418,8 +23623,8 @@ export const TTS_T3_TURBO_EN_CHATTERBOX_Q4_0 = {
   params: models[647].params
 } as const
 
-export const TTS_T3_TURBO_EN_CHATTERBOX_Q8_0 = {
-  name: 'TTS_T3_TURBO_EN_CHATTERBOX_Q8_0',
+export const WHISPER_TINY = {
+  name: 'WHISPER_TINY',
   src: `registry://${models[648].registrySource}/${models[648].registryPath}`,
   registryPath: models[648].registryPath,
   registrySource: models[648].registrySource,
@@ -26436,8 +23641,8 @@ export const TTS_T3_TURBO_EN_CHATTERBOX_Q8_0 = {
   params: models[648].params
 } as const
 
-export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0 = {
-  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0',
+export const WHISPER_EN_TINY_Q8_0 = {
+  name: 'WHISPER_EN_TINY_Q8_0',
   src: `registry://${models[649].registrySource}/${models[649].registryPath}`,
   registryPath: models[649].registryPath,
   registrySource: models[649].registrySource,
@@ -26454,8 +23659,8 @@ export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0 = {
   params: models[649].params
 } as const
 
-export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q5_0 = {
-  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q5_0',
+export const WHISPER_EN_TINY_Q0F16 = {
+  name: 'WHISPER_EN_TINY_Q0F16',
   src: `registry://${models[650].registrySource}/${models[650].registryPath}`,
   registryPath: models[650].registryPath,
   registrySource: models[650].registrySource,
@@ -26472,8 +23677,8 @@ export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q5_0 = {
   params: models[650].params
 } as const
 
-export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q8_0 = {
-  name: 'TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q8_0',
+export const VAD_SILERO_5_1_2 = {
+  name: 'VAD_SILERO_5_1_2',
   src: `registry://${models[651].registrySource}/${models[651].registryPath}`,
   registryPath: models[651].registryPath,
   registrySource: models[651].registrySource,
@@ -26490,8 +23695,8 @@ export const TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q8_0 = {
   params: models[651].params
 } as const
 
-export const TTS_S3GEN_EN_CHATTERBOX_Q4_0 = {
-  name: 'TTS_S3GEN_EN_CHATTERBOX_Q4_0',
+export const WHISPER_FRENCH_BASE_F16 = {
+  name: 'WHISPER_FRENCH_BASE_F16',
   src: `registry://${models[652].registrySource}/${models[652].registryPath}`,
   registryPath: models[652].registryPath,
   registrySource: models[652].registrySource,
@@ -26508,8 +23713,8 @@ export const TTS_S3GEN_EN_CHATTERBOX_Q4_0 = {
   params: models[652].params
 } as const
 
-export const TTS_S3GEN_EN_CHATTERBOX_Q5_0 = {
-  name: 'TTS_S3GEN_EN_CHATTERBOX_Q5_0',
+export const WHISPER_FRENCH_BASE_Q8_0 = {
+  name: 'WHISPER_FRENCH_BASE_Q8_0',
   src: `registry://${models[653].registrySource}/${models[653].registryPath}`,
   registryPath: models[653].registryPath,
   registrySource: models[653].registrySource,
@@ -26526,8 +23731,8 @@ export const TTS_S3GEN_EN_CHATTERBOX_Q5_0 = {
   params: models[653].params
 } as const
 
-export const TTS_S3GEN_EN_CHATTERBOX_Q8_0 = {
-  name: 'TTS_S3GEN_EN_CHATTERBOX_Q8_0',
+export const WHISPER_FRENCH_TINY_F16 = {
+  name: 'WHISPER_FRENCH_TINY_F16',
   src: `registry://${models[654].registrySource}/${models[654].registryPath}`,
   registryPath: models[654].registryPath,
   registrySource: models[654].registrySource,
@@ -26544,8 +23749,8 @@ export const TTS_S3GEN_EN_CHATTERBOX_Q8_0 = {
   params: models[654].params
 } as const
 
-export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q5_0 = {
-  name: 'TTS_T3_MULTILINGUAL_CHATTERBOX_Q5_0',
+export const WHISPER_FRENCH_TINY_Q8_0 = {
+  name: 'WHISPER_FRENCH_TINY_Q8_0',
   src: `registry://${models[655].registrySource}/${models[655].registryPath}`,
   registryPath: models[655].registryPath,
   registrySource: models[655].registrySource,
@@ -26562,8 +23767,8 @@ export const TTS_T3_MULTILINGUAL_CHATTERBOX_Q5_0 = {
   params: models[655].params
 } as const
 
-export const TTS_T3_TURBO_EN_CHATTERBOX_Q5_0 = {
-  name: 'TTS_T3_TURBO_EN_CHATTERBOX_Q5_0',
+export const WHISPER_GERMAN_BASE_F16 = {
+  name: 'WHISPER_GERMAN_BASE_F16',
   src: `registry://${models[656].registrySource}/${models[656].registryPath}`,
   registryPath: models[656].registryPath,
   registrySource: models[656].registrySource,
@@ -26580,8 +23785,8 @@ export const TTS_T3_TURBO_EN_CHATTERBOX_Q5_0 = {
   params: models[656].params
 } as const
 
-export const TTS_CANGJIE_ZH_CHATTERBOX = {
-  name: 'TTS_CANGJIE_ZH_CHATTERBOX',
+export const WHISPER_GERMAN_BASE_Q8_0 = {
+  name: 'WHISPER_GERMAN_BASE_Q8_0',
   src: `registry://${models[657].registrySource}/${models[657].registryPath}`,
   registryPath: models[657].registryPath,
   registrySource: models[657].registrySource,
@@ -26598,8 +23803,8 @@ export const TTS_CANGJIE_ZH_CHATTERBOX = {
   params: models[657].params
 } as const
 
-export const TTS_ENHANCER_LAVASR_FP16 = {
-  name: 'TTS_ENHANCER_LAVASR_FP16',
+export const WHISPER_GERMAN_TINY_F16 = {
+  name: 'WHISPER_GERMAN_TINY_F16',
   src: `registry://${models[658].registrySource}/${models[658].registryPath}`,
   registryPath: models[658].registryPath,
   registrySource: models[658].registrySource,
@@ -26616,8 +23821,8 @@ export const TTS_ENHANCER_LAVASR_FP16 = {
   params: models[658].params
 } as const
 
-export const TTS_ENHANCER_LAVASR_FP32 = {
-  name: 'TTS_ENHANCER_LAVASR_FP32',
+export const WHISPER_GERMAN_TINY_Q8_0 = {
+  name: 'WHISPER_GERMAN_TINY_Q8_0',
   src: `registry://${models[659].registrySource}/${models[659].registryPath}`,
   registryPath: models[659].registryPath,
   registrySource: models[659].registrySource,
@@ -26634,8 +23839,8 @@ export const TTS_ENHANCER_LAVASR_FP32 = {
   params: models[659].params
 } as const
 
-export const TTS_DENOISER_LAVASR_FP16 = {
-  name: 'TTS_DENOISER_LAVASR_FP16',
+export const WHISPER_ITALIAN_BASE_F16 = {
+  name: 'WHISPER_ITALIAN_BASE_F16',
   src: `registry://${models[660].registrySource}/${models[660].registryPath}`,
   registryPath: models[660].registryPath,
   registrySource: models[660].registrySource,
@@ -26652,8 +23857,8 @@ export const TTS_DENOISER_LAVASR_FP16 = {
   params: models[660].params
 } as const
 
-export const TTS_DENOISER_LAVASR_FP32 = {
-  name: 'TTS_DENOISER_LAVASR_FP32',
+export const WHISPER_ITALIAN_BASE_Q8_0 = {
+  name: 'WHISPER_ITALIAN_BASE_Q8_0',
   src: `registry://${models[661].registrySource}/${models[661].registryPath}`,
   registryPath: models[661].registryPath,
   registrySource: models[661].registrySource,
@@ -26670,8 +23875,8 @@ export const TTS_DENOISER_LAVASR_FP32 = {
   params: models[661].params
 } as const
 
-export const TTS_EN_SUPERTONIC_Q4_0 = {
-  name: 'TTS_EN_SUPERTONIC_Q4_0',
+export const WHISPER_ITALIAN_TINY_F16 = {
+  name: 'WHISPER_ITALIAN_TINY_F16',
   src: `registry://${models[662].registrySource}/${models[662].registryPath}`,
   registryPath: models[662].registryPath,
   registrySource: models[662].registrySource,
@@ -26688,8 +23893,8 @@ export const TTS_EN_SUPERTONIC_Q4_0 = {
   params: models[662].params
 } as const
 
-export const TTS_EN_SUPERTONIC_Q8_0 = {
-  name: 'TTS_EN_SUPERTONIC_Q8_0',
+export const WHISPER_ITALIAN_TINY_Q8_0 = {
+  name: 'WHISPER_ITALIAN_TINY_Q8_0',
   src: `registry://${models[663].registrySource}/${models[663].registryPath}`,
   registryPath: models[663].registryPath,
   registrySource: models[663].registrySource,
@@ -26706,8 +23911,8 @@ export const TTS_EN_SUPERTONIC_Q8_0 = {
   params: models[663].params
 } as const
 
-export const TTS_MULTILINGUAL_SUPERTONIC2_Q4_0 = {
-  name: 'TTS_MULTILINGUAL_SUPERTONIC2_Q4_0',
+export const WHISPER_JAPANESE_BASE_F16 = {
+  name: 'WHISPER_JAPANESE_BASE_F16',
   src: `registry://${models[664].registrySource}/${models[664].registryPath}`,
   registryPath: models[664].registryPath,
   registrySource: models[664].registrySource,
@@ -26724,8 +23929,8 @@ export const TTS_MULTILINGUAL_SUPERTONIC2_Q4_0 = {
   params: models[664].params
 } as const
 
-export const TTS_MULTILINGUAL_SUPERTONIC2_Q8_0 = {
-  name: 'TTS_MULTILINGUAL_SUPERTONIC2_Q8_0',
+export const WHISPER_JAPANESE_BASE_Q8_0 = {
+  name: 'WHISPER_JAPANESE_BASE_Q8_0',
   src: `registry://${models[665].registrySource}/${models[665].registryPath}`,
   registryPath: models[665].registryPath,
   registrySource: models[665].registrySource,
@@ -26742,8 +23947,8 @@ export const TTS_MULTILINGUAL_SUPERTONIC2_Q8_0 = {
   params: models[665].params
 } as const
 
-export const TTS_MULTILINGUAL_SUPERTONIC3_FP16 = {
-  name: 'TTS_MULTILINGUAL_SUPERTONIC3_FP16',
+export const WHISPER_JAPANESE_TINY_F16 = {
+  name: 'WHISPER_JAPANESE_TINY_F16',
   src: `registry://${models[666].registrySource}/${models[666].registryPath}`,
   registryPath: models[666].registryPath,
   registrySource: models[666].registrySource,
@@ -26760,8 +23965,8 @@ export const TTS_MULTILINGUAL_SUPERTONIC3_FP16 = {
   params: models[666].params
 } as const
 
-export const TTS_MULTILINGUAL_SUPERTONIC3_FP32 = {
-  name: 'TTS_MULTILINGUAL_SUPERTONIC3_FP32',
+export const WHISPER_JAPANESE_TINY_Q8_0 = {
+  name: 'WHISPER_JAPANESE_TINY_Q8_0',
   src: `registry://${models[667].registrySource}/${models[667].registryPath}`,
   registryPath: models[667].registryPath,
   registrySource: models[667].registrySource,
@@ -26778,8 +23983,8 @@ export const TTS_MULTILINGUAL_SUPERTONIC3_FP32 = {
   params: models[667].params
 } as const
 
-export const TTS_MULTILINGUAL_SUPERTONIC3_Q8_0 = {
-  name: 'TTS_MULTILINGUAL_SUPERTONIC3_Q8_0',
+export const WHISPER_NORWEGIAN_TINY = {
+  name: 'WHISPER_NORWEGIAN_TINY',
   src: `registry://${models[668].registrySource}/${models[668].registryPath}`,
   registryPath: models[668].registryPath,
   registrySource: models[668].registrySource,
@@ -26796,8 +24001,8 @@ export const TTS_MULTILINGUAL_SUPERTONIC3_Q8_0 = {
   params: models[668].params
 } as const
 
-export const TTS_MULTILINGUAL_SUPERTONIC3_Q4_0 = {
-  name: 'TTS_MULTILINGUAL_SUPERTONIC3_Q4_0',
+export const WHISPER_PORTUGUESE_BASE_F16 = {
+  name: 'WHISPER_PORTUGUESE_BASE_F16',
   src: `registry://${models[669].registrySource}/${models[669].registryPath}`,
   registryPath: models[669].registryPath,
   registrySource: models[669].registrySource,
@@ -26814,8 +24019,8 @@ export const TTS_MULTILINGUAL_SUPERTONIC3_Q4_0 = {
   params: models[669].params
 } as const
 
-export const TTS_DENOISER_LAVASR_FP32_1 = {
-  name: 'TTS_DENOISER_LAVASR_FP32_1',
+export const WHISPER_PORTUGUESE_BASE_Q8_0 = {
+  name: 'WHISPER_PORTUGUESE_BASE_Q8_0',
   src: `registry://${models[670].registrySource}/${models[670].registryPath}`,
   registryPath: models[670].registryPath,
   registrySource: models[670].registrySource,
@@ -26832,8 +24037,8 @@ export const TTS_DENOISER_LAVASR_FP32_1 = {
   params: models[670].params
 } as const
 
-export const TTS_ENHANCER_BACKBONE_LAVASR_FP32 = {
-  name: 'TTS_ENHANCER_BACKBONE_LAVASR_FP32',
+export const WHISPER_PORTUGUESE_TINY_F16 = {
+  name: 'WHISPER_PORTUGUESE_TINY_F16',
   src: `registry://${models[671].registrySource}/${models[671].registryPath}`,
   registryPath: models[671].registryPath,
   registrySource: models[671].registrySource,
@@ -26850,8 +24055,26 @@ export const TTS_ENHANCER_BACKBONE_LAVASR_FP32 = {
   params: models[671].params
 } as const
 
-export const TTS_ENHANCER_SPEC_HEAD_LAVASR_FP32 = {
-  name: 'TTS_ENHANCER_SPEC_HEAD_LAVASR_FP32',
+export const WHISPER_PORTUGUESE_TINY_Q8_0 = {
+  name: 'WHISPER_PORTUGUESE_TINY_Q8_0',
+  src: `registry://${models[672].registrySource}/${models[672].registryPath}`,
+  registryPath: models[672].registryPath,
+  registrySource: models[672].registrySource,
+  blobCoreKey: models[672].blobCoreKey,
+  blobBlockOffset: models[672].blobBlockOffset,
+  blobBlockLength: models[672].blobBlockLength,
+  blobByteOffset: models[672].blobByteOffset,
+  modelId: models[672].modelId,
+  expectedSize: models[672].expectedSize,
+  sha256Checksum: models[672].sha256Checksum,
+  addon: models[672].addon,
+  engine: models[672].engine,
+  quantization: models[672].quantization,
+  params: models[672].params
+} as const
+
+export const WHISPER_RUSSIAN_BASE_F16 = {
+  name: 'WHISPER_RUSSIAN_BASE_F16',
   src: `registry://${models[673].registrySource}/${models[673].registryPath}`,
   registryPath: models[673].registryPath,
   registrySource: models[673].registrySource,
@@ -26868,8 +24091,26 @@ export const TTS_ENHANCER_SPEC_HEAD_LAVASR_FP32 = {
   params: models[673].params
 } as const
 
-export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP16 = {
-  name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP16',
+export const WHISPER_RUSSIAN_BASE_Q8_0 = {
+  name: 'WHISPER_RUSSIAN_BASE_Q8_0',
+  src: `registry://${models[674].registrySource}/${models[674].registryPath}`,
+  registryPath: models[674].registryPath,
+  registrySource: models[674].registrySource,
+  blobCoreKey: models[674].blobCoreKey,
+  blobBlockOffset: models[674].blobBlockOffset,
+  blobBlockLength: models[674].blobBlockLength,
+  blobByteOffset: models[674].blobByteOffset,
+  modelId: models[674].modelId,
+  expectedSize: models[674].expectedSize,
+  sha256Checksum: models[674].sha256Checksum,
+  addon: models[674].addon,
+  engine: models[674].engine,
+  quantization: models[674].quantization,
+  params: models[674].params
+} as const
+
+export const WHISPER_RUSSIAN_TINY_F16 = {
+  name: 'WHISPER_RUSSIAN_TINY_F16',
   src: `registry://${models[675].registrySource}/${models[675].registryPath}`,
   registryPath: models[675].registryPath,
   registrySource: models[675].registrySource,
@@ -26886,8 +24127,26 @@ export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP16 = {
   params: models[675].params
 } as const
 
-export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4 = {
-  name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4',
+export const WHISPER_RUSSIAN_TINY_Q8_0 = {
+  name: 'WHISPER_RUSSIAN_TINY_Q8_0',
+  src: `registry://${models[676].registrySource}/${models[676].registryPath}`,
+  registryPath: models[676].registryPath,
+  registrySource: models[676].registrySource,
+  blobCoreKey: models[676].blobCoreKey,
+  blobBlockOffset: models[676].blobBlockOffset,
+  blobBlockLength: models[676].blobBlockLength,
+  blobByteOffset: models[676].blobByteOffset,
+  modelId: models[676].modelId,
+  expectedSize: models[676].expectedSize,
+  sha256Checksum: models[676].sha256Checksum,
+  addon: models[676].addon,
+  engine: models[676].engine,
+  quantization: models[676].quantization,
+  params: models[676].params
+} as const
+
+export const WHISPER_SPANISH_TINY_F16 = {
+  name: 'WHISPER_SPANISH_TINY_F16',
   src: `registry://${models[677].registrySource}/${models[677].registryPath}`,
   registryPath: models[677].registryPath,
   registrySource: models[677].registrySource,
@@ -26904,8 +24163,26 @@ export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4 = {
   params: models[677].params
 } as const
 
-export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4F16 = {
-  name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4F16',
+export const WHISPER_SPANISH_TINY_Q8_0 = {
+  name: 'WHISPER_SPANISH_TINY_Q8_0',
+  src: `registry://${models[678].registrySource}/${models[678].registryPath}`,
+  registryPath: models[678].registryPath,
+  registrySource: models[678].registrySource,
+  blobCoreKey: models[678].blobCoreKey,
+  blobBlockOffset: models[678].blobBlockOffset,
+  blobBlockLength: models[678].blobBlockLength,
+  blobByteOffset: models[678].blobByteOffset,
+  modelId: models[678].modelId,
+  expectedSize: models[678].expectedSize,
+  sha256Checksum: models[678].sha256Checksum,
+  addon: models[678].addon,
+  engine: models[678].engine,
+  quantization: models[678].quantization,
+  params: models[678].params
+} as const
+
+export const WHISPER_Q8_0 = {
+  name: 'WHISPER_Q8_0',
   src: `registry://${models[679].registrySource}/${models[679].registryPath}`,
   registryPath: models[679].registryPath,
   registrySource: models[679].registrySource,
@@ -26922,1696 +24199,22 @@ export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_Q4F16 = {
   params: models[679].params
 } as const
 
-export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_QUANTIZED = {
-  name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_QUANTIZED',
-  src: `registry://${models[681].registrySource}/${models[681].registryPath}`,
-  registryPath: models[681].registryPath,
-  registrySource: models[681].registrySource,
-  blobCoreKey: models[681].blobCoreKey,
-  blobBlockOffset: models[681].blobBlockOffset,
-  blobBlockLength: models[681].blobBlockLength,
-  blobByteOffset: models[681].blobByteOffset,
-  modelId: models[681].modelId,
-  expectedSize: models[681].expectedSize,
-  sha256Checksum: models[681].sha256Checksum,
-  addon: models[681].addon,
-  engine: models[681].engine,
-  quantization: models[681].quantization,
-  params: models[681].params
-} as const
-
-export const TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP32 = {
-  name: 'TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP32',
-  src: `registry://${models[683].registrySource}/${models[683].registryPath}`,
-  registryPath: models[683].registryPath,
-  registrySource: models[683].registrySource,
-  blobCoreKey: models[683].blobCoreKey,
-  blobBlockOffset: models[683].blobBlockOffset,
-  blobBlockLength: models[683].blobBlockLength,
-  blobByteOffset: models[683].blobByteOffset,
-  modelId: models[683].modelId,
-  expectedSize: models[683].expectedSize,
-  sha256Checksum: models[683].sha256Checksum,
-  addon: models[683].addon,
-  engine: models[683].engine,
-  quantization: models[683].quantization,
-  params: models[683].params
-} as const
-
-export const TTS_EMBED_TOKENS_EN_CHATTERBOX_FP16 = {
-  name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_FP16',
-  src: `registry://${models[685].registrySource}/${models[685].registryPath}`,
-  registryPath: models[685].registryPath,
-  registrySource: models[685].registrySource,
-  blobCoreKey: models[685].blobCoreKey,
-  blobBlockOffset: models[685].blobBlockOffset,
-  blobBlockLength: models[685].blobBlockLength,
-  blobByteOffset: models[685].blobByteOffset,
-  modelId: models[685].modelId,
-  expectedSize: models[685].expectedSize,
-  sha256Checksum: models[685].sha256Checksum,
-  addon: models[685].addon,
-  engine: models[685].engine,
-  quantization: models[685].quantization,
-  params: models[685].params
-} as const
-
-export const TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4 = {
-  name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4',
-  src: `registry://${models[687].registrySource}/${models[687].registryPath}`,
-  registryPath: models[687].registryPath,
-  registrySource: models[687].registrySource,
-  blobCoreKey: models[687].blobCoreKey,
-  blobBlockOffset: models[687].blobBlockOffset,
-  blobBlockLength: models[687].blobBlockLength,
-  blobByteOffset: models[687].blobByteOffset,
-  modelId: models[687].modelId,
-  expectedSize: models[687].expectedSize,
-  sha256Checksum: models[687].sha256Checksum,
-  addon: models[687].addon,
-  engine: models[687].engine,
-  quantization: models[687].quantization,
-  params: models[687].params
-} as const
-
-export const TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4F16 = {
-  name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_Q4F16',
-  src: `registry://${models[689].registrySource}/${models[689].registryPath}`,
-  registryPath: models[689].registryPath,
-  registrySource: models[689].registrySource,
-  blobCoreKey: models[689].blobCoreKey,
-  blobBlockOffset: models[689].blobBlockOffset,
-  blobBlockLength: models[689].blobBlockLength,
-  blobByteOffset: models[689].blobByteOffset,
-  modelId: models[689].modelId,
-  expectedSize: models[689].expectedSize,
-  sha256Checksum: models[689].sha256Checksum,
-  addon: models[689].addon,
-  engine: models[689].engine,
-  quantization: models[689].quantization,
-  params: models[689].params
-} as const
-
-export const TTS_EMBED_TOKENS_EN_CHATTERBOX_QUANTIZED = {
-  name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_QUANTIZED',
-  src: `registry://${models[691].registrySource}/${models[691].registryPath}`,
-  registryPath: models[691].registryPath,
-  registrySource: models[691].registrySource,
-  blobCoreKey: models[691].blobCoreKey,
-  blobBlockOffset: models[691].blobBlockOffset,
-  blobBlockLength: models[691].blobBlockLength,
-  blobByteOffset: models[691].blobByteOffset,
-  modelId: models[691].modelId,
-  expectedSize: models[691].expectedSize,
-  sha256Checksum: models[691].sha256Checksum,
-  addon: models[691].addon,
-  engine: models[691].engine,
-  quantization: models[691].quantization,
-  params: models[691].params
-} as const
-
-export const TTS_EMBED_TOKENS_EN_CHATTERBOX_FP32 = {
-  name: 'TTS_EMBED_TOKENS_EN_CHATTERBOX_FP32',
-  src: `registry://${models[693].registrySource}/${models[693].registryPath}`,
-  registryPath: models[693].registryPath,
-  registrySource: models[693].registrySource,
-  blobCoreKey: models[693].blobCoreKey,
-  blobBlockOffset: models[693].blobBlockOffset,
-  blobBlockLength: models[693].blobBlockLength,
-  blobByteOffset: models[693].blobByteOffset,
-  modelId: models[693].modelId,
-  expectedSize: models[693].expectedSize,
-  sha256Checksum: models[693].sha256Checksum,
-  addon: models[693].addon,
-  engine: models[693].engine,
-  quantization: models[693].quantization,
-  params: models[693].params
-} as const
-
-export const TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP16 = {
-  name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP16',
-  src: `registry://${models[695].registrySource}/${models[695].registryPath}`,
-  registryPath: models[695].registryPath,
-  registrySource: models[695].registrySource,
-  blobCoreKey: models[695].blobCoreKey,
-  blobBlockOffset: models[695].blobBlockOffset,
-  blobBlockLength: models[695].blobBlockLength,
-  blobByteOffset: models[695].blobByteOffset,
-  modelId: models[695].modelId,
-  expectedSize: models[695].expectedSize,
-  sha256Checksum: models[695].sha256Checksum,
-  addon: models[695].addon,
-  engine: models[695].engine,
-  quantization: models[695].quantization,
-  params: models[695].params
-} as const
-
-export const TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4 = {
-  name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4',
-  src: `registry://${models[697].registrySource}/${models[697].registryPath}`,
-  registryPath: models[697].registryPath,
-  registrySource: models[697].registrySource,
-  blobCoreKey: models[697].blobCoreKey,
-  blobBlockOffset: models[697].blobBlockOffset,
-  blobBlockLength: models[697].blobBlockLength,
-  blobByteOffset: models[697].blobByteOffset,
-  modelId: models[697].modelId,
-  expectedSize: models[697].expectedSize,
-  sha256Checksum: models[697].sha256Checksum,
-  addon: models[697].addon,
-  engine: models[697].engine,
-  quantization: models[697].quantization,
-  params: models[697].params
-} as const
-
-export const TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4F16 = {
-  name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_Q4F16',
-  src: `registry://${models[699].registrySource}/${models[699].registryPath}`,
-  registryPath: models[699].registryPath,
-  registrySource: models[699].registrySource,
-  blobCoreKey: models[699].blobCoreKey,
-  blobBlockOffset: models[699].blobBlockOffset,
-  blobBlockLength: models[699].blobBlockLength,
-  blobByteOffset: models[699].blobByteOffset,
-  modelId: models[699].modelId,
-  expectedSize: models[699].expectedSize,
-  sha256Checksum: models[699].sha256Checksum,
-  addon: models[699].addon,
-  engine: models[699].engine,
-  quantization: models[699].quantization,
-  params: models[699].params
-} as const
-
-export const TTS_LANGUAGE_MODEL_EN_CHATTERBOX_QUANTIZED = {
-  name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_QUANTIZED',
-  src: `registry://${models[701].registrySource}/${models[701].registryPath}`,
-  registryPath: models[701].registryPath,
-  registrySource: models[701].registrySource,
-  blobCoreKey: models[701].blobCoreKey,
-  blobBlockOffset: models[701].blobBlockOffset,
-  blobBlockLength: models[701].blobBlockLength,
-  blobByteOffset: models[701].blobByteOffset,
-  modelId: models[701].modelId,
-  expectedSize: models[701].expectedSize,
-  sha256Checksum: models[701].sha256Checksum,
-  addon: models[701].addon,
-  engine: models[701].engine,
-  quantization: models[701].quantization,
-  params: models[701].params
-} as const
-
-export const TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP32 = {
-  name: 'TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP32',
-  src: `registry://${models[703].registrySource}/${models[703].registryPath}`,
-  registryPath: models[703].registryPath,
-  registrySource: models[703].registrySource,
-  blobCoreKey: models[703].blobCoreKey,
-  blobBlockOffset: models[703].blobBlockOffset,
-  blobBlockLength: models[703].blobBlockLength,
-  blobByteOffset: models[703].blobByteOffset,
-  modelId: models[703].modelId,
-  expectedSize: models[703].expectedSize,
-  sha256Checksum: models[703].sha256Checksum,
-  addon: models[703].addon,
-  engine: models[703].engine,
-  quantization: models[703].quantization,
-  params: models[703].params
-} as const
-
-export const TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP16 = {
-  name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP16',
-  src: `registry://${models[705].registrySource}/${models[705].registryPath}`,
-  registryPath: models[705].registryPath,
-  registrySource: models[705].registrySource,
-  blobCoreKey: models[705].blobCoreKey,
-  blobBlockOffset: models[705].blobBlockOffset,
-  blobBlockLength: models[705].blobBlockLength,
-  blobByteOffset: models[705].blobByteOffset,
-  modelId: models[705].modelId,
-  expectedSize: models[705].expectedSize,
-  sha256Checksum: models[705].sha256Checksum,
-  addon: models[705].addon,
-  engine: models[705].engine,
-  quantization: models[705].quantization,
-  params: models[705].params
-} as const
-
-export const TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4 = {
-  name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4',
-  src: `registry://${models[707].registrySource}/${models[707].registryPath}`,
-  registryPath: models[707].registryPath,
-  registrySource: models[707].registrySource,
-  blobCoreKey: models[707].blobCoreKey,
-  blobBlockOffset: models[707].blobBlockOffset,
-  blobBlockLength: models[707].blobBlockLength,
-  blobByteOffset: models[707].blobByteOffset,
-  modelId: models[707].modelId,
-  expectedSize: models[707].expectedSize,
-  sha256Checksum: models[707].sha256Checksum,
-  addon: models[707].addon,
-  engine: models[707].engine,
-  quantization: models[707].quantization,
-  params: models[707].params
-} as const
-
-export const TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4F16 = {
-  name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_Q4F16',
-  src: `registry://${models[709].registrySource}/${models[709].registryPath}`,
-  registryPath: models[709].registryPath,
-  registrySource: models[709].registrySource,
-  blobCoreKey: models[709].blobCoreKey,
-  blobBlockOffset: models[709].blobBlockOffset,
-  blobBlockLength: models[709].blobBlockLength,
-  blobByteOffset: models[709].blobByteOffset,
-  modelId: models[709].modelId,
-  expectedSize: models[709].expectedSize,
-  sha256Checksum: models[709].sha256Checksum,
-  addon: models[709].addon,
-  engine: models[709].engine,
-  quantization: models[709].quantization,
-  params: models[709].params
-} as const
-
-export const TTS_SPEECH_ENCODER_EN_CHATTERBOX_QUANTIZED = {
-  name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_QUANTIZED',
-  src: `registry://${models[711].registrySource}/${models[711].registryPath}`,
-  registryPath: models[711].registryPath,
-  registrySource: models[711].registrySource,
-  blobCoreKey: models[711].blobCoreKey,
-  blobBlockOffset: models[711].blobBlockOffset,
-  blobBlockLength: models[711].blobBlockLength,
-  blobByteOffset: models[711].blobByteOffset,
-  modelId: models[711].modelId,
-  expectedSize: models[711].expectedSize,
-  sha256Checksum: models[711].sha256Checksum,
-  addon: models[711].addon,
-  engine: models[711].engine,
-  quantization: models[711].quantization,
-  params: models[711].params
-} as const
-
-export const TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP32 = {
-  name: 'TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP32',
-  src: `registry://${models[713].registrySource}/${models[713].registryPath}`,
-  registryPath: models[713].registryPath,
-  registrySource: models[713].registrySource,
-  blobCoreKey: models[713].blobCoreKey,
-  blobBlockOffset: models[713].blobBlockOffset,
-  blobBlockLength: models[713].blobBlockLength,
-  blobByteOffset: models[713].blobByteOffset,
-  modelId: models[713].modelId,
-  expectedSize: models[713].expectedSize,
-  sha256Checksum: models[713].sha256Checksum,
-  addon: models[713].addon,
-  engine: models[713].engine,
-  quantization: models[713].quantization,
-  params: models[713].params
-} as const
-
-export const TTS_TOKENIZER_EN_CHATTERBOX = {
-  name: 'TTS_TOKENIZER_EN_CHATTERBOX',
-  src: `registry://${models[715].registrySource}/${models[715].registryPath}`,
-  registryPath: models[715].registryPath,
-  registrySource: models[715].registrySource,
-  blobCoreKey: models[715].blobCoreKey,
-  blobBlockOffset: models[715].blobBlockOffset,
-  blobBlockLength: models[715].blobBlockLength,
-  blobByteOffset: models[715].blobByteOffset,
-  modelId: models[715].modelId,
-  expectedSize: models[715].expectedSize,
-  sha256Checksum: models[715].sha256Checksum,
-  addon: models[715].addon,
-  engine: models[715].engine,
-  quantization: models[715].quantization,
-  params: models[715].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32',
-  src: `registry://${models[716].registrySource}/${models[716].registryPath}`,
-  registryPath: models[716].registryPath,
-  registrySource: models[716].registrySource,
-  blobCoreKey: models[716].blobCoreKey,
-  blobBlockOffset: models[716].blobBlockOffset,
-  blobBlockLength: models[716].blobBlockLength,
-  blobByteOffset: models[716].blobByteOffset,
-  modelId: models[716].modelId,
-  expectedSize: models[716].expectedSize,
-  sha256Checksum: models[716].sha256Checksum,
-  addon: models[716].addon,
-  engine: models[716].engine,
-  quantization: models[716].quantization,
-  params: models[716].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32',
-  src: `registry://${models[717].registrySource}/${models[717].registryPath}`,
-  registryPath: models[717].registryPath,
-  registrySource: models[717].registrySource,
-  blobCoreKey: models[717].blobCoreKey,
-  blobBlockOffset: models[717].blobBlockOffset,
-  blobBlockLength: models[717].blobBlockLength,
-  blobByteOffset: models[717].blobByteOffset,
-  modelId: models[717].modelId,
-  expectedSize: models[717].expectedSize,
-  sha256Checksum: models[717].sha256Checksum,
-  addon: models[717].addon,
-  engine: models[717].engine,
-  quantization: models[717].quantization,
-  params: models[717].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_TTS_CONFIG_SUPERTONE = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_TTS_CONFIG_SUPERTONE',
-  src: `registry://${models[718].registrySource}/${models[718].registryPath}`,
-  registryPath: models[718].registryPath,
-  registrySource: models[718].registrySource,
-  blobCoreKey: models[718].blobCoreKey,
-  blobBlockOffset: models[718].blobBlockOffset,
-  blobBlockLength: models[718].blobBlockLength,
-  blobByteOffset: models[718].blobByteOffset,
-  modelId: models[718].modelId,
-  expectedSize: models[718].expectedSize,
-  sha256Checksum: models[718].sha256Checksum,
-  addon: models[718].addon,
-  engine: models[718].engine,
-  quantization: models[718].quantization,
-  params: models[718].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_UNICODE_INDEXER_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_UNICODE_INDEXER_SUPERTONE_FP32',
-  src: `registry://${models[719].registrySource}/${models[719].registryPath}`,
-  registryPath: models[719].registryPath,
-  registrySource: models[719].registrySource,
-  blobCoreKey: models[719].blobCoreKey,
-  blobBlockOffset: models[719].blobBlockOffset,
-  blobBlockLength: models[719].blobBlockLength,
-  blobByteOffset: models[719].blobByteOffset,
-  modelId: models[719].modelId,
-  expectedSize: models[719].expectedSize,
-  sha256Checksum: models[719].sha256Checksum,
-  addon: models[719].addon,
-  engine: models[719].engine,
-  quantization: models[719].quantization,
-  params: models[719].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32',
-  src: `registry://${models[720].registrySource}/${models[720].registryPath}`,
-  registryPath: models[720].registryPath,
-  registrySource: models[720].registrySource,
-  blobCoreKey: models[720].blobCoreKey,
-  blobBlockOffset: models[720].blobBlockOffset,
-  blobBlockLength: models[720].blobBlockLength,
-  blobByteOffset: models[720].blobByteOffset,
-  modelId: models[720].modelId,
-  expectedSize: models[720].expectedSize,
-  sha256Checksum: models[720].sha256Checksum,
-  addon: models[720].addon,
-  engine: models[720].engine,
-  quantization: models[720].quantization,
-  params: models[720].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOCODER_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOCODER_SUPERTONE_FP32',
-  src: `registry://${models[721].registrySource}/${models[721].registryPath}`,
-  registryPath: models[721].registryPath,
-  registrySource: models[721].registrySource,
-  blobCoreKey: models[721].blobCoreKey,
-  blobBlockOffset: models[721].blobBlockOffset,
-  blobBlockLength: models[721].blobBlockLength,
-  blobByteOffset: models[721].blobByteOffset,
-  modelId: models[721].modelId,
-  expectedSize: models[721].expectedSize,
-  sha256Checksum: models[721].sha256Checksum,
-  addon: models[721].addon,
-  engine: models[721].engine,
-  quantization: models[721].quantization,
-  params: models[721].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE',
-  src: `registry://${models[722].registrySource}/${models[722].registryPath}`,
-  registryPath: models[722].registryPath,
-  registrySource: models[722].registrySource,
-  blobCoreKey: models[722].blobCoreKey,
-  blobBlockOffset: models[722].blobBlockOffset,
-  blobBlockLength: models[722].blobBlockLength,
-  blobByteOffset: models[722].blobByteOffset,
-  modelId: models[722].modelId,
-  expectedSize: models[722].expectedSize,
-  sha256Checksum: models[722].sha256Checksum,
-  addon: models[722].addon,
-  engine: models[722].engine,
-  quantization: models[722].quantization,
-  params: models[722].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_1 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_1',
-  src: `registry://${models[723].registrySource}/${models[723].registryPath}`,
-  registryPath: models[723].registryPath,
-  registrySource: models[723].registrySource,
-  blobCoreKey: models[723].blobCoreKey,
-  blobBlockOffset: models[723].blobBlockOffset,
-  blobBlockLength: models[723].blobBlockLength,
-  blobByteOffset: models[723].blobByteOffset,
-  modelId: models[723].modelId,
-  expectedSize: models[723].expectedSize,
-  sha256Checksum: models[723].sha256Checksum,
-  addon: models[723].addon,
-  engine: models[723].engine,
-  quantization: models[723].quantization,
-  params: models[723].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_2 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_2',
-  src: `registry://${models[724].registrySource}/${models[724].registryPath}`,
-  registryPath: models[724].registryPath,
-  registrySource: models[724].registrySource,
-  blobCoreKey: models[724].blobCoreKey,
-  blobBlockOffset: models[724].blobBlockOffset,
-  blobBlockLength: models[724].blobBlockLength,
-  blobByteOffset: models[724].blobByteOffset,
-  modelId: models[724].modelId,
-  expectedSize: models[724].expectedSize,
-  sha256Checksum: models[724].sha256Checksum,
-  addon: models[724].addon,
-  engine: models[724].engine,
-  quantization: models[724].quantization,
-  params: models[724].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_3 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_3',
-  src: `registry://${models[725].registrySource}/${models[725].registryPath}`,
-  registryPath: models[725].registryPath,
-  registrySource: models[725].registrySource,
-  blobCoreKey: models[725].blobCoreKey,
-  blobBlockOffset: models[725].blobBlockOffset,
-  blobBlockLength: models[725].blobBlockLength,
-  blobByteOffset: models[725].blobByteOffset,
-  modelId: models[725].modelId,
-  expectedSize: models[725].expectedSize,
-  sha256Checksum: models[725].sha256Checksum,
-  addon: models[725].addon,
-  engine: models[725].engine,
-  quantization: models[725].quantization,
-  params: models[725].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_4 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_4',
-  src: `registry://${models[726].registrySource}/${models[726].registryPath}`,
-  registryPath: models[726].registryPath,
-  registrySource: models[726].registrySource,
-  blobCoreKey: models[726].blobCoreKey,
-  blobBlockOffset: models[726].blobBlockOffset,
-  blobBlockLength: models[726].blobBlockLength,
-  blobByteOffset: models[726].blobByteOffset,
-  modelId: models[726].modelId,
-  expectedSize: models[726].expectedSize,
-  sha256Checksum: models[726].sha256Checksum,
-  addon: models[726].addon,
-  engine: models[726].engine,
-  quantization: models[726].quantization,
-  params: models[726].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_5 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_5',
-  src: `registry://${models[727].registrySource}/${models[727].registryPath}`,
-  registryPath: models[727].registryPath,
-  registrySource: models[727].registrySource,
-  blobCoreKey: models[727].blobCoreKey,
-  blobBlockOffset: models[727].blobBlockOffset,
-  blobBlockLength: models[727].blobBlockLength,
-  blobByteOffset: models[727].blobByteOffset,
-  modelId: models[727].modelId,
-  expectedSize: models[727].expectedSize,
-  sha256Checksum: models[727].sha256Checksum,
-  addon: models[727].addon,
-  engine: models[727].engine,
-  quantization: models[727].quantization,
-  params: models[727].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_6 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_6',
-  src: `registry://${models[728].registrySource}/${models[728].registryPath}`,
-  registryPath: models[728].registryPath,
-  registrySource: models[728].registrySource,
-  blobCoreKey: models[728].blobCoreKey,
-  blobBlockOffset: models[728].blobBlockOffset,
-  blobBlockLength: models[728].blobBlockLength,
-  blobByteOffset: models[728].blobByteOffset,
-  modelId: models[728].modelId,
-  expectedSize: models[728].expectedSize,
-  sha256Checksum: models[728].sha256Checksum,
-  addon: models[728].addon,
-  engine: models[728].engine,
-  quantization: models[728].quantization,
-  params: models[728].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_7 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_7',
-  src: `registry://${models[729].registrySource}/${models[729].registryPath}`,
-  registryPath: models[729].registryPath,
-  registrySource: models[729].registrySource,
-  blobCoreKey: models[729].blobCoreKey,
-  blobBlockOffset: models[729].blobBlockOffset,
-  blobBlockLength: models[729].blobBlockLength,
-  blobByteOffset: models[729].blobByteOffset,
-  modelId: models[729].modelId,
-  expectedSize: models[729].expectedSize,
-  sha256Checksum: models[729].sha256Checksum,
-  addon: models[729].addon,
-  engine: models[729].engine,
-  quantization: models[729].quantization,
-  params: models[729].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_8 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_8',
-  src: `registry://${models[730].registrySource}/${models[730].registryPath}`,
-  registryPath: models[730].registryPath,
-  registrySource: models[730].registrySource,
-  blobCoreKey: models[730].blobCoreKey,
-  blobBlockOffset: models[730].blobBlockOffset,
-  blobBlockLength: models[730].blobBlockLength,
-  blobByteOffset: models[730].blobByteOffset,
-  modelId: models[730].modelId,
-  expectedSize: models[730].expectedSize,
-  sha256Checksum: models[730].sha256Checksum,
-  addon: models[730].addon,
-  engine: models[730].engine,
-  quantization: models[730].quantization,
-  params: models[730].params
-} as const
-
-export const TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_9 = {
-  name: 'TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE_9',
-  src: `registry://${models[731].registrySource}/${models[731].registryPath}`,
-  registryPath: models[731].registryPath,
-  registrySource: models[731].registrySource,
-  blobCoreKey: models[731].blobCoreKey,
-  blobBlockOffset: models[731].blobBlockOffset,
-  blobBlockLength: models[731].blobBlockLength,
-  blobByteOffset: models[731].blobByteOffset,
-  modelId: models[731].modelId,
-  expectedSize: models[731].expectedSize,
-  sha256Checksum: models[731].sha256Checksum,
-  addon: models[731].addon,
-  engine: models[731].engine,
-  quantization: models[731].quantization,
-  params: models[731].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32',
-  src: `registry://${models[732].registrySource}/${models[732].registryPath}`,
-  registryPath: models[732].registryPath,
-  registrySource: models[732].registrySource,
-  blobCoreKey: models[732].blobCoreKey,
-  blobBlockOffset: models[732].blobBlockOffset,
-  blobBlockLength: models[732].blobBlockLength,
-  blobByteOffset: models[732].blobByteOffset,
-  modelId: models[732].modelId,
-  expectedSize: models[732].expectedSize,
-  sha256Checksum: models[732].sha256Checksum,
-  addon: models[732].addon,
-  engine: models[732].engine,
-  quantization: models[732].quantization,
-  params: models[732].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32',
-  src: `registry://${models[733].registrySource}/${models[733].registryPath}`,
-  registryPath: models[733].registryPath,
-  registrySource: models[733].registrySource,
-  blobCoreKey: models[733].blobCoreKey,
-  blobBlockOffset: models[733].blobBlockOffset,
-  blobBlockLength: models[733].blobBlockLength,
-  blobByteOffset: models[733].blobByteOffset,
-  modelId: models[733].modelId,
-  expectedSize: models[733].expectedSize,
-  sha256Checksum: models[733].sha256Checksum,
-  addon: models[733].addon,
-  engine: models[733].engine,
-  quantization: models[733].quantization,
-  params: models[733].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_TTS_CONFIG_SUPERTONE = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_TTS_CONFIG_SUPERTONE',
-  src: `registry://${models[734].registrySource}/${models[734].registryPath}`,
-  registryPath: models[734].registryPath,
-  registrySource: models[734].registrySource,
-  blobCoreKey: models[734].blobCoreKey,
-  blobBlockOffset: models[734].blobBlockOffset,
-  blobBlockLength: models[734].blobBlockLength,
-  blobByteOffset: models[734].blobByteOffset,
-  modelId: models[734].modelId,
-  expectedSize: models[734].expectedSize,
-  sha256Checksum: models[734].sha256Checksum,
-  addon: models[734].addon,
-  engine: models[734].engine,
-  quantization: models[734].quantization,
-  params: models[734].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_UNICODE_INDEXER_SUPERTONE = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_UNICODE_INDEXER_SUPERTONE',
-  src: `registry://${models[735].registrySource}/${models[735].registryPath}`,
-  registryPath: models[735].registryPath,
-  registrySource: models[735].registrySource,
-  blobCoreKey: models[735].blobCoreKey,
-  blobBlockOffset: models[735].blobBlockOffset,
-  blobBlockLength: models[735].blobBlockLength,
-  blobByteOffset: models[735].blobByteOffset,
-  modelId: models[735].modelId,
-  expectedSize: models[735].expectedSize,
-  sha256Checksum: models[735].sha256Checksum,
-  addon: models[735].addon,
-  engine: models[735].engine,
-  quantization: models[735].quantization,
-  params: models[735].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32',
-  src: `registry://${models[736].registrySource}/${models[736].registryPath}`,
-  registryPath: models[736].registryPath,
-  registrySource: models[736].registrySource,
-  blobCoreKey: models[736].blobCoreKey,
-  blobBlockOffset: models[736].blobBlockOffset,
-  blobBlockLength: models[736].blobBlockLength,
-  blobByteOffset: models[736].blobByteOffset,
-  modelId: models[736].modelId,
-  expectedSize: models[736].expectedSize,
-  sha256Checksum: models[736].sha256Checksum,
-  addon: models[736].addon,
-  engine: models[736].engine,
-  quantization: models[736].quantization,
-  params: models[736].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE',
-  src: `registry://${models[737].registrySource}/${models[737].registryPath}`,
-  registryPath: models[737].registryPath,
-  registrySource: models[737].registrySource,
-  blobCoreKey: models[737].blobCoreKey,
-  blobBlockOffset: models[737].blobBlockOffset,
-  blobBlockLength: models[737].blobBlockLength,
-  blobByteOffset: models[737].blobByteOffset,
-  modelId: models[737].modelId,
-  expectedSize: models[737].expectedSize,
-  sha256Checksum: models[737].sha256Checksum,
-  addon: models[737].addon,
-  engine: models[737].engine,
-  quantization: models[737].quantization,
-  params: models[737].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_1 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_1',
-  src: `registry://${models[738].registrySource}/${models[738].registryPath}`,
-  registryPath: models[738].registryPath,
-  registrySource: models[738].registrySource,
-  blobCoreKey: models[738].blobCoreKey,
-  blobBlockOffset: models[738].blobBlockOffset,
-  blobBlockLength: models[738].blobBlockLength,
-  blobByteOffset: models[738].blobByteOffset,
-  modelId: models[738].modelId,
-  expectedSize: models[738].expectedSize,
-  sha256Checksum: models[738].sha256Checksum,
-  addon: models[738].addon,
-  engine: models[738].engine,
-  quantization: models[738].quantization,
-  params: models[738].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_2 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_2',
-  src: `registry://${models[739].registrySource}/${models[739].registryPath}`,
-  registryPath: models[739].registryPath,
-  registrySource: models[739].registrySource,
-  blobCoreKey: models[739].blobCoreKey,
-  blobBlockOffset: models[739].blobBlockOffset,
-  blobBlockLength: models[739].blobBlockLength,
-  blobByteOffset: models[739].blobByteOffset,
-  modelId: models[739].modelId,
-  expectedSize: models[739].expectedSize,
-  sha256Checksum: models[739].sha256Checksum,
-  addon: models[739].addon,
-  engine: models[739].engine,
-  quantization: models[739].quantization,
-  params: models[739].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_3 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_3',
-  src: `registry://${models[740].registrySource}/${models[740].registryPath}`,
-  registryPath: models[740].registryPath,
-  registrySource: models[740].registrySource,
-  blobCoreKey: models[740].blobCoreKey,
-  blobBlockOffset: models[740].blobBlockOffset,
-  blobBlockLength: models[740].blobBlockLength,
-  blobByteOffset: models[740].blobByteOffset,
-  modelId: models[740].modelId,
-  expectedSize: models[740].expectedSize,
-  sha256Checksum: models[740].sha256Checksum,
-  addon: models[740].addon,
-  engine: models[740].engine,
-  quantization: models[740].quantization,
-  params: models[740].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_4 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_4',
-  src: `registry://${models[741].registrySource}/${models[741].registryPath}`,
-  registryPath: models[741].registryPath,
-  registrySource: models[741].registrySource,
-  blobCoreKey: models[741].blobCoreKey,
-  blobBlockOffset: models[741].blobBlockOffset,
-  blobBlockLength: models[741].blobBlockLength,
-  blobByteOffset: models[741].blobByteOffset,
-  modelId: models[741].modelId,
-  expectedSize: models[741].expectedSize,
-  sha256Checksum: models[741].sha256Checksum,
-  addon: models[741].addon,
-  engine: models[741].engine,
-  quantization: models[741].quantization,
-  params: models[741].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_5 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_5',
-  src: `registry://${models[742].registrySource}/${models[742].registryPath}`,
-  registryPath: models[742].registryPath,
-  registrySource: models[742].registrySource,
-  blobCoreKey: models[742].blobCoreKey,
-  blobBlockOffset: models[742].blobBlockOffset,
-  blobBlockLength: models[742].blobBlockLength,
-  blobByteOffset: models[742].blobByteOffset,
-  modelId: models[742].modelId,
-  expectedSize: models[742].expectedSize,
-  sha256Checksum: models[742].sha256Checksum,
-  addon: models[742].addon,
-  engine: models[742].engine,
-  quantization: models[742].quantization,
-  params: models[742].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_6 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_6',
-  src: `registry://${models[743].registrySource}/${models[743].registryPath}`,
-  registryPath: models[743].registryPath,
-  registrySource: models[743].registrySource,
-  blobCoreKey: models[743].blobCoreKey,
-  blobBlockOffset: models[743].blobBlockOffset,
-  blobBlockLength: models[743].blobBlockLength,
-  blobByteOffset: models[743].blobByteOffset,
-  modelId: models[743].modelId,
-  expectedSize: models[743].expectedSize,
-  sha256Checksum: models[743].sha256Checksum,
-  addon: models[743].addon,
-  engine: models[743].engine,
-  quantization: models[743].quantization,
-  params: models[743].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_7 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_7',
-  src: `registry://${models[744].registrySource}/${models[744].registryPath}`,
-  registryPath: models[744].registryPath,
-  registrySource: models[744].registrySource,
-  blobCoreKey: models[744].blobCoreKey,
-  blobBlockOffset: models[744].blobBlockOffset,
-  blobBlockLength: models[744].blobBlockLength,
-  blobByteOffset: models[744].blobByteOffset,
-  modelId: models[744].modelId,
-  expectedSize: models[744].expectedSize,
-  sha256Checksum: models[744].sha256Checksum,
-  addon: models[744].addon,
-  engine: models[744].engine,
-  quantization: models[744].quantization,
-  params: models[744].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_8 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_8',
-  src: `registry://${models[745].registrySource}/${models[745].registryPath}`,
-  registryPath: models[745].registryPath,
-  registrySource: models[745].registrySource,
-  blobCoreKey: models[745].blobCoreKey,
-  blobBlockOffset: models[745].blobBlockOffset,
-  blobBlockLength: models[745].blobBlockLength,
-  blobByteOffset: models[745].blobByteOffset,
-  modelId: models[745].modelId,
-  expectedSize: models[745].expectedSize,
-  sha256Checksum: models[745].sha256Checksum,
-  addon: models[745].addon,
-  engine: models[745].engine,
-  quantization: models[745].quantization,
-  params: models[745].params
-} as const
-
-export const TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_9 = {
-  name: 'TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE_9',
-  src: `registry://${models[746].registrySource}/${models[746].registryPath}`,
-  registryPath: models[746].registryPath,
-  registrySource: models[746].registrySource,
-  blobCoreKey: models[746].blobCoreKey,
-  blobBlockOffset: models[746].blobBlockOffset,
-  blobBlockLength: models[746].blobBlockLength,
-  blobByteOffset: models[746].blobByteOffset,
-  modelId: models[746].modelId,
-  expectedSize: models[746].expectedSize,
-  sha256Checksum: models[746].sha256Checksum,
-  addon: models[746].addon,
-  engine: models[746].engine,
-  quantization: models[746].quantization,
-  params: models[746].params
-} as const
-
-export const PI05_BASE_Q_AGGRESSIVE = {
-  name: 'PI05_BASE_Q_AGGRESSIVE',
-  src: `registry://${models[747].registrySource}/${models[747].registryPath}`,
-  registryPath: models[747].registryPath,
-  registrySource: models[747].registrySource,
-  blobCoreKey: models[747].blobCoreKey,
-  blobBlockOffset: models[747].blobBlockOffset,
-  blobBlockLength: models[747].blobBlockLength,
-  blobByteOffset: models[747].blobByteOffset,
-  modelId: models[747].modelId,
-  expectedSize: models[747].expectedSize,
-  sha256Checksum: models[747].sha256Checksum,
-  addon: models[747].addon,
-  engine: models[747].engine,
-  quantization: models[747].quantization,
-  params: models[747].params
-} as const
-
-export const SMOLVLA_LIBERO_VISION_Q8 = {
-  name: 'SMOLVLA_LIBERO_VISION_Q8',
-  src: `registry://${models[748].registrySource}/${models[748].registryPath}`,
-  registryPath: models[748].registryPath,
-  registrySource: models[748].registrySource,
-  blobCoreKey: models[748].blobCoreKey,
-  blobBlockOffset: models[748].blobBlockOffset,
-  blobBlockLength: models[748].blobBlockLength,
-  blobByteOffset: models[748].blobByteOffset,
-  modelId: models[748].modelId,
-  expectedSize: models[748].expectedSize,
-  sha256Checksum: models[748].sha256Checksum,
-  addon: models[748].addon,
-  engine: models[748].engine,
-  quantization: models[748].quantization,
-  params: models[748].params
-} as const
-
-export const WHISPER_BASE_Q8_0 = {
-  name: 'WHISPER_BASE_Q8_0',
-  src: `registry://${models[749].registrySource}/${models[749].registryPath}`,
-  registryPath: models[749].registryPath,
-  registrySource: models[749].registrySource,
-  blobCoreKey: models[749].blobCoreKey,
-  blobBlockOffset: models[749].blobBlockOffset,
-  blobBlockLength: models[749].blobBlockLength,
-  blobByteOffset: models[749].blobByteOffset,
-  modelId: models[749].modelId,
-  expectedSize: models[749].expectedSize,
-  sha256Checksum: models[749].sha256Checksum,
-  addon: models[749].addon,
-  engine: models[749].engine,
-  quantization: models[749].quantization,
-  params: models[749].params
-} as const
-
-export const WHISPER_BASE_Q0F16 = {
-  name: 'WHISPER_BASE_Q0F16',
-  src: `registry://${models[750].registrySource}/${models[750].registryPath}`,
-  registryPath: models[750].registryPath,
-  registrySource: models[750].registrySource,
-  blobCoreKey: models[750].blobCoreKey,
-  blobBlockOffset: models[750].blobBlockOffset,
-  blobBlockLength: models[750].blobBlockLength,
-  blobByteOffset: models[750].blobByteOffset,
-  modelId: models[750].modelId,
-  expectedSize: models[750].expectedSize,
-  sha256Checksum: models[750].sha256Checksum,
-  addon: models[750].addon,
-  engine: models[750].engine,
-  quantization: models[750].quantization,
-  params: models[750].params
-} as const
-
-export const WHISPER_EN_BASE_Q8_0 = {
-  name: 'WHISPER_EN_BASE_Q8_0',
-  src: `registry://${models[751].registrySource}/${models[751].registryPath}`,
-  registryPath: models[751].registryPath,
-  registrySource: models[751].registrySource,
-  blobCoreKey: models[751].blobCoreKey,
-  blobBlockOffset: models[751].blobBlockOffset,
-  blobBlockLength: models[751].blobBlockLength,
-  blobByteOffset: models[751].blobByteOffset,
-  modelId: models[751].modelId,
-  expectedSize: models[751].expectedSize,
-  sha256Checksum: models[751].sha256Checksum,
-  addon: models[751].addon,
-  engine: models[751].engine,
-  quantization: models[751].quantization,
-  params: models[751].params
-} as const
-
-export const WHISPER_EN_BASE_Q0F16 = {
-  name: 'WHISPER_EN_BASE_Q0F16',
-  src: `registry://${models[752].registrySource}/${models[752].registryPath}`,
-  registryPath: models[752].registryPath,
-  registrySource: models[752].registrySource,
-  blobCoreKey: models[752].blobCoreKey,
-  blobBlockOffset: models[752].blobBlockOffset,
-  blobBlockLength: models[752].blobBlockLength,
-  blobByteOffset: models[752].blobByteOffset,
-  modelId: models[752].modelId,
-  expectedSize: models[752].expectedSize,
-  sha256Checksum: models[752].sha256Checksum,
-  addon: models[752].addon,
-  engine: models[752].engine,
-  quantization: models[752].quantization,
-  params: models[752].params
-} as const
-
-export const WHISPER_LARGE_V3_TURBO = {
-  name: 'WHISPER_LARGE_V3_TURBO',
-  src: `registry://${models[753].registrySource}/${models[753].registryPath}`,
-  registryPath: models[753].registryPath,
-  registrySource: models[753].registrySource,
-  blobCoreKey: models[753].blobCoreKey,
-  blobBlockOffset: models[753].blobBlockOffset,
-  blobBlockLength: models[753].blobBlockLength,
-  blobByteOffset: models[753].blobByteOffset,
-  modelId: models[753].modelId,
-  expectedSize: models[753].expectedSize,
-  sha256Checksum: models[753].sha256Checksum,
-  addon: models[753].addon,
-  engine: models[753].engine,
-  quantization: models[753].quantization,
-  params: models[753].params
-} as const
-
-export const WHISPER_SMALL_Q8_0 = {
-  name: 'WHISPER_SMALL_Q8_0',
-  src: `registry://${models[754].registrySource}/${models[754].registryPath}`,
-  registryPath: models[754].registryPath,
-  registrySource: models[754].registrySource,
-  blobCoreKey: models[754].blobCoreKey,
-  blobBlockOffset: models[754].blobBlockOffset,
-  blobBlockLength: models[754].blobBlockLength,
-  blobByteOffset: models[754].blobByteOffset,
-  modelId: models[754].modelId,
-  expectedSize: models[754].expectedSize,
-  sha256Checksum: models[754].sha256Checksum,
-  addon: models[754].addon,
-  engine: models[754].engine,
-  quantization: models[754].quantization,
-  params: models[754].params
-} as const
-
-export const WHISPER_SMALL_Q0F16 = {
-  name: 'WHISPER_SMALL_Q0F16',
-  src: `registry://${models[755].registrySource}/${models[755].registryPath}`,
-  registryPath: models[755].registryPath,
-  registrySource: models[755].registrySource,
-  blobCoreKey: models[755].blobCoreKey,
-  blobBlockOffset: models[755].blobBlockOffset,
-  blobBlockLength: models[755].blobBlockLength,
-  blobByteOffset: models[755].blobByteOffset,
-  modelId: models[755].modelId,
-  expectedSize: models[755].expectedSize,
-  sha256Checksum: models[755].sha256Checksum,
-  addon: models[755].addon,
-  engine: models[755].engine,
-  quantization: models[755].quantization,
-  params: models[755].params
-} as const
-
-export const WHISPER_EN_SMALL_Q8_0 = {
-  name: 'WHISPER_EN_SMALL_Q8_0',
-  src: `registry://${models[756].registrySource}/${models[756].registryPath}`,
-  registryPath: models[756].registryPath,
-  registrySource: models[756].registrySource,
-  blobCoreKey: models[756].blobCoreKey,
-  blobBlockOffset: models[756].blobBlockOffset,
-  blobBlockLength: models[756].blobBlockLength,
-  blobByteOffset: models[756].blobByteOffset,
-  modelId: models[756].modelId,
-  expectedSize: models[756].expectedSize,
-  sha256Checksum: models[756].sha256Checksum,
-  addon: models[756].addon,
-  engine: models[756].engine,
-  quantization: models[756].quantization,
-  params: models[756].params
-} as const
-
-export const WHISPER_EN_SMALL_Q0F16 = {
-  name: 'WHISPER_EN_SMALL_Q0F16',
-  src: `registry://${models[757].registrySource}/${models[757].registryPath}`,
-  registryPath: models[757].registryPath,
-  registrySource: models[757].registrySource,
-  blobCoreKey: models[757].blobCoreKey,
-  blobBlockOffset: models[757].blobBlockOffset,
-  blobBlockLength: models[757].blobBlockLength,
-  blobByteOffset: models[757].blobByteOffset,
-  modelId: models[757].modelId,
-  expectedSize: models[757].expectedSize,
-  sha256Checksum: models[757].sha256Checksum,
-  addon: models[757].addon,
-  engine: models[757].engine,
-  quantization: models[757].quantization,
-  params: models[757].params
-} as const
-
-export const WHISPER_TINY_Q8_0 = {
-  name: 'WHISPER_TINY_Q8_0',
-  src: `registry://${models[758].registrySource}/${models[758].registryPath}`,
-  registryPath: models[758].registryPath,
-  registrySource: models[758].registrySource,
-  blobCoreKey: models[758].blobCoreKey,
-  blobBlockOffset: models[758].blobBlockOffset,
-  blobBlockLength: models[758].blobBlockLength,
-  blobByteOffset: models[758].blobByteOffset,
-  modelId: models[758].modelId,
-  expectedSize: models[758].expectedSize,
-  sha256Checksum: models[758].sha256Checksum,
-  addon: models[758].addon,
-  engine: models[758].engine,
-  quantization: models[758].quantization,
-  params: models[758].params
-} as const
-
-export const WHISPER_TINY = {
-  name: 'WHISPER_TINY',
-  src: `registry://${models[759].registrySource}/${models[759].registryPath}`,
-  registryPath: models[759].registryPath,
-  registrySource: models[759].registrySource,
-  blobCoreKey: models[759].blobCoreKey,
-  blobBlockOffset: models[759].blobBlockOffset,
-  blobBlockLength: models[759].blobBlockLength,
-  blobByteOffset: models[759].blobByteOffset,
-  modelId: models[759].modelId,
-  expectedSize: models[759].expectedSize,
-  sha256Checksum: models[759].sha256Checksum,
-  addon: models[759].addon,
-  engine: models[759].engine,
-  quantization: models[759].quantization,
-  params: models[759].params
-} as const
-
-export const WHISPER_EN_TINY_Q8_0 = {
-  name: 'WHISPER_EN_TINY_Q8_0',
-  src: `registry://${models[760].registrySource}/${models[760].registryPath}`,
-  registryPath: models[760].registryPath,
-  registrySource: models[760].registrySource,
-  blobCoreKey: models[760].blobCoreKey,
-  blobBlockOffset: models[760].blobBlockOffset,
-  blobBlockLength: models[760].blobBlockLength,
-  blobByteOffset: models[760].blobByteOffset,
-  modelId: models[760].modelId,
-  expectedSize: models[760].expectedSize,
-  sha256Checksum: models[760].sha256Checksum,
-  addon: models[760].addon,
-  engine: models[760].engine,
-  quantization: models[760].quantization,
-  params: models[760].params
-} as const
-
-export const WHISPER_EN_TINY_Q0F16 = {
-  name: 'WHISPER_EN_TINY_Q0F16',
-  src: `registry://${models[761].registrySource}/${models[761].registryPath}`,
-  registryPath: models[761].registryPath,
-  registrySource: models[761].registrySource,
-  blobCoreKey: models[761].blobCoreKey,
-  blobBlockOffset: models[761].blobBlockOffset,
-  blobBlockLength: models[761].blobBlockLength,
-  blobByteOffset: models[761].blobByteOffset,
-  modelId: models[761].modelId,
-  expectedSize: models[761].expectedSize,
-  sha256Checksum: models[761].sha256Checksum,
-  addon: models[761].addon,
-  engine: models[761].engine,
-  quantization: models[761].quantization,
-  params: models[761].params
-} as const
-
-export const VAD_SILERO_5_1_2 = {
-  name: 'VAD_SILERO_5_1_2',
-  src: `registry://${models[762].registrySource}/${models[762].registryPath}`,
-  registryPath: models[762].registryPath,
-  registrySource: models[762].registrySource,
-  blobCoreKey: models[762].blobCoreKey,
-  blobBlockOffset: models[762].blobBlockOffset,
-  blobBlockLength: models[762].blobBlockLength,
-  blobByteOffset: models[762].blobByteOffset,
-  modelId: models[762].modelId,
-  expectedSize: models[762].expectedSize,
-  sha256Checksum: models[762].sha256Checksum,
-  addon: models[762].addon,
-  engine: models[762].engine,
-  quantization: models[762].quantization,
-  params: models[762].params
-} as const
-
-export const WHISPER_FRENCH_BASE_F16 = {
-  name: 'WHISPER_FRENCH_BASE_F16',
-  src: `registry://${models[763].registrySource}/${models[763].registryPath}`,
-  registryPath: models[763].registryPath,
-  registrySource: models[763].registrySource,
-  blobCoreKey: models[763].blobCoreKey,
-  blobBlockOffset: models[763].blobBlockOffset,
-  blobBlockLength: models[763].blobBlockLength,
-  blobByteOffset: models[763].blobByteOffset,
-  modelId: models[763].modelId,
-  expectedSize: models[763].expectedSize,
-  sha256Checksum: models[763].sha256Checksum,
-  addon: models[763].addon,
-  engine: models[763].engine,
-  quantization: models[763].quantization,
-  params: models[763].params
-} as const
-
-export const WHISPER_FRENCH_BASE_Q8_0 = {
-  name: 'WHISPER_FRENCH_BASE_Q8_0',
-  src: `registry://${models[764].registrySource}/${models[764].registryPath}`,
-  registryPath: models[764].registryPath,
-  registrySource: models[764].registrySource,
-  blobCoreKey: models[764].blobCoreKey,
-  blobBlockOffset: models[764].blobBlockOffset,
-  blobBlockLength: models[764].blobBlockLength,
-  blobByteOffset: models[764].blobByteOffset,
-  modelId: models[764].modelId,
-  expectedSize: models[764].expectedSize,
-  sha256Checksum: models[764].sha256Checksum,
-  addon: models[764].addon,
-  engine: models[764].engine,
-  quantization: models[764].quantization,
-  params: models[764].params
-} as const
-
-export const WHISPER_FRENCH_TINY_F16 = {
-  name: 'WHISPER_FRENCH_TINY_F16',
-  src: `registry://${models[765].registrySource}/${models[765].registryPath}`,
-  registryPath: models[765].registryPath,
-  registrySource: models[765].registrySource,
-  blobCoreKey: models[765].blobCoreKey,
-  blobBlockOffset: models[765].blobBlockOffset,
-  blobBlockLength: models[765].blobBlockLength,
-  blobByteOffset: models[765].blobByteOffset,
-  modelId: models[765].modelId,
-  expectedSize: models[765].expectedSize,
-  sha256Checksum: models[765].sha256Checksum,
-  addon: models[765].addon,
-  engine: models[765].engine,
-  quantization: models[765].quantization,
-  params: models[765].params
-} as const
-
-export const WHISPER_FRENCH_TINY_Q8_0 = {
-  name: 'WHISPER_FRENCH_TINY_Q8_0',
-  src: `registry://${models[766].registrySource}/${models[766].registryPath}`,
-  registryPath: models[766].registryPath,
-  registrySource: models[766].registrySource,
-  blobCoreKey: models[766].blobCoreKey,
-  blobBlockOffset: models[766].blobBlockOffset,
-  blobBlockLength: models[766].blobBlockLength,
-  blobByteOffset: models[766].blobByteOffset,
-  modelId: models[766].modelId,
-  expectedSize: models[766].expectedSize,
-  sha256Checksum: models[766].sha256Checksum,
-  addon: models[766].addon,
-  engine: models[766].engine,
-  quantization: models[766].quantization,
-  params: models[766].params
-} as const
-
-export const WHISPER_GERMAN_BASE_F16 = {
-  name: 'WHISPER_GERMAN_BASE_F16',
-  src: `registry://${models[767].registrySource}/${models[767].registryPath}`,
-  registryPath: models[767].registryPath,
-  registrySource: models[767].registrySource,
-  blobCoreKey: models[767].blobCoreKey,
-  blobBlockOffset: models[767].blobBlockOffset,
-  blobBlockLength: models[767].blobBlockLength,
-  blobByteOffset: models[767].blobByteOffset,
-  modelId: models[767].modelId,
-  expectedSize: models[767].expectedSize,
-  sha256Checksum: models[767].sha256Checksum,
-  addon: models[767].addon,
-  engine: models[767].engine,
-  quantization: models[767].quantization,
-  params: models[767].params
-} as const
-
-export const WHISPER_GERMAN_BASE_Q8_0 = {
-  name: 'WHISPER_GERMAN_BASE_Q8_0',
-  src: `registry://${models[768].registrySource}/${models[768].registryPath}`,
-  registryPath: models[768].registryPath,
-  registrySource: models[768].registrySource,
-  blobCoreKey: models[768].blobCoreKey,
-  blobBlockOffset: models[768].blobBlockOffset,
-  blobBlockLength: models[768].blobBlockLength,
-  blobByteOffset: models[768].blobByteOffset,
-  modelId: models[768].modelId,
-  expectedSize: models[768].expectedSize,
-  sha256Checksum: models[768].sha256Checksum,
-  addon: models[768].addon,
-  engine: models[768].engine,
-  quantization: models[768].quantization,
-  params: models[768].params
-} as const
-
-export const WHISPER_GERMAN_TINY_F16 = {
-  name: 'WHISPER_GERMAN_TINY_F16',
-  src: `registry://${models[769].registrySource}/${models[769].registryPath}`,
-  registryPath: models[769].registryPath,
-  registrySource: models[769].registrySource,
-  blobCoreKey: models[769].blobCoreKey,
-  blobBlockOffset: models[769].blobBlockOffset,
-  blobBlockLength: models[769].blobBlockLength,
-  blobByteOffset: models[769].blobByteOffset,
-  modelId: models[769].modelId,
-  expectedSize: models[769].expectedSize,
-  sha256Checksum: models[769].sha256Checksum,
-  addon: models[769].addon,
-  engine: models[769].engine,
-  quantization: models[769].quantization,
-  params: models[769].params
-} as const
-
-export const WHISPER_GERMAN_TINY_Q8_0 = {
-  name: 'WHISPER_GERMAN_TINY_Q8_0',
-  src: `registry://${models[770].registrySource}/${models[770].registryPath}`,
-  registryPath: models[770].registryPath,
-  registrySource: models[770].registrySource,
-  blobCoreKey: models[770].blobCoreKey,
-  blobBlockOffset: models[770].blobBlockOffset,
-  blobBlockLength: models[770].blobBlockLength,
-  blobByteOffset: models[770].blobByteOffset,
-  modelId: models[770].modelId,
-  expectedSize: models[770].expectedSize,
-  sha256Checksum: models[770].sha256Checksum,
-  addon: models[770].addon,
-  engine: models[770].engine,
-  quantization: models[770].quantization,
-  params: models[770].params
-} as const
-
-export const WHISPER_ITALIAN_BASE_F16 = {
-  name: 'WHISPER_ITALIAN_BASE_F16',
-  src: `registry://${models[771].registrySource}/${models[771].registryPath}`,
-  registryPath: models[771].registryPath,
-  registrySource: models[771].registrySource,
-  blobCoreKey: models[771].blobCoreKey,
-  blobBlockOffset: models[771].blobBlockOffset,
-  blobBlockLength: models[771].blobBlockLength,
-  blobByteOffset: models[771].blobByteOffset,
-  modelId: models[771].modelId,
-  expectedSize: models[771].expectedSize,
-  sha256Checksum: models[771].sha256Checksum,
-  addon: models[771].addon,
-  engine: models[771].engine,
-  quantization: models[771].quantization,
-  params: models[771].params
-} as const
-
-export const WHISPER_ITALIAN_BASE_Q8_0 = {
-  name: 'WHISPER_ITALIAN_BASE_Q8_0',
-  src: `registry://${models[772].registrySource}/${models[772].registryPath}`,
-  registryPath: models[772].registryPath,
-  registrySource: models[772].registrySource,
-  blobCoreKey: models[772].blobCoreKey,
-  blobBlockOffset: models[772].blobBlockOffset,
-  blobBlockLength: models[772].blobBlockLength,
-  blobByteOffset: models[772].blobByteOffset,
-  modelId: models[772].modelId,
-  expectedSize: models[772].expectedSize,
-  sha256Checksum: models[772].sha256Checksum,
-  addon: models[772].addon,
-  engine: models[772].engine,
-  quantization: models[772].quantization,
-  params: models[772].params
-} as const
-
-export const WHISPER_ITALIAN_TINY_F16 = {
-  name: 'WHISPER_ITALIAN_TINY_F16',
-  src: `registry://${models[773].registrySource}/${models[773].registryPath}`,
-  registryPath: models[773].registryPath,
-  registrySource: models[773].registrySource,
-  blobCoreKey: models[773].blobCoreKey,
-  blobBlockOffset: models[773].blobBlockOffset,
-  blobBlockLength: models[773].blobBlockLength,
-  blobByteOffset: models[773].blobByteOffset,
-  modelId: models[773].modelId,
-  expectedSize: models[773].expectedSize,
-  sha256Checksum: models[773].sha256Checksum,
-  addon: models[773].addon,
-  engine: models[773].engine,
-  quantization: models[773].quantization,
-  params: models[773].params
-} as const
-
-export const WHISPER_ITALIAN_TINY_Q8_0 = {
-  name: 'WHISPER_ITALIAN_TINY_Q8_0',
-  src: `registry://${models[774].registrySource}/${models[774].registryPath}`,
-  registryPath: models[774].registryPath,
-  registrySource: models[774].registrySource,
-  blobCoreKey: models[774].blobCoreKey,
-  blobBlockOffset: models[774].blobBlockOffset,
-  blobBlockLength: models[774].blobBlockLength,
-  blobByteOffset: models[774].blobByteOffset,
-  modelId: models[774].modelId,
-  expectedSize: models[774].expectedSize,
-  sha256Checksum: models[774].sha256Checksum,
-  addon: models[774].addon,
-  engine: models[774].engine,
-  quantization: models[774].quantization,
-  params: models[774].params
-} as const
-
-export const WHISPER_JAPANESE_BASE_F16 = {
-  name: 'WHISPER_JAPANESE_BASE_F16',
-  src: `registry://${models[775].registrySource}/${models[775].registryPath}`,
-  registryPath: models[775].registryPath,
-  registrySource: models[775].registrySource,
-  blobCoreKey: models[775].blobCoreKey,
-  blobBlockOffset: models[775].blobBlockOffset,
-  blobBlockLength: models[775].blobBlockLength,
-  blobByteOffset: models[775].blobByteOffset,
-  modelId: models[775].modelId,
-  expectedSize: models[775].expectedSize,
-  sha256Checksum: models[775].sha256Checksum,
-  addon: models[775].addon,
-  engine: models[775].engine,
-  quantization: models[775].quantization,
-  params: models[775].params
-} as const
-
-export const WHISPER_JAPANESE_BASE_Q8_0 = {
-  name: 'WHISPER_JAPANESE_BASE_Q8_0',
-  src: `registry://${models[776].registrySource}/${models[776].registryPath}`,
-  registryPath: models[776].registryPath,
-  registrySource: models[776].registrySource,
-  blobCoreKey: models[776].blobCoreKey,
-  blobBlockOffset: models[776].blobBlockOffset,
-  blobBlockLength: models[776].blobBlockLength,
-  blobByteOffset: models[776].blobByteOffset,
-  modelId: models[776].modelId,
-  expectedSize: models[776].expectedSize,
-  sha256Checksum: models[776].sha256Checksum,
-  addon: models[776].addon,
-  engine: models[776].engine,
-  quantization: models[776].quantization,
-  params: models[776].params
-} as const
-
-export const WHISPER_JAPANESE_TINY_F16 = {
-  name: 'WHISPER_JAPANESE_TINY_F16',
-  src: `registry://${models[777].registrySource}/${models[777].registryPath}`,
-  registryPath: models[777].registryPath,
-  registrySource: models[777].registrySource,
-  blobCoreKey: models[777].blobCoreKey,
-  blobBlockOffset: models[777].blobBlockOffset,
-  blobBlockLength: models[777].blobBlockLength,
-  blobByteOffset: models[777].blobByteOffset,
-  modelId: models[777].modelId,
-  expectedSize: models[777].expectedSize,
-  sha256Checksum: models[777].sha256Checksum,
-  addon: models[777].addon,
-  engine: models[777].engine,
-  quantization: models[777].quantization,
-  params: models[777].params
-} as const
-
-export const WHISPER_JAPANESE_TINY_Q8_0 = {
-  name: 'WHISPER_JAPANESE_TINY_Q8_0',
-  src: `registry://${models[778].registrySource}/${models[778].registryPath}`,
-  registryPath: models[778].registryPath,
-  registrySource: models[778].registrySource,
-  blobCoreKey: models[778].blobCoreKey,
-  blobBlockOffset: models[778].blobBlockOffset,
-  blobBlockLength: models[778].blobBlockLength,
-  blobByteOffset: models[778].blobByteOffset,
-  modelId: models[778].modelId,
-  expectedSize: models[778].expectedSize,
-  sha256Checksum: models[778].sha256Checksum,
-  addon: models[778].addon,
-  engine: models[778].engine,
-  quantization: models[778].quantization,
-  params: models[778].params
-} as const
-
-export const WHISPER_NORWEGIAN_TINY = {
-  name: 'WHISPER_NORWEGIAN_TINY',
-  src: `registry://${models[779].registrySource}/${models[779].registryPath}`,
-  registryPath: models[779].registryPath,
-  registrySource: models[779].registrySource,
-  blobCoreKey: models[779].blobCoreKey,
-  blobBlockOffset: models[779].blobBlockOffset,
-  blobBlockLength: models[779].blobBlockLength,
-  blobByteOffset: models[779].blobByteOffset,
-  modelId: models[779].modelId,
-  expectedSize: models[779].expectedSize,
-  sha256Checksum: models[779].sha256Checksum,
-  addon: models[779].addon,
-  engine: models[779].engine,
-  quantization: models[779].quantization,
-  params: models[779].params
-} as const
-
-export const WHISPER_PORTUGUESE_BASE_F16 = {
-  name: 'WHISPER_PORTUGUESE_BASE_F16',
-  src: `registry://${models[780].registrySource}/${models[780].registryPath}`,
-  registryPath: models[780].registryPath,
-  registrySource: models[780].registrySource,
-  blobCoreKey: models[780].blobCoreKey,
-  blobBlockOffset: models[780].blobBlockOffset,
-  blobBlockLength: models[780].blobBlockLength,
-  blobByteOffset: models[780].blobByteOffset,
-  modelId: models[780].modelId,
-  expectedSize: models[780].expectedSize,
-  sha256Checksum: models[780].sha256Checksum,
-  addon: models[780].addon,
-  engine: models[780].engine,
-  quantization: models[780].quantization,
-  params: models[780].params
-} as const
-
-export const WHISPER_PORTUGUESE_BASE_Q8_0 = {
-  name: 'WHISPER_PORTUGUESE_BASE_Q8_0',
-  src: `registry://${models[781].registrySource}/${models[781].registryPath}`,
-  registryPath: models[781].registryPath,
-  registrySource: models[781].registrySource,
-  blobCoreKey: models[781].blobCoreKey,
-  blobBlockOffset: models[781].blobBlockOffset,
-  blobBlockLength: models[781].blobBlockLength,
-  blobByteOffset: models[781].blobByteOffset,
-  modelId: models[781].modelId,
-  expectedSize: models[781].expectedSize,
-  sha256Checksum: models[781].sha256Checksum,
-  addon: models[781].addon,
-  engine: models[781].engine,
-  quantization: models[781].quantization,
-  params: models[781].params
-} as const
-
-export const WHISPER_PORTUGUESE_TINY_F16 = {
-  name: 'WHISPER_PORTUGUESE_TINY_F16',
-  src: `registry://${models[782].registrySource}/${models[782].registryPath}`,
-  registryPath: models[782].registryPath,
-  registrySource: models[782].registrySource,
-  blobCoreKey: models[782].blobCoreKey,
-  blobBlockOffset: models[782].blobBlockOffset,
-  blobBlockLength: models[782].blobBlockLength,
-  blobByteOffset: models[782].blobByteOffset,
-  modelId: models[782].modelId,
-  expectedSize: models[782].expectedSize,
-  sha256Checksum: models[782].sha256Checksum,
-  addon: models[782].addon,
-  engine: models[782].engine,
-  quantization: models[782].quantization,
-  params: models[782].params
-} as const
-
-export const WHISPER_PORTUGUESE_TINY_Q8_0 = {
-  name: 'WHISPER_PORTUGUESE_TINY_Q8_0',
-  src: `registry://${models[783].registrySource}/${models[783].registryPath}`,
-  registryPath: models[783].registryPath,
-  registrySource: models[783].registrySource,
-  blobCoreKey: models[783].blobCoreKey,
-  blobBlockOffset: models[783].blobBlockOffset,
-  blobBlockLength: models[783].blobBlockLength,
-  blobByteOffset: models[783].blobByteOffset,
-  modelId: models[783].modelId,
-  expectedSize: models[783].expectedSize,
-  sha256Checksum: models[783].sha256Checksum,
-  addon: models[783].addon,
-  engine: models[783].engine,
-  quantization: models[783].quantization,
-  params: models[783].params
-} as const
-
-export const WHISPER_RUSSIAN_BASE_F16 = {
-  name: 'WHISPER_RUSSIAN_BASE_F16',
-  src: `registry://${models[784].registrySource}/${models[784].registryPath}`,
-  registryPath: models[784].registryPath,
-  registrySource: models[784].registrySource,
-  blobCoreKey: models[784].blobCoreKey,
-  blobBlockOffset: models[784].blobBlockOffset,
-  blobBlockLength: models[784].blobBlockLength,
-  blobByteOffset: models[784].blobByteOffset,
-  modelId: models[784].modelId,
-  expectedSize: models[784].expectedSize,
-  sha256Checksum: models[784].sha256Checksum,
-  addon: models[784].addon,
-  engine: models[784].engine,
-  quantization: models[784].quantization,
-  params: models[784].params
-} as const
-
-export const WHISPER_RUSSIAN_BASE_Q8_0 = {
-  name: 'WHISPER_RUSSIAN_BASE_Q8_0',
-  src: `registry://${models[785].registrySource}/${models[785].registryPath}`,
-  registryPath: models[785].registryPath,
-  registrySource: models[785].registrySource,
-  blobCoreKey: models[785].blobCoreKey,
-  blobBlockOffset: models[785].blobBlockOffset,
-  blobBlockLength: models[785].blobBlockLength,
-  blobByteOffset: models[785].blobByteOffset,
-  modelId: models[785].modelId,
-  expectedSize: models[785].expectedSize,
-  sha256Checksum: models[785].sha256Checksum,
-  addon: models[785].addon,
-  engine: models[785].engine,
-  quantization: models[785].quantization,
-  params: models[785].params
-} as const
-
-export const WHISPER_RUSSIAN_TINY_F16 = {
-  name: 'WHISPER_RUSSIAN_TINY_F16',
-  src: `registry://${models[786].registrySource}/${models[786].registryPath}`,
-  registryPath: models[786].registryPath,
-  registrySource: models[786].registrySource,
-  blobCoreKey: models[786].blobCoreKey,
-  blobBlockOffset: models[786].blobBlockOffset,
-  blobBlockLength: models[786].blobBlockLength,
-  blobByteOffset: models[786].blobByteOffset,
-  modelId: models[786].modelId,
-  expectedSize: models[786].expectedSize,
-  sha256Checksum: models[786].sha256Checksum,
-  addon: models[786].addon,
-  engine: models[786].engine,
-  quantization: models[786].quantization,
-  params: models[786].params
-} as const
-
-export const WHISPER_RUSSIAN_TINY_Q8_0 = {
-  name: 'WHISPER_RUSSIAN_TINY_Q8_0',
-  src: `registry://${models[787].registrySource}/${models[787].registryPath}`,
-  registryPath: models[787].registryPath,
-  registrySource: models[787].registrySource,
-  blobCoreKey: models[787].blobCoreKey,
-  blobBlockOffset: models[787].blobBlockOffset,
-  blobBlockLength: models[787].blobBlockLength,
-  blobByteOffset: models[787].blobByteOffset,
-  modelId: models[787].modelId,
-  expectedSize: models[787].expectedSize,
-  sha256Checksum: models[787].sha256Checksum,
-  addon: models[787].addon,
-  engine: models[787].engine,
-  quantization: models[787].quantization,
-  params: models[787].params
-} as const
-
-export const WHISPER_SPANISH_TINY_F16 = {
-  name: 'WHISPER_SPANISH_TINY_F16',
-  src: `registry://${models[788].registrySource}/${models[788].registryPath}`,
-  registryPath: models[788].registryPath,
-  registrySource: models[788].registrySource,
-  blobCoreKey: models[788].blobCoreKey,
-  blobBlockOffset: models[788].blobBlockOffset,
-  blobBlockLength: models[788].blobBlockLength,
-  blobByteOffset: models[788].blobByteOffset,
-  modelId: models[788].modelId,
-  expectedSize: models[788].expectedSize,
-  sha256Checksum: models[788].sha256Checksum,
-  addon: models[788].addon,
-  engine: models[788].engine,
-  quantization: models[788].quantization,
-  params: models[788].params
-} as const
-
-export const WHISPER_SPANISH_TINY_Q8_0 = {
-  name: 'WHISPER_SPANISH_TINY_Q8_0',
-  src: `registry://${models[789].registrySource}/${models[789].registryPath}`,
-  registryPath: models[789].registryPath,
-  registrySource: models[789].registrySource,
-  blobCoreKey: models[789].blobCoreKey,
-  blobBlockOffset: models[789].blobBlockOffset,
-  blobBlockLength: models[789].blobBlockLength,
-  blobByteOffset: models[789].blobByteOffset,
-  modelId: models[789].modelId,
-  expectedSize: models[789].expectedSize,
-  sha256Checksum: models[789].sha256Checksum,
-  addon: models[789].addon,
-  engine: models[789].engine,
-  quantization: models[789].quantization,
-  params: models[789].params
-} as const
-
-export const WHISPER_Q8_0 = {
-  name: 'WHISPER_Q8_0',
-  src: `registry://${models[790].registrySource}/${models[790].registryPath}`,
-  registryPath: models[790].registryPath,
-  registrySource: models[790].registrySource,
-  blobCoreKey: models[790].blobCoreKey,
-  blobBlockOffset: models[790].blobBlockOffset,
-  blobBlockLength: models[790].blobBlockLength,
-  blobByteOffset: models[790].blobByteOffset,
-  modelId: models[790].modelId,
-  expectedSize: models[790].expectedSize,
-  sha256Checksum: models[790].sha256Checksum,
-  addon: models[790].addon,
-  engine: models[790].engine,
-  quantization: models[790].quantization,
-  params: models[790].params
-} as const
-
 export const WHISPER_Q8_0_1 = {
   name: 'WHISPER_Q8_0_1',
-  src: `registry://${models[791].registrySource}/${models[791].registryPath}`,
-  registryPath: models[791].registryPath,
-  registrySource: models[791].registrySource,
-  blobCoreKey: models[791].blobCoreKey,
-  blobBlockOffset: models[791].blobBlockOffset,
-  blobBlockLength: models[791].blobBlockLength,
-  blobByteOffset: models[791].blobByteOffset,
-  modelId: models[791].modelId,
-  expectedSize: models[791].expectedSize,
-  sha256Checksum: models[791].sha256Checksum,
-  addon: models[791].addon,
-  engine: models[791].engine,
-  quantization: models[791].quantization,
-  params: models[791].params
+  src: `registry://${models[680].registrySource}/${models[680].registryPath}`,
+  registryPath: models[680].registryPath,
+  registrySource: models[680].registrySource,
+  blobCoreKey: models[680].blobCoreKey,
+  blobBlockOffset: models[680].blobBlockOffset,
+  blobBlockLength: models[680].blobBlockLength,
+  blobByteOffset: models[680].blobByteOffset,
+  modelId: models[680].modelId,
+  expectedSize: models[680].expectedSize,
+  sha256Checksum: models[680].sha256Checksum,
+  addon: models[680].addon,
+  engine: models[680].engine,
+  quantization: models[680].quantization,
+  params: models[680].params
 } as const
 
 /**

--- a/packages/inference/src/plugins/builtin/ggml-ocr/plugin.ts
+++ b/packages/inference/src/plugins/builtin/ggml-ocr/plugin.ts
@@ -13,26 +13,12 @@ import {
   type ResolveResult
 } from '../../../schemas/index.ts'
 import { ModelLoadFailedError } from '../../../errors/index.ts'
-import { hyperdriveUrlSchema } from '../../../schemas/load-model.ts'
 import { createStreamLogger, registerAddonLogger } from '../../../logging/index.ts'
 import ocrAddonLogging from '@qvac/ocr-ggml/addonLogging'
 import { OcrGgml } from '@qvac/ocr-ggml'
 import { ocr } from './ops/ocr-stream.ts'
 import { attachModelExecutionMs } from '../../../profiling/model-execution.ts'
-import { OCR_CRAFT } from '../../../models/registry/index.ts'
-
-const OCR_DETECTOR_FILENAME = 'craft_mlt_25k.gguf'
-
-function deriveDetectorSource(modelSrc: string): string | undefined {
-  if (modelSrc.startsWith('pear://')) {
-    const { key } = hyperdriveUrlSchema.parse(modelSrc)
-    return `pear://${key}/${OCR_DETECTOR_FILENAME}`
-  }
-  if (modelSrc.startsWith('registry://')) {
-    return OCR_CRAFT.src
-  }
-  return undefined
-}
+import { resolveOcrConfig } from './resolve-config.ts'
 
 function createOCRModel(
   modelId: string,
@@ -96,20 +82,7 @@ export const ocrPlugin = definePlugin({
     cfg: OCRConfig,
     ctx: ResolveContext
   ): Promise<ResolveResult<Record<string, unknown>, 'detectorModelPath'>> {
-    const { detectorModelSrc, ...ocrConfig } = cfg
-
-    const detectorSrc = detectorModelSrc ?? deriveDetectorSource(ctx.modelSrc)
-    if (!detectorSrc) {
-      throw new ModelLoadFailedError(
-        'Detector model required for OCR. Use a hyperdrive source or provide detectorModelSrc'
-      )
-    }
-
-    const detectorModelPath = await ctx.resolveModelPath(detectorSrc)
-    return {
-      config: ocrConfig,
-      artifacts: { detectorModelPath }
-    }
+    return resolveOcrConfig(cfg, ctx)
   },
 
   createModel(params: CreateModelParams): PluginModelResult {

--- a/packages/inference/src/plugins/builtin/ggml-ocr/resolve-config.ts
+++ b/packages/inference/src/plugins/builtin/ggml-ocr/resolve-config.ts
@@ -1,0 +1,99 @@
+import {
+  type OCRConfig,
+  type ModelSrcInput,
+  type ResolveContext,
+  type ResolveResult
+} from '../../../schemas/index.ts'
+import { ModelLoadFailedError } from '../../../errors/index.ts'
+import { hyperdriveUrlSchema } from '../../../schemas/load-model.ts'
+import { OCR_CRAFT, OCR_DOCTR_1 } from '../../../models/registry/index.ts'
+
+type OcrPipelineType = NonNullable<OCRConfig['pipelineType']>
+
+// Detector weights paired with each pipeline. EasyOCR runs CRAFT
+// detection, DocTR runs DBNet detection — the addon cannot load one
+// pipeline's detector into the other.
+export const DETECTOR_FILENAMES: Record<OcrPipelineType, string> = {
+  easyocr: 'craft_mlt_25k.gguf',
+  doctr: 'db_mobilenet_v3_large.gguf'
+}
+
+const DETECTOR_REGISTRY_SOURCES: Record<OcrPipelineType, string> = {
+  easyocr: OCR_CRAFT.src,
+  doctr: OCR_DOCTR_1.src
+}
+
+// The addon defaults to the EasyOCR pipeline, so a DocTR recognizer
+// loaded without an explicit `pipelineType` dies deep in the EasyOCR
+// CRNN weight loader with a raw missing-tensor error (QVAC-22514).
+// Recognize the known DocTR registry artifacts by name and opt in to
+// the DocTR pipeline automatically.
+function inferPipelineType(recognizerSrc: string): OcrPipelineType | undefined {
+  const path = srcPathname(recognizerSrc)
+  const filename = path.split('/').pop() ?? ''
+  if (filename === 'crnn_mobilenet_v3_small.gguf' || path.includes('/gguf/doctr')) {
+    return 'doctr'
+  }
+  return undefined
+}
+
+function srcPathname(src: string): string {
+  return (src.split(/[?#]/)[0] ?? '').toLowerCase()
+}
+
+function srcToString(src: ModelSrcInput): string {
+  return typeof src === 'string' ? src : src.src
+}
+
+// The registry still lists legacy `.onnx` OCR artifacts under the
+// "@qvac/ocr-onnx" engine; the ggml-ocr addon can only open GGUF, so a
+// raw "failed to open GGUF" surfaces mid-load. Fail fast with the
+// supported configurations instead (QVAC-22514).
+function assertGgufSource(src: string, role: 'recognizer' | 'detector'): void {
+  if (!srcPathname(src).endsWith('.onnx')) return
+  throw new ModelLoadFailedError(
+    `ggml-ocr only loads GGUF models, but the ${role} source points to an ONNX file: ${src}. ` +
+      'The .onnx OCR registry entries are legacy artifacts of the removed "onnx-ocr" engine. ' +
+      'Supported registry configurations: EasyOCR (default) — modelSrc: OCR_LATIN.src (detector OCR_CRAFT auto-derived); ' +
+      'DocTR — modelSrc: OCR_DOCTR.src (pipelineType and detector OCR_DOCTR_1 auto-derived).'
+  )
+}
+
+function deriveDetectorSource(modelSrc: string, pipelineType: OcrPipelineType): string | undefined {
+  if (modelSrc.startsWith('pear://')) {
+    const { key } = hyperdriveUrlSchema.parse(modelSrc)
+    return `pear://${key}/${DETECTOR_FILENAMES[pipelineType]}`
+  }
+  if (modelSrc.startsWith('registry://')) {
+    return DETECTOR_REGISTRY_SOURCES[pipelineType]
+  }
+  return undefined
+}
+
+export async function resolveOcrConfig(
+  cfg: OCRConfig,
+  ctx: ResolveContext
+): Promise<ResolveResult<Record<string, unknown>, 'detectorModelPath'>> {
+  const { detectorModelSrc, ...ocrConfig } = cfg
+
+  assertGgufSource(ctx.modelSrc, 'recognizer')
+
+  const pipelineType = ocrConfig.pipelineType ?? inferPipelineType(ctx.modelSrc) ?? 'easyocr'
+
+  const detectorSrc = detectorModelSrc ?? deriveDetectorSource(ctx.modelSrc, pipelineType)
+  if (!detectorSrc) {
+    throw new ModelLoadFailedError(
+      `Detector model required for OCR (${pipelineType} pipeline expects ` +
+        `${DETECTOR_FILENAMES[pipelineType]}). Use a hyperdrive or registry ` +
+        'source, or provide detectorModelSrc'
+    )
+  }
+
+  assertGgufSource(srcToString(detectorSrc), 'detector')
+
+  const detectorModelPath = await ctx.resolveModelPath(detectorSrc)
+  return {
+    config: { ...ocrConfig, pipelineType },
+    artifacts: { detectorModelPath }
+  }
+}

--- a/packages/inference/src/plugins/builtin/ggml-vla/plugin.ts
+++ b/packages/inference/src/plugins/builtin/ggml-vla/plugin.ts
@@ -40,7 +40,7 @@ function wrapVlaModel(inner: VlaModel, loadOpts: VlaLoadOptions): VlaModel & Vla
 
 export const vlaPlugin = definePlugin({
   modelType: ModelType.ggmlVla,
-  displayName: 'VLA (SmolVLA / π₀.₅ ggml)',
+  displayName: 'VLA (SmolVLA / π₀.₅ / GR00T ggml)',
   addonPackage: ADDON_VLA,
   loadConfigSchema: vlaConfigSchema,
 

--- a/packages/inference/src/plugins/builtin/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/inference/src/plugins/builtin/llamacpp-completion/ops/completion-stream.ts
@@ -13,7 +13,7 @@ import { TOOLS_MODE } from '../../../../schemas/tools.ts'
 import { logCacheDisabled, logCacheInit, logCacheSave, logMessagesToAddon } from './cache-logger.ts'
 import { extractSystemPrompt, getCurrentCacheInfo } from '../../../ops/kv-cache-utils.ts'
 import { getModel, getModelConfig, type AnyModel } from '../../../../runtime/model-registry.ts'
-import { decideCachedHistorySlice } from './kv-cache-state.ts'
+import { decideCachedHistorySlice, shouldCommitCachedTurn } from './kv-cache-state.ts'
 import {
   createKvCacheSession,
   generateConfigHash,
@@ -85,23 +85,6 @@ export type CompletionGenerationParams = GenerationParams & {
 
 type CompletionRunOptions = Pick<RunOptions, 'cacheKey' | 'saveCacheToDisk' | 'prefill'> & {
   generationParams?: CompletionGenerationParams
-}
-
-/**
- * Decide whether a completed turn earned the right to record its kv-cache
- * boundary. A `savedCount` is only safe to write when the turn ran to
- * completion AND produced at least one token — anything else (cancelled
- * mid-decode, zero-token reply, early EOS) leaves the on-disk cache file
- * in an unknown state relative to `history.length + 1`, and a stale entry
- * would slice the next turn's history down to an empty payload.
- *
- * Replaces the pre-0.11.0 `shouldRecordSavedCount(wasCancelled, ...)` with
- * a signal-driven check that reads directly from the request's
- * `AbortSignal`. The local helper keeps the call sites in
- * `completion-stream.ts` honest without importing the registry every time.
- */
-function shouldCommitTurn(signal: AbortSignal, producedTokens: boolean): boolean {
-  return !signal.aborted && producedTokens
 }
 
 function transformMessage(
@@ -556,12 +539,18 @@ export async function* completion(
     { cacheKey: turn.cachePath, saveCacheToDisk: true },
     dialect
   )
+  const shouldCommitTurn = shouldCommitCachedTurn({
+    aborted: signal.aborted,
+    producedTokens: result.producedTokens,
+    generatedTokens: result.stats?.generatedTokens,
+    predict: mergedGenerationParams?.predict ?? (modelConfig as { predict?: number }).predict
+  })
 
   if (typeof kvCache === 'string') {
     // Custom-key path: the addon wrote the new cache state inline at
     // the same path. Either commit (records the boundary, suppresses
     // rollback) or fall through to the deferred rollback.
-    if (shouldCommitTurn(signal, result.producedTokens)) {
+    if (shouldCommitTurn) {
       await session.commitTurn(turn, {
         kind: 'static',
         messageCount: history.length + 1
@@ -585,10 +574,9 @@ export async function* completion(
     return result
   }
 
-  if (!shouldCommitTurn(signal, result.producedTokens)) {
-    // Cancelled or zero-token turn — the addon wrote the file but its
-    // contents don't correspond to a clean turn boundary. Let the
-    // deferred rollback unlink it.
+  if (!shouldCommitTurn) {
+    // Cancelled, zero-token, or budget-exhausted turns do not establish
+    // a trustworthy message boundary.
     return result
   }
 

--- a/packages/inference/src/plugins/builtin/llamacpp-completion/ops/kv-cache-state.ts
+++ b/packages/inference/src/plugins/builtin/llamacpp-completion/ops/kv-cache-state.ts
@@ -33,6 +33,24 @@ export interface HistorySliceDecision {
   clearStaleCount: boolean
 }
 
+interface CacheCommitContext {
+  aborted: boolean
+  producedTokens: boolean
+  generatedTokens?: number | undefined
+  predict?: number | undefined
+}
+
+export function shouldCommitCachedTurn(context: CacheCommitContext): boolean {
+  const { aborted, producedTokens, generatedTokens, predict } = context
+  const stoppedByBudget =
+    predict !== undefined &&
+    predict > 0 &&
+    generatedTokens !== undefined &&
+    generatedTokens >= predict
+
+  return !aborted && producedTokens && !stoppedByBudget
+}
+
 /**
  * Pure slice decision for `prepareMessagesForCache`.
  *

--- a/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech-stream.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech-stream.ts
@@ -20,7 +20,12 @@ type RunStreamingModel = {
     options?: Record<string, unknown>
   ) => Promise<{
     iterate: () => AsyncIterable<TtsStreamChunk>
-    stats?: { audioDurationMs?: number; totalSamples?: number }
+    stats?: {
+      audioDurationMs?: number
+      totalSamples?: number
+      enhancerBackendDevice?: number
+      enhancerBackendId?: number
+    }
   }>
 }
 

--- a/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech.ts
@@ -16,7 +16,12 @@ type RunStreamModel = {
     options?: { locale?: string; maxChunkScalars?: number }
   ) => Promise<{
     iterate: () => AsyncIterable<TtsStreamChunk>
-    stats?: { audioDurationMs?: number; totalSamples?: number }
+    stats?: {
+      audioDurationMs?: number
+      totalSamples?: number
+      enhancerBackendDevice?: number
+      enhancerBackendId?: number
+    }
   }>
 }
 
@@ -109,14 +114,7 @@ export async function* textToSpeech(
     }
 
     const modelExecutionMs = nowMs() - modelStart
-    const stats: TtsStats = {
-      ...(response.stats?.audioDurationMs !== undefined && {
-        audioDuration: response.stats.audioDurationMs
-      }),
-      ...(response.stats?.totalSamples !== undefined && {
-        totalSamples: response.stats.totalSamples
-      })
-    }
+    const stats = collectTtsStats(response)
 
     yield { buffer: completeBuffer }
     return buildStreamResult(modelExecutionMs, hasDefinedValues(stats) ? stats : undefined)
@@ -127,14 +125,7 @@ export async function* textToSpeech(
   }
 
   const modelExecutionMs = nowMs() - modelStart
-  const stats: TtsStats = {
-    ...(response.stats?.audioDurationMs !== undefined && {
-      audioDuration: response.stats.audioDurationMs
-    }),
-    ...(response.stats?.totalSamples !== undefined && {
-      totalSamples: response.stats.totalSamples
-    })
-  }
+  const stats = collectTtsStats(response)
 
   return buildStreamResult(modelExecutionMs, hasDefinedValues(stats) ? stats : undefined)
 }

--- a/packages/inference/src/plugins/builtin/tts-ggml/plugin.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/plugin.ts
@@ -167,6 +167,7 @@ function createChatterboxModel(
       ? { streamFirstChunkTokens: config.streamFirstChunkTokens }
       : {}),
     ...(config.cfmSteps !== undefined ? { cfmSteps: config.cfmSteps } : {}),
+    ...(config.cfgRate !== undefined ? { cfgRate: config.cfgRate } : {}),
     ...(config.threads !== undefined ? { threads: config.threads } : {}),
     ...(config.nGpuLayers !== undefined ? { nGpuLayers: config.nGpuLayers } : {}),
     ...(config.seed !== undefined ? { seed: config.seed } : {}),
@@ -209,7 +210,8 @@ function createSupertonicModel(
       useGPU: config.useGPU ?? false,
       ...(config.outputSampleRate !== undefined
         ? { outputSampleRate: config.outputSampleRate }
-        : {})
+        : {}),
+      ...(config.vulkanCacheDir !== undefined ? { vulkanCacheDir: config.vulkanCacheDir } : {})
     },
     logger,
     opts: { stats: true },

--- a/packages/inference/src/plugins/ops/translate.ts
+++ b/packages/inference/src/plugins/ops/translate.ts
@@ -9,14 +9,15 @@ import {
 } from '../../schemas/index.ts'
 import type TranslationNmtcpp from '@qvac/translation-nmtcpp'
 import type { GenerationParams, RunOptions } from '@qvac/llm-llamacpp'
-import { getLangName } from '@qvac/langdetect-text'
+import { getLangName, detectOne } from '@qvac/langdetect-text'
 import { nowMs } from '../../profiling/index.ts'
 import { buildStreamResult } from '../../profiling/model-execution.ts'
 import type { NmtResponse, LlmResponse } from '../../utils/addon-responses.ts'
 import {
   ModelIsDelegatedError,
   ModelNotFoundError,
-  ModelTypeMismatchError
+  ModelTypeMismatchError,
+  TranslationFailedError
 } from '../../errors/index.ts'
 import { getRequestRegistry, withRequestContext } from '../../runtime/index.ts'
 import { generateRandomRequestId } from '../../runtime/request-id.ts'
@@ -84,11 +85,29 @@ export async function* translate(
   }
 
   const isLlm = canonicalModelType === ModelType.llamacppCompletion
-  const from = isLlm ? (params as { from?: string }).from : undefined
+  let from = isLlm ? (params as { from?: string }).from : undefined
   const to = isLlm ? (params as { to: string }).to : undefined
   const context = isLlm ? (params as { context?: string }).context : undefined
-  const afriquePrompt = isLlm && (isAfrican(from) || isAfrican(to))
+
   translateServerParamsSchema.parse(params)
+
+  // Auto-detect the source language when the caller didn't pass `from` (LLM
+  // only). This used to run in each client; moving it here gives every
+  // language binding one detector instead of each shipping its own (lingua in
+  // Python vs langdetect-text in JS drifted on the same input). Store the
+  // detected code — not the language name — so the explicit-`from` and
+  // detected paths feed getLanguage() identically.
+  if (isLlm && !from) {
+    const detected = detectOne(text as string)
+    if (detected.code === 'und' || detected.language === 'Undetermined') {
+      throw new TranslationFailedError(
+        "Could not detect the source language. Please specify the 'from' parameter explicitly."
+      )
+    }
+    from = detected.code
+  }
+
+  const afriquePrompt = isLlm && (isAfrican(from) || isAfrican(to))
 
   const fromLanguage = getLanguage(from)
   const toLanguage = getLanguage(to)

--- a/packages/inference/src/registry.ts
+++ b/packages/inference/src/registry.ts
@@ -18,6 +18,7 @@ import { handleGetLoadedModelInfo } from './handlers/get-loaded-model-info.ts'
 import { handleHeartbeat } from './handlers/heartbeat.ts'
 import { handleHeartbeatDelegated } from './p2p/heartbeat-delegated.ts'
 import { handleFinetune } from './handlers/finetune.ts'
+import { handleCompletionOrchestrate } from './handlers/completion-orchestrate.ts'
 import { handleCancelDelegated } from './p2p/cancel-delegated.ts'
 import { handlePluginInvoke, handlePluginInvokeStream } from './handlers/plugin-invoke.ts'
 import {
@@ -143,6 +144,12 @@ export const registry: Record<string, HandlerEntry> = {
     delegatedHandler: handleCompletionStreamDelegated,
     isDelegated: isModelDelegated
   },
+
+  // Deliberately no delegated handler: tool callbacks execute code on the
+  // client machine, so only the user's own local worker may orchestrate
+  // (see completionOrchestrateResponseSchema's contract note).
+  completionOrchestrate: { type: 'duplex', handler: handleCompletionOrchestrate },
+
   batchCompletionStream: {
     type: 'stream',
     pluginOp: true,

--- a/packages/inference/src/schemas/common.ts
+++ b/packages/inference/src/schemas/common.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import { perCallProfilingSchema } from './profiling.ts'
 import { heartbeatRequestSchema, heartbeatResponseSchema } from './delegate.ts'
 import {
+  completionOrchestrateRequestSchema,
+  completionOrchestrateResponseSchema,
   completionStreamRequestSchema,
   completionStreamResponseSchema
 } from './completion-stream.ts'
@@ -100,6 +102,7 @@ export const requestSchema = z.union([
   loadModelRequestSchema,
   downloadAssetRequestSchema,
   completionStreamRequestSchema,
+  completionOrchestrateRequestSchema,
   batchCompletionStreamRequestSchema,
   unloadModelRequestSchema,
   transcribeRequestSchema,
@@ -139,6 +142,7 @@ export const responseSchema = z.discriminatedUnion('type', [
   loadModelResponseSchema,
   downloadAssetResponseSchema,
   completionStreamResponseSchema,
+  completionOrchestrateResponseSchema,
   batchCompletionStreamResponseSchema,
   unloadModelResponseSchema,
   modelProgressUpdateSchema,

--- a/packages/inference/src/schemas/completion-stream.ts
+++ b/packages/inference/src/schemas/completion-stream.ts
@@ -217,6 +217,81 @@ export const completionStreamResponseSchema = z
   })
   .strict()
 
+// ============================================
+// Worker-orchestrated completion (duplex)
+// ============================================
+
+export const completionOrchestrateRequestSchema = completionClientParamsBaseSchema
+  .extend({
+    type: z.literal('completionOrchestrate'),
+    maxToolTurns: z
+      .number()
+      .int()
+      .min(1)
+      .max(32)
+      .optional()
+      .describe(
+        'Upper bound on generation turns the worker will run before ending the ' +
+          'loop with `stopReason: "maxToolTurns"`. Each turn is one completion ' +
+          'pass; a turn that requests tool calls consumes callbacks and starts ' +
+          'the next turn. Defaults to 8.'
+      )
+  })
+  .superRefine(refineNoToolsWithStructuredOutput)
+
+/**
+ * Downstream frame of the orchestrated completion duplex stream. Exactly one
+ * payload field is set per frame:
+ *
+ * - `events` — pass-through of the inner completion turn's events (with
+ *   `turn` identifying which generation pass they belong to).
+ * - `toolCallback` — the worker is asking the CLIENT to run a tool. The
+ *   client executes its registered handler and writes a JSON line
+ *   (`toolCallbackResultSchema`) up the request stream. The worker blocks
+ *   this run (not the socket) until the matching `callId` arrives.
+ * - `done` — terminal frame; the loop ended (final answer produced, error,
+ *   cancellation, or the `maxToolTurns` cap).
+ *
+ * Only a LOCAL worker may emit `toolCallback`: tool handlers execute code on
+ * the client machine, so a remote delegate streaming through this shape must
+ * never trigger them.
+ */
+export const completionOrchestrateResponseSchema = z
+  .object({
+    type: z.literal('completionOrchestrate'),
+    turn: z.number().int().nonnegative().optional(),
+    events: z.array(completionEventSchema).optional(),
+    toolCallback: z
+      .object({
+        callId: z.string().describe('Correlates the upstream result line to this request.'),
+        name: z.string(),
+        arguments: z.record(z.string(), z.unknown())
+      })
+      .optional(),
+    done: z.boolean().optional(),
+    stopReason: z
+      .literal('maxToolTurns')
+      .optional()
+      .describe(
+        'Set on the terminal `done` frame only when the loop stopped because it ' +
+          'hit `maxToolTurns` (the model still wanted a tool). Absent on a natural ' +
+          'finish, so the caller can tell a truncated run from a completed one.'
+      )
+  })
+  .strict()
+
+/**
+ * Upstream JSON line the client writes after running a tool callback.
+ * Newline-delimited on the duplex request stream, after the initial request
+ * payload. `error` reports a handler failure; the worker forwards it to the
+ * model as the tool result so the loop can recover or finish.
+ */
+export const toolCallbackResultSchema = z.object({
+  callId: z.string(),
+  result: z.unknown().optional(),
+  error: z.string().optional()
+})
+
 export type GenerationParams = z.infer<typeof generationParamsSchema>
 export type CompletionParams = z.infer<typeof completionParamsSchema>
 export type ToolDialect = z.infer<typeof toolDialectSchema>
@@ -224,4 +299,7 @@ export type ResponseFormat = z.infer<typeof responseFormatSchema>
 export type CompletionClientParams = z.input<typeof completionClientParamsSchema>
 export type CompletionStreamRequest = z.infer<typeof completionStreamRequestSchema>
 export type CompletionStreamResponse = z.infer<typeof completionStreamResponseSchema>
+export type CompletionOrchestrateRequest = z.infer<typeof completionOrchestrateRequestSchema>
+export type CompletionOrchestrateResponse = z.infer<typeof completionOrchestrateResponseSchema>
+export type ToolCallbackResult = z.infer<typeof toolCallbackResultSchema>
 export type Attachment = z.infer<typeof attachmentSchema>

--- a/packages/inference/src/schemas/engine-addon-map.ts
+++ b/packages/inference/src/schemas/engine-addon-map.ts
@@ -38,7 +38,7 @@ export const ENGINE_TO_ADDON = {
 
 // Legacy engine names → canonical engine.
 // Used for backward compatibility with old registry data that uses @qvac/* package names.
-const LEGACY_ENGINE_TO_CANONICAL: Record<string, ModelRegistryEngine> = {
+export const LEGACY_ENGINE_TO_CANONICAL: Record<string, ModelRegistryEngine> = {
   [ADDON_LLM]: ModelType.llamacppCompletion,
   [ADDON_WHISPER]: ModelType.whispercppTranscription,
   [ADDON_BCI]: ModelType.bciWhispercppTranscription,

--- a/packages/inference/src/schemas/errors.ts
+++ b/packages/inference/src/schemas/errors.ts
@@ -620,7 +620,9 @@ const errorDefinitions: ErrorCodesMap = {
   [ERROR_CODES.PLUGIN_NOT_FOUND]: {
     name: 'PLUGIN_NOT_FOUND',
     message: (modelType: string) =>
-      `Plugin not found for model type "${modelType}". Register the plugin in code with \`registerPlugin\` / \`plugins([...])\` before this call.`
+      modelType === 'onnx-ocr'
+        ? 'Plugin not found for model type "onnx-ocr": the ONNX OCR engine has been removed. Use modelType "ggml-ocr" with GGUF registry models instead (EasyOCR: OCR_LATIN; DocTR: OCR_DOCTR).'
+        : `Plugin not found for model type "${modelType}". Register the plugin in code with \`registerPlugin\` / \`plugins([...])\` before this call.`
   },
   [ERROR_CODES.PLUGIN_HANDLER_NOT_FOUND]: {
     name: 'PLUGIN_HANDLER_NOT_FOUND',

--- a/packages/inference/src/schemas/plugin.ts
+++ b/packages/inference/src/schemas/plugin.ts
@@ -366,10 +366,10 @@ export const PLUGIN_OCR = '@qvac/inference/ggml-ocr/plugin' as const
 export const PLUGIN_DIFFUSION = '@qvac/inference/sdcpp-generation/plugin' as const
 
 /**
- * Vision-Language-Action plugin (ggml). Supports SmolVLA and π₀.₅ (pi05),
- * dispatched on the GGUF `general.architecture` key.
+ * Vision-Language-Action plugin (ggml). Supports SmolVLA, π₀.₅ (pi05), and
+ * GR00T, dispatched on the GGUF `general.architecture` key.
  * Provides: robot-action inference from one or more camera frames (2 for
- * SmolVLA, 3 for π₀.₅) and a natural-language instruction.
+ * SmolVLA and GR00T, 3 for π₀.₅) and a natural-language instruction.
  */
 export const PLUGIN_VLA = '@qvac/inference/ggml-vla/plugin' as const
 
@@ -434,7 +434,7 @@ export const ADDON_OCR = '@qvac/ocr-ggml' as const
 /** Native addon package for image generation (stable-diffusion.cpp) */
 export const ADDON_DIFFUSION = '@qvac/diffusion-cpp' as const
 
-/** Native addon package for vision-language-action inference (SmolVLA / π₀.₅ on ggml) */
+/** Native addon package for vision-language-action inference (SmolVLA / π₀.₅ / GR00T on ggml) */
 export const ADDON_VLA = '@qvac/vla-ggml' as const
 
 /** Native addon package for image classification (GGML / MobileNetV3) */

--- a/packages/inference/src/schemas/text-to-speech.ts
+++ b/packages/inference/src/schemas/text-to-speech.ts
@@ -113,6 +113,7 @@ export const ttsChatterboxRuntimeConfigSchema = z.object({
   streamChunkTokens: ttsNonNegativeIntegerSchema.optional(),
   streamFirstChunkTokens: ttsNonNegativeIntegerSchema.optional(),
   cfmSteps: ttsNonNegativeIntegerSchema.optional(),
+  cfgRate: z.number().nonnegative().optional(),
   threads: ttsPositiveIntegerSchema.optional(),
   nGpuLayers: ttsIntegerSchema.optional(),
   seed: ttsIntegerSchema.optional()
@@ -125,7 +126,8 @@ export const ttsSupertonicRuntimeConfigSchema = z.object({
   ttsSpeed: z.number().optional(),
   ttsNumInferenceSteps: z.number().optional(),
   useGPU: z.boolean().optional(),
-  outputSampleRate: ttsOutputSampleRateSchema.optional()
+  outputSampleRate: ttsOutputSampleRateSchema.optional(),
+  vulkanCacheDir: z.string().min(1).optional()
 })
 
 export const ttsRuntimeConfigSchema = z.discriminatedUnion('ttsEngine', [
@@ -247,7 +249,9 @@ export const ttsRequestSchema = ttsClientParamsSchema.extend({
 
 export const ttsStatsSchema = z.object({
   audioDuration: z.number().optional(),
-  totalSamples: z.number().optional()
+  totalSamples: z.number().optional(),
+  enhancerBackendDevice: z.number().optional(),
+  enhancerBackendId: z.number().optional()
 })
 
 export const ttsResponseSchema = z.object({

--- a/packages/inference/src/schemas/translate.ts
+++ b/packages/inference/src/schemas/translate.ts
@@ -107,12 +107,14 @@ export const translateServerParamsSchema = translateParamsSchema
   .refine(
     (data) => {
       if (!llmModelTypes.includes(data.modelType)) return true
-      // For LLM, check from/to exist
-      const llmData = data as { from?: string; to?: string }
-      return llmData.from && llmData.to
+      // For LLM, `to` is required; `from` is resolved by the worker
+      // (explicit, else auto-detected in plugins/ops/translate.ts), so an
+      // absent `from` is valid here — it no longer has to arrive on the wire.
+      const llmData = data as { to?: string }
+      return !!llmData.to
     },
     {
-      message: "Both 'from' and 'to' languages are required for LLM translation models"
+      message: "A 'to' language is required for LLM translation models"
     }
   )
   .transform((data) => ({

--- a/packages/inference/src/schemas/vla.ts
+++ b/packages/inference/src/schemas/vla.ts
@@ -41,18 +41,39 @@ export const vlaHparamsSchema = z.object({
     .positive()
     .optional()
     .describe(
-      'Number of camera views the model expects (2 for SmolVLA, 3 for π₀.₅). ' +
-        'Pass exactly this many preprocessed frames in `images`. Optional for ' +
-        'back-compat — older addon builds may omit it.'
+      'Number of camera views the model expects (2 for SmolVLA and GR00T, 3 ' +
+        'for π₀.₅). Pass exactly this many preprocessed frames in `images`. ' +
+        'Optional for back-compat — older addon builds may omit it.'
     ),
   stateInputMode: z
     .enum(['continuous', 'discrete'])
     .optional()
     .describe(
-      "How the robot state is consumed. `'continuous'` (SmolVLA): the `state` " +
-        "Float32Array is projected by an in-model linear layer. `'discrete'` " +
-        '(π₀.₅): the state is tokenised into the language prompt and the `state` ' +
-        'buffer is ignored — pass an empty `Float32Array(0)`. Optional for back-compat.'
+      "How the robot state is consumed. `'continuous'` (SmolVLA, GR00T): the " +
+        '`state` Float32Array is projected by an in-model linear layer. ' +
+        "`'discrete'` (π₀.₅): the state is tokenised into the language prompt " +
+        'and the `state` buffer is ignored — pass an empty `Float32Array(0)`. ' +
+        'Optional for back-compat.'
+    ),
+  imageInputMode: z
+    .enum(['pixels', 'patches'])
+    .optional()
+    .describe(
+      "How images are supplied. `'pixels'` (SmolVLA, π₀.₅): each `images` " +
+        'entry is a `3 · imgWidth · imgHeight` CHW plane from ' +
+        "`vlaPreprocessImage`. `'patches'` (GR00T): each entry is a " +
+        'pre-patchified buffer of length `imagePatchElems`. Optional for ' +
+        'back-compat.'
+    ),
+  imagePatchElems: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      "For patch-input models (`imageInputMode === 'patches'`), the exact " +
+        'per-camera patch buffer length each `images` entry must have. Absent ' +
+        'for pixel-input models.'
     )
 })
 
@@ -97,9 +118,12 @@ export const vlaRunRequestSchema = z.object({
     .array(z.string().min(1).regex(BASE64_PATTERN))
     .min(1)
     .describe(
-      'Base64-encoded preprocessed images. Each entry is the underlying ' +
-        'ArrayBuffer of a `Float32Array` produced by `vlaPreprocessImage(...)`. ' +
-        'Length per image must equal `3 * imgWidth * imgHeight`.'
+      'Base64-encoded preprocessed images, one per camera. Each entry is the ' +
+        'underlying ArrayBuffer of a `Float32Array`. For pixel-input models ' +
+        '(SmolVLA, π₀.₅) it comes from `vlaPreprocessImage(...)` and its length ' +
+        'must equal `3 * imgWidth * imgHeight`. For patch-input models (GR00T, ' +
+        "`hparams.imageInputMode === 'patches'`) it is a pre-patchified buffer " +
+        'of length `hparams.imagePatchElems`.'
     ),
   imgWidth: z.number().int().positive(),
   imgHeight: z.number().int().positive(),
@@ -107,7 +131,7 @@ export const vlaRunRequestSchema = z.object({
     .string()
     .regex(BASE64_PATTERN)
     .describe(
-      'Base64-encoded `Float32Array`. For continuous-state models (SmolVLA) ' +
+      'Base64-encoded `Float32Array`. For continuous-state models (SmolVLA, GR00T) ' +
         'this is length `hparams.maxStateDim` — use ' +
         '`vlaPadState(state, hparams.maxStateDim)` to zero-pad. For ' +
         "discrete-state models (π₀.₅, `stateInputMode: 'discrete'`) the state " +

--- a/packages/inference/src/surface.ts
+++ b/packages/inference/src/surface.ts
@@ -154,7 +154,9 @@ export * from './models/registry/index.ts'
 
 export { SUPPORTED_AUDIO_FORMATS } from './constants/audio.ts'
 
-// Error classes consumers need for `instanceof` checks on rejected promises.
+// Error classes consumers need for `instanceof` checks: on rejected promises,
+// and on the synchronous throws of `plugins()` / `registerPlugin` (the plugin
+// group below).
 export {
   InferenceCancelledError,
   ContextOverflowError,
@@ -163,7 +165,11 @@ export {
   RequestRejectedByPolicyError,
   RequestValidationFailedError,
   ModelNotLoadedError,
-  TranslationFailedError
+  TranslationFailedError,
+  PluginDefinitionInvalidError,
+  PluginModelTypeReservedError,
+  PluginAlreadyRegisteredError,
+  PluginLoggingInvalidError
 } from './errors/index.ts'
 export type { InferenceCancelledPartial } from './errors/index.ts'
 

--- a/packages/inference/src/surface.ts
+++ b/packages/inference/src/surface.ts
@@ -157,7 +157,8 @@ export {
   RequestNotFoundError,
   RequestRejectedByPolicyError,
   RequestValidationFailedError,
-  ModelNotLoadedError
+  ModelNotLoadedError,
+  TranslationFailedError
 } from './errors/index.ts'
 export type { InferenceCancelledPartial } from './errors/index.ts'
 

--- a/packages/inference/src/surface.ts
+++ b/packages/inference/src/surface.ts
@@ -134,7 +134,12 @@ export * from './constants/index.ts'
 
 // Value-clean helpers @qvac/sdk's registry codegen and server-side profiler reach
 // for; not part of either barrel, so re-exported explicitly here.
-export { getAddonFromEngine, resolveCanonicalEngine } from './schemas/engine-addon-map.ts'
+export {
+  getAddonFromEngine,
+  resolveCanonicalEngine,
+  ENGINE_TO_ADDON,
+  LEGACY_ENGINE_TO_CANONICAL
+} from './schemas/engine-addon-map.ts'
 export { generateProfileId } from './profiling/clock.ts'
 export { readModelExecutionMs } from './profiling/model-execution.ts'
 export {

--- a/packages/inference/src/utils/addon-responses.ts
+++ b/packages/inference/src/utils/addon-responses.ts
@@ -30,6 +30,8 @@ export interface NmtResponse {
 export interface TtsStats {
   audioDurationMs?: number
   totalSamples?: number
+  enhancerBackendDevice?: number
+  enhancerBackendId?: number
 }
 
 export interface TtsResponse {

--- a/packages/inference/src/utils/cache/auto-history.ts
+++ b/packages/inference/src/utils/cache/auto-history.ts
@@ -1,11 +1,15 @@
 import { normalizeAssistantCacheContent } from '../cache-normalize.ts'
 import type { CacheMessage } from './types.ts'
 
-function normalizeAssistantMessage(message: CacheMessage): CacheMessage {
-  if (message.role !== 'assistant') {
-    return message
+function normalizeCacheMessage(message: CacheMessage): CacheMessage {
+  const { attachments, ...normalized } = message
+  if (message.role === 'assistant') {
+    normalized.content = normalizeAssistantCacheContent(message.content)
   }
-  return { ...message, content: normalizeAssistantCacheContent(message.content) }
+  return {
+    ...normalized,
+    ...(attachments && attachments.length > 0 ? { attachments } : {})
+  }
 }
 
 export function getAutoCacheLookupHistory(currentHistory: CacheMessage[]): CacheMessage[] {
@@ -13,7 +17,7 @@ export function getAutoCacheLookupHistory(currentHistory: CacheMessage[]): Cache
     return []
   }
 
-  return currentHistory.slice(0, -1).map(normalizeAssistantMessage)
+  return currentHistory.slice(0, -1).map(normalizeCacheMessage)
 }
 
 export function buildAutoCacheSaveHistory(
@@ -21,10 +25,10 @@ export function buildAutoCacheSaveHistory(
   assistantResponse: string
 ): CacheMessage[] {
   return [
-    ...currentHistory,
-    {
+    ...currentHistory.map(normalizeCacheMessage),
+    normalizeCacheMessage({
       role: 'assistant',
-      content: normalizeAssistantCacheContent(assistantResponse)
-    }
+      content: assistantResponse
+    })
   ]
 }

--- a/packages/inference/src/utils/tts-stats.ts
+++ b/packages/inference/src/utils/tts-stats.ts
@@ -17,15 +17,26 @@ export type TtsOpYield = {
   sentenceChunk?: string
 }
 
-export function collectTtsStats(response: {
-  stats?: { audioDurationMs?: number; totalSamples?: number }
-}): TtsStats {
+type AddonTtsStats = {
+  audioDurationMs?: number
+  totalSamples?: number
+  enhancerBackendDevice?: number
+  enhancerBackendId?: number
+}
+
+export function collectTtsStats(response: { stats?: AddonTtsStats }): TtsStats {
   return {
     ...(response.stats?.audioDurationMs !== undefined && {
       audioDuration: response.stats.audioDurationMs
     }),
     ...(response.stats?.totalSamples !== undefined && {
       totalSamples: response.stats.totalSamples
+    }),
+    ...(response.stats?.enhancerBackendDevice !== undefined && {
+      enhancerBackendDevice: response.stats.enhancerBackendDevice
+    }),
+    ...(response.stats?.enhancerBackendId !== undefined && {
+      enhancerBackendId: response.stats.enhancerBackendId
     })
   }
 }

--- a/packages/inference/test/auto-history.test.ts
+++ b/packages/inference/test/auto-history.test.ts
@@ -18,6 +18,31 @@ test('auto kv-cache history: next-turn lookup matches prior saved turn', (t) => 
   t.alike(getAutoCacheLookupHistory(nextTurnHistory), savedHistory)
 })
 
+test('auto kv-cache history: empty attachment arrays do not change the cache key', (t) => {
+  const firstTurnHistory = [
+    { role: 'user', content: 'What is the capital of France?', attachments: [] }
+  ]
+  const savedHistory = buildAutoCacheSaveHistory(firstTurnHistory, 'Paris.')
+  const nextTurnHistory = [
+    { role: 'user', content: 'What is the capital of France?', attachments: [] },
+    { role: 'assistant', content: 'Paris.', attachments: [] },
+    { role: 'user', content: 'What about Germany?', attachments: [] }
+  ]
+
+  t.is(JSON.stringify(getAutoCacheLookupHistory(nextTurnHistory)), JSON.stringify(savedHistory))
+  t.is(savedHistory[0]!.attachments, undefined)
+})
+
+test('auto kv-cache history: non-empty attachments remain part of the cache key', (t) => {
+  const attachment = { path: '/tmp/reference.png' }
+  const savedHistory = buildAutoCacheSaveHistory(
+    [{ role: 'user', content: 'Describe this image.', attachments: [attachment] }],
+    'A landscape.'
+  )
+
+  t.alike(savedHistory[0]!.attachments, [attachment])
+})
+
 test('auto kv-cache history: no lookup target for first turn', (t) => {
   t.alike(
     getAutoCacheLookupHistory([{ role: 'user', content: 'What is the capital of France?' }]),

--- a/packages/inference/test/completion-orchestrate.test.ts
+++ b/packages/inference/test/completion-orchestrate.test.ts
@@ -1,0 +1,226 @@
+import test from 'brittle'
+import { orchestrateCompletion, ToolResultReader } from '../src/handlers/completion-orchestrate.ts'
+import type {
+  CompletionOrchestrateRequest,
+  CompletionOrchestrateResponse,
+  CompletionStreamRequest,
+  CompletionStreamResponse
+} from '../src/schemas/index.ts'
+
+function baseRequest(overrides: Partial<CompletionOrchestrateRequest> = {}) {
+  return {
+    type: 'completionOrchestrate',
+    modelId: 'm-1',
+    history: [{ role: 'user', content: 'weather in Tokyo?' }],
+    stream: true,
+    ...overrides
+  } as CompletionOrchestrateRequest
+}
+
+function doneChunk(events: CompletionStreamResponse['events']): CompletionStreamResponse {
+  return { type: 'completionStream', events, done: true }
+}
+
+function contentTurn(text: string): CompletionStreamResponse {
+  return doneChunk([
+    { type: 'contentDelta', seq: 0, text },
+    { type: 'completionDone', seq: 1, stopReason: 'eos', raw: { fullText: text } }
+  ])
+}
+
+function toolTurn(callId: string, name: string, args: Record<string, unknown>) {
+  return doneChunk([
+    { type: 'toolCall', seq: 0, call: { id: callId, name, arguments: args } },
+    { type: 'completionDone', seq: 1, stopReason: 'eos', raw: { fullText: `<call ${name}>` } }
+  ])
+}
+
+/** In-memory reader: results are pre-seeded per callId. */
+function stubReader(results: Record<string, unknown>) {
+  return {
+    async waitFor(callId: string) {
+      if (!(callId in results)) throw new Error(`unexpected callback ${callId}`)
+      return { callId, result: results[callId] }
+    }
+  }
+}
+
+async function collect(
+  generator: AsyncGenerator<CompletionOrchestrateResponse>
+): Promise<CompletionOrchestrateResponse[]> {
+  const frames: CompletionOrchestrateResponse[] = []
+  for await (const frame of generator) frames.push(frame)
+  return frames
+}
+
+test('orchestrateCompletion: tool-free turn forwards events and ends', async (t) => {
+  const seenHistories: CompletionStreamRequest['history'][] = []
+  async function* runTurn(request: CompletionStreamRequest) {
+    seenHistories.push(request.history)
+    yield contentTurn('Sunny, 22C.')
+  }
+
+  const frames = await collect(orchestrateCompletion(baseRequest(), runTurn, stubReader({})))
+
+  t.is(seenHistories.length, 1, 'exactly one generation turn')
+  t.is(frames.at(-1)?.done, true, 'terminal done frame')
+  const events = frames.flatMap((frame) => frame.events ?? [])
+  t.ok(
+    events.some((event) => event.type === 'contentDelta' && event.text === 'Sunny, 22C.'),
+    'inner events pass through'
+  )
+})
+
+test('orchestrateCompletion: runs the tool loop and threads results into history', async (t) => {
+  let turn = 0
+  const seenHistories: CompletionStreamRequest['history'][] = []
+  async function* runTurn(request: CompletionStreamRequest) {
+    seenHistories.push(request.history)
+    turn++
+    yield turn === 1 ? toolTurn('call-1', 'get_weather', { city: 'Tokyo' }) : contentTurn('22C.')
+  }
+
+  const frames = await collect(
+    orchestrateCompletion(baseRequest(), runTurn, stubReader({ 'call-1': { temp: 22 } }))
+  )
+
+  t.is(turn, 2, 'a second generation turn ran after the tool result')
+  const callback = frames.find((frame) => frame.toolCallback)
+  t.is(callback?.toolCallback?.callId, 'call-1')
+  t.is(callback?.toolCallback?.name, 'get_weather')
+
+  const secondHistory = seenHistories[1]!
+  t.is(secondHistory.length, 3, 'user + assistant tool turn + tool result')
+  t.is(secondHistory[1]?.role, 'assistant')
+  t.is(secondHistory[1]?.content, '<call get_weather>', 'assistant turn keeps raw call syntax')
+  t.is(secondHistory[2]?.role, 'tool')
+  t.is(secondHistory[2]?.content, JSON.stringify({ temp: 22 }))
+  t.is(frames.at(-1)?.done, true)
+})
+
+test('orchestrateCompletion: handler error is forwarded as the tool result', async (t) => {
+  let turn = 0
+  const seenHistories: CompletionStreamRequest['history'][] = []
+  async function* runTurn(request: CompletionStreamRequest) {
+    seenHistories.push(request.history)
+    turn++
+    yield turn === 1 ? toolTurn('call-1', 'boom', {}) : contentTurn('recovered')
+  }
+  const reader = {
+    async waitFor(callId: string) {
+      return { callId, error: 'tool exploded' }
+    }
+  }
+
+  await collect(orchestrateCompletion(baseRequest(), runTurn, reader))
+
+  t.is(seenHistories[1]?.[2]?.content, JSON.stringify({ error: 'tool exploded' }))
+})
+
+test('orchestrateCompletion: maxToolTurns caps a tool-calling loop', async (t) => {
+  let turn = 0
+  async function* runTurn() {
+    turn++
+    yield toolTurn(`call-${turn}`, 'always_more', {})
+  }
+  const reader = {
+    async waitFor(callId: string) {
+      return { callId, result: 'again' }
+    }
+  }
+
+  const frames = await collect(
+    orchestrateCompletion(baseRequest({ maxToolTurns: 3 }), runTurn, reader)
+  )
+
+  t.is(turn, 3, 'stops at the cap')
+  t.is(frames.at(-1)?.done, true, 'still ends with a terminal frame')
+  t.is(
+    frames.at(-1)?.stopReason,
+    'maxToolTurns',
+    'truncation frame is marked so the client can tell it from a natural finish'
+  )
+})
+
+test('orchestrateCompletion: threads the orchestrate requestId into each turn', async (t) => {
+  const seenIds: (string | undefined)[] = []
+  let turn = 0
+  async function* runTurn(request: CompletionStreamRequest) {
+    seenIds.push(request.requestId)
+    turn++
+    yield turn === 1 ? toolTurn('call-1', 'noop', {}) : contentTurn('done')
+  }
+
+  await collect(
+    orchestrateCompletion(
+      baseRequest({ requestId: 'orch-1' }),
+      runTurn,
+      stubReader({ 'call-1': null })
+    )
+  )
+
+  // Every inner turn must run under the orchestrate requestId so
+  // cancel({ requestId }) reaches whichever turn is currently generating.
+  t.is(turn, 2, 'two turns ran')
+  t.alike(seenIds, ['orch-1', 'orch-1'], 'both turns carry the orchestrate requestId')
+})
+
+test('orchestrateCompletion: natural finish leaves stopReason unset', async (t) => {
+  async function* runTurn() {
+    yield contentTurn('all done')
+  }
+  const frames = await collect(orchestrateCompletion(baseRequest(), runTurn, stubReader({})))
+  t.is(frames.at(-1)?.done, true, 'terminal frame')
+  t.absent(frames.at(-1)?.stopReason, 'no stopReason on a natural finish')
+})
+
+test('ToolResultReader: reassembles JSON lines across chunk boundaries', async (t) => {
+  const line = JSON.stringify({ callId: 'call-9', result: { ok: true } }) + '\n'
+  const halves = [line.slice(0, 7), line.slice(7)]
+  async function* input() {
+    for (const half of halves) yield Buffer.from(half)
+  }
+
+  const reader = new ToolResultReader(input())
+  const result = await reader.waitFor('call-9')
+  t.alike(result.result, { ok: true })
+})
+
+test('ToolResultReader: times out when no result arrives', async (t) => {
+  async function* input(): AsyncGenerator<Buffer> {
+    await new Promise<void>((resolve) => setTimeout(resolve, 50))
+  }
+  const reader = new ToolResultReader(input())
+  await t.exception(reader.waitFor('never', 20), /timed out/)
+})
+
+test('ToolResultReader: close() returns the upstream and fails a pending waiter', async (t) => {
+  let returned = false
+  let unblock: () => void = () => {}
+  const gate = new Promise<void>((resolve) => {
+    unblock = resolve
+  })
+  const iterable: AsyncIterable<Buffer> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          await gate
+          return { done: true, value: undefined }
+        },
+        async return() {
+          returned = true
+          unblock()
+          return { done: true, value: undefined }
+        }
+      } as AsyncIterator<Buffer>
+    }
+  }
+
+  const reader = new ToolResultReader(iterable)
+  const pending = reader.waitFor('call-x')
+  reader.close()
+  const result = await pending
+  t.ok(result.error && /closed/.test(result.error), 'pending waiter fails on close')
+  t.ok(returned, 'close() returned the upstream iterator')
+  reader.close() // idempotent -- second call is a no-op
+})

--- a/packages/inference/test/ggml-ocr-resolve-config.test.ts
+++ b/packages/inference/test/ggml-ocr-resolve-config.test.ts
@@ -1,0 +1,167 @@
+import test from 'brittle'
+import { resolveOcrConfig } from '../src/plugins/builtin/ggml-ocr/resolve-config.ts'
+import { OCR_CRAFT, OCR_DOCTR, OCR_DOCTR_1, OCR_LATIN } from '../src/models/registry/index.ts'
+import type { ModelSrcInput, OCRConfig, ResolveContext } from '../src/schemas/index.ts'
+import { ModelLoadFailedError, PluginNotFoundError } from '../src/errors/index.ts'
+
+interface MockResolveCall {
+  src: ModelSrcInput
+}
+
+function makeCtx(modelSrc: string): {
+  ctx: ResolveContext
+  calls: MockResolveCall[]
+} {
+  const calls: MockResolveCall[] = []
+  const ctx: ResolveContext = {
+    modelType: 'ggml-ocr',
+    modelSrc,
+    resolveModelPath: async (src: ModelSrcInput) => {
+      calls.push({ src })
+      const s = typeof src === 'string' ? src : src.src
+      return `/tmp/cache/${s.replace(/[^a-zA-Z0-9.]/g, '_')}`
+    }
+  }
+  return { ctx, calls }
+}
+
+async function resolve(modelSrc: string, cfg: OCRConfig = {}) {
+  const { ctx, calls } = makeCtx(modelSrc)
+  const result = await resolveOcrConfig(cfg, ctx)
+  return { result, calls }
+}
+
+const PEAR_KEY = 'a'.repeat(64)
+
+// Legacy ONNX artifact paths — still present in the live registry under
+// engine "@qvac/ocr-onnx" but no longer exported as SDK constants.
+const ONNX_DETECTOR_SRC =
+  'registry://s3/qvac_models_compiled/ocr/doctr/2026-03-04/db_mobilenet_v3_large.onnx'
+
+// ---------------------------------------------------------------------------
+// QVAC-22514 Case A: DocTR recognizer loaded alone (per docs example) must
+// select the DocTR pipeline and its DBNet detector, not the EasyOCR defaults.
+// ---------------------------------------------------------------------------
+
+test('resolveConfig: registry DocTR recognizer alone infers doctr pipeline + DBNet detector', async (t) => {
+  const { result, calls } = await resolve(OCR_DOCTR.src)
+
+  t.is(
+    (result.config as OCRConfig).pipelineType,
+    'doctr',
+    'pipelineType inferred from the DocTR recognizer artifact'
+  )
+  t.is(calls.length, 1)
+  t.is(
+    calls[0]!.src,
+    OCR_DOCTR_1.src,
+    'detector auto-derived to db_mobilenet_v3_large.gguf (OCR_DOCTR_1)'
+  )
+})
+
+test('resolveConfig: registry EasyOCR recognizer keeps easyocr pipeline + CRAFT detector', async (t) => {
+  const { result, calls } = await resolve(OCR_LATIN.src)
+
+  t.is((result.config as OCRConfig).pipelineType, 'easyocr')
+  t.is(calls.length, 1)
+  t.is(calls[0]!.src, OCR_CRAFT.src, 'detector auto-derived to CRAFT')
+})
+
+test('resolveConfig: explicit pipelineType wins over inference', async (t) => {
+  const { result, calls } = await resolve(OCR_LATIN.src, {
+    pipelineType: 'doctr'
+  })
+
+  t.is((result.config as OCRConfig).pipelineType, 'doctr')
+  t.is(calls[0]!.src, OCR_DOCTR_1.src, 'detector follows the explicit pipeline')
+})
+
+test('resolveConfig: explicit detectorModelSrc is honored unchanged', async (t) => {
+  const { calls } = await resolve(OCR_DOCTR.src, {
+    detectorModelSrc: OCR_DOCTR_1.src
+  })
+
+  t.is(calls.length, 1)
+  t.is(calls[0]!.src, OCR_DOCTR_1.src)
+})
+
+test('resolveConfig: pear:// source derives pipeline-matched detector filename', async (t) => {
+  const doctr = await resolve(`pear://${PEAR_KEY}/crnn_mobilenet_v3_small.gguf`)
+  t.is((doctr.result.config as OCRConfig).pipelineType, 'doctr')
+  t.is(doctr.calls[0]!.src, `pear://${PEAR_KEY}/db_mobilenet_v3_large.gguf`)
+
+  const easy = await resolve(`pear://${PEAR_KEY}/latin_g2.gguf`)
+  t.is((easy.result.config as OCRConfig).pipelineType, 'easyocr')
+  t.is(easy.calls[0]!.src, `pear://${PEAR_KEY}/craft_mlt_25k.gguf`)
+})
+
+test('resolveConfig: local path without detectorModelSrc fails with pipeline-specific hint', async (t) => {
+  await t.exception(
+    async () => resolve('/models/crnn_mobilenet_v3_small.gguf'),
+    ModelLoadFailedError
+  )
+  try {
+    await resolve('/models/crnn_mobilenet_v3_small.gguf')
+    t.fail('expected ModelLoadFailedError')
+  } catch (err) {
+    t.ok(
+      (err as Error).message.includes('db_mobilenet_v3_large.gguf'),
+      'error names the detector the doctr pipeline expects'
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// QVAC-22514 Cases B/C: legacy .onnx registry artifacts cannot be opened by
+// the GGUF-only addon — fail fast with the supported configurations instead
+// of a raw C++ GGUF open error.
+// ---------------------------------------------------------------------------
+
+test('resolveConfig: .onnx detectorModelSrc rejected with actionable error (Case B)', async (t) => {
+  try {
+    await resolve(OCR_DOCTR.src, {
+      detectorModelSrc: ONNX_DETECTOR_SRC
+    })
+    t.fail('expected ModelLoadFailedError')
+  } catch (err) {
+    t.ok(err instanceof ModelLoadFailedError)
+    t.ok((err as Error).message.includes('only loads GGUF'))
+    t.ok((err as Error).message.includes('OCR_DOCTR'), 'error names a supported configuration')
+  }
+})
+
+test('resolveConfig: .onnx detector descriptor object rejected too', async (t) => {
+  await t.exception(
+    async () =>
+      resolve(OCR_DOCTR.src, {
+        detectorModelSrc: {
+          src: ONNX_DETECTOR_SRC,
+          modelId: 'db_mobilenet_v3_large.onnx'
+        }
+      }),
+    ModelLoadFailedError
+  )
+})
+
+test('resolveConfig: .onnx recognizer modelSrc rejected (Case C)', async (t) => {
+  try {
+    await resolve(ONNX_DETECTOR_SRC)
+    t.fail('expected ModelLoadFailedError')
+  } catch (err) {
+    t.ok(err instanceof ModelLoadFailedError)
+    t.ok((err as Error).message.includes('recognizer'))
+  }
+})
+
+// ---------------------------------------------------------------------------
+// QVAC-22514 Case D: removed onnx-ocr plugin gets a migration hint.
+// ---------------------------------------------------------------------------
+
+test('PluginNotFoundError: onnx-ocr carries a migration hint to ggml-ocr', (t) => {
+  const err = new PluginNotFoundError('onnx-ocr')
+  t.ok(err.message.includes('has been removed'))
+  t.ok(err.message.includes('ggml-ocr'))
+
+  const other = new PluginNotFoundError('some-custom-type')
+  t.ok(other.message.includes('registerPlugin'))
+})

--- a/packages/inference/test/kv-cache-cancel.test.ts
+++ b/packages/inference/test/kv-cache-cancel.test.ts
@@ -1,7 +1,8 @@
 import test from 'brittle'
 import {
   decideCachedHistorySlice,
-  type HistoryMessage
+  type HistoryMessage,
+  shouldCommitCachedTurn
 } from '../src/plugins/builtin/llamacpp-completion/ops/kv-cache-state'
 
 // -----------------------------------------------------------------------------
@@ -135,4 +136,61 @@ test('regression: an externally-seeded stale savedCount still triggers the fallb
     { role: 'user', content: 'u2' }
   ])
   t.is(clearStaleCount, true, 'must prompt caller to clean up the stale count')
+})
+
+test('shouldCommitCachedTurn: completed turn with tokens commits', (t) => {
+  t.is(
+    shouldCommitCachedTurn({
+      aborted: false,
+      producedTokens: true,
+      generatedTokens: 12,
+      predict: 64
+    }),
+    true
+  )
+})
+
+test('shouldCommitCachedTurn: token-budget stop rolls back', (t) => {
+  t.is(
+    shouldCommitCachedTurn({
+      aborted: false,
+      producedTokens: true,
+      generatedTokens: 64,
+      predict: 64
+    }),
+    false
+  )
+})
+
+test('shouldCommitCachedTurn: unlimited prediction does not imply truncation', (t) => {
+  t.is(
+    shouldCommitCachedTurn({
+      aborted: false,
+      producedTokens: true,
+      generatedTokens: 64,
+      predict: -1
+    }),
+    true
+  )
+})
+
+test('shouldCommitCachedTurn: aborted or empty turns roll back', (t) => {
+  t.is(
+    shouldCommitCachedTurn({
+      aborted: true,
+      producedTokens: true,
+      generatedTokens: 12,
+      predict: 64
+    }),
+    false
+  )
+  t.is(
+    shouldCommitCachedTurn({
+      aborted: false,
+      producedTokens: false,
+      generatedTokens: 0,
+      predict: 64
+    }),
+    false
+  )
 })

--- a/packages/inference/test/translate-validate-order.test.ts
+++ b/packages/inference/test/translate-validate-order.test.ts
@@ -1,0 +1,66 @@
+import test from 'brittle'
+
+// Bare-only: importing plugins/ops/translate pulls native bare deps that
+// bun unit tests cannot load. Schema coverage for missing `to` lives in
+// translation-schemas.test.ts; this file proves op ordering.
+
+let idCounter = 0
+function makeId(prefix: string): string {
+  idCounter++
+  return `${prefix}-${idCounter}-${Date.now()}`
+}
+
+test('translate: missing LLM `to` fails at schema parse before language detection', async (t) => {
+  const [
+    { registerModel, unregisterModel },
+    { ModelType },
+    { translate },
+    { TranslationFailedError },
+    { detectOne },
+    { ZodError }
+  ] = await Promise.all([
+    import('../src/runtime/model-registry.ts'),
+    import('../src/schemas/index.ts'),
+    import('../src/plugins/ops/translate.ts'),
+    import('../src/errors/index.ts'),
+    import('@qvac/langdetect-text'),
+    import('zod')
+  ])
+
+  // Undetermined text is the regression case: if detectOne runs before
+  // translateServerParamsSchema.parse, the op throws TranslationFailedError
+  // instead of the real missing-`to` schema error.
+  const undeterminedText = '????'
+  const detected = detectOne(undeterminedText)
+  t.is(detected.code, 'und', 'fixture must stay undetermined for this assertion')
+  t.is(detected.language, 'Undetermined')
+
+  const modelId = makeId('llm-translate-missing-to')
+  registerModel(modelId, {
+    model: {} as never,
+    path: '/tmp/llm.bin',
+    config: {},
+    modelType: ModelType.llamacppCompletion
+  } as never)
+
+  try {
+    const gen = translate({
+      modelId,
+      text: undeterminedText,
+      stream: false,
+      modelType: ModelType.llamacppCompletion
+    } as never)
+
+    await gen.next()
+    t.fail('expected translate to reject missing `to`')
+  } catch (error) {
+    t.ok(error instanceof ZodError, 'schema parse must win over language detection')
+    t.ok(!(error instanceof TranslationFailedError), 'must not surface as TranslationFailedError')
+    t.ok(
+      (error as InstanceType<typeof ZodError>).issues.some((issue) => issue.path.includes('to')),
+      'Zod issue path must point at `to`'
+    )
+  } finally {
+    unregisterModel(modelId)
+  }
+})

--- a/packages/inference/test/translation-schemas.test.ts
+++ b/packages/inference/test/translation-schemas.test.ts
@@ -93,3 +93,22 @@ test("translateServerParamsSchema: normalizes 'nmt' to canonical modelType", (t)
     t.is(result.data.modelType, ModelType.nmtcppTranslation)
   }
 })
+
+test('translateServerParamsSchema (LLM): rejects missing `to` while allowing omitted `from`', (t) => {
+  const missingTo = translateServerParamsSchema.safeParse({
+    modelId: 'm1',
+    text: 'Hello',
+    stream: false,
+    modelType: 'llamacpp-completion'
+  })
+  t.is(missingTo.success, false)
+
+  const omittedFrom = translateServerParamsSchema.safeParse({
+    modelId: 'm1',
+    text: 'Hello',
+    stream: false,
+    modelType: 'llamacpp-completion',
+    to: 'fr'
+  })
+  t.is(omittedFrom.success, true)
+})

--- a/packages/inference/test/tts-resolve-config.test.ts
+++ b/packages/inference/test/tts-resolve-config.test.ts
@@ -6,6 +6,7 @@ type TtsGgmlDebugModel = {
   _streamChunkTokens?: number
   _streamFirstChunkTokens?: number
   _cfmSteps?: number
+  _cfgRate?: number
   _threads?: number
   _nGpuLayers?: number
   _seed?: number
@@ -16,6 +17,7 @@ type TtsGgmlDebugModel = {
     language?: string
     useGPU?: boolean
     outputSampleRate?: number
+    vulkanCacheDir?: string
   }
 }
 
@@ -62,6 +64,7 @@ test('ttsPlugin createModel: forwards Chatterbox native constructor options', as
       streamChunkTokens: 25,
       streamFirstChunkTokens: 10,
       cfmSteps: 1,
+      cfgRate: 0.7,
       threads: 8,
       nGpuLayers: 99,
       seed: 42
@@ -72,6 +75,7 @@ test('ttsPlugin createModel: forwards Chatterbox native constructor options', as
   t.is(model._streamChunkTokens, 25)
   t.is(model._streamFirstChunkTokens, 10)
   t.is(model._cfmSteps, 1)
+  t.is(model._cfgRate, 0.7)
   t.is(model._threads, 8)
   t.is(model._nGpuLayers, 99)
   t.is(model._seed, 42)
@@ -148,7 +152,8 @@ test('ttsPlugin createModel: forwards LavaSR files + outputSampleRate (supertoni
     modelConfig: {
       ttsEngine: 'supertonic',
       language: 'en',
-      outputSampleRate: 48000
+      outputSampleRate: 48000,
+      vulkanCacheDir: '/tmp/vulkan-cache'
     }
   })
 
@@ -156,7 +161,12 @@ test('ttsPlugin createModel: forwards LavaSR files + outputSampleRate (supertoni
   t.is(model._enhancerGgufPath, '/tmp/lavasr-enhancer.gguf')
   t.is(model._denoiserGgufPath, '/tmp/lavasr-denoiser.gguf')
   t.is(model._outputSampleRate, 48000)
-  t.is(model._config?.outputSampleRate, 48000)
+  t.alike(model._config, {
+    language: 'en',
+    useGPU: false,
+    outputSampleRate: 48000,
+    vulkanCacheDir: '/tmp/vulkan-cache'
+  })
 })
 
 test('ttsPlugin createModel: forwards LavaSR enhancer (chatterbox)', async (t) => {

--- a/packages/inference/test/tts-schemas.test.ts
+++ b/packages/inference/test/tts-schemas.test.ts
@@ -74,6 +74,7 @@ test('ttsConfigSchema: accepts Chatterbox native constructor options', (t) => {
     streamChunkTokens: 25,
     streamFirstChunkTokens: 10,
     cfmSteps: 1,
+    cfgRate: 0.7,
     threads: 8,
     nGpuLayers: 99,
     seed: 42
@@ -83,6 +84,7 @@ test('ttsConfigSchema: accepts Chatterbox native constructor options', (t) => {
     t.is(r.data['streamChunkTokens'], 25)
     t.is(r.data['streamFirstChunkTokens'], 10)
     t.is(r.data['cfmSteps'], 1)
+    t.is(r.data['cfgRate'], 0.7)
     t.is(r.data['threads'], 8)
     t.is(r.data['nGpuLayers'], 99)
     t.is(r.data['seed'], 42)
@@ -94,6 +96,7 @@ test('ttsConfigSchema: rejects invalid Chatterbox constructor option ranges', (t
     { streamChunkTokens: -1 },
     { streamFirstChunkTokens: -1 },
     { cfmSteps: -1 },
+    { cfgRate: -0.1 },
     { threads: 0 },
     { nGpuLayers: 1.5 },
     { seed: 1.5 }
@@ -139,11 +142,13 @@ test('ttsConfigSchema: accepts LavaSR enhancer/denoiser + outputSampleRate (supe
     language: 'en',
     lavasrEnhancerModelSrc: 'registry://s3/lavasr/enhancer.gguf',
     lavasrDenoiserModelSrc: 'registry://s3/lavasr/denoiser.gguf',
-    outputSampleRate: 24000
+    outputSampleRate: 24000,
+    vulkanCacheDir: '/data/qvac/vulkan-cache'
   })
   t.is(r.success, true)
   if (r.success) {
     t.is(r.data.outputSampleRate, 24000)
+    t.is(r.data.vulkanCacheDir, '/data/qvac/vulkan-cache')
   }
 })
 
@@ -375,6 +380,24 @@ test('ttsResponseSchema: accepts optional chunk metadata', (t) => {
   if (r.success) {
     t.is(r.data.chunkIndex, 0)
     t.is(r.data.sentenceChunk, 'Hello.')
+  }
+})
+
+test('ttsResponseSchema: accepts LavaSR enhancer backend stats', (t) => {
+  const r = ttsResponseSchema.safeParse({
+    type: 'textToSpeech',
+    buffer: [],
+    done: true,
+    stats: {
+      enhancerBackendDevice: 1,
+      enhancerBackendId: 3
+    }
+  })
+
+  t.is(r.success, true)
+  if (r.success) {
+    t.is(r.data.stats?.enhancerBackendDevice, 1)
+    t.is(r.data.stats?.enhancerBackendId, 3)
   }
 })
 

--- a/packages/inference/test/tts-stats.test.ts
+++ b/packages/inference/test/tts-stats.test.ts
@@ -1,0 +1,20 @@
+import test from 'brittle'
+import { collectTtsStats } from '../src/utils/tts-stats'
+
+test('collectTtsStats: maps LavaSR enhancer backend stats', (t) => {
+  const stats = collectTtsStats({
+    stats: {
+      audioDurationMs: 1200,
+      totalSamples: 48000,
+      enhancerBackendDevice: 1,
+      enhancerBackendId: 3
+    }
+  })
+
+  t.alike(stats, {
+    audioDuration: 1200,
+    totalSamples: 48000,
+    enhancerBackendDevice: 1,
+    enhancerBackendId: 3
+  })
+})

--- a/packages/inference/test/vla-schemas.test.ts
+++ b/packages/inference/test/vla-schemas.test.ts
@@ -105,6 +105,40 @@ test('vlaHparamsSchema: accepts canonical π₀.₅ shape (numCameras + discrete
   }
 })
 
+test('vlaHparamsSchema: accepts canonical GR00T shape (patches image mode + continuous state)', (t) => {
+  const result = vlaHparamsSchema.safeParse({
+    chunkSize: 40,
+    actionDim: 32,
+    maxActionDim: 132,
+    maxStateDim: 64,
+    tokenizerMaxLength: 148,
+    visionImageSize: 224,
+    numCameras: 2,
+    stateInputMode: 'continuous',
+    imageInputMode: 'patches',
+    imagePatchElems: 262144
+  })
+  t.is(result.success, true)
+  if (result.success) {
+    t.is(result.data.numCameras, 2)
+    t.is(result.data.imageInputMode, 'patches')
+    t.is(result.data.imagePatchElems, 262144)
+  }
+})
+
+test('vlaHparamsSchema: rejects unknown imageInputMode', (t) => {
+  const result = vlaHparamsSchema.safeParse({
+    chunkSize: 40,
+    actionDim: 32,
+    maxActionDim: 132,
+    maxStateDim: 64,
+    tokenizerMaxLength: 148,
+    visionImageSize: 224,
+    imageInputMode: 'tiles'
+  })
+  t.is(result.success, false)
+})
+
 test('vlaHparamsSchema: rejects unknown stateInputMode', (t) => {
   const result = vlaHparamsSchema.safeParse({
     chunkSize: 50,
@@ -698,6 +732,51 @@ test('vlaRun op: omits noise when not provided', async function (t) {
   )
 })
 
+test('vlaRun op: forwards GR00T patch-buffer images (imageInputMode patches)', async function (t) {
+  // GR00T supplies pre-patchified image buffers of hparams.imagePatchElems
+  // floats per camera, not 3*w*h pixel planes. The op must base64-decode and
+  // forward each patch buffer to model.run intact — the pixel-length contract
+  // does not apply on the patch path (patch/pixel dispatch is addon-side via
+  // hparams.imageInputMode).
+  let observedInput: Record<string, unknown> | undefined
+  const patchElems = 8 // stand-in for hparams.imagePatchElems (real: e.g. 262144)
+  const cam0 = new Float32Array(patchElems).fill(0.1)
+  const cam1 = new Float32Array(patchElems).fill(0.2)
+  await withRegisteredVlaModel(
+    {
+      runImpl: async function (input: unknown) {
+        observedInput = input as Record<string, unknown>
+        return {
+          await: async () => ({ actions: new Float32Array([0]), stats: { total_ms: 1 } })
+        }
+      },
+      hparams: { actionDim: 32, chunkSize: 40 }
+    },
+    async (modelId) => {
+      await vlaRun({
+        type: 'vlaRun',
+        modelId,
+        // Two cameras (LIBERO GR00T), each a patch buffer, not a pixel plane.
+        images: [
+          encodeBase64(new Uint8Array(cam0.buffer)),
+          encodeBase64(new Uint8Array(cam1.buffer))
+        ],
+        imgWidth: 224,
+        imgHeight: 224,
+        state: encodeBase64(new Uint8Array(new Float32Array(64).buffer)),
+        tokens: encodeBase64(new Uint8Array(new Int32Array(148).buffer)),
+        mask: encodeBase64(new Uint8Array(148))
+      })
+
+      const images = observedInput?.['images'] as Float32Array[]
+      t.is(images.length, 2, 'two camera patch buffers forwarded')
+      t.is(images[0]?.length, patchElems, 'patch buffer length preserved (not 3*w*h)')
+      t.ok(Math.abs((images[0]?.[0] ?? NaN) - 0.1) < 1e-6)
+      t.ok(Math.abs((images[1]?.[0] ?? NaN) - 0.2) < 1e-6)
+    }
+  )
+})
+
 // ============================================
 // vlaGetHparams op
 // ============================================
@@ -749,6 +828,38 @@ test('vlaGetHparams op: surfaces π₀.₅ numCameras + stateInputMode', async f
       t.alike(result.hparams, hp)
       t.is(result.hparams.numCameras, 3)
       t.is(result.hparams.stateInputMode, 'discrete')
+    }
+  )
+})
+
+test('vlaGetHparams op: surfaces GR00T imageInputMode + imagePatchElems', async function (t) {
+  // The patch-input hparams must survive the vlaHparamsSchema.parse() in the
+  // hparams path (they were being stripped before they were added to the
+  // schema), so a consumer can discover patch mode + size the patch buffer.
+  const hp = {
+    chunkSize: 40,
+    actionDim: 32,
+    maxActionDim: 132,
+    maxStateDim: 64,
+    tokenizerMaxLength: 148,
+    visionImageSize: 224,
+    numCameras: 2,
+    stateInputMode: 'continuous' as const,
+    imageInputMode: 'patches' as const,
+    imagePatchElems: 262144
+  }
+  await withRegisteredVlaModel(
+    {
+      runImpl: async function () {
+        throw new Error('run not exercised')
+      },
+      hparams: hp as unknown as { actionDim: number; chunkSize: number }
+    },
+    async (modelId) => {
+      const result = await vlaGetHparams({ type: 'vlaHparams', modelId })
+      t.alike(result.hparams, hp)
+      t.is(result.hparams.imageInputMode, 'patches')
+      t.is(result.hparams.imagePatchElems, 262144)
     }
   )
 })


### PR DESCRIPTION

## 🎯 What problem does this PR solve?

- `@qvac/inference` was split from the SDK engine at `main@ac28beda`. The SDK has since advanced to `0.16.0`, so the engine package lagged its source: missing the latest tts-ggml APIs, GR00T VLA support, the registry OCR-load fix, `TranslationFailedError`, worker-orchestrated completion, KV-cache reuse across turns, the refreshed model registry, and the addon version bumps.
- This brings the engine up to the SDK `0.16.0` state so `@qvac/sdk` can adopt it (`useInference`) without behavioural drift.

## 📝 How does it solve it?

- Mirrors the engine-relevant slice of every SDK change since `ac28beda` into `packages/inference`, adapted to the engine's layout (relative `.ts` imports, `errors/` + `registry.ts` structure, engine-natural error wording — no SDK references). One recipe-style commit per feature:
  - `feat[api]: expose latest tts-ggml APIs` — `cfgRate`, `vulkanCacheDir`, `enhancerBackend*` stats
  - `feat[mod]: refresh the model registry`
  - `feat[api]: first-class GR00T exposure in VLA` — `imageInputMode` / `imagePatchElems` hparams
  - `fix: make registry GGUF OCR models load via the ocr() path`
  - `feat[api]: auto-detect translate source language and export TranslationFailedError`
  - `feat[api]: add worker-orchestrated completion (completionOrchestrate)`
  - `feat: reuse KV cache across turns`
  - `chore: bump to 0.16.0 and align addon dependency ranges`
- SDK-only parts of the same drift (contract, changelog, client-side API, examples, e2e, Python client, `create-server`) are deliberately left for the `useInference` adoption.

## 🧪 How was it tested?

- Each commit passes the full inference gate: `typecheck`, `lint`, `format`, and `test:bare` (1043/1043 tests).
- A per-file completeness sweep confirms every engine-path file in the SDK `0.16.0` drift is reflected in `packages/inference`.

## 🔌 API Changes

```typescript
// New engine surfaces (re-exported by @qvac/sdk):
import { TranslationFailedError } from '@qvac/inference/surface'

// completionOrchestrate: a worker-run tool loop over a duplex request/response
// (routable request type; only a local worker may emit toolCallback).

// tts-ggml runtime config gains cfgRate (chatterbox) + vulkanCacheDir (supertonic);
// tts stats gain enhancerBackendDevice / enhancerBackendId.

// VLA hparams gain imageInputMode ('pixels' | 'patches') + imagePatchElems (GR00T).

// translate: `from` is now optional on the wire (server auto-detects when omitted).
```

## 📦 Models

**Registry regenerated to match the SDK `0.16.0` registry** (byte-mirrored with engine import paths).

### Added models

```
GROOT_Q8_VF16, GROOT_Q5_VF16
QWEN3_5_2B_MULTIMODAL_Q8_0, GEMMA4_2B_MULTIMODAL_Q8_0
TTS_MINI_V1_EN_PARLER_TTS_{FP16,FP32,Q8_0}
TTS_LARGE_V1_EN_PARLER_TTS_{FP16,FP32,Q8_0}
TTS_INDIC_MULTILINGUAL_PARLER_TTS_{FP16,FP32,Q8_0}
```

### Removed models

Legacy component-level TTS/Parakeet constants superseded by the Parler-TTS set and the consolidated registry:

```
# Chatterbox TTS (EN + multilingual) components
TTS_SPEECH_ENCODER_EN_CHATTERBOX_{QUANTIZED,FP16,FP32,Q4,Q4F16}
TTS_EMBED_TOKENS_EN_CHATTERBOX_{QUANTIZED,FP16,FP32,Q4,Q4F16}
TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_{QUANTIZED,FP16,FP32,Q4,Q4F16}
TTS_LANGUAGE_MODEL_EN_CHATTERBOX_{QUANTIZED,FP16,FP32,Q4,Q4F16}
TTS_TOKENIZER_EN_CHATTERBOX, TTS_EN_ES_CHATTERBOX_Q4F16
TTS_MULTILINGUAL_{SPEECH_ENCODER,EMBED_TOKENS,CONDITIONAL_DECODER}_CHATTERBOX_FP32
TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX{,_FP16,_FP32,_Q4}

# Supertonic v1/v2 components + voice styles
TTS_SUPERTONIC_OFFICIAL_{TEXT_ENCODER,UNICODE_INDEXER,TTS_CONFIG,DURATION_PREDICTOR,VECTOR_ESTIMATOR}_SUPERTONE(_FP32)
TTS_SUPERTONIC_OFFICIAL_VOICE_STYLE_SUPERTONE(_1..9)
TTS_SUPERTONIC2_OFFICIAL_{TEXT_ENCODER,UNICODE_INDEXER,TTS_CONFIG,DURATION_PREDICTOR,VECTOR_ESTIMATOR,VOCODER}_SUPERTONE_FP32
TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE(_1..9)
TTS_VOICE_STYLE_SUPERTONIC(_1..9)
TTS_{VOICE_DECODER,LATENT_DENOISER,TEXT_ENCODER}_SUPERTONIC_FP32, TTS_TOKENIZER_SUPERTONIC

# LavaSR enhancer/denoiser
TTS_ENHANCER_BACKBONE_LAVASR_FP32, TTS_ENHANCER_SPEC_HEAD_LAVASR_FP32, TTS_DENOISER_LAVASR_FP32_1

# Parakeet component models
PARAKEET_TDT_{ENCODER,DECODER,PREPROCESSOR}_{FP32,INT8}, PARAKEET_TDT_VOCAB
PARAKEET_CTC_FP32, PARAKEET_CTC_TOKENIZER
PARAKEET_EOU_{ENCODER,DECODER}_FP32, PARAKEET_EOU_TOKENIZER
PARAKEET_SORTFORMER_FP32
```