### PR TITLE
chore[api]: bump Classification Fabric dependency

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-07-30
+
+### Changed
+
+- `@qvac/fabric` dependency bumped `^0.3.0` -> `^0.3.1`, picking up
+  `qvac-fabric` 9840.1.1 compatibility. No API change for this package.
+
 ## [0.15.0] - 2026-07-28
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {
@@ -74,7 +74,7 @@
     "typescript-eslint": "^8.63.0"
   },
   "dependencies": {
-    "@qvac/fabric": "^0.3.0",
+    "@qvac/fabric": "^0.3.1",
     "@qvac/infer-base": "^0.4.0",
     "@qvac/logging": "^0.1.0",
     "bare-env": "^3.0.0",


### PR DESCRIPTION
## Summary
- bump Classification to @qvac/fabric 0.3.1
- patch-release the addon and update its changelog

## Test plan
- [x] verify @qvac/fabric@0.3.1 is published on npm
- [x] install dependencies with npm and resolve @qvac/fabric to 0.3.1
- [x] validate package and vcpkg JSON manifests
- [x] run npm run lint
- [x] run npm run test:dts
- [x] run npm pack --dry-run --json
- [x] run git diff --check