### PR TITLE
QVAC-18397 chore[notask]: trace diffusion iOS teardown memory

### DIFF
--- a/packages/diffusion-cpp/CMakeLists.txt
+++ b/packages/diffusion-cpp/CMakeLists.txt
@@ -30,6 +30,17 @@ set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/tri
 
 project(inference-addon-sd C CXX)
 
+if(APPLE)
+  enable_language(OBJCXX)
+  set(APPLE_MEMORY_TELEMETRY_SOURCE
+    ${PROJECT_SOURCE_DIR}/addon/src/utils/AppleMemoryTelemetry.mm)
+  find_library(METAL_FRAMEWORK Metal REQUIRED)
+  find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+else()
+  set(APPLE_MEMORY_TELEMETRY_SOURCE
+    ${PROJECT_SOURCE_DIR}/addon/src/utils/AppleMemoryTelemetry.cpp)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_compile_options(-stdlib=libc++)
   add_link_options(-stdlib=libc++ -static-libstdc++)
@@ -102,6 +113,7 @@ add_bare_module(inference-addon-sd EXPORTS ${BACKEND_DL_EXPORTS})
     ${PROJECT_SOURCE_DIR}/addon/src/handlers/SdVidGenHandlers.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/EsrganUpscalerModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/SdModel.cpp
+    ${APPLE_MEMORY_TELEMETRY_SOURCE}
     ${PROJECT_SOURCE_DIR}/addon/src/utils/BackendLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/EsrganUpscaler.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/ImageCodec.cpp
@@ -132,6 +144,15 @@ add_bare_module(inference-addon-sd EXPORTS ${BACKEND_DL_EXPORTS})
     PRIVATE
       stable-diffusion::stable-diffusion
   )
+
+  if(APPLE)
+    target_link_libraries(
+      ${inference-addon-sd}
+      PRIVATE
+        ${METAL_FRAMEWORK}
+        ${FOUNDATION_FRAMEWORK}
+    )
+  endif()
 
 target_compile_features(${inference-addon-sd} PRIVATE cxx_std_20)
 target_compile_definitions(${inference-addon-sd} PUBLIC JS_LOGGER)

--- a/packages/diffusion-cpp/addon/src/addon/AddonJs.hpp
+++ b/packages/diffusion-cpp/addon/src/addon/AddonJs.hpp
@@ -21,8 +21,23 @@
 #include "model-interface/SdModel.hpp"
 #include "utils/BackendLoader.hpp"
 #include "utils/BackendSelection.hpp"
