### PR TITLE
QVAC infra: roll back partially-created Device Farm runs when scheduling fails

### DIFF
--- a/.github/actions/run-mobile-integration-tests/schedule-test-run/action.yml
+++ b/.github/actions/run-mobile-integration-tests/schedule-test-run/action.yml
@@ -112,6 +112,39 @@ runs:
           RUN_NAME_BASE="PR-${{ github.event.pull_request.number || github.run_number }}-${PLATFORM}"
         fi
 
+        # Partial-scheduling rollback.
+        #
+        # run_arns is only published to $GITHUB_OUTPUT after ALL runs are created,
+        # so if a later schedule-run fails (sharded loop group 2+, or the second
+        # dual-flagship target) the caller sees no ARNs and cannot cancel the runs
+        # that DID get created — they keep executing on real devices and billing
+        # until their own timeout. Track what we create and stop it on failure.
+        #
+        # `shell: bash` runs with -e, so any failed schedule-run aborts the step and
+        # fires this trap.
+        CREATED_RUN_ARNS=""
+
+        rollback_created_runs() {
+          local status=$?
+          trap - ERR
+          if [ -n "$CREATED_RUN_ARNS" ]; then
+            echo "::warning::Scheduling failed part way — stopping the runs already created to avoid billing them."
+            for arn in $CREATED_RUN_ARNS; do
+              if aws devicefarm stop-run --arn "$arn" >/dev/null 2>&1; then
+                echo "  stopped $arn"
+              else
+                echo "  ::warning::could not stop $arn (it may have already finished)"
+              fi
+            done
+          fi
+          exit "$status"
+        }
+        trap rollback_created_runs ERR
+
+        record_created_run() {
+          CREATED_RUN_ARNS="$CREATED_RUN_ARNS $1"
+        }
+
         schedule_run_with_pool() {
           local pool_arn="$1"
           local name="$2"
@@ -163,6 +196,7 @@ runs:
             SPEC_ARN=$(echo "$TEST_SPECS_JSON" | jq -r ".[$IDX].arn")
             RUN_NAME="${RUN_NAME_BASE}-${GROUP_NAME}"
             RUN_ARN=$(schedule_run_with_pool "$POOL_ARN" "$RUN_NAME" "$SPEC_ARN")
+            record_created_run "$RUN_ARN"
             echo "  $RUN_NAME -> $RUN_ARN"
             RUN_ARNS_JSON=$(echo "$RUN_ARNS_JSON" | jq --arg arn "$RUN_ARN" '. + [$arn]')
           done
@@ -179,6 +213,7 @@ runs:
           fi
           SPEC_ARN=$(echo "$TEST_SPECS_JSON" | jq -r '.[0].arn')
           RUN_ARN=$(schedule_run_with_pool "$POOL_ARN" "$RUN_NAME_BASE" "$SPEC_ARN")
+          record_created_run "$RUN_ARN"
           echo "  $RUN_NAME_BASE -> $RUN_ARN"
           RUN_ARNS_JSON=$(echo "$RUN_ARNS_JSON" | jq --arg arn "$RUN_ARN" '. + [$arn]')
         elif [ "$SCHEDULING_MODE" = "single-device" ]; then
@@ -208,6 +243,7 @@ runs:
           }')
           SAFE_MODEL=$(printf '%s' "$DEVICE_MODEL" | tr -c '[:alnum:]' '_')
           RUN_ARN=$(schedule_run_with_filter "${RUN_NAME_BASE}-${SAFE_MODEL}" "$FILTER" "$SPEC_ARN")
+          record_created_run "$RUN_ARN"
           echo "  ${RUN_NAME_BASE}-${SAFE_MODEL} -> $RUN_ARN"
           RUN_ARNS_JSON=$(echo "$RUN_ARNS_JSON" | jq --arg arn "$RUN_ARN" '. + [$arn]')
         else
