### PR TITLE
fix[notask]: repair model drift detection in check-models

### DIFF
--- a/packages/sdk/models/update-models/history.ts
+++ b/packages/sdk/models/update-models/history.ts
@@ -3,6 +3,53 @@ import { generateExportName } from './naming'
 import type { CurrentModel, ProcessedModel } from './types'
 import { getCommitHash } from './utils'
 
+// Splits the body of the generated `models` array into one string per
+// top-level entry. Brace-depth scanning (rather than a `[^}]+` regex) is
+// required because entries carrying `shardMetadata` / `companionSet` contain
+// nested objects, and quote tracking keeps braces inside string literals from
+// throwing the depth off.
+export function extractEntryBlocks(arrayContent: string): string[] {
+  const entries: string[] = []
+  let depth = 0
+  let start = -1
+  let quote: string | null = null
+
+  for (let i = 0; i < arrayContent.length; i++) {
+    const char = arrayContent[i]
+
+    if (quote !== null) {
+      if (char === '\\') i++
+      else if (char === quote) quote = null
+      continue
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char
+    } else if (char === '{') {
+      if (depth === 0) start = i
+      depth++
+    } else if (char === '}') {
+      depth--
+      if (depth === 0 && start !== -1) {
+        entries.push(arrayContent.slice(start, i + 1))
+        start = -1
+      }
+    }
+  }
+
+  return entries
+}
+
+// Reads the first `<field>: '<value>'` pair out of an entry block. Accepts
+// either quote style because codegen emits double quotes and Prettier then
+// rewrites them to single quotes, and tolerates the line break Prettier
+// inserts after the colon on long values.
+function readStringField(entry: string, field: string): string | null {
+  const match = new RegExp(`\\b${field}:\\s*(?:'([^']*)'|"([^"]*)")`).exec(entry)
+  if (!match) return null
+  return match[1] ?? match[2] ?? null
+}
+
 export function loadCurrentModels(outputFile: string): CurrentModel[] {
   try {
     if (!fs.existsSync(outputFile)) {
@@ -10,26 +57,30 @@ export function loadCurrentModels(outputFile: string): CurrentModel[] {
     }
 
     const content = fs.readFileSync(outputFile, 'utf-8')
-    const modelsMatch = content.match(/export const models = \[([\s\S]*?)\] as const/)
+    const modelsMatch = content.match(/export const models = \[([\s\S]*?)\n\] as const/)
 
     if (!modelsMatch?.[1]) {
+      console.warn(`⚠️  Could not locate the models array in ${outputFile}`)
       return []
     }
 
-    const modelsArrayContent = modelsMatch[1]
     const currentModels: CurrentModel[] = []
 
-    const modelRegex =
-      /\{[^}]+name:\s*"([^"]+)"[^}]+(?:registryPath|hyperbeeKey):\s*"([^"]+)"[^}]+\}/g
-    let match
-
-    while ((match = modelRegex.exec(modelsArrayContent)) !== null) {
-      if (match[1] && match[2]) {
-        currentModels.push({
-          name: match[1],
-          registryPath: match[2]
-        })
+    // `name` and `registryPath` are emitted as the first two fields of every
+    // entry, so the first match in a block always belongs to the model itself
+    // and never to a nested companion file.
+    for (const entry of extractEntryBlocks(modelsMatch[1])) {
+      const name = readStringField(entry, 'name')
+      const registryPath = readStringField(entry, 'registryPath')
+      if (name && registryPath) {
+        currentModels.push({ name, registryPath })
       }
+    }
+
+    if (currentModels.length === 0) {
+      // Silently returning an empty list makes every remote model look new and
+      // hides removals entirely, so surface it instead of reporting bogus drift.
+      console.warn(`⚠️  Parsed 0 models from ${outputFile} — drift comparison is unreliable`)
     }
 
     return currentModels

--- a/packages/sdk/test/unit/update-models-history.test.ts
+++ b/packages/sdk/test/unit/update-models-history.test.ts
@@ -1,0 +1,192 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import test from 'brittle'
+import { generateModelsFileContent } from '@/models/update-models/codegen'
+import { extractEntryBlocks, loadCurrentModels } from '@/models/update-models/history'
+import type { ProcessedModel } from '@/models/update-models/types'
+
+function makeModel(overrides: Partial<ProcessedModel> & { registryPath: string }): ProcessedModel {
+  return {
+    registrySource: 's3',
+    modelId: overrides.registryPath.split('/').pop() || '',
+    addon: 'llm',
+    engine: 'llamacpp-completion',
+    modelName: 'qwen3',
+    quantization: 'q4_0',
+    params: '4B',
+    tags: ['generation'],
+    expectedSize: 1000,
+    sha256Checksum: 'sha',
+    blobCoreKey: 'key',
+    blobBlockOffset: 0,
+    blobBlockLength: 1,
+    blobByteOffset: 0,
+    ...overrides
+  }
+}
+
+function withTempFile(contents: string, fn: (file: string) => void): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qvac-history-'))
+  const file = path.join(dir, 'models.ts')
+  try {
+    fs.writeFileSync(file, contents)
+    fn(file)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('loadCurrentModels: round-trips the generated file', (t) => {
+  const content = generateModelsFileContent([
+    makeModel({ registryPath: 'org/repo/qwen3-4b-q4_0.gguf' }),
+    makeModel({ registryPath: 'org/repo/qwen3-8b-q8_0.gguf', params: '8B', quantization: 'q8_0' })
+  ])
+
+  withTempFile(content, (file) => {
+    const loaded = loadCurrentModels(file)
+
+    t.is(loaded.length, 2, 'reads every entry back')
+    t.is(loaded[0]!.registryPath, 'org/repo/qwen3-4b-q4_0.gguf', 'keeps the first path')
+    t.is(loaded[1]!.registryPath, 'org/repo/qwen3-8b-q8_0.gguf', 'keeps the second path')
+    t.ok(
+      loaded.every((m) => m.name.length > 0),
+      'every entry carries a name'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: codegen emits double quotes, then `update-models` runs Prettier
+// over the file, which rewrites them to single quotes. A reader that only
+// matched double quotes parsed 0 models at rest, so every remote model looked
+// new and removals were reported as none at all.
+// ---------------------------------------------------------------------------
+
+test('loadCurrentModels: reads Prettier-normalised single quotes', (t) => {
+  const content = `export const models = [
+  {
+    name: 'QWEN3_4B_Q4_0',
+    registryPath: 'org/repo/qwen3-4b-q4_0.gguf',
+    registrySource: 's3',
+    quantization: 'q4_0'
+  }
+] as const satisfies readonly RegistryItem[];
+`
+
+  withTempFile(content, (file) => {
+    const loaded = loadCurrentModels(file)
+
+    t.is(loaded.length, 1, 'parses the entry')
+    t.is(loaded[0]!.name, 'QWEN3_4B_Q4_0', 'reads the name')
+    t.is(loaded[0]!.registryPath, 'org/repo/qwen3-4b-q4_0.gguf', 'reads the registry path')
+  })
+})
+
+test('loadCurrentModels: reads values Prettier wrapped onto the next line', (t) => {
+  const content = `export const models = [
+  {
+    name: 'MMPROJ_UNLIMITED_OCR_F16',
+    registryPath:
+      'someuser/unlimited-ocr-gguf/resolve/45cd66ec6b46a7c4de49f376084ecec2b8d3c59a/mmproj-unlimited-ocr-F16.gguf',
+    registrySource: 'hf'
+  }
+] as const satisfies readonly RegistryItem[];
+`
+
+  withTempFile(content, (file) => {
+    const loaded = loadCurrentModels(file)
+
+    t.is(loaded.length, 1, 'parses the wrapped entry')
+    t.is(
+      loaded[0]!.registryPath,
+      'someuser/unlimited-ocr-gguf/resolve/45cd66ec6b46a7c4de49f376084ecec2b8d3c59a/mmproj-unlimited-ocr-F16.gguf',
+      'reads the wrapped registry path'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: entries carrying `companionSet` / `shardMetadata` contain nested
+// objects. A `[^}]+`-bounded regex could not span them, so those entries were
+// skipped and their companion files could be mistaken for models of their own.
+// ---------------------------------------------------------------------------
+
+test('loadCurrentModels: handles entries with nested companion sets', (t) => {
+  const companionSet = {
+    setKey: 'bergamot-fren',
+    primaryKey: 'model',
+    files: [
+      {
+        key: 'model',
+        registryPath: 'bergamot-fren/model.fren.bin',
+        registrySource: 's3',
+        targetName: 'model.bin',
+        expectedSize: 10,
+        sha256Checksum: 'a',
+        blobCoreKey: 'k',
+        blobBlockOffset: 0,
+        blobBlockLength: 1,
+        blobByteOffset: 0,
+        primary: true
+      },
+      {
+        key: 'vocab',
+        registryPath: 'bergamot-fren/vocab.fren.spm',
+        registrySource: 's3',
+        targetName: 'vocab.spm',
+        expectedSize: 20,
+        sha256Checksum: 'b',
+        blobCoreKey: 'k',
+        blobBlockOffset: 0,
+        blobBlockLength: 1,
+        blobByteOffset: 0
+      }
+    ]
+  }
+
+  const content = generateModelsFileContent([
+    makeModel({
+      registryPath: 'bergamot-fren/model.fren.bin',
+      addon: 'nmt',
+      engine: 'nmtcpp-translation',
+      companionSet
+    }),
+    makeModel({ registryPath: 'org/repo/qwen3-4b-q4_0.gguf' })
+  ])
+
+  withTempFile(content, (file) => {
+    const loaded = loadCurrentModels(file)
+
+    t.is(loaded.length, 2, 'the nested object does not swallow the following entry')
+    t.is(
+      loaded[0]!.registryPath,
+      'bergamot-fren/model.fren.bin',
+      'takes the top-level path, not a companion file path'
+    )
+    t.absent(
+      loaded.some((m) => m.registryPath === 'bergamot-fren/vocab.fren.spm'),
+      'companion files are not reported as models'
+    )
+  })
+})
+
+test('extractEntryBlocks: ignores braces inside string literals', (t) => {
+  const blocks = extractEntryBlocks(`
+  {
+    name: 'A',
+    notes: 'a } brace and a { brace'
+  },
+  {
+    name: 'B'
+  }
+`)
+
+  t.is(blocks.length, 2, 'splits into two entries')
+  t.ok(blocks[0]!.includes("name: 'A'"), 'first block is the first entry')
+  t.ok(blocks[1]!.includes("name: 'B'"), 'second block is the second entry')
+})
+
+test('loadCurrentModels: returns empty for a missing file', (t) => {
+  t.is(loadCurrentModels(path.join(os.tmpdir(), 'qvac-does-not-exist', 'models.ts')).length, 0)
+})


### PR DESCRIPTION
## Problem

`loadCurrentModels` parses **zero** models out of `models/registry/models.ts`. Everything downstream of it is therefore wrong:

- `check-models` reports every model in the registry as new, and can never report a removal. The pre-commit `check-models:hook` has been pure noise.
- History files written by `update-models` record `previous_count=0` and list the entire catalog under `[added]`, so a regeneration that drops models looks identical to one that adds them.

Concretely, the history file for the current catalog said `previous_count=0` / 681 added / 0 removed. The real drift is 19 added and 19 removed — including 19 legacy ONNX OCR constants (`OCR_LATIN_RECOGNIZER`, `OCR_CRAFT_DETECTOR`, …) that the live registry no longer serves. A breaking removal of public model constants was invisible.

## Cause

Two independent defects in the entry regex at `models/update-models/history.ts`, either of which alone caused under-parsing:

**1. Quote style.** `codegen.ts` emits `name: "..."`, and then `update-models` runs `npx prettier --write` over the generated file, which rewrites every string to single quotes. The reader only matched double quotes, so against the file as it exists on disk it matched nothing. This regressed when Prettier was adopted across the SDK pod (`8498b5f`).

**2. Nested braces.** The `\{[^}]+...\}` pattern cannot span an entry containing `shardMetadata` or `companionSet`. Those entries were skipped outright, and the companion files nested inside them could be matched as models in their own right.

## Fix

- Split the `models` array into entries by quote-aware brace-depth scanning (`extractEntryBlocks`) rather than a brace-bounded regex, so nested objects and braces inside string literals are both handled.
- Read `name` / `registryPath` with a matcher that accepts either quote style and tolerates the line break Prettier inserts after the colon on long values.
- Warn when the file is present but nothing parses. Silently returning `[]` is what let this go unnoticed; a loud "drift comparison is unreliable" would have surfaced it immediately.

No change to codegen or to the generated file format — this is read-side only.

## Verification

Against the current catalog:

| | before | after |
|---|---|---|
| `previous_count` | 0 | 681 |
| drift reported | 681 added, 0 removed | 19 added, 19 removed |

The 19/19 figure was cross-checked against an independent diff of the exported constant names between the committed and regenerated files. `bun run check-models` against an up-to-date file now correctly prints `✅ Models are up to date (681 models)` instead of listing the whole catalog as new.

New unit test `test/unit/update-models-history.test.ts` (6 tests / 16 asserts) covers:

- codegen → load round-trip
- single-quoted (Prettier-normalised) input — the primary regression
- values wrapped onto the next line by Prettier
- entries with nested companion sets, asserting the following entry is not swallowed and companion files are not reported as models
- braces inside string literals not skewing depth

`test:unit` (97 files), `typecheck`, `lint`, `format` and `build` all pass.

## Notes for reviewers

This is split out of a larger models regeneration so it can be reviewed on its own. The follow-up PR regenerating `models/registry/models.ts` carries the 19 ONNX OCR constant removals and needs a breaking-change changelog entry — that removal is only legible in the history file once this fix is in.
