### PR TITLE
QVAC-22177 chore: bump @qvac/vla-ggml to 0.16.1

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.16.1] - 2026-07-29
+
+### Fixed
+
+- ESM named imports (`import { VlaModel } from '@qvac/vla-ggml'`) failed at link time on Node and Bare against the 0.16.0 wrapper: the TypeScript namespace merge attached the six exported members inside an IIFE that cjs-module-lexer cannot statically analyze. The generated `index.js` now also assigns them as top-level `module.exports.X = …` statements — the exact pattern the lexer detects — restoring the pre-migration interop. Guarded by a new runtime integration test (`test/integration/esm-named-exports.test.js`); the type-level consumer tests structurally cannot catch this class of regression.
+- `new VlaModel({ files, config: null })` no longer leaks the registered native-logger callback (pinning the Bare event loop) and no longer fails `load()` with a `TypeError` re-wrapped as `FAILED_TO_LOAD_WEIGHTS`: `this._config` is normalized to `{}` at construction, restoring the pre-migration `this._config &&` guard semantics.
+- `validateRunInput` treats an `undefined` `hparams` like `null` again when deciding pixel- vs patch-mode input (the migration's `hparams !== null` check would have thrown a raw `TypeError` instead of falling back to pixel-mode validation).
+
+### Changed
+
+- Documenting a 0.16.0 behavioral nuance: `new VlaModel(null)` now throws a structured `MISSING_REQUIRED_PARAMETER` `QvacError` where pre-0.16.0 threw a raw destructuring `TypeError`.
+
 ## [0.16.0] - 2026-07-29
 
 ### Changed

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-## [0.16.1] - 2026-07-29
-
-### Fixed
-
-- ESM named imports (`import { VlaModel } from '@qvac/vla-ggml'`) failed at link time on Node and Bare against the 0.16.0 wrapper: the TypeScript namespace merge attached the six exported members inside an IIFE that cjs-module-lexer cannot statically analyze. The generated `index.js` now also assigns them as top-level `module.exports.X = …` statements — the exact pattern the lexer detects — restoring the pre-migration interop. Guarded by a new runtime integration test (`test/integration/esm-named-exports.test.js`); the type-level consumer tests structurally cannot catch this class of regression.
-- `new VlaModel({ files, config: null })` no longer leaks the registered native-logger callback (pinning the Bare event loop) and no longer fails `load()` with a `TypeError` re-wrapped as `FAILED_TO_LOAD_WEIGHTS`: `this._config` is normalized to `{}` at construction, restoring the pre-migration `this._config &&` guard semantics.
-- `validateRunInput` treats an `undefined` `hparams` like `null` again when deciding pixel- vs patch-mode input (the migration's `hparams !== null` check would have thrown a raw `TypeError` instead of falling back to pixel-mode validation).
-
-### Changed
-
-- Documenting a 0.16.0 behavioral nuance: `new VlaModel(null)` now throws a structured `MISSING_REQUIRED_PARAMETER` `QvacError` where pre-0.16.0 threw a raw destructuring `TypeError`.
-
 ## [0.16.0] - 2026-07-29
 
 ### Changed

--- a/packages/vla-ggml/index.js
+++ b/packages/vla-ggml/index.js
@@ -64,7 +64,7 @@ function validateRunInput(input, hparams) {
     // here. The length is fixed per model (imgWidth is pinned to visionImageSize),
     // surfaced as `hparams.imagePatchElems`. `imageInputMode` is the
     // distinguishing axis (both groot and smolvla are `continuous` state).
-    const imagesArePatches = hparams !== null && hparams.imageInputMode === "patches";
+    const imagesArePatches = hparams != null && hparams.imageInputMode === "patches";
     const patchElems = imagesArePatches ? (hparams.imagePatchElems ?? 0) : 0;
     const patchElemsKnown = Number.isInteger(patchElems) && patchElems > 0;
     const expectedPerImage = 3 * imgWidth * imgHeight;
@@ -271,7 +271,11 @@ class VlaModel {
             }
         }
         this._files = files.model;
-        this._config = config;
+        // Normalize here rather than relying on the destructuring default: that
+        // default only fires for `undefined`, so a JS consumer passing
+        // `config: null` (symmetric with the documented `logger: null`) would
+        // otherwise store null and crash the native-logger and load paths.
+        this._config = config ?? {};
         this.logger = new QvacLogger(logger);
         this.opts = opts;
         // The cancel hook is wired to the framework's binding.cancel(handle)
@@ -578,4 +582,18 @@ var VlaModelClass = VlaModel;
     VlaModel.QvacErrorAddonVla = errorModule.QvacErrorAddonVla;
     VlaModel.ERR_CODES = errorModule.ERR_CODES;
 })(VlaModel || (VlaModel = {}));
