### PR TITLE
QVAC-22838 mod[mod]: audiogen-ggml CPU map-in-place weights (no iOS memory entitlement)

### DIFF
--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "audiogen-cpp",
-      "version>=": "2026-07-28"
+      "version>=": "2026-07-29"
     }
   ],
   "features": {

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "audiogen-cpp",
-      "version>=": "2026-07-27"
+      "version>=": "2026-07-28"
     }
   ],
   "features": {


### PR DESCRIPTION
## What

Bump `@qvac/audiogen-ggml`'s `audiogen-cpp` dependency to **2026-07-28**, which brings CPU **map-in-place** weight loading in the ACE-Step engine.

Weights are now backed directly by the GGUF mmap (clean, file-backed pages) instead of being copied into a ggml backend buffer (dirty RAM). The ~3.1 GB turbo-q4 stack loads and generates on iOS under the **default** memory budget, so consumers of this package no longer need the `com.apple.developer.kernel.increased-memory-limit` entitlement.

Only `packages/audiogen-ggml/vcpkg.json` changes (`version>=` → `2026-07-28`). The `vcpkg-configuration.json` default-registry baseline is intentionally left untouched.

## Depends on

- Registry PR: **tetherto/qvac-registry-vcpkg#266** (registers `audiogen-cpp 2026-07-28`). Merge that first — `version>=` resolves from the registry's `main` HEAD, so this PR's build stays red until #266 lands.
- Engine PR: **tetherto/qvac-ext-lib-whisper.cpp#111** (the source change #266 pins).

## Validated

Full monorepo preflight against a forked registry pinning this exact engine commit: all 8 prebuild platforms green (incl. android-arm64 / linux-arm64) + integration tests green. On-device: iPad Pro (M2, iOS 26.5) loads + generates the full stack with the entitlement removed.

Follow-ups (separate): addon version bump + release; re-enable the iOS Device Farm mobile lane on #3504 (the OOM is fixed).
