### PR TITLE
[DO NOT MERGE] QVAC-21597 tts-ggml Parler on Adreno OpenCL — ggml #49 + whisper #115

### DIFF
--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports;${VCPKG_OVERLAY_PORTS}")
 
 project(tts-ggml CXX C)
 

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -47,10 +47,6 @@ const { recordTtsStats } = require('../utils/perf-helper')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
-// Parler's only validated GPU backend is Metal (Apple); it has no vulkan/opencl/
-// cuda kernels yet, so its GPU smoke is gated to Apple — every other platform
-// runs Parler on CPU (covered by the unconditional CPU smoke below).
-const isApple = platform === 'darwin' || platform === 'ios'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 
@@ -539,18 +535,18 @@ test(
   }
 )
 
-// Parler smoke over the two mobile-target variants (mini + indic, q8). The GPU
-// leg is gated to Apple: Metal is Parler's only validated GPU backend, so it
-// runs on darwin/ios GPU runners and the iOS Device Farm where useGPU=true must
-// engage Metal (backendId=1). The CPU leg runs everywhere and locks the
-// explicit-CPU contract in. Both are strict assertions.
+// Parler smoke over the two mobile-target variants (mini + indic, q8). Parler's
+// validated GPU backends are Metal, Vulkan and Adreno OpenCL, so the GPU leg runs
+// on every GPU-capable platform and asserts strictly -- no allowPolicyCpu hatch,
+// because there is no longer a backend Parler declines. The CPU leg runs
+// everywhere and locks the explicit-CPU contract in.
 for (const v of [
   { variant: 'mini', label: 'mini q8' },
   { variant: 'indic', label: 'indic q8', optional: true }
 ]) {
   test(
-    `Parler GPU smoke (${v.label}) - useGPU=true must engage the Metal backend on Apple`,
-    { timeout: 600000, skip: NO_GPU || !isApple },
+    `Parler GPU smoke (${v.label}) - useGPU=true must engage the GPU backend on GPU-capable platforms`,
+    { timeout: 600000, skip: NO_GPU || !expectsGpu() },
     async (t) => {
       const modelsDir = path.join(getBaseDir(), 'models')
       const download = await ensureParlerModel({ targetDir: modelsDir, variant: v.variant })

--- a/packages/tts-ggml/test/integration/parler.test.js
+++ b/packages/tts-ggml/test/integration/parler.test.js
@@ -16,7 +16,6 @@ const { recordTtsStats } = require('../utils/perf-helper')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
-const isApple = platform === 'darwin' || platform === 'ios'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 
 function getBaseDir() {
@@ -374,7 +373,7 @@ test(
     const TTSGgml = require('@qvac/tts-ggml')
     const text =
       'The quick brown fox jumps over the lazy dog while the sun sets slowly behind the hills.'
-    const useGPU = isApple && !NO_GPU
+    const useGPU = !NO_GPU
 
     async function synth(extra) {
       const model = new TTSGgml({
@@ -489,8 +488,8 @@ test(
 )
 
 // Desktop quant + backend coverage: q8_0 + f16 for indic/mini, q8_0 for large.
-// Runs on the platform's GPU-if-available backend (Metal on Apple GPU runners,
-// CPU otherwise). large self-gates on RAM; any tier that isn't staged skips
+// Runs on the platform's GPU-if-available backend (Metal on Apple, Vulkan on
+// Linux/Windows). large self-gates on RAM; any tier that isn't staged skips
 // (t.pass) so a not-yet-registered tier never fails CI. Registered per PR #3372.
 // Desktop-only: the mobile Parler surface is covered by the gpu-smoke legs.
 const PARLER_QUANT_MATRIX = [
@@ -524,7 +523,7 @@ for (const { variant, quant } of PARLER_QUANT_MATRIX) {
         return
       }
 
-      const useGPU = isApple && !NO_GPU
+      const useGPU = !NO_GPU
       const model = await loadParlerTTS({ parlerModelPath: download.path, seed: 42, useGPU })
       try {
         const text =

--- a/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/portfile.cmake
@@ -1,0 +1,249 @@
+# ggml-speech: tetherto/qvac-ext-ggml@speech.
+#
+# THROWAWAY CI OVERLAY — do not merge. REF is the tip of the unmerged
+# QVAC-21597/parler-opencl branch (qvac-ext-ggml PR #49): the Adreno q8_0 image
+# GEMM honours GGML_PREC_F32, f32 x f32 gains an Adreno image GEMM, and
+# conv-as-matmul fuses IM2COL into it. All three are generic backend fixes.
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF aeccf6ecd6b1952afacc1dbbd9af7d3eda1cf9c8
+    SHA512 3c87538b5fecda8689b8ea4104a146419e9a27fb98e31afe20b8fffda1565892b6fe3189943e0fbb3ab3fa00ae1ff05947b3a46640750a430ee5ab2419fda9ba
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# Desktop aarch64 Linux: same per-arch CPU-variant packaging as Android.
+# This build is not GGML_NATIVE and passes no -march override, so a
+# single-variant CPU backend lands on the compiler's plain armv8-a
+# baseline: the dotprod/fp16/i8mm ARM kernels (incl. the repack GEMM
+# kernels in ggml-cpu/arch/arm/repack.cpp) are compiled out and both
+# f16 and quantized (q4_0/q8_0) GEMMs stay on the slowest generic
+# paths. GGML_CPU_ALL_VARIANTS builds one MODULE .so per ARMv8.x/9.x
+# feature tier and scores them against the running CPU at first use,
+# so the prebuild stays SIGILL-safe on any aarch64 host. The speech
+# addons stage lib/libqvac-speech-ggml-*.so next to their .bare and
+# forward backendsDir to ggml_backend_load_all_from_path(), same as
+# Android. Verified on the Parakeet + Whisper RTF benchmarks (qvac
+# runs 29243365879 / 29333221534): parakeet tdt q4_0 mean RTF
+# 0.2285 -> 0.0612, whisper base f16 0.3316 -> 0.0970.
+set(QVAC_LINUX_ARM64_DL_CPU OFF)
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(QVAC_LINUX_ARM64_DL_CPU ON)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        # The dlopen'd MODULE backends must not carry shared-library
+        # dependencies the host machine doesn't ship. The qvac linux
+        # triplets compile with clang -stdlib=libc++ but only the final
+        # addon binary links libc++ statically; a module with NEEDED
+        # libc++.so.1 / libc++abi.so.1 entries fails to dlopen on a
+        # stock host (no libc++ runtime package) and the registry
+        # loader skips it *silently* -- the CPU backend then simply
+        # never registers ("no CPU device registered"). Link the C++
+        # runtime statically into the modules instead, matching the
+        # addon convention. Composed with the triplet's own
+        # VCPKG_LINKER_FLAGS because a bare -DCMAKE_MODULE_LINKER_FLAGS
+        # would override vcpkg's *_INIT seeding and drop the triplet's
+        # -stdlib=libc++ at link time (under gcc triplets this composes
+        # to plain -static-libstdc++, which is equally valid).
+        "-DCMAKE_MODULE_LINKER_FLAGS=${VCPKG_LINKER_FLAGS} -static-libstdc++"
+    )
+endif()
+
+# The v0.10.2 ggml sync introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+# Desktop Linux MODULE backend pickup. ggml's own install() places the
+# MODULE backends in bin/ (CMAKE_INSTALL_BINDIR) and -- unlike Android,
+# where CMake never versions module filenames -- as versioned files
+# (libqvac-speech-ggml-cpu-armv8.2_1.so.<ver>) plus unversioned .so
+# symlinks. Two problems with leaving them there: the runtime loader
+# only matches the exact `.so` extension, and the speech addons stage
+# backends by file(INSTALL)-ing a glob of lib/libqvac-speech-ggml-*.so,
+# which would copy a symlink without its target. Dereference each
+# unversioned name onto its real file, publish plain .so files in lib/,
+# and drop bin/ (static triplets must not ship a bin/ dir anyway).
+if(QVAC_LINUX_ARM64_DL_CPU)
+    foreach(_cfg "" "/debug")
+        file(GLOB _backend_mods
+            "${CURRENT_PACKAGES_DIR}${_cfg}/bin/libqvac-speech-ggml-*.so")
+        foreach(_mod IN LISTS _backend_mods)
+            get_filename_component(_mod_name "${_mod}" NAME)
+            file(REAL_PATH "${_mod}" _mod_real)
+            file(COPY_FILE "${_mod_real}"
+                 "${CURRENT_PACKAGES_DIR}${_cfg}/lib/${_mod_name}")
+        endforeach()
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}${_cfg}/bin")
+        # Do not ship the SVE-bearing CPU variants. ggml's SVE code
+        # paths are drastically slower than the NEON dotprod/fp16 paths
+        # on the 128-bit-vector cores that make up the desktop
+        # arm64-linux fleet (Neoverse-N2 runners; Apple VMs and
+        # Snapdragon X have no SVE at all): whisper base q8_0 RTF
+        # 0.2224 via armv8.6_2 (SVE) vs 0.0626 via armv8.2_2 (no SVE),
+        # f16 0.2586 vs 0.0938 (qvac A/B runs 29328745233 /
+        # 29332248742) -- and the runtime score would pick the SVE
+        # tiers on SVE hardware. Parakeet is within 3% either way (its
+        # hot GEMMs use the NEON repack kernels). Revisit when the
+        # speech branch grows an SVE-free i8mm tier (the Android
+        # variant list has one) or VL-aware scoring.
+        foreach(_sve_tier armv8.2_3 armv8.6_1 armv8.6_2 armv9.2_1 armv9.2_2)
+            file(REMOVE
+                "${CURRENT_PACKAGES_DIR}${_cfg}/lib/libqvac-speech-ggml-cpu-${_sve_tier}.so")
+        endforeach()
+    endforeach()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/usage
+++ b/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/vcpkg.json
+++ b/packages/tts-ggml/vcpkg-overlay-ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-07-31",
+  "description": "THROWAWAY CI OVERLAY - do not merge. Speech-stack ggml flavour (tetherto/qvac-ext-ggml@speech) with REF repointed to the unmerged QVAC-21597/parler-opencl branch (PR #49): three Adreno OpenCL fixes - the q8_0 image GEMM now honours GGML_PREC_F32, f32 x f32 gains an Adreno image GEMM it previously had none of, and conv-as-matmul fuses IM2COL into that GEMM instead of materialising and transposing an im2col matrix. The version-date is bumped past the published port so the addon prebuild cache misses and CI actually rebuilds against this REF.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/portfile.cmake
@@ -1,0 +1,78 @@
+# tts-cpp: tetherto/qvac-ext-lib-whisper.cpp (engines/tts).
+#
+# THROWAWAY CI OVERLAY - do not merge. Identical to the published tts-cpp port
+# except REF, which is the tip of the unmerged QVAC-21597/parler-opencl branch
+# (PR #115): OpenCL joins Parler's validated-backend allowlist, and the fused
+# qkv / lm_head weights are uploaded whole instead of in partial windows, which
+# is what SIGSEGV'd the Qualcomm driver at model load. Pairs with the
+# ggml-speech overlay beside it (qvac-ext-ggml PR #49).
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF 43d2b1a6d7ffa8cbec03361a4b9ff9ed59f25a9b
+    SHA512 e1c33cb23bef9a27b0240ab6409af4526fd3736ac13cafe1292c58b00dc3e3429ef6a6b7d099a0256482f8dc256565e5aa93adc50d07c87b8b1e7ed0adb5c658
+    HEAD_REF master
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/engines/tts")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "tts-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the engines/tts/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        cuda    GGML_CUDA
+        opencl  GGML_OPENCL
+)
+
+set(PLATFORM_OPTIONS)
+
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DTTS_CPP_BUILD_LIBRARY=ON
+        -DTTS_CPP_BUILD_SHARED=OFF
+        -DTTS_CPP_BUILD_EXECUTABLES=OFF
+        -DTTS_CPP_BUILD_TESTS=OFF
+        -DTTS_CPP_INSTALL=ON
+        -DTTS_CPP_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DTTS_CPP_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DTTS_CPP_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME tts-cpp CONFIG_PATH share/tts-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/vcpkg.json
+++ b/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/vcpkg.json
@@ -1,0 +1,82 @@
+{
+  "name": "tts-cpp",
+  "version-date": "2026-07-31",
+  "description": "THROWAWAY CI OVERLAY - do not merge. The published tts-cpp port with REF repointed to the unmerged QVAC-21597/parler-opencl branch (PR #115), which admits OpenCL to Parler's validated-backend allowlist and builds the fused qkv / lm_head weights with one whole-tensor upload (OpenCL rebuilds its struct-of-arrays layout from the whole tensor on set_tensor, so the previous partial-window writes handed the Qualcomm driver an out-of-bounds host pointer and SIGSEGV'd at model load). Pairs with the ggml-speech overlay beside it, which carries the three Adreno OpenCL backend fixes. Measured on an Adreno 740: Parler ~2.06x faster than CPU on mini q8_0 and ~1.95x on indic q8_0. Text-to-speech in pure C++/ggml: Resemble Chatterbox (Turbo + Multilingual), Supertonic, Fun-CosyVoice3, Parler-TTS (CPU + Metal / Vulkan / OpenCL GPU), and LavaSR speech enhancement. Sourced from tetherto/qvac-ext-lib-whisper.cpp (engines/tts).",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/engines/tts",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-07-29"
+    },
+    "mecab",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -1,4 +1,6 @@
 {
+  "name": "tts-ggml",
+  "version": "0.6.1",
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
**DO NOT MERGE.** Throwaway overlay-CI branch, reused in place (it previously carried the
QVAC-22613 Vulkan overlay test, whose three upstream PRs — ggml #45, ggml #47,
whisper #109 — are all merged, so nothing of value was overwritten). Rebased onto current
`main`, since the old base was 34 commits behind and predated the
`transcription-whispercpp` -> `asr-ggml` consolidation.

## What this proves

Parler-TTS on **Adreno OpenCL**, end to end through the addon, on the Device Farm.

Pins tts-ggml at two unmerged branches via vcpkg overlay ports:

| port | repo | REF | PR |
|---|---|---|---|
| `ggml-speech` | `tetherto/qvac-ext-ggml` | `aeccf6ec` | tetherto/qvac-ext-ggml#49 |
| `tts-cpp` | `tetherto/qvac-ext-lib-whisper.cpp` | `43d2b1a6` | tetherto/qvac-ext-lib-whisper.cpp#115 |

`ggml-speech#49` carries three generic Adreno backend fixes — the q8_0 image GEMM now
honours `GGML_PREC_F32`, `f32 x f32` gains an Adreno image GEMM it previously had none of,
and conv-as-matmul fuses IM2COL into that GEMM. `tts-cpp#115` admits OpenCL to Parler's
validated-backend allowlist and fixes a model-load SIGSEGV in the fused-weight upload.

Measured locally on an Adreno 740: Parler **2.06x** faster than CPU on `mini q8_0`,
**1.95x** on `indic q8_0`.

## Wiring (all of it required, none of it optional)

- `CMakeLists.txt` — adds `set(VCPKG_OVERLAY_PORTS ...)` before `project()`. Without it no
  overlay is consulted at all.
- `vcpkg.json` — adds top-level `"name"` / `"version"`. This addon's manifest is a nameless
  application manifest; vcpkg tolerates that in plain manifest mode but rejects it
  (`missing required field 'name'`) the moment `VCPKG_OVERLAY_PORTS` is set. Metadata only,
  no resolution impact, and it matches the sibling addons.
- Both overlay `vcpkg.json` files bump `version-date` to `2026-07-31`. **This is what makes
  CI actually rebuild.** The prebuild reuse key hashes
  `*.cpp|hpp|c|h|CMakeLists.txt|vcpkg.json|vcpkg-configuration.json|/vcpkg/`;
  `vcpkg-overlay-ports/` does not match `/vcpkg/` and `portfile.cmake` is neither `.json`
  nor `CMakeLists.txt`, so a REF-only edit leaves the hash unchanged, the `prebuild` job is
  **skipped**, and CI silently tests the old refs. The date bump also satisfies the
  `tts-cpp >= 2026-07-30` / `ggml-speech >= 2026-07-29` floors.

## Test changes

`gpu-smoke.test.js` and `parler.test.js` gated Parler's GPU legs to Apple only — "Parler's
only validated GPU backend is Metal; it has no vulkan/opencl/cuda kernels yet". That is no
longer true, and left in place it would **skip Parler's GPU smoke on Android entirely**,
making a green run meaningless. The gate is removed so the GPU leg runs on every
GPU-capable platform.

The Parler assertion is also **tightened**: the `allowPolicyCpu` hatch (which let a silent
CPU fallback pass whenever the engine set `gpuUnsupported`) is dropped, because there is no
longer a backend Parler declines. `assertGpuBackend`'s android branch already accepts
`backendId` 3 **or** 4, so this stays correct on both pool devices — OpenCL on the
Adreno part, Vulkan on the Mali part — while a genuine CPU fallback now fails loudly.

## How to read the result

A green tick is **not** sufficient evidence. The android assertion accepts Vulkan or
OpenCL, so a passing Mali leg says nothing about Adreno. `assertGpuBackend` logs

```
[Parler mini q8/GPU] backendDevice=1 backendId=4 (OpenCL)
```

Confirm the **Adreno** device reports `backendId=4 (OpenCL)` and the Mali device reports
`backendId=3 (Vulkan)`. Also confirm the `prebuild` job ran and was not `skipped`.
