### PR TITLE
QVAC-18397 fix: environment-scope JsAsyncTask teardown in inference-addon-cpp

### DIFF
--- a/packages/inference-addon-cpp/CHANGELOG.md
+++ b/packages/inference-addon-cpp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.2] - 2026-07-29
+
+### Fixed
+- `JsAsyncTask` now defers environment teardown until queued completions finish, preventing background work from touching disposed JavaScript state.
+
 ## [1.3.1] - 2026-07-24
 
 ### Fixed

--- a/packages/inference-addon-cpp/src/inference-addon-cpp/JsUtils.hpp
+++ b/packages/inference-addon-cpp/src/inference-addon-cpp/JsUtils.hpp
@@ -832,7 +832,11 @@ std::vector<CppType> toVector(js_env_t* env, Array array) {
 /// @brief Utility for executing blocking C++ operations asynchronously and
 /// returning a JavaScript Promise/Future
 /// @details Handles thread spawning, promise creation, and result delivery
-/// back to the JavaScript event loop via uv_async.
+/// back to the JavaScript event loop via uv_async. Environment-scoped: a
+/// deferred env teardown callback keeps a dying env (worklet terminate /
+/// unload) alive until the worker finishes, and completion skips every
+/// promise/JS operation once teardown has begun — the promise is simply
+/// abandoned, its env is going away with it.
 ///
 /// @example
 /// return js::JsAsyncTask::run(env, []() {
@@ -844,11 +848,28 @@ class JsAsyncTask {
     js_env_t* env;
     js_deferred_t* deferred;
     uv_async_t* async_handle;
+    /// Blocks env teardown (keeping the env and its loop alive) until the
+    /// worker has finished; finished by the uv close callback.
+    js_deferred_teardown_t* teardown = nullptr;
+    /// Loop-thread only: flipped by onEnvTeardown, read by onComplete. JS
+    /// APIs beyond the teardown handshake are illegal once false.
+    bool envAlive = true;
     std::exception_ptr error;
 
     CallbackData(js_env_t* e, js_deferred_t* d, uv_async_t* h)
         : env(e), deferred(d), async_handle(h), error(nullptr) {}
   };
+
+  /// Deferred env teardown hook (loop thread): the env is dying while the
+  /// worker may still be blocked — e.g. a cancel waiting for the scheduler
+  /// to release a slot. Marking the env dead makes onComplete skip every JS
+  /// operation; deliberately NOT finishing the deferred teardown here keeps
+  /// the env's loop running until the worker is done, so the detached
+  /// thread's uv_async_send always targets a live loop and the uv close
+  /// callback finishes the teardown afterwards.
+  static void onEnvTeardown(js_deferred_teardown_t*, void* data) {
+    static_cast<CallbackData*>(data)->envAlive = false;
+  }
 
   static void
   rejectWithError(js_env_t* env, js_deferred_t* deferred, const char* msg) {
@@ -860,32 +881,41 @@ class JsAsyncTask {
   }
 
   static void onComplete(uv_async_t* handle) {
-    std::unique_ptr<CallbackData> data(
-        static_cast<CallbackData*>(handle->data));
+    auto* data = static_cast<CallbackData*>(handle->data);
 
-    js_handle_scope_t* scope;
-    JS(js_open_handle_scope(data->env, &scope));
+    // Once env teardown has begun, settling the promise would touch a dying
+    // env; skip all JS work and just run the close/finish handshake below.
+    if (data->envAlive) {
+      js_handle_scope_t* scope;
+      JS(js_open_handle_scope(data->env, &scope));
 
-    if (data->error) {
-      try {
-        std::rethrow_exception(data->error);
-      } catch (const std::exception& e) {
-        rejectWithError(data->env, data->deferred, e.what());
-      } catch (...) {
-        const char* unknownMsg = "Unknown error at JsAsyncTask";
-        rejectWithError(data->env, data->deferred, unknownMsg);
+      if (data->error) {
+        try {
+          std::rethrow_exception(data->error);
+        } catch (const std::exception& e) {
+          rejectWithError(data->env, data->deferred, e.what());
+        } catch (...) {
+          const char* unknownMsg = "Unknown error at JsAsyncTask";
+          rejectWithError(data->env, data->deferred, unknownMsg);
+        }
+      } else {
+        // Resolve promise with undefined
+        js_value_t* undefined;
+        JS(js_get_undefined(data->env, &undefined));
+        JS(js_resolve_deferred(data->env, data->deferred, undefined));
       }
-    } else {
-      // Resolve promise with undefined
-      js_value_t* undefined;
-      JS(js_get_undefined(data->env, &undefined));
-      JS(js_resolve_deferred(data->env, data->deferred, undefined));
+
+      js_close_handle_scope(data->env, scope);
     }
 
-    js_close_handle_scope(data->env, scope);
-
     uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* h) {
-      delete reinterpret_cast<uv_async_t*>(h);
+      auto* async = reinterpret_cast<uv_async_t*>(h);
+      std::unique_ptr<CallbackData> data(
+          static_cast<CallbackData*>(async->data));
+      // Lets a pending env teardown complete; on the live-env path it just
+      // unregisters the hook. Legal either way (see bare-signals).
+      js_finish_deferred_teardown_callback(data->teardown);
+      delete async;
     });
   }
 
@@ -914,12 +944,29 @@ public:
     auto* data = new CallbackData(env, deferred, async_handle);
     async_handle->data = data;
 
+    // Environment-scope the task before the worker exists, so env teardown
+    // can never race a thread the env does not know about.
+    if (js_add_deferred_teardown_callback(
+            env, &JsAsyncTask::onEnvTeardown, data, &data->teardown) != 0) {
+      uv_close(
+          reinterpret_cast<uv_handle_t*>(async_handle), [](uv_handle_t* h) {
+            auto* async = reinterpret_cast<uv_async_t*>(h);
+            delete static_cast<CallbackData*>(async->data);
+            delete async;
+          });
+      throw qvac_errors::StatusError(
+          qvac_errors::general_error::InternalError,
+          "Failed to register env teardown callback for JsAsyncTask");
+    }
+
     std::thread([data, work = std::move(work)]() {
       try {
         work();
       } catch (...) {
         data->error = std::current_exception();
       }
+      // Always safe: either the env is alive, or its teardown is blocked on
+      // this task's unfinished deferred teardown, keeping the loop running.
       uv_async_send(data->async_handle);
     }).detach();
 

--- a/packages/inference-addon-cpp/tests/helpers_header/js.h
+++ b/packages/inference-addon-cpp/tests/helpers_header/js.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
@@ -16,12 +17,39 @@ struct js_value_t {
 struct js_ref_t {};
 struct js_callback_info_t {};
 struct js_handle_scope_t {};
-struct js_deferred_t {};
+struct js_deferred_t {
+  // Set by the mocked js_resolve_deferred/js_reject_deferred so tests can
+  // assert whether a given promise was ever settled. Atomic: settled on a
+  // worker thread, read by the test thread.
+  std::atomic<bool> settled{false};
+};
 struct uv_async_t {
   void* data;
+  // Stored by the mocked uv_async_init so uv_async_send can dispatch the
+  // completion callback synchronously (stands in for the libuv loop).
+  void (*async_cb)(uv_async_t*) = nullptr;
 };
 struct uv_handle_t {};
 struct uv_loop_t {};
+
+struct js_deferred_teardown_t {
+  // Set by the mocked js_finish_deferred_teardown_callback; in the real
+  // implementation this is what lets a pending env teardown complete.
+  std::atomic<bool> finished{false};
+};
+
+typedef void (*js_deferred_teardown_cb)(js_deferred_teardown_t*, void* data);
+
+// Test hooks: the mock records the most recent promise and deferred-teardown
+// registration (both happen synchronously inside the code under test on the
+// calling thread) so tests can fire env teardown by hand and observe the
+// finish handshake.
+namespace mock_js {
+inline js_deferred_t* lastCreatedDeferred = nullptr;
+inline js_deferred_teardown_cb lastDeferredTeardownCb = nullptr;
+inline void* lastDeferredTeardownData = nullptr;
+inline js_deferred_teardown_t* lastDeferredTeardownHandle = nullptr;
+} // namespace mock_js
 
 // js_loop_t is an alias for uv_loop_t in the real implementation
 typedef uv_loop_t js_loop_t;
@@ -431,16 +459,35 @@ inline int js_create_promise(
     js_env_t* env, js_deferred_t** deferred, js_value_t** promise) {
   *deferred = new js_deferred_t{};
   *promise = new js_value_t{};
+  mock_js::lastCreatedDeferred = *deferred;
   return 0;
 }
 
 inline int js_resolve_deferred(
     js_env_t* env, js_deferred_t* deferred, js_value_t* resolution) {
+  deferred->settled = true;
   return 0;
 }
 
 inline int js_reject_deferred(
     js_env_t* env, js_deferred_t* deferred, js_value_t* rejection) {
+  deferred->settled = true;
+  return 0;
+}
+
+inline int js_add_deferred_teardown_callback(
+    js_env_t* env, js_deferred_teardown_cb callback, void* data,
+    js_deferred_teardown_t** result) {
+  *result = new js_deferred_teardown_t{};
+  mock_js::lastDeferredTeardownCb = callback;
+  mock_js::lastDeferredTeardownData = data;
+  mock_js::lastDeferredTeardownHandle = *result;
+  return 0;
+}
+
+inline int
+js_finish_deferred_teardown_callback(js_deferred_teardown_t* handle) {
+  handle->finished = true;
   return 0;
 }
 
@@ -450,16 +497,29 @@ inline int js_create_error(
   return 0;
 }
 
-// UV/libuv functions (minimal stubs for compilation)
+// UV/libuv functions: minimal stubs, except that async send and close
+// dispatch their callbacks synchronously on the calling thread so the
+// JsAsyncTask completion chain (worker -> uv_async_send -> completion ->
+// uv_close -> close callback) is observable without a running loop.
 inline int
 uv_async_init(uv_loop_t* loop, uv_async_t* handle, void (*cb)(uv_async_t*)) {
+  handle->async_cb = cb;
   return 0;
 }
 
-inline int uv_async_send(uv_async_t* handle) { return 0; }
+inline int uv_async_send(uv_async_t* handle) {
+  if (handle->async_cb != nullptr) {
+    handle->async_cb(handle);
+  }
+  return 0;
+}
 
 inline void* uv_handle_get_data(uv_handle_t* handle) { return nullptr; }
 
 inline void uv_handle_set_data(uv_handle_t* handle, void* data) {}
 
-inline void uv_close(uv_handle_t* handle, void (*cb)(uv_handle_t*)) {}
+inline void uv_close(uv_handle_t* handle, void (*cb)(uv_handle_t*)) {
+  if (cb != nullptr) {
+    cb(handle);
+  }
+}

--- a/packages/inference-addon-cpp/tests/js_utils_test.cpp
+++ b/packages/inference-addon-cpp/tests/js_utils_test.cpp
@@ -113,4 +113,74 @@ TEST(JsUtilsTest, NumberAsUint64TruncatesWithoutValidation) {
     EXPECT_EQ(number.as<uint64_t>(&env), 42U);
 }
 
+// JsAsyncTask must be environment-scoped, mirroring OutputCallBackJs: its
+// blocking worker — e.g. a cancel waiting for the scheduler to release a
+// slot — can outlive the JS environment when a Bare worklet is terminated
+// without the promise being awaited. run() must register a deferred env
+// teardown callback so a dying env stays alive until the worker finishes,
+// completion must skip every promise/JS operation once teardown has begun,
+// and the uv close callback must finish the deferred teardown so env
+// teardown can complete. Without this, completion opens a handle scope and
+// settles the deferred against a destroyed env: a native use-after-free.
+TEST(JsUtilsTest, JsAsyncTaskEnvTeardownDuringBlockedWorker) {
+  js_env_t env;
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool release = false;
+
+  mock_js::lastCreatedDeferred = nullptr;
+  mock_js::lastDeferredTeardownCb = nullptr;
+  mock_js::lastDeferredTeardownData = nullptr;
+  mock_js::lastDeferredTeardownHandle = nullptr;
+
+  js_value_t* promise =
+      js::JsAsyncTask::run(&env, [&mtx, &cv, &release]() {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait(lock, [&release]() { return release; });
+      });
+  EXPECT_NE(promise, nullptr);
+
+  // Both recordings happen synchronously inside run() on this thread.
+  js_deferred_t* deferred = mock_js::lastCreatedDeferred;
+  ASSERT_NE(deferred, nullptr);
+  js_deferred_teardown_t* teardown = mock_js::lastDeferredTeardownHandle;
+  const bool registered = mock_js::lastDeferredTeardownCb != nullptr;
+
+  // Simulate the env starting teardown while the worker is still blocked.
+  if (registered) {
+    mock_js::lastDeferredTeardownCb(
+        teardown, mock_js::lastDeferredTeardownData);
+  }
+
+  // Unblock the worker; the mocked uv_async_send dispatches completion (and
+  // the uv close callback) synchronously on the worker thread.
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    release = true;
+  }
+  cv.notify_one();
+
+  // Wait for the completion chain to run before asserting, so the detached
+  // worker is done with this test's stack whichever way the test ends. With
+  // the fix the chain ends by finishing the deferred teardown; without it,
+  // the only end-of-chain signal is the (illegal) promise settlement.
+  auto chainDone = [&]() {
+    return registered ? teardown->finished.load() : deferred->settled.load();
+  };
+  for (int i = 0; i != 1000 && !chainDone(); ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  ASSERT_TRUE(chainDone()) << "async task completion chain never ran";
+
+  ASSERT_TRUE(registered)
+      << "JsAsyncTask::run must register a deferred env teardown callback; "
+         "without one a terminated env is torn down under the still-running "
+         "worker and completion uses freed JS state";
+  EXPECT_TRUE(teardown->finished.load())
+      << "completion must finish the deferred teardown so env teardown ends";
+  EXPECT_FALSE(deferred->settled.load())
+      << "no promise/JS operation may run once env teardown has begun";
+}
+
 } // namespace qvac_lib_inference_addon_cpp::js_utils

--- a/packages/inference-addon-cpp/vcpkg.json
+++ b/packages/inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
Split out of #3445 so the `inference-addon-cpp` change can land and publish on its own.

## Problem

`JsAsyncTask` kept process-global state, so a task completing after its JS environment was torn down could touch dead JS state. A cancel captured by shared_ptr can outlive `destroyInstance()`, which makes this reachable during teardown rather than theoretical.

## Fix

`JsAsyncTask` is now scoped to its environment and its cleanup runs behind a deferred teardown guard, so a completion landing after teardown no longer reaches freed JS state.

## Release

Bumps the port to `1.3.2` so downstreams can consume the fix. `packages/llm-llamacpp` in #3445 pins `version>= 1.3.2` and needs this published first.

## Tests

`packages/inference-addon-cpp/tests/js_utils_test.cpp` gains a regression test that completes a `JsAsyncTask` after environment teardown; it fails before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
