### PR TITLE
infra[notask]: grant packages:read to sdk-pod-checks caller in Merge Guard

### DIFF
--- a/.github/workflows/pr-gate-merge.yml
+++ b/.github/workflows/pr-gate-merge.yml
@@ -209,6 +209,7 @@ jobs:
     if: needs.label-gate.outputs.authorised == 'true' && needs.authorize.outputs.allowed == 'true'
     permissions:
       contents: read
+      packages: read
     uses: ./.github/workflows/pr-checks-sdk-pod.yml
 
   qvac-merge-guard:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `Merge Guard` (`pr-gate-merge.yml`) has been `startup_failure`ing on every PR since #3541 landed, blocking merges to `main` with zero jobs ever scheduled.

- GitHub rejects the workflow at parse time with: `Error calling workflow 'pr-checks-sdk-pod.yml'. The nested job 'sdk-pod-checks' is requesting 'packages: read', but is only allowed 'packages: none'.`

## 📝 How does it solve it?

- #3541 added `packages: read` to the nested `sdk-pod-checks` job inside `pr-checks-sdk-pod.yml` (needed to resolve `@tetherto/*` GPR packages via `GITHUB_TOKEN`), but didn't update the caller job of the same name in `pr-gate-merge.yml`, which only grants `contents: read`. A reusable workflow's nested job can never request a permission scope beyond what its caller job was granted, so GitHub fails the whole workflow before scheduling any jobs.

- Adds `packages: read` to the caller `sdk-pod-checks` job's `permissions:` block in `pr-gate-merge.yml` so it matches what the nested job actually requests.

## 🧪 How was it tested?

- `actionlint` clean on `pr-gate-merge.yml` (and the rest of the Merge Guard call chain: `public-pr.yml`, `prebuilds-caller.yml`, `pr-checks-sdk-pod.yml`).
- `python3 -c "import yaml; yaml.safe_load(...)"` parses the edited file cleanly.
- Confirmed via `gh run list --workflow pr-gate-merge.yml` that every run since #3541 merged is `startup_failure` in 0-1s across unrelated branches/PRs, and traced the exact GitHub error message from the failed run's Actions UI to this permission mismatch.

## 🛡️ Permissions changes

- Scope: job `sdk-pod-checks` (caller, in `pr-gate-merge.yml`)
- Before: `contents: read`
- After: `contents: read`, `packages: read`
- Justification: matches the `packages: read` already declared on the nested `sdk-pod-checks` job in `pr-checks-sdk-pod.yml` (added by #3541 to resolve `@tetherto/*` GitHub Packages deps) — a reusable workflow's nested job permissions can't exceed the caller job's grant, so the mismatch was a hard parse-time failure blocking the required merge check for every PR.