+#include "utils/LoggingMacros.hpp"
 
 namespace qvac_lib_inference_addon_sd {
+
+inline js_value_t*
+destroyInstance(js_env_t* env, js_callback_info_t* info) try {
+  using Priority = qvac_lib_inference_addon_cpp::logger::Priority;
+
+  QLOG_IF(Priority::INFO, "Diffusion destroyInstance: native teardown starting");
+  js_value_t* result =
+      qvac_lib_inference_addon_cpp::JsInterface::destroyInstance(env, info);
+  QLOG_IF(
+      Priority::INFO,
+      "Diffusion destroyInstance: native teardown returned to JavaScript");
+  return result;
+}
+JSCATCH
 
 inline int parseStandaloneUpscaleRepeats(const std::string& paramsJson) {
   picojson::value v;

--- a/packages/diffusion-cpp/addon/src/js-interface/binding.cpp
+++ b/packages/diffusion-cpp/addon/src/js-interface/binding.cpp
@@ -25,8 +25,7 @@ js_value_t* qvacLibInferenceAddonSdExports(js_env_t* env, js_value_t* exports) {
   V("activate", qvac_lib_inference_addon_sd::activate)
   V("activateUpscaler", qvac_lib_inference_addon_sd::activateUpscaler)
   V("cancel", qvac_lib_inference_addon_cpp::JsInterface::cancel)
-  V("destroyInstance",
-    qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
+  V("destroyInstance", qvac_lib_inference_addon_sd::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
   V("getExpectedEsrganBackendDevice",

--- a/packages/diffusion-cpp/addon/src/model-interface/SdModel.cpp
+++ b/packages/diffusion-cpp/addon/src/model-interface/SdModel.cpp
@@ -16,6 +16,7 @@
 #include <picojson/picojson.h>
 
 #include "utils/AviWriter.hpp"
+#include "utils/AppleMemoryTelemetry.hpp"
 #include "utils/BackendLoader.hpp"
 #include "utils/BackendSelection.hpp"
 #include "utils/ImageCodec.hpp"
@@ -65,6 +66,16 @@ thread_local ProgressCtx g_progressCtx;
 // g_progressCtx for progress.  Avoids relying on the process-global
 // sd_abort_cb_data when multiple SdModel instances could coexist.
 thread_local const SdModel* g_abortModel = nullptr;
+
+bool logAppleMemory(const std::string& stage) {
+  const auto snapshot = qvac_lib_inference_addon_sd::apple_memory::capture();
+  if (!snapshot.available)
+    return false;
+  QLOG_IF(
+      qvac_lib_inference_addon_cpp::logger::Priority::INFO,
+      qvac_lib_inference_addon_sd::apple_memory::describe(stage, snapshot));
+  return true;
+}
 
 std::string preferredBackendToString(enum sd_backend_preference_t pref) {
   switch (pref) {
@@ -266,7 +277,41 @@ SdModel::SdModel(qvac_lib_inference_addon_sd::SdCtxConfig config)
 // Destructor -- releases the sd_ctx and all associated GPU/CPU memory
 // ---------------------------------------------------------------------------
 
-SdModel::~SdModel() = default;
+SdModel::~SdModel() {
+  using Priority = qvac_lib_inference_addon_cpp::logger::Priority;
+
+  QLOG_IF(
+      Priority::INFO,
+      "SdModel teardown: destructor entered; sd_ctx_loaded=" +
+          std::string(sdCtx_ != nullptr ? "true" : "false"));
+  const bool appleTelemetryAvailable =
+      logAppleMemory("SdModel destructor before free_sd_ctx");
+
+  const auto freeStart = std::chrono::steady_clock::now();
+  sdCtx_.reset();
+  const auto freeElapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - freeStart)
+          .count();
+
+  QLOG_IF(
+      Priority::INFO,
+      "SdModel teardown: free_sd_ctx completed in " +
+          std::to_string(freeElapsedMs) + " ms");
+  logAppleMemory("SdModel destructor after free_sd_ctx");
+
+  if (appleTelemetryAvailable) {
+    const std::size_t relievedBytes =
+        qvac_lib_inference_addon_sd::apple_memory::requestPressureRelief();
+    QLOG_IF(
+        Priority::INFO,
+        "SdModel teardown: malloc_zone_pressure_relief returned bytes=" +
+            std::to_string(relievedBytes));
+    logAppleMemory("SdModel destructor after pressure relief");
+  }
+
+  QLOG_IF(Priority::INFO, "SdModel teardown: destructor body completed");
+}
 
 // ---------------------------------------------------------------------------
 // load() -- maps SdCtxConfig -> sd_ctx_params_t, then calls new_sd_ctx()
@@ -277,6 +322,10 @@ void SdModel::load() {
     return;
 
   const auto tLoadStart = std::chrono::steady_clock::now();
+  QLOG_IF(
+      qvac_lib_inference_addon_cpp::logger::Priority::INFO,
+      "SdModel load: new_sd_ctx starting");
+  logAppleMemory("SdModel load before new_sd_ctx");
 
   sd_ctx_params_t params{};
   sd_ctx_params_init(&params);
@@ -404,6 +453,7 @@ void SdModel::load() {
   }
 
   sdCtx_.reset(raw);
+  logAppleMemory("SdModel load after new_sd_ctx");
 
   // LTX-2 is identified by the embeddings-connectors input, which no other
   // model family uses. Its temporal shape is used for per-job validation.

--- a/packages/diffusion-cpp/addon/src/utils/AppleMemoryTelemetry.cpp
+++ b/packages/diffusion-cpp/addon/src/utils/AppleMemoryTelemetry.cpp
@@ -1,0 +1,23 @@
+#include "AppleMemoryTelemetry.hpp"
+
+#include <sstream>
+
+namespace qvac_lib_inference_addon_sd::apple_memory {
+
+Snapshot capture() noexcept { return {}; }
+
+std::size_t requestPressureRelief() noexcept { return 0; }
+
+std::string describe(const std::string& stage, const Snapshot& snapshot) {
+  std::ostringstream oss;
+  oss << "iOS memory telemetry [" << stage << "]: unavailable"
+      << " phys_footprint_bytes=" << snapshot.physicalFootprintBytes
+      << " resident_bytes=" << snapshot.residentBytes
+      << " metal_allocated_bytes=" << snapshot.metalAllocatedBytes
+      << " metal_recommended_working_set_bytes="
+      << snapshot.metalRecommendedWorkingSetBytes
+      << " os_available_memory_bytes=" << snapshot.availableMemoryBytes;
+  return oss.str();
+}
+
+} // namespace qvac_lib_inference_addon_sd::apple_memory

--- a/packages/diffusion-cpp/addon/src/utils/AppleMemoryTelemetry.hpp
+++ b/packages/diffusion-cpp/addon/src/utils/AppleMemoryTelemetry.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace qvac_lib_inference_addon_sd::apple_memory {
+
+struct Snapshot {
+  bool available{false};
+  uint64_t physicalFootprintBytes{0};
+  uint64_t residentBytes{0};
+  uint64_t metalAllocatedBytes{0};
+  uint64_t metalRecommendedWorkingSetBytes{0};
+  uint64_t availableMemoryBytes{0};
+};
+
+[[nodiscard]] Snapshot capture() noexcept;
+[[nodiscard]] std::size_t requestPressureRelief() noexcept;
+[[nodiscard]] std::string describe(const std::string& stage, const Snapshot& snapshot);
+
+} // namespace qvac_lib_inference_addon_sd::apple_memory

--- a/packages/diffusion-cpp/addon/src/utils/AppleMemoryTelemetry.mm
+++ b/packages/diffusion-cpp/addon/src/utils/AppleMemoryTelemetry.mm
@@ -1,0 +1,76 @@
+#include "AppleMemoryTelemetry.hpp"
+
+#include <mach/mach.h>
+#include <malloc/malloc.h>
+#include <os/proc.h>
+
+#import <Metal/Metal.h>
+#import <TargetConditionals.h>
+
+#include <sstream>
+
+namespace qvac_lib_inference_addon_sd::apple_memory {
+
+Snapshot capture() noexcept {
+  Snapshot snapshot;
+
+  task_vm_info_data_t vmInfo{};
+  mach_msg_type_number_t vmInfoCount = TASK_VM_INFO_COUNT;
+  if (task_info(
+          mach_task_self(), TASK_VM_INFO,
+          reinterpret_cast<task_info_t>(&vmInfo), &vmInfoCount) == KERN_SUCCESS) {
+    snapshot.available = true;
+    snapshot.physicalFootprintBytes = vmInfo.phys_footprint;
+  }
+
+  mach_task_basic_info_data_t basicInfo{};
+  mach_msg_type_number_t basicInfoCount = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(
+          mach_task_self(), MACH_TASK_BASIC_INFO,
+          reinterpret_cast<task_info_t>(&basicInfo),
+          &basicInfoCount) == KERN_SUCCESS) {
+    snapshot.available = true;
+    snapshot.residentBytes = basicInfo.resident_size;
+  }
+
+#if TARGET_OS_IOS
+  snapshot.availableMemoryBytes = os_proc_available_memory();
+#endif
+
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    if (device != nil) {
+      snapshot.available = true;
+      if ([device respondsToSelector:@selector(currentAllocatedSize)]) {
+        snapshot.metalAllocatedBytes = device.currentAllocatedSize;
+      }
+      if (@available(iOS 13.0, macOS 10.15, *)) {
+        snapshot.metalRecommendedWorkingSetBytes =
+            device.recommendedMaxWorkingSetSize;
+      }
+#if !__has_feature(objc_arc)
+      [device release];
+#endif
+    }
+  }
+
+  return snapshot;
+}
+
+std::size_t requestPressureRelief() noexcept {
+  return malloc_zone_pressure_relief(nullptr, 0);
+}
+
+std::string describe(const std::string& stage, const Snapshot& snapshot) {
+  std::ostringstream oss;
+  oss << "iOS memory telemetry [" << stage << "]"
+      << " phys_footprint_bytes=" << snapshot.physicalFootprintBytes
+      << " resident_bytes=" << snapshot.residentBytes
+      << " metal_allocated_bytes=" << snapshot.metalAllocatedBytes
+      << " metal_recommended_working_set_bytes="
+      << snapshot.metalRecommendedWorkingSetBytes
+      << " os_available_memory_bytes=" << snapshot.availableMemoryBytes;
+  return oss.str();
+}
+
+} // namespace qvac_lib_inference_addon_sd::apple_memory

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -105,7 +105,7 @@
     "typescript-eslint": "^8.64.0"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",
     "bare-path": "^3.0.0"
   },

--- a/packages/diffusion-cpp/test/unit/CMakeLists.txt
+++ b/packages/diffusion-cpp/test/unit/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   test_avi_writer.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/BackendLoader.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/BackendSelection.cpp
+  ${APPLE_MEMORY_TELEMETRY_SOURCE}
   ${CMAKE_SOURCE_DIR}/addon/src/utils/EsrganUpscaler.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/ImageCodec.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/ImageUtils.cpp
@@ -103,6 +104,15 @@ target_link_libraries(
     GTest::gtest_main
     GTest::gmock_main
 )
+
+if(APPLE)
+  target_link_libraries(
+    addon-test
+    PRIVATE
+      ${METAL_FRAMEWORK}
+      ${FOUNDATION_FRAMEWORK}
+  )
+endif()
 
 if(NOT WIN32 AND NOT APPLE)
   target_link_libraries(

--- a/packages/diffusion-cpp/vcpkg-configuration.json
+++ b/packages/diffusion-cpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "./vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "d1b2497b1707baf7bd1f352eb08097c7f9d5cfd9",

--- a/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,35 @@
+# Dev overlay: build qvac-lib-inference-addon-cpp 1.3.2 from PR #3564
+# (tetherto/qvac @ fe64ee07) instead of the published registry version.
+# This isolates the JsAsyncTask release-before-settlement fix in diffusion-cpp
+# while collecting iOS unload telemetry. To fall back to the registry version,
+# remove this port directory and the "overlay-ports" configuration entry.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac
+  REF fe64ee074d002c907092816df6cdff2945bd9097
+  SHA512 de0ff119c8509c75f5623eca1ef43bb6c513e11e6bc9941c8eccc73a1ff3dc12dd6c97737adc977e4635dea5c39f958b56bf75801b03227f69f498dbef2f78dc
+  HEAD_REF tmp-addon-cpp-pr-3564-fix
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/packages/inference-addon-cpp/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/diffusion-cpp/vcpkg/ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.3.2",
+  "port-version": 113,
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- isolate diffusion-cpp on the `inference-addon-cpp` PR #3564 overlay and `infer-base` 0.6.2
- log `destroyInstance`, `SdModel` destruction, and `free_sd_ctx` completion/timing
- capture iOS physical footprint, resident memory, available memory, Metal allocated/recommended working-set bytes, and allocator pressure-relief results before and after teardown

## Why
The #3548 iOS lane is being killed by Jetsam after generation. #3564 passes, but the current timing-based explanation is not proven. This PR keeps the tested addon fix isolated to diffusion and records the native memory state at each load/unload boundary so the CI logs can show whether `free_sd_ctx`, Metal release, or allocator reclamation is lagging.

## Test plan
- [x] Objective-C++ telemetry source syntax-checks with ARC and non-ARC compilation
- [x] Portable telemetry source syntax-checks as C++20
- [x] `git diff --check`
- [ ] C++ addon tests
- [ ] Desktop addon tests
- [ ] iOS and Android addon tests

## Telemetry fields
- `phys_footprint_bytes`
- `resident_bytes`
- `metal_allocated_bytes`
- `metal_recommended_working_set_bytes`
- `os_available_memory_bytes`
- `free_sd_ctx` elapsed milliseconds
- `malloc_zone_pressure_relief` released bytes