### PR TITLE
QVAC-18397 fix: settle responses before listener callbacks in infer-base

### DIFF
--- a/packages/infer-base/src/QvacResponse.js
+++ b/packages/infer-base/src/QvacResponse.js
@@ -129,11 +129,11 @@ class QvacResponse extends EventEmitter {
     this._status = statuses.ERRORED
     this._error = error
     this._teardownAbort()
+    this._rejectFinish(error)
     const errorListeners = this.listenerCount('error')
     if (errorListeners > 0) {
       this.emit('error', error)
     }
-    this._rejectFinish(error)
   }
 
   /**
@@ -144,8 +144,8 @@ class QvacResponse extends EventEmitter {
     if (this._status !== statuses.RUNNING) return
     this._status = statuses.ENDED
     this._teardownAbort()
-    this.emit('end', result)
     this._resolveFinish(result)
+    this.emit('end', result)
   }
 
   /**
@@ -259,10 +259,10 @@ class QvacResponse extends EventEmitter {
     this._teardownAbort()
 
     queueMicrotask(() => {
+      this._rejectFinish(error)
       if (this.listenerCount('error') > 0) {
         this.emit('error', error)
       }
-      this._rejectFinish(error)
     })
   }
 

--- a/packages/infer-base/src/utils/createJobHandler.js
+++ b/packages/infer-base/src/utils/createJobHandler.js
@@ -107,13 +107,16 @@ function createJobHandler(opts) {
       if (!active) return
       const ref = active
       active = null
-      if (stats != null) {
-        ref.updateStats(stats)
-      }
-      if (result !== undefined) {
-        ref.ended(result)
-      } else {
-        ref.ended()
+      try {
+        if (stats != null) {
+          ref.updateStats(stats)
+        }
+      } finally {
+        if (result !== undefined) {
+          ref.ended(result)
+        } else {
+          ref.ended()
+        }
       }
     },
 

--- a/packages/infer-base/test/unit/QvacResponse.test.js
+++ b/packages/infer-base/test/unit/QvacResponse.test.js
@@ -227,6 +227,37 @@ test('failed after ended is a no-op', async (t) => {
   t.alike(result, ['value'], 'finish promise still resolves with the original payload')
 })
 
+test('failed settles await even when an error listener throws', async (t) => {
+  const response = new QvacResponse({ cancelHandler: dummyCancelHandler })
+  const failure = new Error('failed')
+  response.onError(() => {
+    throw new Error('listener boom')
+  })
+
+  t.exception(() => response.failed(failure), /listener boom/)
+  const outcome = await Promise.race([
+    response.await().catch((err) => err),
+    new Promise((resolve) => setTimeout(() => resolve('pending'), 50))
+  ])
+
+  t.is(outcome, failure, 'await rejects even when the error listener throws')
+})
+
+test('ended settles await even when a finish listener throws', async (t) => {
+  const response = new QvacResponse({ cancelHandler: dummyCancelHandler })
+  response.onFinish(() => {
+    throw new Error('listener boom')
+  })
+
+  t.exception(() => response.ended('done'), /listener boom/)
+  const outcome = await Promise.race([
+    response.await(),
+    new Promise((resolve) => setTimeout(() => resolve('pending'), 50))
+  ])
+
+  t.is(outcome, 'done', 'await resolves even when the finish listener throws')
+})
+
 // ------------------------------
 // Constructor signal wiring
 // ------------------------------
@@ -253,6 +284,26 @@ test('constructor signal — abort after construction fails the response with th
   } catch (err) {
     t.is(err, reason, 'await rejects with the abort reason unchanged')
   }
+})
+
+test('constructor signal — abort settles await even when an error listener throws', async (t) => {
+  const controller = makeAbortable()
+  const reason = new Error('aborted')
+  const response = new QvacResponse({
+    cancelHandler: dummyCancelHandler,
+    signal: controller.signal
+  })
+  response.onError(() => {
+    throw new Error('listener boom')
+  })
+
+  t.exception(() => controller.abort(reason), /listener boom/)
+  const outcome = await Promise.race([
+    response.await().catch((err) => err),
+    new Promise((resolve) => setTimeout(() => resolve('pending'), 50))
+  ])
+
+  t.is(outcome, reason, 'await rejects even when the abort error listener throws')
 })
 
 test('constructor signal — already-aborted signal fails the response with the abort reason', async (t) => {

--- a/packages/infer-base/test/unit/createJobHandler.test.js
+++ b/packages/infer-base/test/unit/createJobHandler.test.js
@@ -72,6 +72,22 @@ test('createJobHandler - end forwards stats before ending', async (t) => {
   t.alike(response.stats, stats, 'response.stats should be set')
 })
 
+test('createJobHandler - throwing stats listener cannot strand end', async (t) => {
+  const job = createJobHandler({ cancel: () => {} })
+  const response = job.start()
+  response.on('stats', () => {
+    throw new Error('stats listener boom')
+  })
+
+  t.exception(() => job.end({ TPS: 42 }), /stats listener boom/)
+  const outcome = await Promise.race([
+    response.await(),
+    new Promise((resolve) => setTimeout(() => resolve('pending'), 50))
+  ])
+
+  t.alike(outcome, [], 'await resolves after stats delivery throws')
+})
+
 test('createJobHandler - end with null stats does not call updateStats', async (t) => {
   const job = createJobHandler({ cancel: () => {} })
   const response = job.start()


### PR DESCRIPTION
Split out of #3445 so the `infer-base` change can be reviewed and land on its own. Independent of #3523 — no shared files.

## Problem

`QvacResponse` and `createJobHandler` invoked listener callbacks before settling the response. A listener that threw left the response promise stranded: never resolved, never rejected, so callers awaiting it hung.

## Fix

Responses now settle before listener callbacks run, so a throwing listener can no longer strand the promise. The listener exception still propagates as before.

## Tests

`test/unit/QvacResponse.test.js` and `test/unit/createJobHandler.test.js` gain regression tests that install a throwing listener and assert the response still settles; they hang/fail before the fix and pass after.

## Note

No version bump here — per the repo convention those land at the release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
