### PR TITLE
poc[notask]: test 3 [verify-registry] mode

### DIFF
--- a/packages/classification-ggml/index.js
+++ b/packages/classification-ggml/index.js
@@ -230,3 +230,4 @@ exports.default = ImageClassifier;
 const cjsExports = ImageClassifier;
 cjsExports.ImageClassifier = ImageClassifier;
 module.exports = cjsExports;
+// tmp-poc-test-3: verify-against-registry mode


### PR DESCRIPTION
POC test 3/3: verify-against-registry marker present in title. Expect the matrix job to drop the lockfile and resolve against the real registry, and still succeed.