### PR TITLE
QVAC-21599 QVAC-22954 mod[tts-ggml,audiogen-ggml]: consume the 2026-07-30 registry ports

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   progress ticks + the interleaved-Int16 PCM chunk and resolves with the run
   stats (`audioDurationMs`, `totalTimeMs`, `realTimeFactor`), plus `cancel()` /
   `unload()` / `destroy()`.
+- Run stats report the *resolved* backend via `backendDevice` (0 = CPU, 1 = GPU)
+  and `backendId` (0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL,
+  99 = other), matching `@qvac/tts-ggml`. The GPU integration smoke asserts on
+  them, so a `useGPU: true` run that silently falls back to the CPU now fails
+  instead of passing; `QVAC_AUDIOGEN_GPU_SMOKE_RELAX=1` downgrades that to a
+  warning. The smoke also checks the rendered audio is non-silent (peak/RMS) and
+  close to the requested duration.
 - Full ACE-Step pipeline (text-encoder → LM → DiT → Oobleck VAE) with optional
   `lyrics`, `vocalLanguage`, `bpm`, `keyscale`, `timesignature`, `duration` and
   `seed`.

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -66,13 +66,18 @@ for await (const item of response.iterate()) {
     // these chunks as they stream in.
   }
 }
-const stats = await response.await() // { audioDurationMs, totalTimeMs, realTimeFactor }
+const stats = await response.await()
+// { audioDurationMs, totalTimeMs, realTimeFactor, backendDevice, backendId }
+// backendDevice: 0 = CPU, 1 = GPU
+// backendId:     0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other
 
 await gen.destroy()
 ```
 
 > The audio arrives as PCM chunks over the `QvacResponse` stream; `await()`
-> resolves with the run stats once generation completes.
+> resolves with the run stats once generation completes. `backendDevice` /
+> `backendId` report the backend the engine *resolved to*, not the one requested,
+> so a `useGPU: true` run that fell back to the CPU is detectable.
 > [`examples/generate-music.js`](examples/generate-music.js) shows the pattern.
 
 ### 2. A song with lyrics + rhythm

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
@@ -2,9 +2,11 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 #include "audiogen-cpp/acestep/engine.h"
@@ -17,6 +19,29 @@ int16_t f32ToI16(float x) {
   if (v > 32767.0F) v = 32767.0F;
   if (v < -32768.0F) v = -32768.0F;
   return static_cast<int16_t>(v);
+}
+
+constexpr int64_t BACKEND_DEVICE_CPU = 0;
+constexpr int64_t BACKEND_DEVICE_GPU = 1;
+
+// Mirrors tts-ggml's BackendUtils.hpp mapping so the codes the two addons
+// report cannot drift apart. Metal registers as "MTL" on newer ggml.
+int64_t backendIdFromName(const std::string& name) {
+  if (name == "CPU")
+    return 0;
+  if (name.rfind("Metal", 0) == 0 || name.rfind("MTL", 0) == 0)
+    return 1;
+  if (name.rfind("CUDA", 0) == 0)
+    return 2;
+  if (name.rfind("Vulkan", 0) == 0)
+    return 3;
+  if (name.rfind("OpenCL", 0) == 0)
+    return 4;
+  return 99;
+}
+
+int64_t backendDeviceFromName(const std::string& name) {
+  return name == "CPU" ? BACKEND_DEVICE_CPU : BACKEND_DEVICE_GPU;
 }
 }  // namespace
 
@@ -196,6 +221,10 @@ qvac_lib_inference_addon_cpp::RuntimeStats AcestepModel::runtimeStats() const {
   stats.emplace_back("totalTimeMs", totalTime_);
   stats.emplace_back("realTimeFactor", realTimeFactor_);
   stats.emplace_back("audioDurationMs", audioDurationMs_);
+  // The *resolved* backend, so a useGPU request that silently fell back to the
+  // CPU is visible to callers (gpu-smoke.test.js asserts on these).
+  stats.emplace_back("backendDevice", backendDeviceFromName(backendName_));
+  stats.emplace_back("backendId", backendIdFromName(backendName_));
   return stats;
 }
 

--- a/packages/audiogen-ggml/index.d.ts
+++ b/packages/audiogen-ggml/index.d.ts
@@ -80,13 +80,22 @@ export type AudiogenOutputChunk = AudiogenPcmChunk | AudiogenProgressChunk;
 /**
  * Terminal run stats, resolved by `QvacResponse.await()`. These mirror exactly
  * what the native `AcestepModel::runtimeStats()` emits — `totalTimeMs`,
- * `realTimeFactor` and `audioDurationMs`. Sample rate and channel count are NOT
- * here: they ride on each PCM chunk instead (see `AudiogenPcmChunk`).
+ * `realTimeFactor`, `audioDurationMs` and the resolved backend. Sample rate and
+ * channel count are NOT here: they ride on each PCM chunk instead (see
+ * `AudiogenPcmChunk`).
+ *
+ * `backendDevice` / `backendId` describe the backend the engine actually ran
+ * on, not the one requested, so a `useGPU: true` run that fell back to the CPU
+ * is detectable. Codes match @qvac/tts-ggml.
  */
 export interface AudiogenStats {
     audioDurationMs?: number;
     totalTimeMs?: number;
     realTimeFactor?: number;
+    /** 0 = CPU, 1 = GPU. */
+    backendDevice?: number;
+    /** 0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other. */
+    backendId?: number;
 }
 /**
  * GGML-backed music generation via the ACE-Step engine. Owns a persistent

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -210,7 +210,9 @@ class AudioGen {
             const stats = {
                 ...(typeof d.audioDurationMs === 'number' ? { audioDurationMs: d.audioDurationMs } : {}),
                 ...(typeof d.totalTimeMs === 'number' ? { totalTimeMs: d.totalTimeMs } : {}),
-                ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {})
+                ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {}),
+                ...(typeof d.backendDevice === 'number' ? { backendDevice: d.backendDevice } : {}),
+                ...(typeof d.backendId === 'number' ? { backendId: d.backendId } : {})
             };
             this._job.end(stats, stats);
         }

--- a/packages/audiogen-ggml/src/index.ts
+++ b/packages/audiogen-ggml/src/index.ts
@@ -111,13 +111,22 @@ export type AudiogenOutputChunk = AudiogenPcmChunk | AudiogenProgressChunk
 /**
  * Terminal run stats, resolved by `QvacResponse.await()`. These mirror exactly
  * what the native `AcestepModel::runtimeStats()` emits — `totalTimeMs`,
- * `realTimeFactor` and `audioDurationMs`. Sample rate and channel count are NOT
- * here: they ride on each PCM chunk instead (see `AudiogenPcmChunk`).
+ * `realTimeFactor`, `audioDurationMs` and the resolved backend. Sample rate and
+ * channel count are NOT here: they ride on each PCM chunk instead (see
+ * `AudiogenPcmChunk`).
+ *
+ * `backendDevice` / `backendId` describe the backend the engine actually ran
+ * on, not the one requested, so a `useGPU: true` run that fell back to the CPU
+ * is detectable. Codes match @qvac/tts-ggml.
  */
 export interface AudiogenStats {
   audioDurationMs?: number
   totalTimeMs?: number
   realTimeFactor?: number
+  /** 0 = CPU, 1 = GPU. */
+  backendDevice?: number
+  /** 0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other. */
+  backendId?: number
 }
 
 /** Raw shape of the native output-callback payload. */
@@ -129,6 +138,8 @@ interface NativeAudiogenData {
   audioDurationMs?: number
   totalTimeMs?: number
   realTimeFactor?: number
+  backendDevice?: number
+  backendId?: number
   progressStage?: string
   progressStep?: number
   progressTotal?: number
@@ -367,7 +378,9 @@ export class AudioGen {
       const stats: AudiogenStats = {
         ...(typeof d.audioDurationMs === 'number' ? { audioDurationMs: d.audioDurationMs } : {}),
         ...(typeof d.totalTimeMs === 'number' ? { totalTimeMs: d.totalTimeMs } : {}),
-        ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {})
+        ...(typeof d.realTimeFactor === 'number' ? { realTimeFactor: d.realTimeFactor } : {}),
+        ...(typeof d.backendDevice === 'number' ? { backendDevice: d.backendDevice } : {}),
+        ...(typeof d.backendId === 'number' ? { backendId: d.backendId } : {})
       }
       this._job.end(stats, stats)
     }

--- a/packages/audiogen-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/audiogen-ggml/test/integration/gpu-smoke.test.js
@@ -2,31 +2,100 @@
 
 // GPU / CPU backend smoke for @qvac/audiogen-ggml.
 //
-// LIMITATION vs tts-ggml's gpu-smoke: audiogen's native run stats expose only
-// totalTimeMs / realTimeFactor / audioDurationMs — there is NO
-// backendDevice / backendId field — so this suite can only assert that a
-// GPU-requested run completes and produces audio, NOT which backend actually
-// executed. The GPU leg is skipped under NO_GPU (CPU-only matrix entries); the
-// CPU leg runs everywhere and asserts the useGPU:false path still generates.
+// The GPU leg is strict: a useGPU:true run that resolves to the CPU backend is
+// treated as a regression. The engine degrades silently ("GPU requested but no
+// GPU backend available; using CPU"), so without this gate a broken GPU build
+// still reports green. CI sets NO_GPU=true on the CPU-only matrix entries and
+// every NO_GPU=false entry runs on a dedicated GPU runner, so requiring a GPU
+// whenever NO_GPU is false is safe. Set QVAC_AUDIOGEN_GPU_SMOKE_RELAX=1 to
+// downgrade the gate to a warning.
+//
+// Both legs also check the audio is real, not merely present: a run returning
+// the right number of *silent* samples satisfies `sampleCount > 0` yet is a
+// miscompute. QVAC-22954 is the motivating case — a missing Vulkan CPY kernel.
 
 const test = require('brittle')
 const path = require('bare-path')
+const proc = require('bare-process')
 const { ensureAudiogenModels, getBaseDir } = require('../utils/downloadModel')
 const {
   loadAudioGen,
   runAudioGen,
+  backendIdToName,
   NO_GPU,
   INTEGRATION_TIMEOUT_MS
 } = require('../utils/runAudioGen')
 
 const VARIANT = 'turbo-q4'
+const RELAX = proc.env && proc.env.QVAC_AUDIOGEN_GPU_SMOKE_RELAX === '1'
+
+// Silence floors. A real 6 s render measures rms ~0.08-0.14 and peak ~0.9 (the
+// addon normalises the peak to 0.9), so these leave a wide margin while still
+// failing hard on an all-zero or near-zero buffer.
+const MIN_PEAK = 0.1
+const MIN_RMS = 0.005
+
+const DURATION_S = 6
 
 function modelsDir() {
   return path.join(getBaseDir(), 'models')
 }
 
+// Shape + loudness + length of a render, for either backend.
+function assertAudio(t, data, tag) {
+  t.is(data.channels, 2, `${tag}: stereo output`)
+  t.is(data.sampleRate, 48000, `${tag}: 48 kHz output`)
+  t.ok(data.sampleCount > 0, `${tag}: produced ${data.sampleCount} interleaved samples`)
+  t.ok(
+    data.peak > MIN_PEAK,
+    `${tag}: audio is not silent (peak ${data.peak.toFixed(4)} > ${MIN_PEAK})`
+  )
+  t.ok(data.rms > MIN_RMS, `${tag}: audio carries energy (rms ${data.rms.toFixed(5)} > ${MIN_RMS})`)
+
+  // The LM quantises the request into whole audio codes, so a render lands near
+  // the requested length rather than on it (6 s -> ~5.6 s). Bound it loosely to
+  // catch a truncated or runaway render without encoding the code grid.
+  const requestedMs = DURATION_S * 1000
+  t.ok(
+    data.durationMs >= requestedMs * 0.5 && data.durationMs <= requestedMs * 1.5,
+    `${tag}: duration ${Math.round(data.durationMs)} ms is within 50-150% of the requested ${requestedMs} ms`
+  )
+}
+
+// Strict check that a useGPU:true run really executed on a GPU backend.
+function assertRanOnGpu(t, stats) {
+  if (!stats) {
+    t.fail('GPU: no run stats returned, cannot verify which backend executed')
+    return
+  }
+  const dev = stats.backendDevice
+  const id = stats.backendId
+  if (typeof dev !== 'number' || typeof id !== 'number') {
+    t.fail(
+      `GPU: stats carry no backendDevice/backendId (got ${dev}/${id}) — ` +
+        'AcestepModel::runtimeStats() must report the resolved backend'
+    )
+    return
+  }
+  console.log(`[audiogen/GPU] backendDevice=${dev} backendId=${id} (${backendIdToName(id)})`)
+
+  if (dev === 1) {
+    t.pass(`GPU: ran on ${backendIdToName(id)} (backendId=${id})`)
+    return
+  }
+  const msg =
+    `GPU: expected a GPU backend, got ${backendIdToName(id)} ` +
+    `(backendDevice=${dev}, backendId=${id}). useGPU:true was requested but the ` +
+    'engine resolved to the CPU — a silent GPU fallback, not a passing run.'
+  if (RELAX) {
+    t.pass(`${msg} [relaxed via QVAC_AUDIOGEN_GPU_SMOKE_RELAX]`)
+    return
+  }
+  t.fail(msg)
+}
+
 test(
-  'GPU smoke: useGPU generation produces audio',
+  'GPU smoke: useGPU generation produces audio on a GPU backend',
   { timeout: INTEGRATION_TIMEOUT_MS, skip: NO_GPU },
   async (t) => {
     const download = await ensureAudiogenModels({ targetDir: modelsDir(), variant: VARIANT })
@@ -44,16 +113,16 @@ test(
 
     const { data } = await runAudioGen(gen, {
       caption: 'cinematic orchestral, epic drums, rising strings',
-      opts: { lyrics: '[Instrumental]', duration: 6, seed: 3 }
+      opts: { lyrics: '[Instrumental]', duration: DURATION_S, seed: 3 }
     })
 
-    t.ok(data.sampleCount > 0, `GPU run produced ${data.sampleCount} samples`)
-    t.is(data.channels, 2, 'stereo output')
+    assertRanOnGpu(t, data.stats)
+    assertAudio(t, data, 'GPU')
   }
 )
 
 test(
-  'CPU contract: useGPU:false generation produces audio',
+  'CPU contract: useGPU:false generation produces audio on the CPU backend',
   { timeout: INTEGRATION_TIMEOUT_MS },
   async (t) => {
     const download = await ensureAudiogenModels({ targetDir: modelsDir(), variant: VARIANT })
@@ -71,9 +140,12 @@ test(
 
     const { data } = await runAudioGen(gen, {
       caption: 'simple solo piano melody, sparse and gentle',
-      opts: { lyrics: '[Instrumental]', duration: 6, seed: 4 }
+      opts: { lyrics: '[Instrumental]', duration: DURATION_S, seed: 4 }
     })
 
-    t.ok(data.sampleCount > 0, `CPU run produced ${data.sampleCount} samples`)
+    if (data.stats && typeof data.stats.backendDevice === 'number') {
+      t.is(data.stats.backendDevice, 0, 'CPU: useGPU:false resolved to the CPU backend')
+    }
+    assertAudio(t, data, 'CPU')
   }
 )

--- a/packages/audiogen-ggml/test/utils/runAudioGen.js
+++ b/packages/audiogen-ggml/test/utils/runAudioGen.js
@@ -67,6 +67,21 @@ async function runAudioGen(gen, { caption, opts = {} } = {}) {
   const durationMs =
     sampleRate > 0 && channels > 0 ? (sampleCount / channels / sampleRate) * 1000 : 0
 
+  // Loudness of the interleaved int16 PCM, normalised to [0,1]. `sampleCount > 0`
+  // alone cannot tell a real render from a buffer of silence, which is what a
+  // miscomputing GPU kernel tends to produce, so the tests assert on these.
+  let peakAbs = 0
+  let sumSquares = 0
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i++) {
+      const v = chunk[i] / 32768
+      const a = v < 0 ? -v : v
+      if (a > peakAbs) peakAbs = a
+      sumSquares += v * v
+    }
+  }
+  const rms = sampleCount > 0 ? Math.sqrt(sumSquares / sampleCount) : 0
+
   return {
     data: {
       sampleCount,
@@ -75,8 +90,28 @@ async function runAudioGen(gen, { caption, opts = {} } = {}) {
       durationMs,
       chunkCount: chunks.length,
       stages: [...stages],
+      peak: peakAbs,
+      rms,
       stats
     }
+  }
+}
+
+// Human-readable name for an AudiogenStats.backendId. Mirrors @qvac/tts-ggml.
+function backendIdToName(id) {
+  switch (id) {
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    default:
+      return 'other-GPU'
   }
 }
 
@@ -84,5 +119,6 @@ module.exports = {
   NO_GPU,
   INTEGRATION_TIMEOUT_MS,
   loadAudioGen,
-  runAudioGen
+  runAudioGen,
+  backendIdToName
 }

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "audiogen-cpp",
-      "version>=": "2026-07-30"
+      "version>=": "2026-07-30#1"
     }
   ],
   "features": {

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Parler no longer fails on iOS with `parler: DAC decode failed`.** The DAC
+  decoder's compute arena grew with the output length (~13.6 + 1.957 MiB per
+  frame, unbounded), and streaming re-decoded the whole code prefix on every
+  chunk, so a streamed utterance walked ~10 growing allocations up to 837 MiB.
+  That is fatal on iOS, where Metal buffers are backed by `posix_memalign`, and
+  invisible on macOS, which uses `vm_allocate`. Decoding is now windowed, so
+  peak DAC memory is constant in output length and streaming is 2.2–2.5×
+  faster. Audio is unchanged.
+
+### Changed
+
+- **Parler always samples.** `topK: 1` selects argmax decoding, which this model
+  family cannot terminate — it collapses into a silence attractor after the
+  first word, and end-of-sequence is gated on the first codebook emitting EOS as
+  its argmax, so generation runs to `maxFrames` and yields a truncated utterance
+  followed by silence. Such requests are now repaired to the model's sampled
+  defaults (temperature 1.0, `topK` 50) with a warning on stderr. Use `seed` for
+  reproducible output — a fixed seed is bit-reproducible.
+
 ## [0.6.0] - 2026-07-24
 
 ### Added

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-07-24#1"
+      "version>=": "2026-07-30"
     }
   ],
   "features": {


### PR DESCRIPTION
Moves `tts-ggml` and `audiogen-ggml` onto the ports published by
[qvac-registry-vcpkg#273](https://github.com/tetherto/qvac-registry-vcpkg/pull/273) (merged,
`2658120a`): `ggml-speech 2026-07-30`, `tts-cpp 2026-07-30`, `audiogen-cpp 2026-07-30#1`.

