### PR TITLE
QVAC-22961 fix: bump inference-addon-cpp to 1.3.2 (JsAsyncTask teardown crash in translation-nmtcpp)

### DIFF
--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.1] - 2026-07-30
+
+### Fixed
+
+- Bumped the `qvac-lib-inference-addon-cpp` vcpkg dependency `1.2.4` → `1.3.2`
+  to pick up the environment-scoped `JsAsyncTask` teardown fix (QVAC-18397,
+  [#3525](https://github.com/tetherto/qvac/pull/3525)). `cancel()` and
+  `destroyInstance()` run as `JsAsyncTask`s, and before 1.3.2 the detached
+  worker owned the work functor — so its captures (commonly the last
+  `shared_ptr` to the addon) were destroyed after `uv_async_send`, by which
+  point the loop could have finished teardown and the JS env could be gone.
+  A settlement failure could also throw out of `onComplete`, a C callback,
+  reaching `std::terminate`. In the integration suites this surfaced as the
+  process dying at teardown with all assertions passing — `exit 134` with
+  `libc++abi: terminate_handler unexpectedly threw an exception`, or `exit 133`
+  (`Disposing the isolate that is entered by a thread`) / `exit 139`, depending
+  on platform and timing. Flaky in CI since 2026-07-06 across linux-x64,
+  linux-arm64 and darwin-arm64. QVAC-22961.
+
 ## [8.2.0] - 2026-07-28
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.2.4"
+      "version>=": "1.3.2"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## Summary

`translation-nmtcpp` pinned `qvac-lib-inference-addon-cpp >= 1.2.4`, which resolves to REF `c68ee33d` — **before** the environment-scoped `JsAsyncTask` teardown fix (QVAC-18397, #3525). This bumps the constraint to `>= 1.3.2`.

`cancel()` and `destroyInstance()` run as `JsAsyncTask`s. In the pinned revision:

- the detached worker owned the work functor, so its captures (commonly the last `shared_ptr` to the addon) were destroyed **after** `uv_async_send` — by which point the loop could have finished teardown and the JS env could be gone;
- a settlement failure could throw out of `onComplete`, a C callback, reaching `std::terminate`.

## Symptom

The process dies at teardown **with every assertion passing** — the TAP summary reads `TOTAL: 30 | PASSED: 30 | FAILED: 0` and the job fails only on the exit code, which is why this reads as CI flakiness rather than a test failure. It always lands on the `cancel then immediate destroy` → `run after destroy` → `run before load` sequence, in both the IndicTrans and pivot-bergamot suites.

Three exit codes, one defect, varying with platform and timing:

| Exit | Signature |
|---|---|
| 134 | SIGSEGV inside V8, converted by marian's handler → `libc++abi: terminate_handler unexpectedly threw an exception` |
| 134 | glibc heap corruption — `free(): unaligned chunk detected in tcache 2` |
| 133 | `Fatal error in v8::Isolate::Dispose(): Disposing the isolate that is entered by a thread` |
| 139 | plain SIGSEGV (macOS) |

Flaky in CI since **2026-07-06** — ~14 occurrences across 10+ unrelated branches on linux-x64, linux-arm64 and darwin-arm64. These are easy to miss because a re-run turns the run green, so the *run's* final conclusion is usually `success` and only the first attempt is red.

## Verification

The deterministic gated test shipped by #3525 (`tests/integration_js/js-async-task-teardown`) parks a `JsAsyncTask` worker inside its C++ work behind an atomic gate and terminates the env while it is provably running — no race to lose. Built against both headers on the same machine, compiler and runtime, with only `JsUtils.hpp` differing:

| `JsUtils.hpp` | `test.js` | `teardown.test.js` |
|---|---|---|
| `c68ee33d` (1.2.4 — what this package pinned) | pass | **Segmentation fault (core dumped), exit 139** |
| `47eccb47` (1.3.2 — this bump) | pass | **pass**, incl. the 40-round terminate sweep |

The pre-fix run completes `ok 1 - worker still blocked after terminate — teardown is deferred, not forced` and then dies exactly where the terminated env's worker completes.

Also verified: 1.3.2 compiles with no source changes to this package — its addon code doesn't reference the APIs 1.3.0 renamed (`JobRunner` → `SingleJobScheduler`, `OutputQueue::clear` signature).

## What is *not* proven

The nmtcpp integration crash reproduced locally twice (pivot suite, exit 134, same signature and test position as CI job 90207980528), but at too low a rate to measure its disappearance. Crash counts on the **pre-fix** build:

| Conditions | Crashes / runs |
|---|---|
| cold page cache, right after build + 127 MB model download | **2 / 40** |
| warm, 13 cores | 0 / 60 |
| warm, 2 cores (`taskset`) | 0 / 30 |
| forced cold cache (`posix_fadvise(DONTNEED)`, 262 MB evicted per run) | 0 / 30 |
| under gdb | 0 / 40 |

Since the pre-fix build is clean in every state where the bumped build is also clean, no valid A/B was possible — 0/60 on the fixed build carries no information on its own. **The case for this fix is the deterministic red/green above plus the signature match, not a measured drop in the flake rate.** The arm64 / IndicTrans manifestation in particular has only ever been seen on CI runners, so CI on this branch is the real check for it.

## Follow-ups (not in this PR)

- **Other consumers.** Every addon still pinning pre-1.3.2 `qvac-lib-inference-addon-cpp` carries the same demonstrably-defective teardown path. That sweep is the actual remediation; this PR fixes one instance.
- **Diagnosability.** `addon/src/model-interface/bergamot.cpp:81` calls `marian::setThrowExceptionOnAbort(true)`, so marian's SIGSEGV handler throws a C++ exception from signal context — undefined behaviour that destroys the real backtrace and misattributes every crash to marian. It is why 14 CI failures were unreadable, and it stays wrong after this fix.

QVAC-22961
