### PR TITLE
QVAC-22926 chore: fix lint and format issues in registry-server client

### DIFF
--- a/packages/registry-server/.gitignore
+++ b/packages/registry-server/.gitignore
@@ -2,8 +2,11 @@
 node_modules
 .env*
 
+bun.lock
 package-lock.json
+client/bun.lock
 client/package-lock.json
+shared/bun.lock
 shared/package-lock.json
 
 # Corestore for registry

--- a/packages/registry-server/.prettierignore
+++ b/packages/registry-server/.prettierignore
@@ -1,1 +1,2 @@
 shared/spec/
+data/models.prod.json

--- a/packages/registry-server/client/lib/client.js
+++ b/packages/registry-server/client/lib/client.js
@@ -518,7 +518,7 @@ class QVACRegistryClient extends ReadyResource {
     // Stop replication before clearing to prevent blocks from being refetched.
     if (rangeDownload) rangeDownload.destroy()
 
-    if (core && blockStart != null) {
+    if (core && blockStart !== undefined) {
       await this._clearBlobBlocks(core, blockStart, blockEnd)
     }
     if (blobs) {

--- a/packages/registry-server/client/lib/client.js
+++ b/packages/registry-server/client/lib/client.js
@@ -497,7 +497,7 @@ class QVACRegistryClient extends ReadyResource {
     }
   }
 
-  _releaseOnStreamEnd (stream, core, blobs, rangeDownload, blockStart, blockEnd) {
+  _releaseOnStreamEnd(stream, core, blobs, rangeDownload, blockStart, blockEnd) {
     let released = false
 
     // 'close' also covers a destroyed or errored stream; on 'end' alone a
@@ -505,15 +505,16 @@ class QVACRegistryClient extends ReadyResource {
     const release = () => {
       if (released) return
       released = true
-      return this._releaseDownload(core, blobs, rangeDownload, blockStart, blockEnd)
-        .catch(e => this.logger.warn('Error releasing blob resources', { error: e.message }))
+      return this._releaseDownload(core, blobs, rangeDownload, blockStart, blockEnd).catch((e) =>
+        this.logger.warn('Error releasing blob resources', { error: e.message })
+      )
     }
 
     stream.once('end', release)
     stream.once('close', release)
   }
 
-  async _releaseDownload (core, blobs, rangeDownload, blockStart, blockEnd) {
+  async _releaseDownload(core, blobs, rangeDownload, blockStart, blockEnd) {
     // Stop replication before clearing to prevent blocks from being refetched.
     if (rangeDownload) rangeDownload.destroy()
 
@@ -521,12 +522,16 @@ class QVACRegistryClient extends ReadyResource {
       await this._clearBlobBlocks(core, blockStart, blockEnd)
     }
     if (blobs) {
-      try { await blobs.close() } catch (e) {
+      try {
+        await blobs.close()
+      } catch (e) {
         this.logger.warn('Error closing blob instance', { error: e.message })
       }
     }
     if (core) {
-      try { await core.close() } catch (e) {
+      try {
+        await core.close()
+      } catch (e) {
         this.logger.warn('Error closing blob core', { error: e.message })
       }
     }
@@ -534,7 +539,7 @@ class QVACRegistryClient extends ReadyResource {
     this.logger.debug('Blob resources released')
   }
 
-  async _clearBlobBlocks (core, start, end) {
+  async _clearBlobBlocks(core, start, end) {
     try {
       const cleared = await core.clear(start, end, { diff: true })
       await core.compact()

--- a/packages/registry-server/client/tests/unit/client.download-retry.test.js
+++ b/packages/registry-server/client/tests/unit/client.download-retry.test.js
@@ -18,10 +18,18 @@ function makeLogger(t) {
   }
 
   return {
-    info(msg, data) { emit('info', msg, data) },
-    debug(msg, data) { emit('debug', msg, data) },
-    warn(msg, data) { emit('warn', msg, data) },
-    error(msg, data) { emit('error', msg, data) }
+    info(msg, data) {
+      emit('info', msg, data)
+    },
+    debug(msg, data) {
+      emit('debug', msg, data)
+    },
+    warn(msg, data) {
+      emit('warn', msg, data)
+    },
+    error(msg, data) {
+      emit('error', msg, data)
+    }
   }
 }
 
@@ -62,7 +70,9 @@ function makeClient(t) {
   // lunte-disable-next-line require-await
   const blobs = {
     async close() {},
-    createReadStream() { return client._stream }
+    createReadStream() {
+      return client._stream
+    }
   }
   client._core = core
   client._blobs = blobs
@@ -102,11 +112,13 @@ function makeClient(t) {
 function fakeStream() {
   const handlers = {}
   return {
-    once(event, fn) { (handlers[event] = handlers[event] || []).push(fn) },
+    once(event, fn) {
+      ;(handlers[event] = handlers[event] || []).push(fn)
+    },
     emit(event) {
       const fns = handlers[event] || []
       handlers[event] = []
-      return Promise.all(fns.map(fn => fn()))
+      return Promise.all(fns.map((fn) => fn()))
     }
   }
 }
@@ -309,14 +321,14 @@ test('downloadModel aborts the reconnect wait when the signal is cancelled', asy
   t.is(attempt, 1, 'no second attempt started after the cancel')
 })
 
-test('downloadModel clears cached blocks when the download fails', async t => {
+test('downloadModel clears cached blocks when the download fails', async (t) => {
   const dir = await tmp(t)
   const outputFile = path.join(dir, 'model.gguf')
 
   const client = makeClient(t)
   const clears = []
   client._core.download = () => ({
-    destroy () {
+    destroy() {
       client._events.push('destroy')
       t.comment('step: rangeDownload.destroy() called from the catch path')
     }
@@ -353,11 +365,11 @@ test('downloadModel clears cached blocks when the download fails', async t => {
   )
 })
 
-test('downloadModel clears cached blocks when the returned stream is destroyed', async t => {
+test('downloadModel clears cached blocks when the returned stream is destroyed', async (t) => {
   const client = makeClient(t)
   const clears = []
   client._core.download = () => ({
-    destroy () {
+    destroy() {
       client._events.push('destroy')
       t.comment('step: rangeDownload.destroy() called from the stream release')
     }
@@ -388,7 +400,7 @@ test('downloadModel clears cached blocks when the returned stream is destroyed',
   )
 })
 
-test('downloadModel releases the stream download exactly once', async t => {
+test('downloadModel releases the stream download exactly once', async (t) => {
   const client = makeClient(t)
   let clears = 0
   client._clearBlobBlocks = async () => {
@@ -406,7 +418,7 @@ test('downloadModel releases the stream download exactly once', async t => {
   t.is(clears, 1, 'the end-then-close sequence releases only once')
 })
 
-test('downloadBlob clears cached blocks when the returned stream is destroyed', async t => {
+test('downloadBlob clears cached blocks when the returned stream is destroyed', async (t) => {
   const client = makeClient(t)
   client.ready = async () => {}
   const clears = []
@@ -429,7 +441,7 @@ test('downloadBlob clears cached blocks when the returned stream is destroyed', 
   t.alike(clears[0], { start: 3, end: 10 }, 'cleared the blob block range')
 })
 
-test('downloadBlob clears cached blocks when the download fails', async t => {
+test('downloadBlob clears cached blocks when the download fails', async (t) => {
   const dir = await tmp(t)
   const outputFile = path.join(dir, 'blob.bin')
 
@@ -437,7 +449,7 @@ test('downloadBlob clears cached blocks when the download fails', async t => {
   client.ready = async () => {}
   const clears = []
   client._core.download = () => ({
-    destroy () {
+    destroy() {
       client._events.push('destroy')
       t.comment('step: rangeDownload.destroy() called from the catch path')
     }
@@ -474,7 +486,7 @@ test('downloadBlob clears cached blocks when the download fails', async t => {
   )
 })
 
-test('downloadModel releases nothing when it fails before the core is opened', async t => {
+test('downloadModel releases nothing when it fails before the core is opened', async (t) => {
   const client = makeClient(t)
   let clears = 0
   client._clearBlobBlocks = async () => {
@@ -495,7 +507,7 @@ test('downloadModel releases nothing when it fails before the core is opened', a
   t.is(clears, 0, 'nothing cleared when no core or block range exists yet')
 })
 
-test('downloadModel closes the core without clearing when the range is unknown', async t => {
+test('downloadModel closes the core without clearing when the range is unknown', async (t) => {
   const client = makeClient(t)
   let clears = 0
   let closed = 0

--- a/packages/registry-server/client/tests/unit/client.download-retry.test.js
+++ b/packages/registry-server/client/tests/unit/client.download-retry.test.js
@@ -67,8 +67,8 @@ function makeClient(t) {
     on() {},
     off() {}
   }
-  // lunte-disable-next-line require-await
   const blobs = {
+    // lunte-disable-next-line require-await
     async close() {},
     createReadStream() {
       return client._stream
@@ -333,11 +333,13 @@ test('downloadModel clears cached blocks when the download fails', async (t) => 
       t.comment('step: rangeDownload.destroy() called from the catch path')
     }
   })
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async (core, start, end) => {
     client._events.push('clear')
     clears.push({ start, end })
     t.comment(`step: _clearBlobBlocks(${start}, ${end}) called`)
   }
+  // lunte-disable-next-line require-await
   client._streamBlobToFile = async () => {
     client._events.push('stream')
     t.comment('step: _streamBlobToFile rejecting to force the catch path')
@@ -374,6 +376,7 @@ test('downloadModel clears cached blocks when the returned stream is destroyed',
       t.comment('step: rangeDownload.destroy() called from the stream release')
     }
   })
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async (core, start, end) => {
     client._events.push('clear')
     clears.push({ start, end })
@@ -403,6 +406,7 @@ test('downloadModel clears cached blocks when the returned stream is destroyed',
 test('downloadModel releases the stream download exactly once', async (t) => {
   const client = makeClient(t)
   let clears = 0
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async () => {
     clears++
     t.comment(`step: _clearBlobBlocks call #${clears}`)
@@ -420,8 +424,10 @@ test('downloadModel releases the stream download exactly once', async (t) => {
 
 test('downloadBlob clears cached blocks when the returned stream is destroyed', async (t) => {
   const client = makeClient(t)
+  // lunte-disable-next-line require-await
   client.ready = async () => {}
   const clears = []
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async (core, start, end) => {
     clears.push({ start, end })
     t.comment(`step: _clearBlobBlocks(${start}, ${end}) called`)
@@ -446,6 +452,7 @@ test('downloadBlob clears cached blocks when the download fails', async (t) => {
   const outputFile = path.join(dir, 'blob.bin')
 
   const client = makeClient(t)
+  // lunte-disable-next-line require-await
   client.ready = async () => {}
   const clears = []
   client._core.download = () => ({
@@ -454,11 +461,13 @@ test('downloadBlob clears cached blocks when the download fails', async (t) => {
       t.comment('step: rangeDownload.destroy() called from the catch path')
     }
   })
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async (core, start, end) => {
     client._events.push('clear')
     clears.push({ start, end })
     t.comment(`step: _clearBlobBlocks(${start}, ${end}) called`)
   }
+  // lunte-disable-next-line require-await
   client._streamBlobToFile = async () => {
     t.comment('step: _streamBlobToFile rejecting to force the catch path')
     throw new Error('Download cancelled')
@@ -489,10 +498,12 @@ test('downloadBlob clears cached blocks when the download fails', async (t) => {
 test('downloadModel releases nothing when it fails before the core is opened', async (t) => {
   const client = makeClient(t)
   let clears = 0
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async () => {
     clears++
     t.comment('step: _clearBlobBlocks called')
   }
+  // lunte-disable-next-line require-await
   client.getModel = async () => {
     t.comment('step: getModel returning null, failing before _getBlobsCore')
     return null
@@ -511,14 +522,17 @@ test('downloadModel closes the core without clearing when the range is unknown',
   const client = makeClient(t)
   let clears = 0
   let closed = 0
+  // lunte-disable-next-line require-await
   client._clearBlobBlocks = async () => {
     clears++
     t.comment('step: _clearBlobBlocks called')
   }
+  // lunte-disable-next-line require-await
   client._core.close = async () => {
     closed++
     t.comment('step: core.close() called')
   }
+  // lunte-disable-next-line require-await
   client._core.update = async () => {
     t.comment('step: core.update() rejecting before the block range is computed')
     throw new Error('core update failed')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `registry-server` client sub-package fails `lunte` lint and `prettier` format checks.
- `prettier` was also flagging `data/models.prod.json`, which is machine-generated.

## 📝 How does it solve it?

Three atomic commits:

1. `chore: ignore generated models.prod.json in prettier` — adds `data/models.prod.json` to `.prettierignore`. It is written by scripts via `JSON.stringify(models, null, 2)`, so its style is owned by the scripts, not prettier.
2. `chore: format registry-server client with prettier` — `prettier --write` over `client/lib/client.js` and `client/tests/unit/client.download-retry.test.js`.
3. `chore: fix lint issues in registry-server client`:
   - `eqeqeq`: `blockStart != null` becomes `blockStart !== undefined` in `_releaseDownload`. `blockStart` is only ever unset (`undefined`) or a numeric `blockOffset`, never `null`, and this still handles `blockOffset === 0`.
   - `require-await`: 15 async test stubs kept as `async` for signature parity with the methods they replace, each suppressed with `// lunte-disable-next-line require-await`.

## 🧪 How was it tested?

- `lint` and `format` pass at both the registry-server root and the client sub-package.
- Unit tests pass: client 33/33 (127 asserts), root 47/47 (140 asserts).