### PR TITLE
poc[notask]: test 1 - classification-ggml only change

### DIFF
--- a/packages/classification-ggml/index.js
+++ b/packages/classification-ggml/index.js
@@ -230,3 +230,4 @@ exports.default = ImageClassifier;
 const cjsExports = ImageClassifier;
 cjsExports.ImageClassifier = ImageClassifier;
 module.exports = cjsExports;
+// tmp-poc-test-1: classification-ggml-only change, should not affect fabric


### PR DESCRIPTION
POC test 1/3: change only in classification-ggml. Expect nx affected to show classification-ggml only, NOT fabric.