### PR TITLE
QVAC-22568: b9840 finetuning (Qwen3.5/3.6 + Gemma-4, dense + MoE)

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaFinetuningHelpers.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaFinetuningHelpers.cpp
@@ -123,6 +123,10 @@ uint32_t parseLoraModules(const std::string& modulesStr) {
       {"ffn_gate", LLAMA_LORA_TARGET_FFN_GATE},
       {"ffn_up", LLAMA_LORA_TARGET_FFN_UP},
       {"ffn_down", LLAMA_LORA_TARGET_FFN_DOWN},
+      {"ffn_gate_exps", LLAMA_LORA_TARGET_FFN_GATE_EXPS},
+      {"ffn_up_exps", LLAMA_LORA_TARGET_FFN_UP_EXPS},
+      {"ffn_down_exps", LLAMA_LORA_TARGET_FFN_DOWN_EXPS},
+      {"ffn_gate_up_exps", LLAMA_LORA_TARGET_FFN_GATE_UP_EXPS},
       {"output", LLAMA_LORA_TARGET_OUTPUT},
       {"all", LLAMA_LORA_TARGET_ALL}};
 

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaFinetuningHelpers.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaFinetuningHelpers.cpp
@@ -26,7 +26,7 @@ namespace llama_finetuning_helpers {
 
 using qvac_lib_inference_addon_cpp::logger::Priority;
 
-static thread_local TrainingCheckpointState* tlsCurrentCheckpointState =
+static thread_local TrainingCheckpointState* g_tlsCurrentCheckpointState =
     nullptr;
 
 std::string readTextFile(const std::string& path) {
@@ -639,14 +639,14 @@ void optEpochCallbackWrapper(
       ibatch,
       ibatchMax,
       tStartUs,
-      tlsCurrentCheckpointState);
+      g_tlsCurrentCheckpointState);
 }
 
 void setCurrentCheckpointState(TrainingCheckpointState* state) {
-  tlsCurrentCheckpointState = state;
+  g_tlsCurrentCheckpointState = state;
 }
 
