### PR TITLE
QVAC-22524 doc: add MongoDB RAG example

### DIFF
--- a/docs/website/content/docs/ai-capabilities/rag.mdx
+++ b/docs/website/content/docs/ai-capabilities/rag.mdx
@@ -37,7 +37,7 @@ Create your RAG pipeline using [text embeddings](/ai-capabilities/text-embedding
 
 Regarding vector storage, you may use:
 - **Built-in vector store:** use the RAG workspace functions ([`ragIngest()`](/reference/api#ragingest), [`ragSearch()`](/reference/api#ragsearch), etc.). QVAC persists the vectors for you, so this is the simplest path.
-- **External vector DB:** use the embedding primitives ([`ragChunk()`](/reference/api#ragchunk), [`embed()`](/reference/api#embed)) and store the vectors wherever you want (e.g., LanceDB, ChromaDB, SQLite-Vector). Choose this when you need custom persistence, filtering, or integration with an existing database.
+- **External vector DB:** use the embedding primitives ([`ragChunk()`](/reference/api#ragchunk), [`embed()`](/reference/api#embed)) and store the vectors wherever you want (e.g., MongoDB, LanceDB, ChromaDB, SQLite-Vector). Choose this when you need custom persistence, filtering, or integration with an existing database.
 
 <Callout type="info">
 **Important:** when using an external vector DB, make sure its schema matches the embedding dimensionality produced by your model (e.g., GTE Large embeddings used in the example are 1024‑dimensional).
@@ -68,6 +68,30 @@ The following script shows how to ingest documents into a built-in RAG workspace
 </Tabs>
 
 ### External vector DB
+
+#### MongoDB
+
+The following script stores each document in MongoDB alongside its vector, builds a vector search index over it, and retrieves matches with a `$vectorSearch` aggregation:
+
+<Tabs>
+<Tab value="js" label="JavaScript" default>
+<WrapCode>
+
+```js file=<rootDir>/packages/sdk/dist/examples/rag/rag-mongodb.js title="rag-mongodb.js" lineNumbers
+```
+</WrapCode>
+</Tab>
+
+<Tab value="ts" label="TypeScript">
+<WrapCode>
+
+```ts file=<rootDir>/packages/sdk/examples/rag/rag-mongodb.ts title="rag-mongodb.ts" lineNumbers
+```
+</WrapCode>
+</Tab>
+</Tabs>
+
+#### SQLite
 
 The following script shows the same workflow using `embed()` plus a SQLite vector index:
 

--- a/packages/sdk/examples/rag/rag-mongodb.ts
+++ b/packages/sdk/examples/rag/rag-mongodb.ts
@@ -1,0 +1,177 @@
+import { embed, loadModel, unloadModel, GTE_LARGE_FP16 } from '@qvac/sdk'
+import { MongoClient } from 'mongodb'
+
+const INDEX_NAME = 'documents_vector_index'
+
+const MONGODB_SETUP_INSTRUCTIONS = `
+▸ This example needs a MongoDB deployment with Atlas Vector Search.
+
+One way to get one is to run it in Docker:
+
+   docker run -p 27017:27017 --name atlas-local mongodb/mongodb-atlas-local
+
+For more details, visit: https://www.mongodb.com/docs/atlas/cli/current/atlas-cli-deploy-docker/
+`
+
+async function initializeMongoClient() {
+  // Replace with your own deployment's connection string if it is not the Docker one
+  // https://www.mongodb.com/docs/manual/reference/connection-string/
+  const client = new MongoClient('mongodb://localhost:27017/?directConnection=true')
+
+  try {
+    await client.connect()
+    await client.db('admin').command({ ping: 1 })
+    console.log('▸ Connected to MongoDB server')
+    return client
+  } catch {
+    console.error('✖ Failed to connect to MongoDB server')
+    console.error('▸ Please ensure the server is running on localhost:27017')
+    console.error(MONGODB_SETUP_INSTRUCTIONS)
+    process.exit(1)
+  }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+try {
+  // Get query from command line or use default
+  const query = process.argv[2] || 'machine learning algorithms'
+  console.log(`▸ Query: "${query}"`)
+
+  const client = await initializeMongoClient()
+  const collection = client.db('qvac').collection('documents')
+
+  const modelId = await loadModel({
+    modelSrc: GTE_LARGE_FP16,
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1)
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`)
+      if (p.percentage >= 100) process.stderr.write('\n')
+    }
+  })
+
+  // Sample corpus
+  const samples = [
+    {
+      id: 1,
+      text: 'Machine learning is a subset of artificial intelligence that focuses on algorithms that can learn and make predictions from data without being explicitly programmed for every task.'
+    },
+    {
+      id: 2,
+      text: 'Deep learning uses neural networks with multiple layers to process and learn from complex data patterns, enabling breakthroughs in image recognition and natural language processing.'
+    },
+    {
+      id: 3,
+      text: 'Natural language processing combines computational linguistics with machine learning to help computers understand, interpret, and generate human language in a meaningful way.'
+    },
+    {
+      id: 4,
+      text: 'Computer vision enables machines to interpret and understand visual information from the world, using techniques like image classification, object detection, and facial recognition.'
+    },
+    {
+      id: 5,
+      text: 'Quantum computing leverages quantum mechanical phenomena to process information in fundamentally different ways than classical computers, potentially solving certain problems exponentially faster.'
+    },
+    {
+      id: 6,
+      text: 'Blockchain technology creates decentralized, immutable ledgers that enable secure peer-to-peer transactions without requiring a central authority or intermediary.'
+    },
+    {
+      id: 7,
+      text: 'Cloud computing delivers computing services over the internet, allowing users to access resources like storage, processing power, and applications on-demand from anywhere.'
+    },
+    {
+      id: 8,
+      text: 'Cybersecurity protects digital systems, networks, and data from malicious attacks, unauthorized access, and various forms of cyber threats through multiple layers of defense.'
+    }
+  ]
+
+  // (Re)create the collection
+  try {
+    await collection.drop()
+  } catch (e) {
+    console.warn(`▸ Collection didn't exist, no need to drop: ${String(e)}`)
+  }
+
+  // Embed and store documents
+  console.log('▸ Embedding documents...')
+  const documents = []
+  for (const sample of samples) {
+    const { embedding } = await embed({ modelId, text: sample.text })
+    documents.push({
+      id: sample.id,
+      text: sample.text,
+      embedding
+    })
+  }
+
+  await collection.insertMany(documents)
+
+  // GTE Large produces 1024-dimensional vectors
+  console.log('▸ Creating vector search index...')
+  await collection.createSearchIndex({
+    name: INDEX_NAME,
+    type: 'vectorSearch',
+    definition: {
+      fields: [
+        {
+          type: 'vector',
+          path: 'embedding',
+          numDimensions: 1024,
+          similarity: 'cosine'
+        }
+      ]
+    }
+  })
+
+  // Index builds are asynchronous; querying too early returns no matches
+  for (let attempt = 0; attempt < 60; attempt++) {
+    const [index] = (await collection.listSearchIndexes(INDEX_NAME).toArray()) as {
+      queryable?: boolean
+    }[]
+    if (index?.queryable) break
+    if (attempt === 59) throw new Error(`Index ${INDEX_NAME} did not become queryable`)
+    await wait(1000)
+  }
+
+  console.log('▸ Searching for similar documents...')
+  const { embedding: queryEmbedding } = await embed({ modelId, text: query })
+
+  const results = await collection
+    .aggregate<{ id: number; text: string; score: number }>([
+      {
+        $vectorSearch: {
+          index: INDEX_NAME,
+          path: 'embedding',
+          queryVector: queryEmbedding,
+          numCandidates: 100,
+          limit: 3
+        }
+      },
+      {
+        $project: {
+          _id: 0,
+          id: 1,
+          text: 1,
+          score: { $meta: 'vectorSearchScore' }
+        }
+      }
+    ])
+    .toArray()
+
+  console.log('▸ Top 3 most similar documents:')
+  results.forEach((result, index) => {
+    console.log(`${index + 1}. (Score: ${result.score.toFixed(4)})`)
+    console.log(`   ${result.text}`)
+    console.log()
+  })
+
+  await unloadModel({ modelId })
+  await client.close()
+} catch (error) {
+  console.error('✖', error)
+  process.exit(1)
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -272,6 +272,7 @@
     "expo-device": "^8.0.10",
     "expo-file-system": "^19.0.21",
     "husky": "^9.1.7",
+    "mongodb": "^7.5.0",
     "pear-pipe": "^1.0.6",
     "prettier": "^3.9.4",
     "prettier-config-holepunch": "^2.0.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Add an example on how to QVAC RAG with MongoDB.

## 📝 How does it solve it?

- Adds `examples/rag/rag-mongodb.ts`: connect to Atlas, store the documents with their `embed()` vectors, create a vector search index, and query it with `$vectorSearch`.
- Lists it in the RAG docs under `### External vector DB`, ahead of SQLite.
- Adds `mongodb` as a `devDependency`.

## 🧪 How was it tested?

- Ran the example under Node against a `mongodb/mongodb-atlas-local` container. Top result for the default query is the machine-learning document at 0.9488, with the vision and NLP documents behind it.
- `bun run format`, `bun run lint`, `bun run typecheck` all clean.