### PR TITLE
QVAC-21599 chore: release @qvac/tts-ggml v0.6.1 (Parler DAC memory + always-sampling)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.1] - 2026-07-30
 
 ### Fixed
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- #3560 landed the Parler DAC-memory fix and the always-sampling change under a
  `## [Unreleased]` CHANGELOG section, and `@qvac/tts-ggml` is still pinned at `0.6.0` — so that
  work has no release version of its own.

## 📝 How does it solve it?

- Cuts the existing `## [Unreleased]` section as `## [0.6.1] - 2026-07-30`. The body is unchanged
  from what merged (the CHANGELOG diff is a single line — only the heading), so it keeps both
  entries:
  - **Fixed** — Parler no longer fails on iOS with `parler: DAC decode failed`. The DAC decoder's
    compute arena grew with the output length and streaming re-decoded the whole prefix per chunk;
    decoding is now windowed, so peak DAC memory is constant in output length and streaming is
    2.2–2.5× faster.
  - **Changed** — Parler always samples. `topK: 1` selects argmax, which this model family cannot
    terminate, so such requests are repaired to the model's sampled defaults with a warning.
- Bumps `packages/tts-ggml/package.json` `0.6.0` → `0.6.1`.

Patch rather than minor: the addon's API surface is unchanged — `topK` is still accepted and still
typed the same — and callers who set `topK: 1` were getting degenerate audio (one word, then
silence), so returning correct audio is a fix rather than a break. The `Changed` entry stays so the
behaviour shift is still documented honestly.

Release bookkeeping only: no source or behaviour change. Mirrors the earlier
"Bump tts-ggml version to v0.6.0" (#3456) and v0.5.1 (#3376) — same two files, same shape.

## 🧪 How was it tested?

- No runtime change to exercise. The underlying work was verified and merged in #3560, and in
  [qvac-ext-lib-whisper.cpp#114](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/114)
  before it: 21/21 parler ctests on both models (CPU + GPU), 36/36 byte-identical against the
  previous pin, and on an iPhone 17 all six e2e cases terminating on content at 0.000 WER.
- Verified here: `package.json` parses and reports `0.6.1`; the CHANGELOG's first section is
  `[0.6.1] - 2026-07-30` with `[0.6.0] - 2026-07-24` directly below it and untouched; no
  `[Unreleased]` heading remains; the diff is exactly those two files.