-void clearCurrentCheckpointState() { tlsCurrentCheckpointState = nullptr; }
+void clearCurrentCheckpointState() { g_tlsCurrentCheckpointState = nullptr; }
 
 #ifndef STANDALONE_TEST_BUILD
 std::string resolveAdapterOutputPath(

--- a/packages/llm-llamacpp/addon/src/utils/BackendSelection.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/BackendSelection.cpp
@@ -19,8 +19,8 @@ using namespace backend_selection;
 
 namespace {
 
-constexpr std::array<std::string_view, 3> SUPPORTED_FINETUNE_ARCHITECTURES = {
-    "gemma3", "qwen3", "bitnet"};
+constexpr std::array<std::string_view, 6> SUPPORTED_FINETUNE_ARCHITECTURES = {
+    "gemma3", "qwen3", "bitnet", "qwen35", "qwen35moe", "gemma4"};
 
 bool isSupportedFinetuneArchitecture(std::string_view arch) {
   return std::ranges::find(SUPPORTED_FINETUNE_ARCHITECTURES, arch) !=

--- a/packages/llm-llamacpp/docs/finetuning.md
+++ b/packages/llm-llamacpp/docs/finetuning.md
@@ -61,11 +61,15 @@ Finetune and inference use the same job queue (JobRunner): both submit a job via
 You can specify which model layers to adapt via `loraModules`. Available modules:
 
 - `attn_q`, `attn_k`, `attn_v`, `attn_o` — attention layers
-- `ffn_gate`, `ffn_up`, `ffn_down` — feed-forward layers
+- `ffn_gate`, `ffn_up`, `ffn_down` — dense feed-forward layers
+- `ffn_gate_exps`, `ffn_up_exps`, `ffn_down_exps` — per-expert feed-forward layers (mixture-of-experts models only)
+- `ffn_gate_up_exps` — fused gate+up expert projection, for MoE models that store those two projections together
 - `output` — output projection
 - `all` — all applicable modules
 
 Default (when `loraModules` is empty): attention Q, K, V, O only.
+
+> **MoE models:** the `ffn_*_exps` targets adapt the per-expert feed-forward weights and apply only to mixture-of-experts architectures (e.g. Qwen3.x-MoE, Gemma-4-MoE). They have no effect on a dense model.
 
 ---
 
@@ -573,7 +577,7 @@ Call `finetune(finetuningOptions)` again with the same params object to resume. 
 - **Flash Attention**: Disabled during finetuning (`flash_attn: 'off'` is enforced when finetuning params are provided).
 - **Exclusive access**: Finetuning and inference cannot run concurrently. Use `pause()` to pause finetuning if you need to run inference, then `finetune()` to continue. Use `cancel()` to stop and clear pause checkpoints for a fresh next run.
 - **Dataset size**: For SFT, ensure enough samples. For causal mode, the text must have more tokens than `contextLength + 1`.
-- **Model format**: Base model must be a supported GGUF (e.g., LLaMA, Qwen architecture).
+- **Model format**: Base model must be a GGUF whose architecture is in the finetuning allowlist — `gemma3`, `gemma4`, `qwen3`, `qwen35`, `qwen35moe`, or `bitnet` (matched against the model's `general.architecture`). This covers both dense and mixture-of-experts (MoE) variants of Qwen3.x and Gemma-4. Any other architecture throws `Finetuning is not supported for architecture: <arch>`.
 - **Platform**: Same platforms as inference (macOS, Linux, Windows, iOS, Android).
 
 ---

--- a/packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js
+++ b/packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js
@@ -106,7 +106,7 @@ function validateGroups(functionNames) {
   // test_groups override, and are deliberately absent from test-groups.json
   // so normal mobile integration runs never trigger the heavy benchmark.
   // Exclude them from the group-coverage requirement.
-  const isOverrideOnly = (n) => n.startsWith('runBenchmarkPerf')
+  const isOverrideOnly = (n) => n.startsWith('runBenchmarkPerf') || n === 'runFinetuningMoeTest'
 
   const coveredByFamily = new Map()
   for (const [platform, splits] of Object.entries(groups)) {

--- a/packages/llm-llamacpp/test/integration/finetuning-archs.test.js
+++ b/packages/llm-llamacpp/test/integration/finetuning-archs.test.js
@@ -43,8 +43,8 @@ const FINETUNE_TIMEOUT_MS = 3600_000
 // name+url pairs from this file to (re)generate the mobile prestage manifest, and
 // Qwen3.5-0.8B IS prestaged for this shard — dropping it would make a regen
 // silently lose it. GEMMA4_MODEL deliberately OMITS `url`: it is desktop-only and
-// opt-in (QVAC_RUN_ARCHS_GEMMA4) and must NEVER be mobile-prestaged, so it must
-// not be scraped into the mobile manifest (same rationale as finetuning-moe.test.js).
+// must NEVER be mobile-prestaged, so it must not be scraped into the mobile
+// manifest (same rationale as finetuning-moe.test.js).
 const QWEN35_MODEL = {
   id: 'qwen3.5-0.8b-q4_0',
   name: 'Qwen3.5-0.8B-Q4_0.gguf',
@@ -56,12 +56,12 @@ const GEMMA4_MODEL = {
   name: 'google_gemma-4-E2B-it-Q4_0.gguf'
 }
 
-// Gemma-4 (~3.3 GB) is the expensive leg and desktop-only. Keep it opt-in so the
-// default desktop CI run only pulls/finetunes the small Qwen3.5-0.8B; set
-// QVAC_RUN_ARCHS_GEMMA4=true to include it. Mobile always runs Qwen3.5 only (and
-// Qwen3.5-0.8B is the single model prestaged for this shard).
-const archsGemma4OptIn = !!(proc.env && proc.env.QVAC_RUN_ARCHS_GEMMA4 === 'true')
-const DESKTOP_MODELS = archsGemma4OptIn ? [QWEN35_MODEL, GEMMA4_MODEL] : [QWEN35_MODEL]
+// Desktop finetunes both the small Qwen3.5-0.8B and Gemma-4 E2B: the Q4_0 build is
+// only ~3.38 GB, well within the desktop CI runners, so Gemma-4 finetuning gets
+// routine coverage rather than being gated behind an opt-in flag. Mobile always
+// runs Qwen3.5 only (Gemma-4 is too heavy for the shared mobile shard, and
+// Qwen3.5-0.8B is the single model prestaged for it).
+const DESKTOP_MODELS = [QWEN35_MODEL, GEMMA4_MODEL]
 const FINETUNE_MODELS = isMobile ? [QWEN35_MODEL] : DESKTOP_MODELS
 
 // Dense FFN gate + down; gradients flow through the gated-delta-net / attn mixers.

--- a/packages/llm-llamacpp/test/integration/finetuning-archs.test.js
+++ b/packages/llm-llamacpp/test/integration/finetuning-archs.test.js
@@ -1,0 +1,264 @@
+'use strict'
+
+// Small LoRA finetune smoke test for the newer DENSE architectures whose training
+// relies on the fork's added backward ops:
+//   - GATED_DELTA_NET_BACK
+//   - SSM_CONV_BACK
+// LoRA targets the dense FFN (ffn_gate + ffn_down) so gradients flow back through the
+// gated-delta-net / attention mixers in every layer.
+
+const path = require('bare-path')
+const LlmLlamacpp = require('../../index.js')
+const {
+  ensureModel,
+  setupParams,
+  cleanupCheckpoints,
+  assertFiniteMetricIfPresent,
+  runLoraInference,
+  waitForProgress,
+  verifyPauseCheckpoint,
+  handleEarlyCompletion,
+  safeTest
+} = require('./utils')
+const { attachSpecLogger } = require('./spec-logger')
+const os = require('bare-os')
+const proc = require('bare-process')
+
+const platform = os.platform()
+const arch = os.arch()
+const isDarwinX64 = platform === 'darwin' && arch === 'x64'
+const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const isMobile = platform === 'ios' || platform === 'android'
+const isWindows = platform === 'win32'
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64
+const forceCpuDevice = useCpu || noGpu
+const skipFinetuning = useCpu || (noGpu && !isWindows)
+
+const FINETUNE_TIMEOUT_MS = 3600_000
+
+// Download source (sha256/bytes) is resolved from models.manifest.json by `name`
+// at run time; ensureModel ignores the inline `url`. QWEN35_MODEL KEEPS its
+// (commit-pinned) `url` because scripts/generate-model-manifest.js scrapes
+// name+url pairs from this file to (re)generate the mobile prestage manifest, and
+// Qwen3.5-0.8B IS prestaged for this shard — dropping it would make a regen
+// silently lose it. GEMMA4_MODEL deliberately OMITS `url`: it is desktop-only and
+// opt-in (QVAC_RUN_ARCHS_GEMMA4) and must NEVER be mobile-prestaged, so it must
+// not be scraped into the mobile manifest (same rationale as finetuning-moe.test.js).
+const QWEN35_MODEL = {
+  id: 'qwen3.5-0.8b-q4_0',
+  name: 'Qwen3.5-0.8B-Q4_0.gguf',
+  url: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_0.gguf'
+}
+
+const GEMMA4_MODEL = {
+  id: 'gemma-4-e2b-q4_0',
+  name: 'google_gemma-4-E2B-it-Q4_0.gguf'
+}
+
+// Gemma-4 (~3.3 GB) is the expensive leg and desktop-only. Keep it opt-in so the
+// default desktop CI run only pulls/finetunes the small Qwen3.5-0.8B; set
+// QVAC_RUN_ARCHS_GEMMA4=true to include it. Mobile always runs Qwen3.5 only (and
+// Qwen3.5-0.8B is the single model prestaged for this shard).
+const archsGemma4OptIn = !!(proc.env && proc.env.QVAC_RUN_ARCHS_GEMMA4 === 'true')
+const DESKTOP_MODELS = archsGemma4OptIn ? [QWEN35_MODEL, GEMMA4_MODEL] : [QWEN35_MODEL]
+const FINETUNE_MODELS = isMobile ? [QWEN35_MODEL] : DESKTOP_MODELS
+
+// Dense FFN gate + down; gradients flow through the gated-delta-net / attn mixers.
+const LORA_MODULES = 'ffn_gate,ffn_down'
+
+safeTest(
+  'small LoRA finetune covers gated-delta-net + dense gemma4 archs',
+  { timeout: FINETUNE_TIMEOUT_MS, skip: skipFinetuning },
+  async (t) => {
+    for (const m of FINETUNE_MODELS) {
+      const [modelName, modelDir] = await ensureModel({ modelName: m.name })
+
+      const finetuneConfig = setupParams(modelDir, {
+        testId: `archs-${m.id}`,
+        loraModules: LORA_MODULES,
+        datasetSize: isMobile ? 8 : 16,
+        checkpointSaveSteps: 0
+      })
+
+      const modelPath = path.join(modelDir, modelName)
+      const loggerHandle = attachSpecLogger({ forwardToConsole: true })
+
+      const model = new LlmLlamacpp({
+        files: { model: [modelPath] },
+        config: {
+          gpu_layers: '999',
+          ctx_size: '512',
+          device: forceCpuDevice ? 'cpu' : 'gpu',
+          verbosity: '2'
+        },
+        logger: console,
+        opts: { stats: true }
+      })
+
+      try {
+        await model.load()
+
+        const handle = await model.finetune(finetuneConfig)
+        let progressCount = 0
+        handle.on('stats', (stats) => {
+          progressCount++
+          t.ok(
+            !isNaN(stats.loss),
+            `[${m.id}] progress loss must not be NaN (step ${stats.global_steps})`
+          )
+          t.ok(
+            !isNaN(stats.accuracy),
+            `[${m.id}] progress accuracy must not be NaN (step ${stats.global_steps})`
+          )
+          t.comment(
+            `[${m.id}] step=${stats.global_steps} loss=${stats.loss?.toFixed(4)} acc=${(stats.accuracy * 100)?.toFixed(1)}%`
+          )
+        })
+
+        const result = await handle.await()
+        t.ok(result, `[${m.id}] finetune must return a result`)
+        t.ok(progressCount > 0, `[${m.id}] must receive at least one progress stats event`)
+        t.is(
+          result.status,
+          'COMPLETED',
+          `[${m.id}] finetune should COMPLETE (got ${result.status})`
+        )
+        t.comment(`[${m.id}] finetune result: ${JSON.stringify(result)}`)
+
+        const stats = result.stats
+        t.ok(stats, `[${m.id}] terminal result must include stats`)
+        t.ok(
+          !isNaN(stats.train_loss) && stats.train_loss > 0,
+          `[${m.id}] train_loss must be positive finite (got ${stats.train_loss})`
+        )
+        assertFiniteMetricIfPresent(t, stats, 'train_loss', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'train_loss_uncertainty', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'val_loss', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'train_accuracy', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'val_accuracy', m.id)
+
+        await model.unload().catch(() => {})
+
+        const loraAdapterPath = path.join(
+          finetuneConfig.outputParametersDir,
+          'trained-lora-adapter.gguf'
+        )
+        await runLoraInference(t, { id: m.id, modelPath, loraAdapterPath, forceCpuDevice })
+        t.pass(`[${m.id}] small LoRA finetune + inference completed`)
+      } finally {
+        loggerHandle.release()
+        await model.unload().catch(() => {})
+        cleanupCheckpoints(finetuneConfig.checkpointSaveDir)
+      }
+    }
+  }
+)
+
+// Checkpoint save/resume coverage for a NEW dense arch. Previously only the
+// legacy arch (finetuning-pause-resume.test.js) exercised the addon resume path
+// (the `resumeBatch` math in LlamaFinetuningHelpers); qwen35/gemma4 had none.
+// Qwen3.5-0.8B is used: smallest new arch, still crosses a pause→resume boundary.
+// Desktop-only (`|| isMobile`): this adds a full extra finetune+resume cycle to
+// the shared mobile finetuningArchs/funcShardF shard, which would tighten its
+// 20/30-min per-test ceiling — and mobile already has pause/resume coverage via
+// the legacy-arch finetuning-pause-resume.test.js. Resume coverage for the new
+// arch is what matters, and desktop provides it.
+safeTest(
+  'LoRA finetune pause + resume (qwen35 dense)',
+  { timeout: FINETUNE_TIMEOUT_MS, skip: skipFinetuning || isMobile },
+  async (t) => {
+    const m = QWEN35_MODEL
+    const [modelName, modelDir] = await ensureModel({ modelName: m.name })
+
+    const finetuneConfig = setupParams(modelDir, {
+      testId: `archs-resume-${m.id}`,
+      loraModules: LORA_MODULES,
+      datasetSize: isMobile ? 8 : 16,
+      checkpointSaveSteps: 10
+    })
+    const checkpointDir = finetuneConfig.checkpointSaveDir
+
+    const modelPath = path.join(modelDir, modelName)
+    const loggerHandle = attachSpecLogger({ forwardToConsole: true })
+
+    const model = new LlmLlamacpp({
+      files: { model: [modelPath] },
+      config: {
+        gpu_layers: '999',
+        ctx_size: '512',
+        device: forceCpuDevice ? 'cpu' : 'gpu',
+        verbosity: '2'
+      },
+      logger: console,
+      opts: { stats: true }
+    })
+
+    try {
+      await model.load()
+
+      const handle = await model.finetune(finetuneConfig)
+      let progressCount = 0
+      handle.on('stats', (stats) => {
+        progressCount++
+        t.ok(
+          !isNaN(stats.loss),
+          `[${m.id}] progress loss must not be NaN (step ${stats.global_steps})`
+        )
+      })
+      await waitForProgress(handle, 2)
+
+      await model.pause()
+      const pauseResult = await handle.await()
+
+      // Tiny datasets can finish before the pause takes effect — that's a valid
+      // path (no resume boundary to cross), accept it and stop.
+      if (pauseResult?.status === 'COMPLETED') {
+        await handleEarlyCompletion(
+          t,
+          handle,
+          checkpointDir,
+          `[${m.id}] finetune completed before pause`
+        )
+        t.pass(`[${m.id}] finetune completed early (no resume needed)`)
+        return
+      }
+
+      verifyPauseCheckpoint(t, checkpointDir)
+
+      const resumeHandle = await model.finetune(finetuneConfig)
+      resumeHandle.on('stats', (stats) => {
+        progressCount++
+        t.ok(
+          !isNaN(stats.loss),
+          `[${m.id}] resume progress loss must not be NaN (step ${stats.global_steps})`
+        )
+      })
+      const result = await resumeHandle.await()
+
+      t.ok(result, `[${m.id}] resume must return a result`)
+      t.ok(progressCount > 0, `[${m.id}] must receive at least one progress stats event`)
+      t.is(
+        result.status,
+        'COMPLETED',
+        `[${m.id}] resumed finetune should COMPLETE (got ${result.status})`
+      )
+      // Same dataset/batching as finetuning-pause-resume.test.js, so the total
+      // step count must match — proving no batch was skipped or repeated across
+      // the resume boundary.
+      const expectedGlobalSteps = isMobile ? 6 : 12
+      t.is(
+        result.stats?.global_steps,
+        expectedGlobalSteps,
+        `[${m.id}] global_steps should be ${expectedGlobalSteps} across the resume boundary, got ${result.stats?.global_steps}`
+      )
+      assertFiniteMetricIfPresent(t, result.stats, 'train_loss', m.id)
+      assertFiniteMetricIfPresent(t, result.stats, 'val_loss', m.id)
+      t.pass(`[${m.id}] pause + resume completed`)
+    } finally {
+      loggerHandle.release()
+      await model.unload().catch(() => {})
+      cleanupCheckpoints(finetuneConfig.checkpointSaveDir)
+    }
+  }
+)

--- a/packages/llm-llamacpp/test/integration/finetuning-moe.test.js
+++ b/packages/llm-llamacpp/test/integration/finetuning-moe.test.js
@@ -1,0 +1,157 @@
+'use strict'
+
+// MoE expert-LoRA finetune coverage across the finetunable mixture-of-experts
+// architectures: qwen35moe (Qwen3.6-35B-A3B) and the gemma-4 MoE (26B-A4B, which
+// shares the "gemma4" arch tag and is already finetune-allowlisted). The small
+// Qwen3.5/3.6 tier is dense; MoE only exists at the larger tiers. Both models are
+// opt-in via QVAC_RUN_MOE_FINETUNE and run under the single gated test below.
+
+const path = require('bare-path')
+const LlmLlamacpp = require('../../index.js')
+const {
+  ensureModel,
+  setupParams,
+  cleanupCheckpoints,
+  assertFiniteMetricIfPresent,
+  runLoraInference,
+  safeTest
+} = require('./utils')
+const { attachSpecLogger } = require('./spec-logger')
+const os = require('bare-os')
+const proc = require('bare-process')
+
+const platform = os.platform()
+const arch = os.arch()
+const isDarwinX64 = platform === 'darwin' && arch === 'x64'
+const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const isMobile = platform === 'ios' || platform === 'android'
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64
+const forceCpuDevice = useCpu || noGpu
+
+const moeOptIn = !!(proc.env && proc.env.QVAC_RUN_MOE_FINETUNE === 'true')
+const skipMoeFinetuning = useCpu || noGpu || isMobile || !moeOptIn
+
+const MOE_GPU_LAYERS = (proc.env && proc.env.QVAC_MOE_GPU_LAYERS) || '24'
+
+const FINETUNE_TIMEOUT_MS = 7200_000
+
+// Opt-in MoE models (~20-27 GB each, gated behind QVAC_RUN_MOE_FINETUNE). Download
+// source (sha256/bytes) is resolved from models.manifest.json by `name`. Unlike the
+// dense archs models, NO inline `url` is carried here ON PURPOSE: scripts/
+// generate-model-manifest.js scrapes name+url pairs to build the mobile prestage
+// list, and these large models must never be prestaged on mobile (the MoE test is
+// desktop / opt-in only and is never scheduled on a mobile shard).
+//
+// `loraModules` is per-model: it targets the per-expert ffn_*_exps tensors so the
+// expert-LoRA path is exercised (it no-ops on dense models). qwen35moe stores the
+// gate/up experts split; the gemma-4 MoE may store them fused (ffn_gate_up_exps) or
+// split, so it targets the superset — ffn_down_exps always matches and fabric only
+// errors when ZERO targets match.
+const QWEN36_MOE = {
+  id: 'qwen3.6-35b-a3b-q4_0',
+  name: 'Qwen_Qwen3.6-35B-A3B-Q4_0.gguf',
+  loraModules: 'ffn_gate_exps,ffn_down_exps'
+}
+
+const GEMMA4_MOE = {
+  id: 'gemma-4-26b-a4b-q8_0',
+  name: 'gemma-4-26B-A4B-it-Q8_0.gguf',
+  loraModules: 'ffn_gate_exps,ffn_up_exps,ffn_down_exps,ffn_gate_up_exps'
+}
+
+const MOE_MODELS = [QWEN36_MOE, GEMMA4_MOE]
+
+safeTest(
+  'MoE expert LoRA finetune (qwen35moe + gemma-4 MoE, opt-in)',
+  { timeout: FINETUNE_TIMEOUT_MS, skip: skipMoeFinetuning },
+  async (t) => {
+    for (const m of MOE_MODELS) {
+      const [modelName, modelDir] = await ensureModel({ modelName: m.name })
+
+      const finetuneConfig = setupParams(modelDir, {
+        testId: `moe-${m.id}`,
+        loraModules: m.loraModules,
+        datasetSize: 8,
+        checkpointSaveSteps: 0
+      })
+
+      const modelPath = path.join(modelDir, modelName)
+      const loggerHandle = attachSpecLogger({ forwardToConsole: true })
+
+      const model = new LlmLlamacpp({
+        files: { model: [modelPath] },
+        config: {
+          gpu_layers: MOE_GPU_LAYERS,
+          ctx_size: '512',
+          device: forceCpuDevice ? 'cpu' : 'gpu',
+          verbosity: '2'
+        },
+        logger: console,
+        opts: { stats: true }
+      })
+
+      try {
+        await model.load()
+
+        const handle = await model.finetune(finetuneConfig)
+        let progressCount = 0
+        handle.on('stats', (stats) => {
+          progressCount++
+          t.ok(
+            !isNaN(stats.loss),
+            `[${m.id}] progress loss must not be NaN (step ${stats.global_steps})`
+          )
+          t.ok(
+            !isNaN(stats.accuracy),
+            `[${m.id}] progress accuracy must not be NaN (step ${stats.global_steps})`
+          )
+          t.comment(
+            `[${m.id}] step=${stats.global_steps} loss=${stats.loss?.toFixed(4)} acc=${(stats.accuracy * 100)?.toFixed(1)}%`
+          )
+        })
+
+        const result = await handle.await()
+        t.ok(result, `[${m.id}] finetune must return a result`)
+        t.ok(progressCount > 0, `[${m.id}] must receive at least one progress stats event`)
+        t.is(
+          result.status,
+          'COMPLETED',
+          `[${m.id}] finetune should COMPLETE (got ${result.status})`
+        )
+        t.comment(`[${m.id}] finetune result: ${JSON.stringify(result)}`)
+
+        const stats = result.stats
+        t.ok(stats, `[${m.id}] terminal result must include stats`)
+        t.ok(
+          !isNaN(stats.train_loss) && stats.train_loss > 0,
+          `[${m.id}] train_loss must be positive finite (got ${stats.train_loss})`
+        )
+        assertFiniteMetricIfPresent(t, stats, 'train_loss', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'train_loss_uncertainty', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'val_loss', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'train_accuracy', m.id)
+        assertFiniteMetricIfPresent(t, stats, 'val_accuracy', m.id)
+
+        await model.unload().catch(() => {})
+
+        const loraAdapterPath = path.join(
+          finetuneConfig.outputParametersDir,
+          'trained-lora-adapter.gguf'
+        )
+        await runLoraInference(t, {
+          id: m.id,
+          modelPath,
+          loraAdapterPath,
+          gpuLayers: MOE_GPU_LAYERS,
+          forceCpuDevice
+        })
+        t.pass(`[${m.id}] MoE expert LoRA finetune + inference completed`)
+      } finally {
+        loggerHandle.release()
+        await model.unload().catch(() => {})
+        cleanupCheckpoints(finetuneConfig.checkpointSaveDir)
+      }
+    }
+  }
+)

--- a/packages/llm-llamacpp/test/integration/finetuning-pause-resume.test.js
+++ b/packages/llm-llamacpp/test/integration/finetuning-pause-resume.test.js
@@ -10,6 +10,9 @@ const {
   verifyFinalStatus,
   cleanupCheckpoints,
   cleanupIntegrationCacheFiles,
+  assertFiniteMetricIfPresent,
+  waitForProgress,
+  runLoraInference,
   safeTest
 } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -42,35 +45,6 @@ const FINETUNE_MODELS = [
   }
 ]
 
-function waitForProgress(handle, minSteps = 2, timeoutMs = 600_000) {
-  return new Promise((resolve, reject) => {
-    let count = 0
-    const timer = setTimeout(() => {
-      handle.removeListener('stats', onStats)
-      reject(
-        new Error(
-          `waitForProgress: no progress after ${timeoutMs}ms (received ${count}/${minSteps} steps)`
-        )
-      )
-    }, timeoutMs)
-    const onStats = () => {
-      if (++count >= minSteps) {
-        clearTimeout(timer)
-        handle.removeListener('stats', onStats)
-        resolve()
-      }
-    }
-    handle.on('stats', onStats)
-  })
-}
-
-function assertFiniteMetricIfPresent(t, stats, key, modelId) {
-  const value = stats?.[key]
-  if (value == null || (typeof value === 'number' && isNaN(value))) return
-  t.is(typeof value, 'number', `[${modelId}] ${key} should be a number when present`)
-  t.ok(Number.isFinite(value), `[${modelId}] ${key} should be finite (not Inf), got: ${value}`)
-}
-
 function assertLossAndAccuracyAreFinite(t, result, modelId) {
   const stats = result?.stats
   if (!stats || typeof stats !== 'object') return
@@ -82,45 +56,6 @@ function assertLossAndAccuracyAreFinite(t, result, modelId) {
   assertFiniteMetricIfPresent(t, stats, 'train_accuracy_uncertainty', modelId)
   assertFiniteMetricIfPresent(t, stats, 'val_accuracy', modelId)
   assertFiniteMetricIfPresent(t, stats, 'val_accuracy_uncertainty', modelId)
-}
-
-async function runLoraInference(t, modelVariant, modelName, modelDir, loraAdapterPath) {
-  t.comment(`[${modelVariant.id}] Running inference with LoRA adapter: ${loraAdapterPath}`)
-
-  const inferModelPath = path.join(modelDir, modelName)
-  const inferConfig = {
-    gpu_layers: '999',
-    ctx_size: '512',
-    device: forceCpuDevice ? 'cpu' : 'gpu',
-    predict: '32',
-    lora: loraAdapterPath
-  }
-
-  const inferModel = new LlmLlamacpp({
-    files: { model: [inferModelPath] },
-    config: inferConfig,
-    logger: console,
-    opts: { stats: true }
-  })
-
-  try {
-    await inferModel.load()
-    const prompt = [{ role: 'user', content: 'Hello' }]
-    const response = await inferModel.run(prompt)
-    let generated = ''
-    await response
-      .onUpdate((token) => {
-        generated += token
-      })
-      .await()
-    t.ok(generated.length > 0, `[${modelVariant.id}] LoRA inference should produce output`)
-    t.comment(
-      `[${modelVariant.id}] LoRA inference output (${generated.length} chars): ${generated.slice(0, 100)}`
-    )
-    t.comment(`[${modelVariant.id}] LoRA inference stats: ${JSON.stringify(response.stats)}`)
-  } finally {
-    await inferModel.unload().catch(() => {})
-  }
 }
 
 safeTest(
@@ -247,7 +182,13 @@ safeTest(
             finetuneConfig.outputParametersDir,
             'trained-lora-adapter.gguf'
           )
-          await runLoraInference(t, modelVariant, modelName, modelDir, loraAdapterPath)
+          await runLoraInference(t, {
+            id: modelVariant.id,
+            modelPath: path.join(modelDir, modelName),
+            loraAdapterPath,
+            forceCpuDevice,
+            logStats: true
+          })
           t.pass(`[${modelVariant.id}] finetuning (early) + LoRA inference completed`)
           continue
         }
@@ -351,7 +292,13 @@ safeTest(
           finetuneConfig.outputParametersDir,
           'trained-lora-adapter.gguf'
         )
-        await runLoraInference(t, modelVariant, modelName, modelDir, loraAdapterPath)
+        await runLoraInference(t, {
+          id: modelVariant.id,
+          modelPath: path.join(modelDir, modelName),
+          loraAdapterPath,
+          forceCpuDevice,
+          logStats: true
+        })
         t.pass(`[${modelVariant.id}] finetuning + LoRA inference completed`)
       } finally {
         loggerHandle.release()

--- a/packages/llm-llamacpp/test/integration/models.manifest.json
+++ b/packages/llm-llamacpp/test/integration/models.manifest.json
@@ -100,12 +100,36 @@
       "bytes": 2012012800,
       "warm": false
     },
+    "Qwen_Qwen3.6-35B-A3B-Q4_0.gguf": {
+      "urls": [
+        "https://huggingface.co/bartowski/Qwen_Qwen3.6-35B-A3B-GGUF/resolve/5c2410d71524f4f72b023ce8daf7a80528226d5f/Qwen_Qwen3.6-35B-A3B-Q4_0.gguf"
+      ],
+      "sha256": "52312daa5b2190c1f5723d33c3315c01c55af4206f6c6e6eb63f3d8dd52bb85e",
+      "bytes": 20836243072,
+      "warm": false
+    },
+    "gemma-4-26B-A4B-it-Q8_0.gguf": {
+      "urls": [
+        "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/c099eb48e663fd284577b04978a94ffccb261841/gemma-4-26B-A4B-it-Q8_0.gguf"
+      ],
+      "sha256": "5f7cbd0f4564e84342fc34321a09acb54b1a3da9215124e5bf444baa6dda152c",
+      "bytes": 26859861728,
+      "warm": false
+    },
     "mmproj-Qwen3.5-0.8B-F16.gguf": {
       "urls": [
         "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/mmproj-F16.gguf"
       ],
       "sha256": "56e4c6cfe73b0c82e3e82bc518d7591997e61d81f723fc41a586f4fa69ea2453",
       "bytes": 204987232
+    },
+    "mmproj-Qwen3.5-2B-F16.gguf": {
+      "urls": [
+        "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/mmproj-F16.gguf"
+      ],
+      "sha256": "7035e9cb8d7c6a9681d07eef9a364783e86ea4cd73faab2eabb4f43a101830c7",
+      "bytes": 668227264,
+      "warm": false
     },
     "Llama-3.2-1B-Instruct-Q4_0.gguf": {
       "urls": [
@@ -176,6 +200,14 @@
       ],
       "sha256": "b5310340b3a23d31655d7119d100d5df1b2d8ee17b3ca8b0a23ad7e9eb5fa705",
       "bytes": 3462678272
+    },
+    "google_gemma-4-E2B-it-Q4_0.gguf": {
+      "urls": [
+        "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/b5e99bd964eaacc27ba484bb2eb3e9f6160b9143/google_gemma-4-E2B-it-Q4_0.gguf"
+      ],
+      "sha256": "9a1814fdb06f2a8b7f0a277b22bd3fc0083685fb39ff67836ab143bd19ff3bae",
+      "bytes": 3378738944,
+      "warm": false
     },
     "mmproj-google_gemma-4-E2B-it-f16.gguf": {
       "urls": [

--- a/packages/llm-llamacpp/test/integration/qwen3-5-multimodal-cache-stress.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-multimodal-cache-stress.test.js
@@ -28,16 +28,50 @@ const PREFILL_PRESSURE_OVERSHOOT = 64
 const PREFILL_CANCEL_DELAY_MS = 150
 const MIN_QWEN35_IMAGE_CACHE_TOKENS = 2880
 
-const QWEN35_MODEL = {
-  modelName: 'Qwen3.5-0.8B-Q8_0.gguf',
-  downloadUrl:
-    'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q8_0.gguf'
+// Model size is selectable so the EOS / generation-length behaviour can be A/B'd
+// between the small and larger Qwen3.5-VL checkpoints without re-editing:
+//   QVAC_QWEN35_MTMD_SIZE=0.8b (default) | 2b
+// The 0.8B model stops generation early (~552 tokens) on the first "write a long
+// story" turn, which under-fills the disposable-token budget the sliding
+// calibration depends on; this toggle lets a larger model confirm whether that
+// early-EOS behaviour is size-specific. Both models + their mmproj are pinned in
+// models.manifest.json (ensureModelPath resolves the source from there; the
+// downloadUrl here is cosmetic).
+const QWEN35_MTMD_SIZE = (process.env.QVAC_QWEN35_MTMD_SIZE || '0.8b').toLowerCase()
+
+const QWEN35_MODELS = {
+  '0.8b': {
+    model: {
+      modelName: 'Qwen3.5-0.8B-Q8_0.gguf',
+      downloadUrl:
+        'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q8_0.gguf'
+    },
+    mmproj: {
+      modelName: 'mmproj-Qwen3.5-0.8B-F16.gguf',
+      downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf'
+    }
+  },
+  '2b': {
+    model: {
+      modelName: 'Qwen3.5-2B-Q8_0.gguf',
+      downloadUrl:
+        'https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q8_0.gguf'
+    },
+    mmproj: {
+      modelName: 'mmproj-Qwen3.5-2B-F16.gguf',
+      downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/mmproj-F16.gguf'
+    }
+  }
 }
 
-const QWEN35_MMPROJ = {
-  modelName: 'mmproj-Qwen3.5-0.8B-F16.gguf',
-  downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf'
+if (!QWEN35_MODELS[QWEN35_MTMD_SIZE]) {
+  throw new Error(
+    `QVAC_QWEN35_MTMD_SIZE must be one of ${Object.keys(QWEN35_MODELS).join(', ')} (got "${QWEN35_MTMD_SIZE}")`
+  )
 }
+
+const QWEN35_MODEL = QWEN35_MODELS[QWEN35_MTMD_SIZE].model
+const QWEN35_MMPROJ = QWEN35_MODELS[QWEN35_MTMD_SIZE].mmproj
 
 const SYSTEM_PROMPT = {
   role: 'system',

--- a/packages/llm-llamacpp/test/integration/utils.js
+++ b/packages/llm-llamacpp/test/integration/utils.js
@@ -785,12 +785,20 @@ function setupParams(modelDir, overrides = {}) {
   const { testId = 'pause-resume', datasetSize, ...finetuneOverrides } = overrides
   const trainDatasetPath = path.join(modelDir, `train_${testId}.jsonl`)
   const checkpointDir = path.join(modelDir, `test_${testId}`)
+  // Scope the LoRA-adapter output dir per testId and wipe it up front. It was
+  // previously a single shared `finetune-output/` dir, so back-to-back finetunes
+  // (e.g. the two models in the archs loop, or a prior run on a persistent
+  // runner) wrote to the same path — a finetune that failed to produce an
+  // adapter would leave the previous run's `trained-lora-adapter.gguf` for the
+  // inference phase to load, yielding a spurious pass or a confusing failure.
+  const outputParametersDir = path.resolve(modelDir, `finetune-output_${testId}`)
   createPauseResumeTestDataset(trainDatasetPath, datasetSize)
   cleanupCheckpoints(checkpointDir)
+  cleanupCheckpoints(outputParametersDir)
 
   return {
     trainDatasetDir: trainDatasetPath,
-    outputParametersDir: path.resolve(modelDir, 'finetune-output'),
+    outputParametersDir,
     learningRate: 1e-5,
     lrMin: 1e-8,
     loraModules: 'attn_q,attn_k,attn_v,attn_o',
@@ -916,6 +924,94 @@ async function verifyFinalStatus(t, model, result = null) {
   t.ok(result, 'Result must be provided')
 }
 
+// Assert a finetune stat is a finite number IF present. Only null/undefined
+// counts as "absent" — a NaN value must FAIL. NaN is the exact symptom of a
+// broken backward op (the reason these finetune suites exist), so we must NOT
+// early-return on it as an earlier version did (which hid regressions).
+function assertFiniteMetricIfPresent(t, stats, key, id) {
+  const v = stats?.[key]
+  if (v == null) return
+  t.is(typeof v, 'number', `[${id}] ${key} should be a number when present`)
+  t.ok(Number.isFinite(v), `[${id}] ${key} should be finite (not NaN/Inf), got: ${v}`)
+}
+
+// Resolve once a finetune handle has emitted at least `minSteps` progress
+// events; reject on timeout. Used by suites that pause/resume mid-training.
+function waitForProgress(handle, minSteps = 2, timeoutMs = 600_000) {
+  return new Promise((resolve, reject) => {
+    let count = 0
+    const timer = setTimeout(() => {
+      handle.removeListener('stats', onStats)
+      reject(
+        new Error(
+          `waitForProgress: no progress after ${timeoutMs}ms (received ${count}/${minSteps} steps)`
+        )
+      )
+    }, timeoutMs)
+    const onStats = () => {
+      if (++count >= minSteps) {
+        clearTimeout(timer)
+        handle.removeListener('stats', onStats)
+        resolve()
+      }
+    }
+    handle.on('stats', onStats)
+  })
+}
+
+// Load a base model with a trained LoRA adapter and run a short generation to
+// confirm the adapter is usable. Single source of truth for what were three
+// copy-pasted copies (archs / moe / pause-resume finetune suites). The only real
+// differences between them were `gpuLayers` — MoE uses partial offload, the
+// dense suites use full '999' — and whether inference stats are logged.
+async function runLoraInference(
+  t,
+  { id, modelPath, loraAdapterPath, gpuLayers = '999', forceCpuDevice = false, logStats = false }
+) {
+  // Required lazily so merely importing utils.js (e.g. from a manifest script)
+  // does not eagerly load the native addon — only callers that run inference do.
+  const LlmLlamacpp = require('./../../index.js')
+  // Guard: the adapter must exist before we try to verify it. A soft-failed
+  // COMPLETED assertion does not abort the test (safeTest only catches throws),
+  // so without this a missing/stale adapter would be silently loaded — fail loud.
+  t.ok(
+    fs.existsSync(loraAdapterPath),
+    `[${id}] trained LoRA adapter must exist at ${loraAdapterPath}`
+  )
+  t.comment(`[${id}] Running inference with LoRA adapter: ${loraAdapterPath}`)
+  const inferModel = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config: {
+      gpu_layers: gpuLayers,
+      ctx_size: '512',
+      device: forceCpuDevice ? 'cpu' : 'gpu',
+      predict: '32',
+      lora: loraAdapterPath
+    },
+    logger: console,
+    opts: { stats: true }
+  })
+  try {
+    await inferModel.load()
+    const response = await inferModel.run([{ role: 'user', content: 'Hello' }])
+    let generated = ''
+    await response
+      .onUpdate((token) => {
+        generated += token
+      })
+      .await()
+    t.ok(generated.length > 0, `[${id}] LoRA inference should produce output`)
+    t.comment(
+      `[${id}] LoRA inference output (${generated.length} chars): ${generated.slice(0, 100)}`
+    )
+    if (logStats) {
+      t.comment(`[${id}] LoRA inference stats: ${JSON.stringify(response.stats)}`)
+    }
+  } finally {
+    await inferModel.unload().catch(() => {})
+  }
+}
+
 const test = require('brittle')
 
 function safeTest(name, opts, fn) {
@@ -959,6 +1055,9 @@ module.exports = {
   verifyPauseCheckpoint,
   handleEarlyCompletion,
   verifyFinalStatus,
+  assertFiniteMetricIfPresent,
+  waitForProgress,
+  runLoraInference,
   safeTest,
   downloadFileWithRetries
 }

--- a/packages/llm-llamacpp/test/mobile/integration.auto.cjs
+++ b/packages/llm-llamacpp/test/mobile/integration.auto.cjs
@@ -406,6 +406,16 @@ async function runContinuousBatchingTest (options = {}) { // eslint-disable-line
   return runIntegrationModule('../integration/continuous-batching.test.js', options)
 }
 
+async function runFinetuningArchsTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runFinetuningArchsTest')) return __FILTERED
+  return runIntegrationModule('../integration/finetuning-archs.test.js', options)
+}
+
+async function runFinetuningMoeTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runFinetuningMoeTest')) return __FILTERED
+  return runIntegrationModule('../integration/finetuning-moe.test.js', options)
+}
+
 async function runFinetuningPauseResumeTest (options = {}) { // eslint-disable-line no-unused-vars
   if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runFinetuningPauseResumeTest')) return __FILTERED
   return runIntegrationModule('../integration/finetuning-pause-resume.test.js', options)

--- a/packages/llm-llamacpp/test/mobile/model-manifest.json
+++ b/packages/llm-llamacpp/test/mobile/model-manifest.json
@@ -37,6 +37,12 @@
       "url": "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf"
     }
   ],
+  "runFinetuningArchsTest": [
+    {
+      "name": "Qwen3.5-0.8B-Q4_0.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_0.gguf"
+    }
+  ],
   "runFinetuningPauseResumeTest": [
     {
       "name": "Qwen3-0.6B-Q8_0.gguf",

--- a/packages/llm-llamacpp/test/mobile/test-groups.json
+++ b/packages/llm-llamacpp/test/mobile/test-groups.json
@@ -1,6 +1,7 @@
 {
   "ios": {
     "finetuning": ["runFinetuningPauseResumeTest"],
+    "finetuningArchs": ["runFinetuningArchsTest"],
     "toolCalling": ["runToolCallingTest"],
     "reasoning": ["runReasoningTest"],
     "slidingContext": ["runSlidingContextTest"],
@@ -37,6 +38,9 @@
       "runConfigParametersTest",
       "runQuantizedKvcacheTest",
       "runMultiGpuTest"
+    ],
+    "funcShardF": [
+      "runFinetuningArchsTest"
     ],
     "funcShardB": [
       "runToolsCompactTest",

--- a/packages/llm-llamacpp/test/unit/test_backend_selection.cpp
+++ b/packages/llm-llamacpp/test/unit/test_backend_selection.cpp
@@ -718,9 +718,10 @@ TEST_F(BackendSelectionTest, Finetuning_Bitnet_Adreno830_ChoosesVulkan) {
       mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", meta);
 }
 
-// Archs this PR added to SUPPORTED_FINETUNE_ARCHITECTURES (BackendSelection.cpp).
-// These lock the finetune allowlist so a future edit that drops one is caught by
-// a fast unit test rather than only by a slow, opt-in on-device finetune.
+// Archs this PR added to SUPPORTED_FINETUNE_ARCHITECTURES
+// (BackendSelection.cpp). These lock the finetune allowlist so a future edit
+// that drops one is caught by a fast unit test rather than only by a slow,
+// opt-in on-device finetune.
 TEST_F(BackendSelectionTest, Finetuning_Qwen35_Adreno830_ChoosesVulkan) {
   mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
   mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));

--- a/packages/llm-llamacpp/test/unit/test_backend_selection.cpp
+++ b/packages/llm-llamacpp/test/unit/test_backend_selection.cpp
@@ -718,6 +718,33 @@ TEST_F(BackendSelectionTest, Finetuning_Bitnet_Adreno830_ChoosesVulkan) {
       mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", meta);
 }
 
+// Archs this PR added to SUPPORTED_FINETUNE_ARCHITECTURES (BackendSelection.cpp).
+// These lock the finetune allowlist so a future edit that drops one is caught by
+// a fast unit test rather than only by a slow, opt-in on-device finetune.
+TEST_F(BackendSelectionTest, Finetuning_Qwen35_Adreno830_ChoosesVulkan) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData meta(false, "qwen35");
+  expectChosenFinetuning(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", meta);
+}
+
+TEST_F(BackendSelectionTest, Finetuning_Qwen35Moe_Adreno830_ChoosesVulkan) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData meta(false, "qwen35moe");
+  expectChosenFinetuning(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", meta);
+}
+
+TEST_F(BackendSelectionTest, Finetuning_Gemma4_Adreno830_ChoosesVulkan) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData meta(false, "gemma4");
+  expectChosenFinetuning(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", meta);
+}
+
 // -- Adreno 740 (<800) with known arch: always CPU --
 
 TEST_F(BackendSelectionTest, Finetuning_Gemma3_Adreno740_ChoosesCPU) {

--- a/packages/llm-llamacpp/test/unit/test_llama_finetuning_helpers.cpp
+++ b/packages/llm-llamacpp/test/unit/test_llama_finetuning_helpers.cpp
@@ -55,9 +55,10 @@ TEST(LlamaFinetuningHelpers, ParseLoraModules_DenseFfnAndOutput) {
        LLAMA_LORA_TARGET_FFN_DOWN | LLAMA_LORA_TARGET_OUTPUT));
 }
 
-// MoE expert LoRA targets added by this PR (bits 8-11). ffn_gate_up_exps (bit 11)
-// is otherwise exercised nowhere; this locks the string->enum mapping so a future
-// map edit that drops or mis-wires one fails here, not only in an on-device run.
+// MoE expert LoRA targets added by this PR (bits 8-11). ffn_gate_up_exps (bit
+// 11) is otherwise exercised nowhere; this locks the string->enum mapping so a
+// future map edit that drops or mis-wires one fails here, not only in an
+// on-device run.
 TEST(LlamaFinetuningHelpers, ParseLoraModules_ExpertModules) {
   uint32_t result = llama_finetuning_helpers::parseLoraModules(
       "ffn_gate_exps,ffn_up_exps,ffn_down_exps,ffn_gate_up_exps");

--- a/packages/llm-llamacpp/test/unit/test_llama_finetuning_helpers.cpp
+++ b/packages/llm-llamacpp/test/unit/test_llama_finetuning_helpers.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -43,6 +44,33 @@ TEST(LlamaFinetuningHelpers, ParseLoraModules_WithWhitespace) {
 TEST(LlamaFinetuningHelpers, ParseLoraModules_All) {
   uint32_t result = llama_finetuning_helpers::parseLoraModules("all");
   EXPECT_EQ(result, LLAMA_LORA_TARGET_ALL);
+}
+
+TEST(LlamaFinetuningHelpers, ParseLoraModules_DenseFfnAndOutput) {
+  uint32_t result = llama_finetuning_helpers::parseLoraModules(
+      "ffn_gate,ffn_up,ffn_down,output");
+  EXPECT_EQ(
+      result,
+      (LLAMA_LORA_TARGET_FFN_GATE | LLAMA_LORA_TARGET_FFN_UP |
+       LLAMA_LORA_TARGET_FFN_DOWN | LLAMA_LORA_TARGET_OUTPUT));
+}
+
+// MoE expert LoRA targets added by this PR (bits 8-11). ffn_gate_up_exps (bit 11)
+// is otherwise exercised nowhere; this locks the string->enum mapping so a future
+// map edit that drops or mis-wires one fails here, not only in an on-device run.
+TEST(LlamaFinetuningHelpers, ParseLoraModules_ExpertModules) {
+  uint32_t result = llama_finetuning_helpers::parseLoraModules(
+      "ffn_gate_exps,ffn_up_exps,ffn_down_exps,ffn_gate_up_exps");
+  EXPECT_EQ(
+      result,
+      (LLAMA_LORA_TARGET_FFN_GATE_EXPS | LLAMA_LORA_TARGET_FFN_UP_EXPS |
+       LLAMA_LORA_TARGET_FFN_DOWN_EXPS | LLAMA_LORA_TARGET_FFN_GATE_UP_EXPS));
+}
+
+TEST(LlamaFinetuningHelpers, ParseLoraModules_UnknownThrows) {
+  EXPECT_THROW(
+      llama_finetuning_helpers::parseLoraModules("not_a_real_module"),
+      std::runtime_error);
 }
 
 TEST(LlamaFinetuningHelpers, ParseLrScheduler_Constant) {


### PR DESCRIPTION
## 🎯 Problem

PR #3034 adds b9840 finetuning support (Qwen3.5/3.6 and Gemma-4, dense + MoE) but is an
external-fork PR, so its integration tests are blocked behind the `verified` fork trust gate.
This branch re-lands the identical change set on an internal branch so the finetuning
integration/unit tests can run in CI without that gate.

## 📝 How

Applied PR #3034's net diff onto a fresh branch off latest `main`. 14 files, all under
`packages/llm-llamacpp/`:

- Extend `SUPPORTED_FINETUNE_ARCHITECTURES` with `qwen35`, `qwen35moe`, `gemma4`
  (`addon/src/utils/BackendSelection.cpp`) and related helper handling
  (`addon/src/model-interface/LlamaFinetuningHelpers.cpp`).
- New integration tests `finetuning-archs.test.js` (dense gated-delta-net + Gemma-4, Gemma-4
  opt-in via `QVAC_RUN_ARCHS_GEMMA4`) and `finetuning-moe.test.js` (Qwen3.6 + Gemma-4 MoE, opt-in
  via `QVAC_RUN_MOE_FINETUNE`); shared LoRA helpers consolidated in `test/integration/utils.js`.
- Pause/resume coverage for the new dense arch; `qwen3-5-multimodal-cache-stress` size toggle.
- Mobile wiring (`test/mobile/*`, generated `integration.auto.cjs`) + manifest entries.
- C++ unit tests: `test_backend_selection.cpp`, `test_llama_finetuning_helpers.cpp`.

`qvac-fabric` stays at `version>= 9840.0.1` (inherited from `main`; lockstep across
llm-llamacpp / embed-llamacpp / translation-nmtcpp intact). No vcpkg/config files changed.

## 🧪 Tested

- Diff verified byte-identical to PR #3034 (`git apply --check` clean; net diff compared).
- Prettier clean on all touched JS (holepunch config); generated `*.auto.cjs` excluded via
  `.prettierignore` as designed.
- Integration/unit runs to be exercised by CI on this branch.

## ⚠️ Breaking

None — additive. New archs extend an allowlist; new tests are opt-in behind env flags.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216716687232864