### PR TITLE
ci[transcription-whispercpp]: make the linux-arm64 integration leg gating

### DIFF
--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -60,7 +60,12 @@ on:
 jobs:
   run-integration-tests:
     timeout-minutes: 60
-    continue-on-error: true
+    # Non-gating by default (most legs run on self-hosted GPU runners whose
+    # flakiness shouldn't block PRs), except for matrix entries that opt in
+    # with `gating: true`. An unset `matrix.gating` evaluates to null, so
+    # `!= true` keeps every other leg on the previous continue-on-error
+    # behaviour.
+    continue-on-error: ${{ matrix.gating != true }}
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
     name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu != 'true' && '-gpu' || '' }}-integration-tests
@@ -96,10 +101,19 @@ jobs:
             no_gpu: 'true'
             benchmark_matrix_json: >-
               [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"}]
+          # Gating: linux-arm64 is the only desktop leg where the ggml CPU
+          # backend ships as dlopen'd per-microarch MODULE .so files
+          # (GGML_BACKEND_DL + GGML_CPU_ALL_VARIANTS since ggml-speech
+          # 2026-07-14). Everywhere else the CPU backend is static-linked, so a
+          # backend-discovery regression leaves the device registry empty here
+          # and only here -- and aborts the process (SIGABRT, exit 134) inside
+          # whisper_init rather than failing an assertion a reviewer would see.
+          # This leg must block the merge guard; see PR #3430.
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
             no_gpu: 'true'
+            gating: true
             benchmark_matrix_json: >-
               [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"}]
           - os: macos-26


### PR DESCRIPTION
## Why

`run-integration-tests` in `integration-test-transcription-whispercpp.yml` carried a **job-level `continue-on-error: true`** for the entire matrix. A red leg therefore still reported the reusable workflow as successful, `merge-guard`'s `integration-tests-status` stayed `true`, and nothing blocked the PR.

That is why the linux-arm64 `GGML_ASSERT(device)` abort (exit 134 during model activation) survived for a week across several PRs. [Run 30022251641](https://github.com/tetherto/qvac/actions/runs/30022251641) reported **success** with `ubuntu-24.04-arm-linux-arm64-integration-tests` failed. It was eventually fixed by #3430, but only because someone read the logs by hand.

## What

Make the flag opt-in per matrix entry instead of blanket-on:

- `continue-on-error: ${{ matrix.gating != true }}`
- only the `ubuntu-24.04-arm` entry sets `gating: true`

An unset `matrix.gating` evaluates to `null`, and `null != true` is `true`, so the other six legs keep the previous behaviour byte-for-byte. The non-gating posture is deliberate for those — they run on self-hosted GPU runners whose flakiness shouldn't block PRs (same note as `integration-test-tts-ggml.yml`).

## Why linux-arm64 specifically

Since `ggml-speech 2026-07-14` it is the only desktop leg whose ggml CPU backend ships as dlopen'd per-microarch MODULE `.so` files (`GGML_BACKEND_DL` + `GGML_CPU_ALL_VARIANTS`). Every other platform static-links the CPU backend, so a backend-discovery regression leaves the ggml device registry empty **there and only there** — and it aborts the process inside `whisper_init` (`ggml_backend_dev_backend_reg(nullptr)` via `make_buft_list`) rather than failing a test a reviewer would read in the summary.

## Risk

The leg is currently green on source-built prebuilds ([run 30254613308](https://github.com/tetherto/qvac/actions/runs/30254613308) — linux-arm64 prebuild + arm64 integration both pass, CPU module `libqvac-speech-ggml-cpu-armv8.2_2.so` loads), so this doesn't convert an existing failure into a blocker. Scope is one workflow file; the parakeet / tts-ggml / bci lanes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)