### PR TITLE
DO NOT MERGE — QVAC-22954 overlay CI: prove the audiogen Vulkan GPU jobs go green

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   progress ticks + the interleaved-Int16 PCM chunk and resolves with the run
   stats (`audioDurationMs`, `totalTimeMs`, `realTimeFactor`), plus `cancel()` /
   `unload()` / `destroy()`.
+- Run stats report the *resolved* backend via `backendDevice` (0 = CPU, 1 = GPU)
+  and `backendId` (0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL,
+  99 = other), matching `@qvac/tts-ggml`. The GPU integration smoke asserts on
+  them, so a `useGPU: true` run that silently falls back to the CPU now fails
+  instead of passing; `QVAC_AUDIOGEN_GPU_SMOKE_RELAX=1` downgrades that to a
+  warning. The smoke also checks the rendered audio is non-silent (peak/RMS) and
+  close to the requested duration.
 - Full ACE-Step pipeline (text-encoder → LM → DiT → Oobleck VAE) with optional
   `lyrics`, `vocalLanguage`, `bpm`, `keyscale`, `timesignature`, `duration` and
   `seed`.

--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -16,6 +16,10 @@ find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
 
+# DO NOT MERGE. Points ggml-speech at qvac-ext-ggml PR #47 so CI can prove the
+# audiogen Vulkan GPU jobs go green before that PR is republished to the registry.
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports;${VCPKG_OVERLAY_PORTS}")
+
 project(audiogen-ggml CXX C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -66,13 +66,18 @@ for await (const item of response.iterate()) {
     // these chunks as they stream in.
   }
 }