| package | dependency | from | to |
|---|---|---|---|
| `tts-ggml` | `tts-cpp` | `2026-07-24#1` | **`2026-07-30`** |
| `audiogen-ggml` | `audiogen-cpp` | `2026-07-30` | **`2026-07-30#1`** |

Neither addon declares `ggml-speech` directly — it arrives transitively through the `-cpp` ports.
`transcription-whispercpp` is untouched: the `whisper-cpp` port did not change in that release.

## What the bumps deliver

**tts-cpp 2026-07-30** — [whisper.cpp#114](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/114),
QVAC-21599. Fixes the iOS e2e failure `parler.synthesize: parler: DAC decode failed`, which had two
compounding causes:

1. The DAC compute arena was unbounded in output length (`≈13.6 + 1.957 × n_frames` MiB) and the
   streaming path re-decoded the whole code prefix on every chunk — O(n²) work and ~10 growing
   allocations up to 837 MiB. Fatal on iOS, where Metal buffers are backed by `posix_memalign`;
   invisible on macOS, which uses `vm_allocate`. DAC decode now runs in fixed 128-frame windows, so
   peak DAC memory is O(1) in output length and streaming is 2.2–2.5× faster.
2. Argmax decoding never terminates for this model family — the LM collapses into a silence
   attractor and EOS is gated on codebook 0 emitting EOS *as its argmax*. The engine now always
   samples; `greedy` and `top_k = 1` are repaired to the model's sampled defaults with a warning.

The e2e resources set `topK: 1`, which is why every parler case ran to the `maxFrames: 430` cap.
On an iPhone 17 all six e2e cases now terminate on content (162 / 126 / 196 / 292 / 126 / 181
frames, previously a uniform 421) at 0.000 WER.

**audiogen-cpp 2026-07-30 → 2026-07-30#1.** #3556 already moved the addon to `2026-07-30`, which
pins engine `26803b09` ([whisper.cpp#113](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/113),
QVAC-22955 sequential stage loading). The `#1` republish **changes no source at all** — same REF —
and only raises the port's `ggml-speech` floor to `2026-07-30`, which is what pulls in
[ggml#47](https://github.com/tetherto/qvac-ext-ggml/pull/47) (QVAC-22954). Without it the resolved
`ggml-speech` stays at `2026-07-29` and every Vulkan runner still aborts on
`Missing CPY op for types: q4_K f32` when the FSQ detokenizer casts its Q4_K special-tokens tensor
to F32. With #3556 having re-enabled the iOS Device Farm lane, that lane now also covers this.

## Also included: audiogen reports its resolved backend

Carries `QVAC-22954 test[audiogen-ggml]: prove the GPU smoke really ran on the GPU` (previously
only on the throwaway overlay-CI branch). This is not incidental to the bump — it is the assertion
that proves the Vulkan fix above actually took effect.

`backendDevice` / `backendId` were already reported by `tts-ggml` but **not** by `audiogen-ggml`, so
its GPU smoke asserted only that a `useGPU:true` run returned samples. The engine degrades quietly
to CPU, so a GPU job that lost its device still reported green — which is exactly why QVAC-22954 was
caught by an abort rather than by an assertion. `AcestepModel::runtimeStats()` now emits both
fields using the same codes `tts-ggml` uses (so the two addons cannot drift), `gpu-smoke` fails a
`useGPU:true` run that resolves to CPU (`QVAC_AUDIOGEN_GPU_SMOKE_RELAX=1` downgrades to a warning),
and both legs now check peak/rms so a buffer of silence no longer passes.

## Notes

* Registry baselines in `vcpkg-configuration.json` are deliberately **untouched** in both packages —
  `version>=` resolves against the registry HEAD, not the baseline tree.
* `detect-native-changes` matches `<workdir>/vcpkg.json` exactly, so these edits bust the prebuild
  cache and CI rebuilds rather than reusing stale binaries.
* Supersedes the throwaway overlay-CI PRs #3511 and #3539, whose source PRs are now all merged and
  published.

## Verification

Both addons were built locally from this branch before pushing
(`npm install && bare-make generate && bare-make build`, macOS arm64):

* `tts-ggml` resolved **`tts-cpp@2026-07-30`** from
  `qvac-registry-vcpkg.git@c498ab08` — the exact git-tree hash recorded for that version in the
  merged registry — and linked `qvac__tts-ggml@0.bare`. It correctly keeps `ggml-speech@2026-07-29`,
  since `tts-cpp`'s floor did not move.
* `audiogen-ggml` resolved **`audiogen-cpp@2026-07-30#1`** *and* **`ggml-speech@2026-07-30`**,
  confirming the port-version bump pulls the new ggml, and linked `qvac__audiogen-ggml@0.bare`.
* `tts-ggml` `check:generated` passes.

This also confirms `version>=` resolves against the registry HEAD rather than the pinned
`default-registry.baseline` (`4dbe15d8`), which is why no baseline change is needed.