@@ -217,7 +253,9 @@ runs:
             SAMSUNG_FILTER='{"filters":[{"attribute":"MANUFACTURER","operator":"EQUALS","values":["Samsung"]},{"attribute":"MODEL","operator":"CONTAINS","values":["S25 Ultra"]},{"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]}],"maxDevices":1}'
             PIXEL_FILTER='{"filters":[{"attribute":"MANUFACTURER","operator":"EQUALS","values":["Google"]},{"attribute":"MODEL","operator":"CONTAINS","values":["Pixel 9"]},{"attribute":"PLATFORM","operator":"EQUALS","values":["ANDROID"]}],"maxDevices":1}'
             RUN_ARN_1=$(schedule_run_with_filter "${RUN_NAME_BASE}-Samsung" "$SAMSUNG_FILTER" "$SPEC_ARN")
+            record_created_run "$RUN_ARN_1"
             RUN_ARN_2=$(schedule_run_with_filter "${RUN_NAME_BASE}-Pixel"   "$PIXEL_FILTER"   "$SPEC_ARN")
+            record_created_run "$RUN_ARN_2"
           else
             if [ -z "$IOS_POOL_ARN" ]; then
               echo "ERROR: dual-flagship iOS requires ios-device-pool-arn" >&2
@@ -225,7 +263,9 @@ runs:
             fi
             IPHONE17_FILTER='{"filters":[{"attribute":"MANUFACTURER","operator":"EQUALS","values":["Apple"]},{"attribute":"MODEL","operator":"CONTAINS","values":["iPhone 17"]},{"attribute":"PLATFORM","operator":"EQUALS","values":["IOS"]}],"maxDevices":1}'
             RUN_ARN_1=$(schedule_run_with_pool   "$IOS_POOL_ARN"     "$RUN_NAME_BASE"           "$SPEC_ARN")
+            record_created_run "$RUN_ARN_1"
             RUN_ARN_2=$(schedule_run_with_filter "${RUN_NAME_BASE}-iPhone17" "$IPHONE17_FILTER" "$SPEC_ARN")
+            record_created_run "$RUN_ARN_2"
           fi
           echo "  Run 1: $RUN_ARN_1"
           echo "  Run 2: $RUN_ARN_2"


### PR DESCRIPTION
## Problem

`schedule-test-run` publishes `run_arns` to `$GITHUB_OUTPUT` **only after all runs are created**. If a later `schedule-run` call fails, the caller receives no ARNs — so its cancel step has nothing to act on, and the runs that *did* get created keep executing on real devices, billing until their own `jobTimeoutMinutes` (default 120 min/device).

Two paths create more than one run, so both can leak:

- **sharded** — the loop schedules one run per group; a failure on group 2 leaves group 1 running.
- **dual-flagship** — schedules two targets sequentially; a failure on the second leaves the first running. This is the **default** mode.

Today that means every addon using the shared composite is exposed: dual-flagship by default, and sharded for `llm-llamacpp`, `embed-llamacpp`, `ocr-ggml`, `ocr-onnx`, `tts-ggml`, `vla-ggml`, `audiogen-ggml`.

## Fix

Track every created run and stop it if the step later fails. `shell: bash` runs with `-e`, so a failed `schedule-run` aborts the step and fires an `ERR` trap that issues `aws devicefarm stop-run` for each recorded ARN, then re-exits with the original status (the step still fails — it just doesn't leave paid runs behind).

Recording is added to both multi-run paths plus the single-run modes for uniformity. No behaviour change on the success path, and no change to the output contract.

## Verification

Ran the exact logic under `bash -e -o pipefail` with a faked `aws`:

- **all succeed** → 3 runs scheduled, **nothing stopped**, exit 0
- **group 2 fails** → group 1's run stopped, exit **1** (failure preserved)

```
  group 1 -> arn:run-1
  simulated schedule-run failure (call 2)
  ::warning::Scheduling failed part way — stopping the runs already created to avoid billing them.
    stopped arn:run-1
  exit=1
```

`actionlint` clean.

## Context

Raised from review of #3313 (thanks @tobi-legan). The caller-side half — cleaning up on `failure()` as well as `cancelled()` — is in that PR; this covers the case the caller *can't* see, because the ARNs never reach it.
