### PR TITLE
 QVAC-23067 fix: make clearPlugins resilient to a throwing plugin releaseLogger

### DIFF
--- a/packages/sdk/server/plugins/registry.ts
+++ b/packages/sdk/server/plugins/registry.ts
@@ -11,6 +11,7 @@ import {
   PluginModelTypeReservedError
 } from '@/utils/errors-server'
 import { createAddonLoggerCallback } from '@/logging/addon'
+import { getServerLogger } from '@/logging'
 import { formatZodError } from '@/utils/zod-error'
 
 const plugins = new Map<string, QvacPlugin>()
@@ -108,7 +109,18 @@ export function clearPlugins(): void {
       const loggingModule = plugin.logging.module as {
         releaseLogger?: () => void
       }
-      loggingModule.releaseLogger?.()
+      try {
+        loggingModule.releaseLogger?.()
+      } catch (error) {
+        // A plugin's logger teardown must not abort the sweep or leave the
+        // registry half-cleared for the next caller — but surface it, so a leaked
+        // reference or async handle is not masked as a clean teardown.
+        getServerLogger().warn(
+          `[${plugin.modelType}] releaseLogger failed during clearPlugins: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
     }
   }
   plugins.clear()

--- a/packages/sdk/test/unit/clear-plugins.test.ts
+++ b/packages/sdk/test/unit/clear-plugins.test.ts
@@ -1,0 +1,51 @@
+import test from 'brittle'
+import { z } from 'zod'
+import { registerPlugin, clearPlugins, getAllPlugins, hasPlugin } from '@/server/plugins'
+import type { QvacPlugin } from '@/schemas/plugin'
+
+function fakePlugin(modelType: string, releaseLogger: () => void): QvacPlugin {
+  return {
+    modelType,
+    displayName: modelType,
+    addonPackage: modelType,
+    loadConfigSchema: z.object({}),
+    async createModel() {
+      return undefined
+    },
+    handlers: {},
+    logging: {
+      namespace: modelType,
+      module: {
+        setLogger() {},
+        releaseLogger
+      }
+    }
+  } as unknown as QvacPlugin
+}
+
+test('clearPlugins releases every plugin and empties the registry even when one releaseLogger throws', (t) => {
+  clearPlugins()
+
+  let releasedThrowing = false
+  let releasedNext = false
+
+  registerPlugin(
+    fakePlugin('clear-plugins-throwing', () => {
+      releasedThrowing = true
+      throw new Error('release failed')
+    })
+  )
+  registerPlugin(
+    fakePlugin('clear-plugins-next', () => {
+      releasedNext = true
+    })
+  )
+
+  t.execution(() => clearPlugins())
+
+  t.ok(releasedThrowing, 'the throwing plugin was released')
+  t.ok(releasedNext, 'the sweep continued to the next plugin after the throw')
+  t.absent(hasPlugin('clear-plugins-throwing'))
+  t.absent(hasPlugin('clear-plugins-next'))
+  t.is(getAllPlugins().length, 0, 'the registry is empty after the sweep')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `clearPlugins` calls each plugin's `releaseLogger()` unguarded, then `plugins.clear()`.
  If any plugin's `releaseLogger` throws (e.g. a native addon teardown error), the loop
  aborts **before** `plugins.clear()` — the error escapes uncaught **and** the registry
  is left half-cleared, leaking the plugin.
- `cleanupForTerminate` clears plugins (`server/worker-core.ts`), so a plugin whose
  `releaseLogger` throws leaks into the next caller, whose `clearPlugins()` then throws
  uncaught. It's order-dependent: exposed under one test-file order, latent under another.

## 📝 How does it solve it?

- Wrap each `releaseLogger()` in try/catch so one plugin's teardown error can neither
  abort the sweep nor leave the registry uncleared — `plugins.clear()` always runs.
  Mirrors the resource collector's own `destroyContext` containment.

## 🧪 How was it tested?

- `bun run build` (lint + tsc + tsc-alias) — clean.
- `bun run test:bare` — 86/86 (the Bare resource-collector cleanup test exercises a
  throwing `releaseLogger`).
- `bun run test:unit` — all pass.