### PR TITLE
QVAC-21925 test[skiplog]: preserve system resources e2e literal types

### DIFF
--- a/packages/sdk/e2e/tests/system-resources-tests.ts
+++ b/packages/sdk/e2e/tests/system-resources-tests.ts
@@ -12,7 +12,7 @@ export const systemResourcesCapabilities = {
     dependency: 'none',
     estimatedDurationMs: 5_000
   }
-} satisfies TestDefinition
+} as const satisfies TestDefinition
 
 export const systemResourcesSample = {
   testId: 'system-resources-sample',
@@ -26,7 +26,7 @@ export const systemResourcesSample = {
     dependency: 'none',
     estimatedDurationMs: 5_000
   }
-} satisfies TestDefinition
+} as const satisfies TestDefinition
 
 export const systemResourcesInvalidInput = {
   testId: 'system-resources-invalid-input',
@@ -40,7 +40,7 @@ export const systemResourcesInvalidInput = {
     dependency: 'none',
     estimatedDurationMs: 5_000
   }
-} satisfies TestDefinition
+} as const satisfies TestDefinition
 
 export const systemResourcesTests = [
   systemResourcesCapabilities,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The SDK e2e workflow fails while compiling every consumer because the system resources test definitions widen their IDs and parameters.
- This prevents the framework from mapping each test to its correctly typed handler.

## 📝 How does it solve it?

- Preserve literal types for the system resources test definitions so each handler receives its test-specific parameter type.

## 🧪 How was it tested?

- Ran `npm run install:build:full` from `packages/sdk/e2e`.
- Confirmed the SDK build, e2e TypeScript build, and SDK worker bundle complete successfully.