-const stats = await response.await() // { audioDurationMs, totalTimeMs, realTimeFactor }
+const stats = await response.await()
+// { audioDurationMs, totalTimeMs, realTimeFactor, backendDevice, backendId }
+// backendDevice: 0 = CPU, 1 = GPU
+// backendId:     0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other
 
 await gen.destroy()
 ```
 
 > The audio arrives as PCM chunks over the `QvacResponse` stream; `await()`
-> resolves with the run stats once generation completes.
+> resolves with the run stats once generation completes. `backendDevice` /
+> `backendId` report the backend the engine *resolved to*, not the one requested,
+> so a `useGPU: true` run that fell back to the CPU is detectable.
 > [`examples/generate-music.js`](examples/generate-music.js) shows the pattern.
 
 ### 2. A song with lyrics + rhythm

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
@@ -2,9 +2,11 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "audiogen-cpp/acestep/engine.h"
@@ -17,6 +19,29 @@ int16_t f32ToI16(float x) {
   if (v > 32767.0F) v = 32767.0F;
   if (v < -32768.0F) v = -32768.0F;
   return static_cast<int16_t>(v);
+}
+
+constexpr int64_t BACKEND_DEVICE_CPU = 0;
+constexpr int64_t BACKEND_DEVICE_GPU = 1;
+
+// Mirrors tts-ggml's BackendUtils.hpp mapping so the codes the two addons
+// report cannot drift apart. Metal registers as "MTL" on newer ggml.
+int64_t backendIdFromName(const std::string& name) {
+  if (name == "CPU")
+    return 0;
+  if (name.rfind("Metal", 0) == 0 || name.rfind("MTL", 0) == 0)
+    return 1;
+  if (name.rfind("CUDA", 0) == 0)
+    return 2;
+  if (name.rfind("Vulkan", 0) == 0)
+    return 3;
+  if (name.rfind("OpenCL", 0) == 0)
+    return 4;
+  return 99;
+}
+
+int64_t backendDeviceFromName(const std::string& name) {
+  return name == "CPU" ? BACKEND_DEVICE_CPU : BACKEND_DEVICE_GPU;
 }
 }  // namespace
 
@@ -196,6 +221,10 @@ qvac_lib_inference_addon_cpp::RuntimeStats AcestepModel::runtimeStats() const {
   stats.emplace_back("totalTimeMs", totalTime_);
   stats.emplace_back("realTimeFactor", realTimeFactor_);
   stats.emplace_back("audioDurationMs", audioDurationMs_);
+  // The *resolved* backend, so a useGPU request that silently fell back to the
+  // CPU is visible to callers (gpu-smoke.test.js asserts on these).
+  stats.emplace_back("backendDevice", backendDeviceFromName(backendName_));
+  stats.emplace_back("backendId", backendIdFromName(backendName_));
   return stats;
 }
 

--- a/packages/audiogen-ggml/index.d.ts
+++ b/packages/audiogen-ggml/index.d.ts
@@ -80,13 +80,22 @@ export type AudiogenOutputChunk = AudiogenPcmChunk | AudiogenProgressChunk;
 /**
  * Terminal run stats, resolved by `QvacResponse.await()`. These mirror exactly
  * what the native `AcestepModel::runtimeStats()` emits — `totalTimeMs`,
- * `realTimeFactor` and `audioDurationMs`. Sample rate and channel count are NOT
- * here: they ride on each PCM chunk instead (see `AudiogenPcmChunk`).
+ * `realTimeFactor`, `audioDurationMs` and the resolved backend. Sample rate and
+ * channel count are NOT here: they ride on each PCM chunk instead (see
+ * `AudiogenPcmChunk`).
+ *
+ * `backendDevice` / `backendId` describe the backend the engine actually ran
+ * on, not the one requested, so a `useGPU: true` run that fell back to the CPU
+ * is detectable. Codes match @qvac/tts-ggml.
  */
 export interface AudiogenStats {
     audioDurationMs?: number;
     totalTimeMs?: number;
     realTimeFactor?: number;
+    /** 0 = CPU, 1 = GPU. */
+    backendDevice?: number;
+    /** 0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other. */
+    backendId?: number;
 }
 /**
  * GGML-backed music generation via the ACE-Step engine. Owns a persistent

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -210,7 +210,9 @@ class AudioGen {
             const stats = {
                 ...(typeof d.audioDurationMs === 'number' ? { audioDurationMs: d.audioDurationMs } : {}),
                 ...(typeof d.totalTimeMs === 'number' ? { totalTimeMs: d.totalTimeMs } : {}),
-                ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {})
+                ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {}),
+                ...(typeof d.backendDevice === 'number' ? { backendDevice: d.backendDevice } : {}),
+                ...(typeof d.backendId === 'number' ? { backendId: d.backendId } : {})
             };
             this._job.end(stats, stats);
         }

--- a/packages/audiogen-ggml/src/index.ts
+++ b/packages/audiogen-ggml/src/index.ts
@@ -111,13 +111,22 @@ export type AudiogenOutputChunk = AudiogenPcmChunk | AudiogenProgressChunk
 /**
  * Terminal run stats, resolved by `QvacResponse.await()`. These mirror exactly
  * what the native `AcestepModel::runtimeStats()` emits — `totalTimeMs`,
- * `realTimeFactor` and `audioDurationMs`. Sample rate and channel count are NOT
- * here: they ride on each PCM chunk instead (see `AudiogenPcmChunk`).
+ * `realTimeFactor`, `audioDurationMs` and the resolved backend. Sample rate and
+ * channel count are NOT here: they ride on each PCM chunk instead (see
+ * `AudiogenPcmChunk`).
+ *
+ * `backendDevice` / `backendId` describe the backend the engine actually ran
+ * on, not the one requested, so a `useGPU: true` run that fell back to the CPU
+ * is detectable. Codes match @qvac/tts-ggml.
  */
 export interface AudiogenStats {
   audioDurationMs?: number
   totalTimeMs?: number
   realTimeFactor?: number
+  /** 0 = CPU, 1 = GPU. */
+  backendDevice?: number
+  /** 0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other. */
+  backendId?: number
 }
 
 /** Raw shape of the native output-callback payload. */
@@ -129,6 +138,8 @@ interface NativeAudiogenData {
   audioDurationMs?: number
   totalTimeMs?: number
   realTimeFactor?: number
+  backendDevice?: number
+  backendId?: number
   progressStage?: string
   progressStep?: number
   progressTotal?: number
@@ -367,7 +378,9 @@ export class AudioGen {
       const stats: AudiogenStats = {
         ...(typeof d.audioDurationMs === 'number' ? { audioDurationMs: d.audioDurationMs } : {}),
         ...(typeof d.totalTimeMs === 'number' ? { totalTimeMs: d.totalTimeMs } : {}),
-        ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {})
+        ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {}),
+        ...(typeof d.backendDevice === 'number' ? { backendDevice: d.backendDevice } : {}),
+        ...(typeof d.backendId === 'number' ? { backendId: d.backendId } : {})
       }
       this._job.end(stats, stats)
     }

--- a/packages/audiogen-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/audiogen-ggml/test/integration/gpu-smoke.test.js
@@ -2,31 +2,100 @@
 
 // GPU / CPU backend smoke for @qvac/audiogen-ggml.
 //
-// LIMITATION vs tts-ggml's gpu-smoke: audiogen's native run stats expose only
-// totalTimeMs / realTimeFactor / audioDurationMs — there is NO
-// backendDevice / backendId field — so this suite can only assert that a
-// GPU-requested run completes and produces audio, NOT which backend actually
-// executed. The GPU leg is skipped under NO_GPU (CPU-only matrix entries); the
-// CPU leg runs everywhere and asserts the useGPU:false path still generates.
+// The GPU leg is strict: a useGPU:true run that resolves to the CPU backend is
+// treated as a regression. The engine degrades silently ("GPU requested but no
+// GPU backend available; using CPU"), so without this gate a broken GPU build
+// still reports green. CI sets NO_GPU=true on the CPU-only matrix entries and
+// every NO_GPU=false entry runs on a dedicated GPU runner, so requiring a GPU
+// whenever NO_GPU is false is safe. Set QVAC_AUDIOGEN_GPU_SMOKE_RELAX=1 to
+// downgrade the gate to a warning.
+//
+// Both legs also check the audio is real, not merely present: a run returning
+// the right number of *silent* samples satisfies `sampleCount > 0` yet is a
+// miscompute. QVAC-22954 is the motivating case — a missing Vulkan CPY kernel.
 
 const test = require('brittle')
 const path = require('bare-path')
+const proc = require('bare-process')
 const { ensureAudiogenModels, getBaseDir } = require('../utils/downloadModel')
 const {
   loadAudioGen,
   runAudioGen,
+  backendIdToName,
   NO_GPU,
   INTEGRATION_TIMEOUT_MS
 } = require('../utils/runAudioGen')
 
 const VARIANT = 'turbo-q4'
+const RELAX = proc.env && proc.env.QVAC_AUDIOGEN_GPU_SMOKE_RELAX === '1'
+
+// Silence floors. A real 6 s render measures rms ~0.08-0.14 and peak ~0.9 (the
+// addon normalises the peak to 0.9), so these leave a wide margin while still
+// failing hard on an all-zero or near-zero buffer.
+const MIN_PEAK = 0.1
+const MIN_RMS = 0.005
+
+const DURATION_S = 6
 
 function modelsDir() {
   return path.join(getBaseDir(), 'models')
 }
 
+// Shape + loudness + length of a render, for either backend.
+function assertAudio(t, data, tag) {
+  t.is(data.channels, 2, `${tag}: stereo output`)
+  t.is(data.sampleRate, 48000, `${tag}: 48 kHz output`)
+  t.ok(data.sampleCount > 0, `${tag}: produced ${data.sampleCount} interleaved samples`)
+  t.ok(
+    data.peak > MIN_PEAK,
+    `${tag}: audio is not silent (peak ${data.peak.toFixed(4)} > ${MIN_PEAK})`
+  )
+  t.ok(data.rms > MIN_RMS, `${tag}: audio carries energy (rms ${data.rms.toFixed(5)} > ${MIN_RMS})`)
+
+  // The LM quantises the request into whole audio codes, so a render lands near
+  // the requested length rather than on it (6 s -> ~5.6 s). Bound it loosely to
+  // catch a truncated or runaway render without encoding the code grid.
+  const requestedMs = DURATION_S * 1000
+  t.ok(
+    data.durationMs >= requestedMs * 0.5 && data.durationMs <= requestedMs * 1.5,
+    `${tag}: duration ${Math.round(data.durationMs)} ms is within 50-150% of the requested ${requestedMs} ms`
+  )
+}
+
+// Strict check that a useGPU:true run really executed on a GPU backend.
+function assertRanOnGpu(t, stats) {
+  if (!stats) {
+    t.fail('GPU: no run stats returned, cannot verify which backend executed')
+    return
+  }
+  const dev = stats.backendDevice
+  const id = stats.backendId
+  if (typeof dev !== 'number' || typeof id !== 'number') {
+    t.fail(
+      `GPU: stats carry no backendDevice/backendId (got ${dev}/${id}) — ` +
+        'AcestepModel::runtimeStats() must report the resolved backend'
+    )
+    return
+  }
+  console.log(`[audiogen/GPU] backendDevice=${dev} backendId=${id} (${backendIdToName(id)})`)
+
+  if (dev === 1) {
+    t.pass(`GPU: ran on ${backendIdToName(id)} (backendId=${id})`)
+    return
+  }
+  const msg =
+    `GPU: expected a GPU backend, got ${backendIdToName(id)} ` +
+    `(backendDevice=${dev}, backendId=${id}). useGPU:true was requested but the ` +
+    'engine resolved to the CPU — a silent GPU fallback, not a passing run.'
+  if (RELAX) {
+    t.pass(`${msg} [relaxed via QVAC_AUDIOGEN_GPU_SMOKE_RELAX]`)
+    return
+  }
+  t.fail(msg)
+}
+
 test(
-  'GPU smoke: useGPU generation produces audio',
+  'GPU smoke: useGPU generation produces audio on a GPU backend',
   { timeout: INTEGRATION_TIMEOUT_MS, skip: NO_GPU },
   async (t) => {
     const download = await ensureAudiogenModels({ targetDir: modelsDir(), variant: VARIANT })
@@ -44,16 +113,16 @@ test(
 
     const { data } = await runAudioGen(gen, {
       caption: 'cinematic orchestral, epic drums, rising strings',
-      opts: { lyrics: '[Instrumental]', duration: 6, seed: 3 }
+      opts: { lyrics: '[Instrumental]', duration: DURATION_S, seed: 3 }
     })
 
-    t.ok(data.sampleCount > 0, `GPU run produced ${data.sampleCount} samples`)
-    t.is(data.channels, 2, 'stereo output')
+    assertRanOnGpu(t, data.stats)
+    assertAudio(t, data, 'GPU')
   }
 )
 
 test(
-  'CPU contract: useGPU:false generation produces audio',
+  'CPU contract: useGPU:false generation produces audio on the CPU backend',
   { timeout: INTEGRATION_TIMEOUT_MS },
   async (t) => {
     const download = await ensureAudiogenModels({ targetDir: modelsDir(), variant: VARIANT })
@@ -71,9 +140,12 @@ test(
 
     const { data } = await runAudioGen(gen, {
       caption: 'simple solo piano melody, sparse and gentle',
-      opts: { lyrics: '[Instrumental]', duration: 6, seed: 4 }
+      opts: { lyrics: '[Instrumental]', duration: DURATION_S, seed: 4 }
     })
 
-    t.ok(data.sampleCount > 0, `CPU run produced ${data.sampleCount} samples`)
+    if (data.stats && typeof data.stats.backendDevice === 'number') {
+      t.is(data.stats.backendDevice, 0, 'CPU: useGPU:false resolved to the CPU backend')
+    }
+    assertAudio(t, data, 'CPU')
   }
 )

--- a/packages/audiogen-ggml/test/utils/runAudioGen.js
+++ b/packages/audiogen-ggml/test/utils/runAudioGen.js
@@ -67,6 +67,21 @@ async function runAudioGen(gen, { caption, opts = {} } = {}) {
   const durationMs =
     sampleRate > 0 && channels > 0 ? (sampleCount / channels / sampleRate) * 1000 : 0
 
+  // Loudness of the interleaved int16 PCM, normalised to [0,1]. `sampleCount > 0`
+  // alone cannot tell a real render from a buffer of silence, which is what a
+  // miscomputing GPU kernel tends to produce, so the tests assert on these.
+  let peakAbs = 0
+  let sumSquares = 0
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i++) {
+      const v = chunk[i] / 32768
+      const a = v < 0 ? -v : v
+      if (a > peakAbs) peakAbs = a
+      sumSquares += v * v
+    }
+  }
+  const rms = sampleCount > 0 ? Math.sqrt(sumSquares / sampleCount) : 0
+
   return {
     data: {
       sampleCount,
@@ -75,8 +90,28 @@ async function runAudioGen(gen, { caption, opts = {} } = {}) {
       durationMs,
       chunkCount: chunks.length,
       stages: [...stages],
+      peak: peakAbs,
+      rms,
       stats
     }
+  }
+}
+
+// Human-readable name for an AudiogenStats.backendId. Mirrors @qvac/tts-ggml.
+function backendIdToName(id) {
+  switch (id) {
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    default:
+      return 'other-GPU'
   }
 }
 
@@ -84,5 +119,6 @@ module.exports = {
   NO_GPU,
   INTEGRATION_TIMEOUT_MS,
   loadAudioGen,
-  runAudioGen
+  runAudioGen,
+  backendIdToName
 }

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/portfile.cmake
@@ -1,0 +1,247 @@
+# DO NOT MERGE. Temporary overlay that points ggml-speech at qvac-ext-ggml PR #47
+# (Vulkan CPY from the k-quants to F32) so CI can prove the audiogen GPU jobs go
+# green before that PR is merged and republished to the registry. Delete this
+# overlay and raise the registry pin instead.
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF 9e4cb8bbe547d3a00f18c57ce113627e1530358a
+    SHA512 f7ba471fb531dd6be81d3725d8d7dfeac2335f6d597ed8fd063ac414a029f63b070c5840ceb7e795bc274dd9092246bc43bf74c114c110a0077f6d0fb3973a36
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# Desktop aarch64 Linux: same per-arch CPU-variant packaging as Android.
+# This build is not GGML_NATIVE and passes no -march override, so a
+# single-variant CPU backend lands on the compiler's plain armv8-a
+# baseline: the dotprod/fp16/i8mm ARM kernels (incl. the repack GEMM
+# kernels in ggml-cpu/arch/arm/repack.cpp) are compiled out and both
+# f16 and quantized (q4_0/q8_0) GEMMs stay on the slowest generic
+# paths. GGML_CPU_ALL_VARIANTS builds one MODULE .so per ARMv8.x/9.x
+# feature tier and scores them against the running CPU at first use,
+# so the prebuild stays SIGILL-safe on any aarch64 host. The speech
+# addons stage lib/libqvac-speech-ggml-*.so next to their .bare and
+# forward backendsDir to ggml_backend_load_all_from_path(), same as
+# Android. Verified on the Parakeet + Whisper RTF benchmarks (qvac
+# runs 29243365879 / 29333221534): parakeet tdt q4_0 mean RTF
+# 0.2285 -> 0.0612, whisper base f16 0.3316 -> 0.0970.
+set(QVAC_LINUX_ARM64_DL_CPU OFF)
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(QVAC_LINUX_ARM64_DL_CPU ON)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        # The dlopen'd MODULE backends must not carry shared-library
+        # dependencies the host machine doesn't ship. The qvac linux
+        # triplets compile with clang -stdlib=libc++ but only the final
+        # addon binary links libc++ statically; a module with NEEDED
+        # libc++.so.1 / libc++abi.so.1 entries fails to dlopen on a
+        # stock host (no libc++ runtime package) and the registry
+        # loader skips it *silently* -- the CPU backend then simply
+        # never registers ("no CPU device registered"). Link the C++
+        # runtime statically into the modules instead, matching the
+        # addon convention. Composed with the triplet's own
+        # VCPKG_LINKER_FLAGS because a bare -DCMAKE_MODULE_LINKER_FLAGS
+        # would override vcpkg's *_INIT seeding and drop the triplet's
+        # -stdlib=libc++ at link time (under gcc triplets this composes
+        # to plain -static-libstdc++, which is equally valid).
+        "-DCMAKE_MODULE_LINKER_FLAGS=${VCPKG_LINKER_FLAGS} -static-libstdc++"
+    )
+endif()
+
+# The v0.10.2 ggml sync introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+# Desktop Linux MODULE backend pickup. ggml's own install() places the
+# MODULE backends in bin/ (CMAKE_INSTALL_BINDIR) and -- unlike Android,
+# where CMake never versions module filenames -- as versioned files
+# (libqvac-speech-ggml-cpu-armv8.2_1.so.<ver>) plus unversioned .so
+# symlinks. Two problems with leaving them there: the runtime loader
+# only matches the exact `.so` extension, and the speech addons stage
+# backends by file(INSTALL)-ing a glob of lib/libqvac-speech-ggml-*.so,
+# which would copy a symlink without its target. Dereference each
+# unversioned name onto its real file, publish plain .so files in lib/,
+# and drop bin/ (static triplets must not ship a bin/ dir anyway).
+if(QVAC_LINUX_ARM64_DL_CPU)
+    foreach(_cfg "" "/debug")
+        file(GLOB _backend_mods
+            "${CURRENT_PACKAGES_DIR}${_cfg}/bin/libqvac-speech-ggml-*.so")
+        foreach(_mod IN LISTS _backend_mods)
+            get_filename_component(_mod_name "${_mod}" NAME)
+            file(REAL_PATH "${_mod}" _mod_real)
+            file(COPY_FILE "${_mod_real}"
+                 "${CURRENT_PACKAGES_DIR}${_cfg}/lib/${_mod_name}")
+        endforeach()
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}${_cfg}/bin")
+        # Do not ship the SVE-bearing CPU variants. ggml's SVE code
+        # paths are drastically slower than the NEON dotprod/fp16 paths
+        # on the 128-bit-vector cores that make up the desktop
+        # arm64-linux fleet (Neoverse-N2 runners; Apple VMs and
+        # Snapdragon X have no SVE at all): whisper base q8_0 RTF
+        # 0.2224 via armv8.6_2 (SVE) vs 0.0626 via armv8.2_2 (no SVE),
+        # f16 0.2586 vs 0.0938 (qvac A/B runs 29328745233 /
+        # 29332248742) -- and the runtime score would pick the SVE
+        # tiers on SVE hardware. Parakeet is within 3% either way (its
+        # hot GEMMs use the NEON repack kernels). Revisit when the
+        # speech branch grows an SVE-free i8mm tier (the Android
+        # variant list has one) or VL-aware scoring.
+        foreach(_sve_tier armv8.2_3 armv8.6_1 armv8.6_2 armv9.2_1 armv9.2_2)
+            file(REMOVE
+                "${CURRENT_PACKAGES_DIR}${_cfg}/lib/libqvac-speech-ggml-cpu-${_sve_tier}.so")
+        endforeach()
+    endforeach()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/usage
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-07-30",
+  "description": "Speech-stack ggml flavour (tetherto/qvac-ext-ggml@speech). This pin makes GGML_PREC_F32 effective on the GPU backends: Vulkan and Metal previously reduced f32 matmuls in fp16 regardless of the requested precision, so callers carrying large-magnitude activations (Parler-TTS T5/DAC, ACE-Step) lost accuracy or saturated past 65504. Adds scalar fp32 matmul pipelines (dense and quantized) selected on GGML_PREC_F32, a Vulkan GET_ROWS offset fix, and Vulkan kernels for the ACE-Step Oobleck VAE custom ops (snake, col2im_1d) whose CPU + Metal implementations landed in the prior pin. CPU output is unchanged.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -1,4 +1,6 @@
 {
+  "name": "audiogen-ggml",
+  "version": "0.1.0",
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
**Do not merge.** Throwaway branch whose only purpose is to run the audiogen-ggml integration matrix against [qvac-ext-ggml PR #47](https://github.com/tetherto/qvac-ext-ggml/pull/47) before that PR is merged and republished to the registry.

## What is red today

On `main` (and identically on `QVAC-22838-audiogen-mmap` — the two have byte-identical `packages/audiogen-ggml` trees and the same `audiogen-cpp` pin) all three Vulkan GPU integration jobs abort with exit 134:

```
Missing CPY op for types: q4_K f32
src/ggml-vulkan/ggml-vulkan.cpp:8005: fatal error
```

`ubuntu-22.04-x64-gpu`, `ubuntu-24.04-x64-gpu`, `windows-2025-x64-gpu`. Metal and both CPU jobs pass, because the audiogen engine allowlists the FSQ detokenizer onto the GPU **only** under Vulkan; everywhere else it is CPU-pinned. The detokenizer casts `detokenizer.special_tokens` to F32 in-graph and that tensor is `Q4_K` in `acestep-v15-turbo-Q4_K_M.gguf`, which is the DiT every integration suite uses.

## This branch

Two commits:

1. `QVAC-22954 test[audiogen-ggml]` — the real change, also up for review on its own as `QVAC-22954-audiogen-gpu-assert`.
2. `DO NOT MERGE: overlay ggml-speech onto qvac-ext-ggml PR #47` — a copy of the registry `ggml-speech` port with `REF` pointed at PR #47 and `version-date` bumped to `2026-07-30` (still satisfies audiogen-cpp's `version>= 2026-07-29` floor), wired via `VCPKG_OVERLAY_PORTS` alongside the existing `VCPKG_OVERLAY_TRIPLETS`.

## Expected result

The three Vulkan jobs go green. Already verified off-CI on an RTX 3080: `test-backend-ops -o CPY` 131/131 → 141/141, full `test-backend-ops` 13640/13640, the isolated `ggml_cast(k-quant → F32)` is bit-exact against CPU, and the audiogen detokenizer plus the full ACE-Step pipeline both run on Vulkan with the Q4_K_M DiT.

The hardened smoke was also run locally on Metal: `backendDevice=1 backendId=1 (Metal)`, 2/2 tests and 14/14 asserts pass.

Needs the `verified` label to actually run the matrix.