### PR TITLE
QVAC-22568 chore: bump llm-llamacpp to 0.39.1 for b9840 finetuning support

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.39.1] - 2026-07-29
+
+Extends LoRA finetuning to the b9840 model families: Qwen3.5/3.6 and Gemma-4, dense and
+mixture-of-experts. These architectures were previously rejected outright — `finetune()` threw
+`Finetuning is not supported for architecture: <arch>`. MoE models additionally need their expert FFN
+tensors targeted, so four expert LoRA target modules are now accepted. Complements the fabric-side
+training fixes already pinned via `qvac-fabric` 9840.0.1.
+
+### Added
+
+- Qwen3.5/3.6 dense (`qwen35`), Qwen3.x MoE (`qwen35moe`) and Gemma-4 (`gemma4`) are now supported
+  finetuning architectures — the allowlist grows from `gemma3`, `qwen3`, `bitnet` to six entries.
+- Four MoE expert LoRA target modules accepted in `loraModules`: `ffn_gate_exps`, `ffn_up_exps`,
+  `ffn_down_exps`, `ffn_gate_up_exps`. Required to train MoE experts at all — targeting only the dense
+  FFN names leaves expert weights untouched.
+- Integration coverage: `finetuning-archs` finetunes Qwen3.5-0.8B (desktop + mobile) and Gemma-4-E2B
+  (desktop), plus a pause/resume cycle on the new dense architecture; `finetuning-moe` covers
+  Qwen3.6-35B-A3B and Gemma-4-26B-A4B, opt-in behind `QVAC_RUN_MOE_FINETUNE=true` because those models
+  are ~20–27 GB. C++ unit tests lock backend selection for the new architectures and the expert-target
+  bit mapping.
+- `QVAC_QWEN35_MTMD_SIZE` (`0.8b` | `2b`) selects the model size for the Qwen3.5 multimodal
+  cache-stress test.
+
+### Changed
+
+- `docs/finetuning.md` model-format requirements now list the real architecture allowlist and document
+  the MoE expert LoRA targets.
+
+### Pull Requests
+
+- [#3509](https://github.com/tetherto/qvac/pull/3509) - b9840 finetuning (Qwen3.5/3.6 + Gemma-4, dense + MoE)
+
 ## [0.39.0] - 2026-07-28
 
 ### Changed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 Problem

[#3509](https://github.com/tetherto/qvac/pull/3509) (`347db9324`) landed addon-side finetuning support for the b9840 model families but bumped **neither `package.json` nor `CHANGELOG.md`** — so the capability sits on `main` and cannot be released. It is the only commit touching `packages/llm-llamacpp` since the 0.39.0 bump (`7026cc617`).

This also leaves ticket QVAC-22568 half-released. 0.39.0 shipped the **fabric** half (`qvac-fabric` → 9840.0.1, the MoE/GDN LoRA *training* fixes) and its entry states "No API change for this package" — accurate then, stale now, because #3509 added the **addon** half that actually exposes those fixes to users.

## 📝 How

Version + changelog only. No source changes.

| File | Change |
|---|---|
| `packages/llm-llamacpp/package.json` | `0.39.0` → `0.39.1` |
| `packages/llm-llamacpp/CHANGELOG.md` | New `## [0.39.1] - 2026-07-29` entry |

The entry documents what #3509 made user-visible:

- `SUPPORTED_FINETUNE_ARCHITECTURES` grows from `{gemma3, qwen3, bitnet}` to six entries, adding `qwen35`, `qwen35moe`, `gemma4`. These previously threw `Finetuning is not supported for architecture: <arch>`.
- `parseLoraModules()` accepts four MoE expert targets — `ffn_gate_exps`, `ffn_up_exps`, `ffn_down_exps`, `ffn_gate_up_exps` — required to train MoE experts at all; targeting only the dense FFN names leaves expert weights untouched.
- New `finetuning-archs` / `finetuning-moe` integration tests, C++ unit tests for backend selection and the expert-target bit mapping, mobile wiring.
- `QVAC_QWEN35_MTMD_SIZE` (`0.8b` | `2b`) toggle for the Qwen3.5 multimodal cache-stress test.

**Patch rather than minor** — deliberate: `index.js` and `index.d.ts` are untouched, so no public API, type, or config key changed; only the set of *accepted values* widened.

**No `vcpkg.json` change** — the pin is already `qvac-fabric >= 9840.0.1` from 0.39.0.

Written in the house style of `[0.38.1]` / `[0.38.2]` (`### Added` / `### Changed` / `### Pull Requests`) rather than via `/qv-addon-changelog`, whose same-level `## Features` sections would have broken consistency with the surrounding entries.

## 🧪 Tested

Pre-commit checks:

- `package.json` version reads `0.39.1`
- `grep -nE "^## \[0\.39\.1\]" CHANGELOG.md` matches at line 3 — this is the exact regex `release-merge-guard` and `create-github-release.yml` use to slice the release body; an unbracketed heading would fail the publish
- `git diff --stat origin/main` → exactly 2 files, +33/−1, nothing else swept in

The underlying capability is covered by the tests #3509 added: `finetuning-archs` (Qwen3.5-0.8B desktop + mobile, Gemma-4-E2B desktop, plus a pause/resume cycle) runs by default; `finetuning-moe` (Qwen3.6-35B-A3B, Gemma-4-26B-A4B) is opt-in behind `QVAC_RUN_MOE_FINETUNE=true` since those models are ~20–27 GB.

Two known pre-existing `llm-llamacpp` reds are expected and unrelated to this change: `test-darwin-x64` (`Qwen3 sliding context hard-fails stale reasoning compaction`, non-gating `continue-on-error`) and the intermittent `test-linux-arm64` prefill-cancel hang (tests 91/92, QVAC-21914 class).

## ⚠️ Breaking changes

None. No public API or config surface changes; the diff is a version string and a changelog entry.