+// The namespace merge above attaches the six members inside an IIFE, which
+// cjs-module-lexer (Node's and Bare's CJS→ESM interop) cannot statically see —
+// an ESM `import { VlaModel } from '@qvac/vla-ggml'` would fail at link time
+// with "Named export not found". These top-level assignments are redundant at
+// runtime (same values the IIFE already attached) but are the exact pattern the
+// lexer detects, keeping named ESM imports working on Node and Bare.
+/* eslint-disable @typescript-eslint/no-unsafe-member-access -- `module.exports` is untyped CommonJS surface; these mirror the typed namespace members above. */
+module.exports.VlaModel = VlaModel;
+module.exports.preprocessImage = addonModule.preprocessImage;
+module.exports.padState = addonModule.padState;
+module.exports.DEFAULT_IMAGE_SIZE = addonModule.DEFAULT_IMAGE_SIZE;
+module.exports.QvacErrorAddonVla = errorModule.QvacErrorAddonVla;
+module.exports.ERR_CODES = errorModule.ERR_CODES;
 module.exports = VlaModel;
+/* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.16.1",
+  "version": "0.16.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/src/index.ts
+++ b/packages/vla-ggml/src/index.ts
@@ -134,7 +134,7 @@ function validateRunInput(
   // surfaced as `hparams.imagePatchElems`. `imageInputMode` is the
   // distinguishing axis (both groot and smolvla are `continuous` state).
   const imagesArePatches =
-    hparams !== null && hparams.imageInputMode === "patches";
+    hparams != null && hparams.imageInputMode === "patches";
   const patchElems = imagesArePatches ? (hparams.imagePatchElems ?? 0) : 0;
   const patchElemsKnown = Number.isInteger(patchElems) && patchElems > 0;
   const expectedPerImage = 3 * imgWidth * imgHeight;
@@ -380,7 +380,11 @@ class VlaModel {
       }
     }
     this._files = files.model;
-    this._config = config;
+    // Normalize here rather than relying on the destructuring default: that
+    // default only fires for `undefined`, so a JS consumer passing
+    // `config: null` (symmetric with the documented `logger: null`) would
+    // otherwise store null and crash the native-logger and load paths.
+    this._config = config ?? {};
     this.logger = new QvacLogger(logger as QvacLogger.LoggerInterface);
     this.opts = opts;
     // The cancel hook is wired to the framework's binding.cancel(handle)
@@ -798,3 +802,18 @@ namespace VlaModel {
 }
 
 export = VlaModel;
+
+// The namespace merge above attaches the six members inside an IIFE, which
+// cjs-module-lexer (Node's and Bare's CJS→ESM interop) cannot statically see —
+// an ESM `import { VlaModel } from '@qvac/vla-ggml'` would fail at link time
+// with "Named export not found". These top-level assignments are redundant at
+// runtime (same values the IIFE already attached) but are the exact pattern the
+// lexer detects, keeping named ESM imports working on Node and Bare.
+/* eslint-disable @typescript-eslint/no-unsafe-member-access -- `module.exports` is untyped CommonJS surface; these mirror the typed namespace members above. */
+module.exports.VlaModel = VlaModel;
+module.exports.preprocessImage = addonModule.preprocessImage;
+module.exports.padState = addonModule.padState;
+module.exports.DEFAULT_IMAGE_SIZE = addonModule.DEFAULT_IMAGE_SIZE;
+module.exports.QvacErrorAddonVla = errorModule.QvacErrorAddonVla;
+module.exports.ERR_CODES = errorModule.ERR_CODES;
+/* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/packages/vla-ggml/test/integration/esm-named-exports.test.js
+++ b/packages/vla-ggml/test/integration/esm-named-exports.test.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const test = require('brittle')
+
+// Guards the CJS→ESM interop surface: Node's and Bare's module lexers must be
+// able to statically discover the attached members of `module.exports` so ESM
+// consumers (like the SDK's `import { VlaModel } from '@qvac/vla-ggml'`) link.
+// A type-level test cannot catch this — the declarations can be correct while
+// the lexer sees nothing (see the 0.16.0 → 0.16.1 regression) — so this test
+// exercises the real runtime import machinery via dynamic import.
+test('ESM named exports are statically discoverable', async (t) => {
+  const ns = await import('../../index.js')
+
+  t.is(typeof ns.VlaModel, 'function', 'VlaModel named export')
+  t.is(typeof ns.preprocessImage, 'function', 'preprocessImage named export')
+  t.is(typeof ns.padState, 'function', 'padState named export')
+  t.is(typeof ns.DEFAULT_IMAGE_SIZE, 'number', 'DEFAULT_IMAGE_SIZE named export')
+  t.is(typeof ns.QvacErrorAddonVla, 'function', 'QvacErrorAddonVla named export')
+  t.is(typeof ns.ERR_CODES, 'object', 'ERR_CODES named export')
+
+  t.is(typeof ns.default, 'function', 'default export is the class')
+  t.is(ns.default, ns.VlaModel, 'default and named VlaModel are the same binding')
+})

--- a/packages/vla-ggml/test/mobile/integration.auto.cjs
+++ b/packages/vla-ggml/test/mobile/integration.auto.cjs
@@ -16,6 +16,11 @@ async function runAddonTest (options = {}) { // eslint-disable-line no-unused-va
   return runIntegrationModule('../integration/addon.test.js', options)
 }
 
+async function runEsmNamedExportsTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runEsmNamedExportsTest')) return __FILTERED
+  return runIntegrationModule('../integration/esm-named-exports.test.js', options)
+}
+
 async function runGrootTest (options = {}) { // eslint-disable-line no-unused-vars
   if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runGrootTest')) return __FILTERED
   return runIntegrationModule('../integration/groot.test.js', options)

--- a/packages/vla-ggml/test/mobile/test-groups.json
+++ b/packages/vla-ggml/test/mobile/test-groups.json
@@ -1,11 +1,11 @@
 {
   "ios": {
-    "smolvla": ["runAddonTest"],
+    "smolvla": ["runAddonTest", "runEsmNamedExportsTest"],
     "pi05":    ["runPi05Test"],
     "groot":   ["runGrootTest"]
   },
   "android": {
-    "smolvla": ["runAddonTest"],
+    "smolvla": ["runAddonTest", "runEsmNamedExportsTest"],
     "pi05":    ["runPi05Test"],
     "groot":   ["runGrootTest"]
   }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Follow-up to #3519: the version bump and CHANGELOG entries were split out of the fix PR per review request, so the fix lands content-only and the release bookkeeping is reviewable on its own.

## 📝 How does it solve it?

- Bumps `@qvac/vla-ggml` `0.16.0 → 0.16.1`.
- Adds the `[0.16.1]` CHANGELOG section covering the ESM named-export lexer fix, the `config: null` native-logger/`load()` fix, the `hparams != null` guard fix, and the documented `new VlaModel(null)` error-class nuance from 0.16.0.

Stacked on `fix/vla-ggml-esm-named-exports` (#3519) — merge after it; the base retargets to `main` automatically when #3519 lands.
