### PR TITLE
QVAC-22177 chore: bump vla-ggml to 0.16.2 + changelog

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.16.2] - 2026-07-31
+
+This release fixes three regressions introduced by the 0.16.0 TypeScript migration. ESM named imports work again, a `null` config no longer breaks `load()`, and `run()` input validation is consistent for a missing `hparams`. There are no intentional API changes - the named-export surface matches 0.15.x again.
+
+### Fixed
+
+- ESM named imports such as `import { VlaModel } from '@qvac/vla-ggml'` failed at
+  link time on both Node.js and Bare with `SyntaxError: Named export 'VlaModel'
+  not found`. The generated `index.js` attached its exported members through a
+  namespace-merge helper that `cjs-module-lexer` cannot see, so the CommonJS to
+  ESM interop discovered no named exports. The six public members (`VlaModel`,
+  `preprocessImage`, `padState`, `DEFAULT_IMAGE_SIZE`, `QvacErrorAddonVla`,
+  `ERR_CODES`) are now also assigned as top-level `module.exports.X = ...`
+  statements, which the lexer detects. Default imports and `require()` are
+  unchanged. A runtime integration test now guards this, because the type-level
+  consumer tests cannot detect lexer visibility problems.
+- `load()` failed with a `TypeError` reported as `FAILED_TO_LOAD_WEIGHTS` when
+  the model was constructed with `config: null`, instead of falling back to the
+  default configuration: the destructuring default only applies to `undefined`,
+  so the null value survived into the load path. The same failure also left the
+  registered native-logger callback attached, which keeps the Bare event loop
+  alive. The config is now normalized to `{}` at construction, restoring the
+  pre-0.16.0 behaviour.
+- Internal `run()` input validation now treats a missing `hparams` the same way
+  as a `null` one, like every other guard in that function. The patch-mode check
+  tested against `null` only, so a missing value would have thrown a raw
+  `TypeError` instead of falling back to pixel-mode validation. This is a
+  consistency fix rather than a user-visible bug: the validated value is always
+  either `null` or a loaded hparams object, so the raw throw was not reachable
+  through the public API.
+
+### Pull Requests
+
+- [#3519](https://github.com/tetherto/qvac/pull/3519) - QVAC-22177 fix: restore ESM named exports + config null-safety in vla wrapper
+
 ## [0.16.1] - 2026-07-30
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- [#3519](https://github.com/tetherto/qvac/pull/3519) fixed three regressions from the 0.16.0 TypeScript migration but deliberately deferred the version bump and changelog.

## 📝 How does it solve it?

- Bumps `@qvac/vla-ggml` from 0.16.1 to 0.16.2. Patch level is correct: three bug fixes restoring pre-0.16.0 behaviour, no API added, removed, or changed.
- Adds the `## [0.16.2] - 2026-07-31` changelog block covering the ESM named-export visibility fix for `cjs-module-lexer`, `config: null` no longer breaking `load()`, and the internal `hparams` guard consistency fix.

## 🧪 How was it tested?

N/A