### PR TITLE
QVAC-23064 feat[api]: add LavaSR enhancer + denoiser support to CosyVoice3

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `@qvac/tts-ggml`: Qwen2.5 LM → DiT conditional-flow-matching → CausalHiFT
   vocoder (24 kHz), on CPU. Instruct2 control (dialect / emotion / speed /
   volume / style) via the `instruct` option.
+- **LavaSR enhancer + denoiser for CosyVoice3.** `files.lavasrEnhancer` /
+  `enhancer` now bandwidth-extend CosyVoice3's native 24 kHz output to 48 kHz,
+  on both batch synthesis and native chunk streaming (seam-free). The
+  `files.lavasrDenoiser` / `denoiser` stage runs before it on the batch path.
+  `enhancerBackendDevice` / `enhancerBackendId` are reported in runtime stats,
+  matching Chatterbox and Supertonic.
+
+### Changed
+
+- **`outputSampleRate` with CosyVoice3 streaming.** Previously rejected for any
+  non-native rate; it is now accepted while streaming when the LavaSR enhancer
+  is active, because the enhancer resamples inside its overlap-reprocess window
+  without introducing chunk seams.
 
 ## [0.6.1] - 2026-07-30
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is active, because the enhancer resamples inside its overlap-reprocess window
   without introducing chunk seams.
 
+### Fixed
+
+- **`denoiser` with an explicit `streamChunkTokens: 0`.** A zero token count
+  means batch synthesis, but it was still rejected as a streaming request, so
+  passing `0` explicitly disabled the denoiser path. Only a positive count now
+  counts as native chunk streaming, matching the addon.
+
 ## [0.6.1] - 2026-07-30
 
 ### Fixed

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -261,11 +261,20 @@ Notes:
   streaming.
 - That window re-runs the enhancer over a fixed left context + look-ahead around
   every chunk, so streamed enhancement costs a constant factor above a single
-  batch pass: **~1.7×** at the default `streamChunkTokens: 25` (~1 s chunks),
-  ~2.7× at 10 tokens, ~4.4× at 5 tokens. The factor is flat in utterance length,
-  and the enhancer is only a small share of synthesis, so ~1 s chunks cost
-  roughly 2% of total synthesis time. Prefer larger chunks if enhancer CPU
-  matters more to you than first-audio latency.
+  batch pass: **~1.7×** for ~1 s chunks, ~2.7× for ~0.4 s, ~4.4× for ~0.2 s. How
+  many tokens that is depends on the engine's speech-token rate (Chatterbox's S3
+  tokens run at a fixed 25 Hz, so `streamChunkTokens: 25` ≈ 1 s). The factor is
+  flat in utterance length, and the enhancer is only a small share of synthesis,
+  so ~1 s chunks cost roughly 2% of total synthesis time.
+- That extra enhancer CPU buys a real latency win on **Chatterbox**, so prefer
+  larger chunks there only if enhancer CPU matters more to you than first-audio
+  latency. On **CosyVoice3** it currently buys nothing: the tts-cpp engine
+  computes the whole utterance and only then slices it, so chunks arrive
+  progressively but first-audio latency is not yet reduced (true token2wav
+  streaming is reserved upstream). Until that lands, prefer **batch** synthesis
+  when enhancing CosyVoice3 — streaming there pays the reprocess cost and yields
+  a seam-free result that is not bit-identical to the batch pass, with no
+  latency benefit in return.
 - The enhancer always runs at 48 kHz internally. By default the emitted audio
   is 48 kHz; set `config.outputSampleRate` to resample the enhanced output to a
   different rate (`TTSOutputChunk.sampleRate` reports the actual rate).

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -259,6 +259,13 @@ Notes:
   This adds **~0.34 s of look-ahead latency** (inherent to the enhancer's
   receptive field), so first-audio-out arrives a little later than un-enhanced
   streaming.
+- That window re-runs the enhancer over a fixed left context + look-ahead around
+  every chunk, so streamed enhancement costs a constant factor above a single
+  batch pass: **~1.7×** at the default `streamChunkTokens: 25` (~1 s chunks),
+  ~2.7× at 10 tokens, ~4.4× at 5 tokens. The factor is flat in utterance length,
+  and the enhancer is only a small share of synthesis, so ~1 s chunks cost
+  roughly 2% of total synthesis time. Prefer larger chunks if enhancer CPU
+  matters more to you than first-audio latency.
 - The enhancer always runs at 48 kHz internally. By default the emitted audio
   is 48 kHz; set `config.outputSampleRate` to resample the enhanced output to a
   different rate (`TTSOutputChunk.sampleRate` reports the actual rate).

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -250,8 +250,10 @@ python scripts/convert-lavasr-enhancer-to-gguf.py \
 
 Notes:
 
-- Works for Supertonic and Chatterbox, on the batch path, sentence-level
-  streaming, **and** Chatterbox native chunk streaming (`streamChunkTokens > 0`).
+- Works for Supertonic, Chatterbox and CosyVoice3, on the batch path,
+  sentence-level streaming, **and** native chunk streaming
+  (`streamChunkTokens > 0`) for the engines that support it (Chatterbox,
+  CosyVoice3). Parler is rejected — it already emits 44.1 kHz.
 - For native chunk streaming the enhancer runs over a sliding window with
   look-ahead + crossfade so each emitted chunk is bandwidth-extended seam-free.
   This adds **~0.34 s of look-ahead latency** (inherent to the enhancer's
@@ -260,6 +262,9 @@ Notes:
 - The enhancer always runs at 48 kHz internally. By default the emitted audio
   is 48 kHz; set `config.outputSampleRate` to resample the enhanced output to a
   different rate (`TTSOutputChunk.sampleRate` reports the actual rate).
+- CosyVoice3 native chunk streaming otherwise emits only at its native 24 kHz;
+  enabling the enhancer is what makes a different `config.outputSampleRate`
+  valid there, since the resample happens inside the seam-free window.
 - With `opts.stats`, `response.stats.enhancerBackendDevice` (`-1` none / `0` CPU
   / `1` GPU) and `enhancerBackendId` report where the enhancer actually ran.
 
@@ -269,7 +274,8 @@ LavaSR's first stage — the UL-UNAS **denoiser**, which cleans the signal befor
 the enhancer bandwidth-extends it — is wired through the addon. It is enabled the
 same way as the enhancer, via `files.lavasrDenoiser` (or a
 `denoiser: { type: 'lavasr', denoiserPath }` block), and runs before the
-enhancer (rate-preserving) on the batch path for both engines:
+enhancer (rate-preserving) on the batch path for Supertonic, Chatterbox and
+CosyVoice3:
 
 ```js
 const model = new TTSGgml({
@@ -299,9 +305,9 @@ Notes:
 - The UL-UNAS forward runs at 16 kHz internally (resampled in/out), so the
   denoiser is **rate-preserving**: the emitted audio keeps the engine's sample
   rate. With no denoiser path the output is unchanged (full backward compat).
-- Denoiser + Chatterbox native chunk streaming (`streamChunkTokens > 0`) is
-  rejected up front — a stateful streaming denoiser is the follow-up. Use batch
-  synthesis, or drop the denoiser for streaming.
+- Denoiser + native chunk streaming (`streamChunkTokens > 0`) is rejected up
+  front for every engine — a stateful streaming denoiser is the follow-up. Use
+  batch synthesis, or drop the denoiser for streaming.
 - The tts-cpp UL-UNAS forward is implemented in
   [qvac-ext-lib-whisper.cpp#78](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/78)
   (scalar CPU port, validated bit-close to the ONNX reference); it requires a
@@ -499,6 +505,8 @@ Runnable demos under `examples/`:
 | `supertonic-mtl-sweep-tts.js` | Multilingual Supertonic sweep across languages |
 | `supertonic-sentence-stream-tts.js` | Supertonic sentence-level streaming |
 | `supertonic-enhanced.js` | Supertonic + LavaSR 48 kHz enhancement. `bare examples/supertonic-enhanced.js "Hello"` |
+| `cosyvoice-tts.js` | CosyVoice3 batch synth. `bare examples/cosyvoice-tts.js "Hello"` |
+| `cosyvoice-enhanced.js` | CosyVoice3 + LavaSR 48 kHz enhancement (add `--denoise` for the denoiser). `bare examples/cosyvoice-enhanced.js "Hello"` |
 | `parler-tts.js` | Parler batch synth with voice/emotion templates. `bare examples/parler-tts.js "Hello" Laura happy` |
 
 The two streaming examples feed PCM into a single long-running

--- a/packages/tts-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/tts-ggml/addon/src/addon/AddonJs.hpp
@@ -114,9 +114,12 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
     model = std::move(stm);
   } else if (engineType == EngineType::Cosyvoice) {
     auto cfg = adapter.buildCosyvoiceConfig(configurationParams, env);
+    const bool enhanced = !cfg.enhancerGgufPath.empty();
     const int outSr = cfg.outputSampleRate.value_or(0);
     auto cvm = make_unique<CosyvoiceModel>(std::move(cfg));
-    sampleRate = outSr > 0 ? outSr : cvm->sampleRate(); // native 24 kHz
+    sampleRate = outSr > 0 ? outSr
+                           : (enhanced ? kLavasrEnhancedSampleRate
+                                       : cvm->sampleRate()); // native 24 kHz
     model = std::move(cvm);
   } else if (engineType == EngineType::Parler) {
     auto cfg = adapter.buildParlerConfig(configurationParams, env);

--- a/packages/tts-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/tts-ggml/addon/src/addon/AddonJs.hpp
@@ -17,6 +17,7 @@
 #include <js.h>
 
 #include "js-interface/JSAdapter.hpp"
+#include "model-interface/EnhancerLoader.hpp"
 #include "model-interface/chatterbox/ChatterboxModel.hpp"
 #include "model-interface/cosyvoice/CosyvoiceModel.hpp"
 #include "model-interface/parler/ParlerModel.hpp"
@@ -101,8 +102,6 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   //      enhancer) — always the final emitted rate when set;
   //   2. 48000 when the LavaSR enhancer is active (it always emits 48 kHz);
   //   3. the engine's native rate.
-  constexpr int kLavasrEnhancedSampleRate = 48000;
-
   if (engineType == EngineType::Supertonic) {
     auto cfg = adapter.buildSupertonicConfig(configurationParams, env);
     const bool enhanced = !cfg.enhancerGgufPath.empty();

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -279,6 +279,15 @@ JSAdapter::buildCosyvoiceConfig(js::Object configurationParams, js_env_t* env) {
   cfg.streamLeftContextTokens =
       readOptionalInt(configurationParams, env, "streamLeftContextTokens");
   cfg.backendsDir = readOptionalString(configurationParams, env, "backendsDir");
+  // LavaSR neural enhancement: a non-empty GGUF path turns it on. CosyVoice3's
+  // native 24 kHz output is bandwidth-extended to 48 kHz.
+  cfg.enhancerGgufPath =
+      readOptionalString(configurationParams, env, "lavasrEnhancerPath");
+  // LavaSR neural denoiser (runs before the enhancer): a non-empty GGUF path
+  // turns it on. Batch-only; the streaming combo is rejected in
+  // CosyvoiceModel::validateConfig.
+  cfg.denoiserGgufPath =
+      readOptionalString(configurationParams, env, "lavasrDenoiserPath");
   return cfg;
 }
 }

--- a/packages/tts-ggml/addon/src/model-interface/EnhancerLoader.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/EnhancerLoader.hpp
@@ -10,6 +10,12 @@
 
 namespace qvac::ttsggml {
 
+// Rate every LavaSR enhancer GGUF emits. The models read the real value off the
+// loaded network via Enhancer::output_sample_rate(); this mirror is for callers
+// that must know the emitted rate before any enhancer exists — AddonJs bakes it
+// into the JS output handlers at instance creation, before load() runs.
+inline constexpr int kLavasrEnhancedSampleRate = 48000;
+
 // Outcome of loadEnhancer: the enhancer (null when disabled) plus the
 // runtimeStats backend codes (backendDeviceCode / backendIdFromName), or the
 // kBackend*None sentinels when no enhancer is loaded.

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceConfig.hpp
@@ -82,7 +82,9 @@ struct CosyvoiceConfig {
   std::optional<bool> useGpu;
   /**
    * Desired output sample rate in Hz (8000–192000), or unset/0 to keep the
-   * engine's native 24 kHz.
+   * engine's native 24 kHz. When the LavaSR enhancer is active the enhancer
+   * emits 48 kHz and the addon resamples to this value afterwards (batch), or
+   * folds it into the seam-free streaming window (native chunk streaming).
    */
   std::optional<int> outputSampleRate;
   /**
@@ -109,6 +111,20 @@ struct CosyvoiceConfig {
 
   /** Forwarded to `tts_cpp::cosyvoice::EngineOptions::backends_dir`. */
   std::string backendsDir;
+
+  // LavaSR neural speech enhancement. A non-empty `enhancerGgufPath` is the
+  // single switch: when set, the model bandwidth-extends CosyVoice3's native
+  // 24 kHz output to 48 kHz; empty disables enhancement (full backward compat).
+  // Works on both the batch path and native chunk streaming (the latter via
+  // StreamingEnhancer, which keeps chunk seams inaudible).
+  std::string enhancerGgufPath;
+
+  // LavaSR neural speech denoiser (UL-UNAS). A non-empty `denoiserGgufPath` is
+  // the single switch: when set, the model denoises the synthesized PCM BEFORE
+  // the enhancer (rate-preserving); empty disables it (full backward compat).
+  // Batch-only: tts-cpp exposes a one-shot denoise(), so combining it with
+  // native chunk streaming is rejected by CosyvoiceModel::validateConfig.
+  std::string denoiserGgufPath;
 };
 
 } // namespace qvac::ttsggml::cosyvoice

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
@@ -221,18 +221,7 @@ struct StreamChunkPostProcessor {
   }
 };
 
-} // namespace
-
-CosyvoiceModel::CosyvoiceModel(CosyvoiceConfig config)
-    : cfg_(std::move(config)) {
-  validateConfig(cfg_);
-  // load() is deferred to waitForLoadInitialization() so any heavy model
-  // parse runs off the JS event loop via JsAsyncTask::run-driven activate().
-}
-
-CosyvoiceModel::~CosyvoiceModel() noexcept = default;
-
-void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
+void validateModelPaths(const CosyvoiceConfig& cfg) {
   if (cfg.modelDir.empty() && cfg.llmModelPath.empty()) {
     throw StatusError(
         general_error::InvalidArgument,
@@ -290,6 +279,9 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
         TTSErrorCode::ModelFileNotFound,
         "lavasr denoiser GGUF not found: " + cfg.denoiserGgufPath);
   }
+}
+
+void validateSynthesisRanges(const CosyvoiceConfig& cfg) {
   if (cfg.cfmSteps.has_value() && *cfg.cfmSteps < 0) {
     throw StatusError(general_error::InvalidArgument, "cfmSteps must be >= 0");
   }
@@ -299,6 +291,9 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
         general_error::InvalidArgument,
         "outputSampleRate must be 0 or in [8000, 192000]");
   }
+}
+
+void validateStreamTokens(const CosyvoiceConfig& cfg) {
   if (cfg.streamChunkTokens.has_value() && *cfg.streamChunkTokens < 0) {
     throw StatusError(
         general_error::InvalidArgument,
@@ -315,15 +310,22 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
     throw StatusError(
         general_error::InvalidArgument, "streamLeftContextTokens must be >= 0");
   }
+}
+
+// AddonJs always installs a chunkCallback for CosyVoice, so streaming ==
+// streamChunkTokens>0 at construction.
+bool streamsNativeChunks(const CosyvoiceConfig& cfg) {
+  return cfg.streamChunkTokens.value_or(0) > 0;
+}
+
+void validateStreamingCompatibility(const CosyvoiceConfig& cfg) {
   // CosyVoice emits its native 24 kHz per chunk while streaming; naive
   // addon-side per-chunk resampling would break the seams, so reject a
   // non-native output rate while streaming (batch output is resampled
   // instead). The LavaSR enhancer is the exception: StreamingEnhancer already
   // reprocesses an overlapping window and crossfades the seams, so it folds the
-  // requested rate into that seam-free stage. AddonJs always installs a
-  // chunkCallback for CosyVoice, so streaming == streamChunkTokens>0 at
-  // construction.
-  if (cfg.streamChunkTokens.value_or(0) > 0 && cfg.enhancerGgufPath.empty() &&
+  // requested rate into that seam-free stage.
+  if (streamsNativeChunks(cfg) && cfg.enhancerGgufPath.empty() &&
       cfg.outputSampleRate.has_value() && *cfg.outputSampleRate != 0 &&
       *cfg.outputSampleRate != kCosyvoiceNativeSampleRate) {
     throw StatusError(
@@ -334,10 +336,10 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
   }
   // LavaSR denoiser + native chunk streaming is not supported yet: the UL-UNAS
   // denoiser is causal but tts-cpp only exposes a one-shot denoise(), so a
-  // stateful streaming denoiser (à la StreamingEnhancer) is the follow-up.
+  // stateful streaming denoiser (like StreamingEnhancer) is the follow-up.
   // Reject the combo up front rather than silently dropping denoising on the
   // streaming path. Defense-in-depth: index.js rejects it before we get here.
-  if (!cfg.denoiserGgufPath.empty() && cfg.streamChunkTokens.value_or(0) > 0) {
+  if (!cfg.denoiserGgufPath.empty() && streamsNativeChunks(cfg)) {
     throw StatusError(
         general_error::InvalidArgument,
         "CosyvoiceModel: the LavaSR denoiser is not yet supported with native "
@@ -345,22 +347,43 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
         "the denoiser for streaming (streaming denoise is a planned "
         "follow-up).");
   }
-  // useGPU / nGpuLayers conflict check — mirrors the sibling engines so the
-  // option surface behaves identically even though iteration 1 runs CPU-only.
-  if (cfg.useGpu.has_value() && cfg.nGpuLayers.has_value()) {
-    const bool wantsGpuFlag = *cfg.useGpu;
-    const int layers = *cfg.nGpuLayers;
-    const bool layersWantGpu = layers != 0;
-    if (wantsGpuFlag != layersWantGpu) {
-      throw StatusError(
-          general_error::InvalidArgument,
-          std::string("CosyvoiceModel: useGPU=") +
-              (wantsGpuFlag ? "true" : "false") +
-              " conflicts with nGpuLayers=" + std::to_string(layers) +
-              ". Either drop one of the two, or make them agree "
-              "(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).");
-    }
-  }
+}
+
+// useGPU / nGpuLayers conflict check — mirrors the sibling engines so the
+// option surface behaves identically even though iteration 1 runs CPU-only.
+void validateGpuIntent(const CosyvoiceConfig& cfg) {
+  if (!cfg.useGpu.has_value() || !cfg.nGpuLayers.has_value())
+    return;
+  const bool wantsGpuFlag = *cfg.useGpu;
+  const int layers = *cfg.nGpuLayers;
+  if (wantsGpuFlag == (layers != 0))
+    return;
+  throw StatusError(
+      general_error::InvalidArgument,
+      std::string("CosyvoiceModel: useGPU=") +
+          (wantsGpuFlag ? "true" : "false") +
+          " conflicts with nGpuLayers=" + std::to_string(layers) +
+          ". Either drop one of the two, or make them agree "
+          "(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).");
+}
+
+} // namespace
+
+CosyvoiceModel::CosyvoiceModel(CosyvoiceConfig config)
+    : cfg_(std::move(config)) {
+  validateConfig(cfg_);
+  // load() is deferred to waitForLoadInitialization() so any heavy model
+  // parse runs off the JS event loop via JsAsyncTask::run-driven activate().
+}
+
+CosyvoiceModel::~CosyvoiceModel() noexcept = default;
+
+void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
+  validateModelPaths(cfg);
+  validateSynthesisRanges(cfg);
+  validateStreamTokens(cfg);
+  validateStreamingCompatibility(cfg);
+  validateGpuIntent(cfg);
 }
 
 void CosyvoiceModel::setConfig(CosyvoiceConfig config) {

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
@@ -403,6 +403,14 @@ bool streamingRequested(const CosyvoiceConfig& cfg, bool hasChunkCallback) {
   return cfg.streamChunkTokens.value_or(0) > 0 && hasChunkCallback;
 }
 
+EmittedAudio resolveEmittedAudio(
+    bool streaming, bool enhanced, int streamFinalRate,
+    std::size_t streamedSamples, std::size_t batchSamples, int batchRate) {
+  if (!streaming)
+    return {batchSamples, batchRate};
+  return {streamedSamples, enhanced ? streamFinalRate : batchRate};
+}
+
 void CosyvoiceModel::load() {
   std::lock_guard lk(engineMu_);
   loadLocked();
@@ -528,14 +536,15 @@ CosyvoiceModel::SynthResult CosyvoiceModel::synthesize(
   }
   const auto t1 = std::chrono::steady_clock::now();
 
-  // On the streaming+enhancer path chunks are emitted at streamFinalRate while
-  // result.sample_rate stays native; elsewhere result.sample_rate is already
-  // the emitted rate (batch enhance/resample updates it in place).
-  const int emittedRate =
-      (streaming && enhancer) ? rates.streamFinalRate : result.sample_rate;
-  const std::size_t emittedSamples =
-      streaming ? streamedSamples : result.pcm.size();
-  recordSynthesisStats(emittedSamples, emittedRate, result.duration_s, t0, t1);
+  const EmittedAudio emitted = resolveEmittedAudio(
+      streaming,
+      static_cast<bool>(enhancer),
+      rates.streamFinalRate,
+      streamedSamples,
+      result.pcm.size(),
+      result.sample_rate);
+  recordSynthesisStats(
+      emitted.samples, emitted.sampleRate, result.duration_s, t0, t1);
 
   if (streaming) {
     return {Output{}, true}; // chunks already emitted via onChunk

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
@@ -86,10 +86,10 @@ tts_cpp::cosyvoice::EngineOptions toEngineOptions(const CosyvoiceConfig& cfg) {
 
 } // namespace
 
-// Batch-only output-rate conversion (the tts-cpp engine ignores
-// output_sample_rate; unenhanced streaming is validated to the native rate).
-// No-op unless a non-native outputSampleRate was requested. Runs before stats
-// so sampleRate_/duration reflect the emitted rate.
+// The tts-cpp engine ignores output_sample_rate, so the addon resamples the
+// batch output itself; unenhanced streaming is validated to the native rate
+// instead. Must run before stats so sampleRate_/duration reflect the emitted
+// rate.
 void resampleBatchOutput(
     const CosyvoiceConfig& cfg, tts_cpp::cosyvoice::SynthesisResult& result) {
   if (cfg.outputSampleRate.has_value() && *cfg.outputSampleRate > 0 &&
@@ -102,10 +102,10 @@ void resampleBatchOutput(
 
 namespace {
 
-// Sample rates once the LavaSR enhancer is active: the engine emits its native
-// 24 kHz, the enhancer upsamples to `workRate` (48 kHz), and the streaming path
-// finally emits at `streamFinalRate` (a caller-requested rate, else the work
-// rate). All zero when no enhancer is loaded.
+// Rates once the LavaSR enhancer is active: it upsamples the engine's native
+// 24 kHz to `workRate` (48 kHz), and the streaming path emits at
+// `streamFinalRate` (a caller-requested rate, else the work rate). Both stay
+// zero when no enhancer is loaded.
 struct EnhancerRates {
   int workRate = 0;
   int streamFinalRate = 0;
@@ -122,9 +122,7 @@ EnhancerRates resolveEnhancerRates(
   return {workRate, hasRequestedRate ? *outputSampleRate : workRate};
 }
 
-// Wraps the one-shot enhancer as a streaming stage: enhance at the engine's
-// native rate, then resample to the streaming final rate when they differ.
-// Mirrors ChatterboxModel::makeStreamingEnhancer.
+// Mirrors ChatterboxModel::makeStreamingEnhancer; keep the two in sync.
 std::shared_ptr<StreamingEnhancer> makeStreamingEnhancer(
     const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer,
     const EnhancerRates& rates) {
@@ -145,9 +143,21 @@ std::shared_ptr<StreamingEnhancer> makeStreamingEnhancer(
       finalRate);
 }
 
-// LavaSR neural denoiser (batch path). Runs BEFORE the enhancer and preserves
-// the sample rate. Streaming + denoiser is rejected in validateConfig, so this
-// only ever applies to batch synthesis.
+// Mirrors loadEnhancer: an empty path leaves the stage disabled.
+std::shared_ptr<tts_cpp::lavasr::Denoiser>
+loadDenoiser(const std::string& ggufPath, const std::string& errorContext) {
+  if (ggufPath.empty())
+    return nullptr;
+  try {
+    return tts_cpp::lavasr::Denoiser::load(ggufPath);
+  } catch (const std::exception& e) {
+    throw createTTSError(
+        TTSErrorCode::InitializationFailed, errorContext + e.what());
+  }
+}
+
+// Rate-preserving. validateConfig rejects denoiser + streaming, so this only
+// ever runs on the batch path.
 void applyBatchDenoiser(
     tts_cpp::cosyvoice::SynthesisResult& result,
     tts_cpp::lavasr::Denoiser& denoiser) {
@@ -160,9 +170,8 @@ void applyBatchDenoiser(
   }
 }
 
-// LavaSR neural bandwidth extension (batch path). Enhances the whole utterance
-// at once (the streaming path enhances per chunk instead) and updates
-// result.sample_rate to the enhancer's 48 kHz output.
+// Enhances the whole utterance in one pass; the streaming path enhances per
+// chunk through StreamingEnhancer instead.
 void applyBatchEnhancer(
     tts_cpp::cosyvoice::SynthesisResult& result,
     tts_cpp::lavasr::Enhancer& enhancer) {
@@ -176,9 +185,9 @@ void applyBatchEnhancer(
   }
 }
 
-// Batch post-processing chain: denoise (rate-preserving) -> enhance (-> 48 kHz)
-// -> honour outputSampleRate. resampleBatchOutput closes both the enhanced and
-// the unenhanced case, since the enhancer leaves result.sample_rate at 48 kHz.
+// resampleBatchOutput is unconditional because it closes both the enhanced and
+// the unenhanced case: applyBatchEnhancer leaves result.sample_rate at 48 kHz,
+// which still has to be reconciled with any requested outputSampleRate.
 void applyBatchPostProcessing(
     const CosyvoiceConfig& cfg, tts_cpp::cosyvoice::SynthesisResult& result,
     const std::shared_ptr<tts_cpp::lavasr::Denoiser>& denoiser,
@@ -190,9 +199,8 @@ void applyBatchPostProcessing(
   resampleBatchOutput(cfg, result);
 }
 
-// Per-chunk post-processing for the native streaming path: an optional
-// seam-free LavaSR enhancement stage emitting int16 PCM through the caller's
-// callback. Kept as a functor so the engine can call it per chunk.
+// The reference members borrow synthesize()'s locals, so an instance must not
+// outlive the engine->synthesize() call it is handed to.
 struct StreamChunkPostProcessor {
   const CosyvoiceModel::ChunkCallback& emit;
   std::shared_ptr<StreamingEnhancer> streamEnhancer;
@@ -430,11 +438,9 @@ void CosyvoiceModel::loadLocked() {
   backendId_ = backendIdFromName(backendName_);
   gpuUnsupported_ = engine_->gpu_unsupported();
 
-  // LavaSR enhancer: load when a GGUF path is set (empty path = disabled).
   // Pass the engine's *resolved* device, not the requested switch: if the
   // engine fell back to CPU, keep the enhancer on CPU too instead of forcing it
-  // onto the GPU. Shared with Chatterbox/Supertonic via loadEnhancer so the
-  // loaders can't drift.
+  // onto the GPU.
   LoadedEnhancer loaded = loadEnhancer(
       cfg_.enhancerGgufPath,
       backendDevice_ == kBackendDeviceGpu,
@@ -443,19 +449,8 @@ void CosyvoiceModel::loadLocked() {
   enhancerBackendDevice_ = loaded.backendDevice;
   enhancerBackendId_ = loaded.backendId;
 
-  // LavaSR denoiser: load when a GGUF path is set (runs before the enhancer).
-  if (!cfg_.denoiserGgufPath.empty()) {
-    try {
-      denoiser_ = tts_cpp::lavasr::Denoiser::load(cfg_.denoiserGgufPath);
-    } catch (const std::exception& e) {
-      denoiser_.reset();
-      throw createTTSError(
-          TTSErrorCode::InitializationFailed,
-          std::string("CosyvoiceModel::load: lavasr denoiser: ") + e.what());
-    }
-  } else {
-    denoiser_.reset();
-  }
+  denoiser_ = loadDenoiser(
+      cfg_.denoiserGgufPath, "CosyvoiceModel::load: lavasr denoiser: ");
 }
 
 void CosyvoiceModel::unloadLocked() {
@@ -513,8 +508,6 @@ CosyvoiceModel::SynthResult CosyvoiceModel::synthesize(
   tts_cpp::cosyvoice::SynthesisResult result;
   try {
     if (streaming) {
-      // Bridge the engine's float chunk callback to the JS int16 sink, running
-      // the seam-free LavaSR stage in between when the enhancer is active.
       result = engine->synthesize(
           text,
           StreamChunkPostProcessor{

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
@@ -6,18 +6,24 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <tts-cpp/cosyvoice/engine.h>
+#include <tts-cpp/lavasr/denoiser.h>
+#include <tts-cpp/lavasr/enhancer.h>
 
 #include "addon/TTSErrors.hpp"
 #include "inference-addon-cpp/Errors.hpp"
 #include "model-interface/BackendUtils.hpp"
+#include "model-interface/EnhancerLoader.hpp"
 #include "model-interface/OutputResampler.hpp"
 #include "model-interface/PcmConversion.hpp"
+#include "model-interface/StreamingEnhancer.hpp"
 
 namespace qvac::ttsggml::cosyvoice {
 
@@ -81,9 +87,9 @@ tts_cpp::cosyvoice::EngineOptions toEngineOptions(const CosyvoiceConfig& cfg) {
 } // namespace
 
 // Batch-only output-rate conversion (the tts-cpp engine ignores
-// output_sample_rate; streaming is validated to the native rate). No-op unless
-// a non-native outputSampleRate was requested. Runs before stats so
-// sampleRate_/duration reflect the emitted rate.
+// output_sample_rate; unenhanced streaming is validated to the native rate).
+// No-op unless a non-native outputSampleRate was requested. Runs before stats
+// so sampleRate_/duration reflect the emitted rate.
 void resampleBatchOutput(
     const CosyvoiceConfig& cfg, tts_cpp::cosyvoice::SynthesisResult& result) {
   if (cfg.outputSampleRate.has_value() && *cfg.outputSampleRate > 0 &&
@@ -93,6 +99,129 @@ void resampleBatchOutput(
     result.sample_rate = *cfg.outputSampleRate;
   }
 }
+
+namespace {
+
+// Sample rates once the LavaSR enhancer is active: the engine emits its native
+// 24 kHz, the enhancer upsamples to `workRate` (48 kHz), and the streaming path
+// finally emits at `streamFinalRate` (a caller-requested rate, else the work
+// rate). All zero when no enhancer is loaded.
+struct EnhancerRates {
+  int workRate = 0;
+  int streamFinalRate = 0;
+};
+
+EnhancerRates resolveEnhancerRates(
+    const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer,
+    const std::optional<int>& outputSampleRate) {
+  if (!enhancer)
+    return {};
+  const int workRate = enhancer->output_sample_rate();
+  const bool hasRequestedRate =
+      outputSampleRate.has_value() && *outputSampleRate > 0;
+  return {workRate, hasRequestedRate ? *outputSampleRate : workRate};
+}
+
+// Wraps the one-shot enhancer as a streaming stage: enhance at the engine's
+// native rate, then resample to the streaming final rate when they differ.
+// Mirrors ChatterboxModel::makeStreamingEnhancer.
+std::shared_ptr<StreamingEnhancer> makeStreamingEnhancer(
+    const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer,
+    const EnhancerRates& rates) {
+  if (!enhancer)
+    return nullptr;
+  const int workRate = rates.workRate;
+  const int finalRate = rates.streamFinalRate;
+  return std::make_shared<StreamingEnhancer>(
+      [enhancer, workRate, finalRate](const std::vector<float>& raw) {
+        std::vector<float> enhanced =
+            enhancer->enhance(raw, kCosyvoiceNativeSampleRate);
+        if (finalRate != workRate) {
+          enhanced = OutputResampler::resample(enhanced, workRate, finalRate);
+        }
+        return enhanced;
+      },
+      kCosyvoiceNativeSampleRate,
+      finalRate);
+}
+
+// LavaSR neural denoiser (batch path). Runs BEFORE the enhancer and preserves
+// the sample rate. Streaming + denoiser is rejected in validateConfig, so this
+// only ever applies to batch synthesis.
+void applyBatchDenoiser(
+    tts_cpp::cosyvoice::SynthesisResult& result,
+    tts_cpp::lavasr::Denoiser& denoiser) {
+  try {
+    result.pcm = denoiser.denoise(result.pcm, result.sample_rate);
+  } catch (const std::exception& e) {
+    throw createTTSError(
+        TTSErrorCode::SynthesisFailed,
+        std::string("cosyvoice.lavasr-denoiser: ") + e.what());
+  }
+}
+
+// LavaSR neural bandwidth extension (batch path). Enhances the whole utterance
+// at once (the streaming path enhances per chunk instead) and updates
+// result.sample_rate to the enhancer's 48 kHz output.
+void applyBatchEnhancer(
+    tts_cpp::cosyvoice::SynthesisResult& result,
+    tts_cpp::lavasr::Enhancer& enhancer) {
+  try {
+    result.pcm = enhancer.enhance(result.pcm, result.sample_rate);
+    result.sample_rate = enhancer.output_sample_rate();
+  } catch (const std::exception& e) {
+    throw createTTSError(
+        TTSErrorCode::SynthesisFailed,
+        std::string("cosyvoice.lavasr: ") + e.what());
+  }
+}
+
+// Batch post-processing chain: denoise (rate-preserving) -> enhance (-> 48 kHz)
+// -> honour outputSampleRate. resampleBatchOutput closes both the enhanced and
+// the unenhanced case, since the enhancer leaves result.sample_rate at 48 kHz.
+void applyBatchPostProcessing(
+    const CosyvoiceConfig& cfg, tts_cpp::cosyvoice::SynthesisResult& result,
+    const std::shared_ptr<tts_cpp::lavasr::Denoiser>& denoiser,
+    const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer) {
+  if (denoiser)
+    applyBatchDenoiser(result, *denoiser);
+  if (enhancer)
+    applyBatchEnhancer(result, *enhancer);
+  resampleBatchOutput(cfg, result);
+}
+
+// Per-chunk post-processing for the native streaming path: an optional
+// seam-free LavaSR enhancement stage emitting int16 PCM through the caller's
+// callback. Kept as a functor so the engine can call it per chunk.
+struct StreamChunkPostProcessor {
+  const CosyvoiceModel::ChunkCallback& emit;
+  std::shared_ptr<StreamingEnhancer> streamEnhancer;
+  std::size_t& emittedSamples;
+
+  std::vector<float>
+  enhanceStage(const float* pcm, std::size_t samples, bool isLast) const {
+    std::vector<float> audio = streamEnhancer->feed(pcm, samples);
+    if (isLast) {
+      const std::vector<float> tail = streamEnhancer->flush();
+      audio.insert(audio.end(), tail.begin(), tail.end());
+    }
+    return audio;
+  }
+
+  void operator()(
+      const float* pcm, std::size_t samples, int chunkIndex, bool isLast) {
+    if (!streamEnhancer) {
+      emittedSamples += samples;
+      emit(pcmFloatToInt16(pcm, samples), chunkIndex, isLast);
+      return;
+    }
+    std::vector<float> audio = enhanceStage(pcm, samples, isLast);
+    emittedSamples += audio.size();
+    emit(pcmFloatToInt16(audio), chunkIndex, isLast);
+  }
+};
+
+} // namespace
 
 CosyvoiceModel::CosyvoiceModel(CosyvoiceConfig config)
     : cfg_(std::move(config)) {
@@ -149,6 +278,18 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
         TTSErrorCode::ModelFileNotFound,
         "reference audio not found: " + cfg.referenceAudio);
   }
+  if (!cfg.enhancerGgufPath.empty() &&
+      !std::filesystem::exists(cfg.enhancerGgufPath)) {
+    throw createTTSError(
+        TTSErrorCode::ModelFileNotFound,
+        "lavasr enhancer GGUF not found: " + cfg.enhancerGgufPath);
+  }
+  if (!cfg.denoiserGgufPath.empty() &&
+      !std::filesystem::exists(cfg.denoiserGgufPath)) {
+    throw createTTSError(
+        TTSErrorCode::ModelFileNotFound,
+        "lavasr denoiser GGUF not found: " + cfg.denoiserGgufPath);
+  }
   if (cfg.cfmSteps.has_value() && *cfg.cfmSteps < 0) {
     throw StatusError(general_error::InvalidArgument, "cfmSteps must be >= 0");
   }
@@ -174,18 +315,35 @@ void CosyvoiceModel::validateConfig(const CosyvoiceConfig& cfg) {
     throw StatusError(
         general_error::InvalidArgument, "streamLeftContextTokens must be >= 0");
   }
-  // CosyVoice emits its native 24 kHz per chunk while streaming; addon-side
-  // per-chunk resampling would break the seams, so reject a non-native output
-  // rate while streaming (batch output is resampled instead). AddonJs always
-  // installs a chunkCallback for CosyVoice, so streaming == streamChunkTokens>0
-  // at construction.
-  if (cfg.streamChunkTokens.value_or(0) > 0 &&
+  // CosyVoice emits its native 24 kHz per chunk while streaming; naive
+  // addon-side per-chunk resampling would break the seams, so reject a
+  // non-native output rate while streaming (batch output is resampled
+  // instead). The LavaSR enhancer is the exception: StreamingEnhancer already
+  // reprocesses an overlapping window and crossfades the seams, so it folds the
+  // requested rate into that seam-free stage. AddonJs always installs a
+  // chunkCallback for CosyVoice, so streaming == streamChunkTokens>0 at
+  // construction.
+  if (cfg.streamChunkTokens.value_or(0) > 0 && cfg.enhancerGgufPath.empty() &&
       cfg.outputSampleRate.has_value() && *cfg.outputSampleRate != 0 &&
       *cfg.outputSampleRate != kCosyvoiceNativeSampleRate) {
     throw StatusError(
         general_error::InvalidArgument,
-        "CosyVoice native streaming emits at 24000 Hz; drop outputSampleRate "
-        "or disable streaming (streamChunkTokens) for resampled batch output.");
+        "CosyVoice native streaming emits at 24000 Hz; drop outputSampleRate, "
+        "enable the LavaSR enhancer (which resamples seam-free), or disable "
+        "streaming (streamChunkTokens) for resampled batch output.");
+  }
+  // LavaSR denoiser + native chunk streaming is not supported yet: the UL-UNAS
+  // denoiser is causal but tts-cpp only exposes a one-shot denoise(), so a
+  // stateful streaming denoiser (à la StreamingEnhancer) is the follow-up.
+  // Reject the combo up front rather than silently dropping denoising on the
+  // streaming path. Defense-in-depth: index.js rejects it before we get here.
+  if (!cfg.denoiserGgufPath.empty() && cfg.streamChunkTokens.value_or(0) > 0) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "CosyvoiceModel: the LavaSR denoiser is not yet supported with native "
+        "chunk streaming (streamChunkTokens > 0). Use batch synthesis, or drop "
+        "the denoiser for streaming (streaming denoise is a planned "
+        "follow-up).");
   }
   // useGPU / nGpuLayers conflict check — mirrors the sibling engines so the
   // option surface behaves identically even though iteration 1 runs CPU-only.
@@ -248,9 +406,40 @@ void CosyvoiceModel::loadLocked() {
   backendDevice_ = backendDeviceCode(engine_->backend_device());
   backendId_ = backendIdFromName(backendName_);
   gpuUnsupported_ = engine_->gpu_unsupported();
+
+  // LavaSR enhancer: load when a GGUF path is set (empty path = disabled).
+  // Pass the engine's *resolved* device, not the requested switch: if the
+  // engine fell back to CPU, keep the enhancer on CPU too instead of forcing it
+  // onto the GPU. Shared with Chatterbox/Supertonic via loadEnhancer so the
+  // loaders can't drift.
+  LoadedEnhancer loaded = loadEnhancer(
+      cfg_.enhancerGgufPath,
+      backendDevice_ == kBackendDeviceGpu,
+      "CosyvoiceModel::load: lavasr enhancer: ");
+  enhancer_ = std::move(loaded.enhancer);
+  enhancerBackendDevice_ = loaded.backendDevice;
+  enhancerBackendId_ = loaded.backendId;
+
+  // LavaSR denoiser: load when a GGUF path is set (runs before the enhancer).
+  if (!cfg_.denoiserGgufPath.empty()) {
+    try {
+      denoiser_ = tts_cpp::lavasr::Denoiser::load(cfg_.denoiserGgufPath);
+    } catch (const std::exception& e) {
+      denoiser_.reset();
+      throw createTTSError(
+          TTSErrorCode::InitializationFailed,
+          std::string("CosyvoiceModel::load: lavasr denoiser: ") + e.what());
+    }
+  } else {
+    denoiser_.reset();
+  }
 }
 
-void CosyvoiceModel::unloadLocked() { engine_.reset(); }
+void CosyvoiceModel::unloadLocked() {
+  engine_.reset();
+  enhancer_.reset();
+  denoiser_.reset();
+}
 
 void CosyvoiceModel::cancel() const {
   cancelRequested_.store(true, std::memory_order_relaxed);
@@ -265,10 +454,17 @@ void CosyvoiceModel::cancel() const {
 
 CosyvoiceModel::SynthResult CosyvoiceModel::synthesize(
     const std::string& text, const ChunkCallback& onChunk) {
+  // Keep the engine (and enhancer/denoiser) alive for the whole call even if
+  // reload() swaps new ones in concurrently — the replacements take effect on
+  // the NEXT synthesize.
   std::shared_ptr<tts_cpp::cosyvoice::Engine> engine;
+  std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer;
+  std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser;
   {
     std::lock_guard lk(engineMu_);
     engine = engine_;
+    enhancer = enhancer_;
+    denoiser = denoiser_;
   }
   if (!engine) {
     throw createTTSError(
@@ -283,20 +479,25 @@ CosyvoiceModel::SynthResult CosyvoiceModel::synthesize(
   textLength_ = text.size();
 
   const bool streaming = streamingRequested(cfg_, static_cast<bool>(onChunk));
+  const EnhancerRates rates =
+      resolveEnhancerRates(enhancer, cfg_.outputSampleRate);
+
+  // The streaming callback runs synchronously on this thread, so this plain
+  // counter safely tallies the emitted sample count for the stats below.
+  std::size_t streamedSamples = 0;
 
   const auto t0 = std::chrono::steady_clock::now();
   tts_cpp::cosyvoice::SynthesisResult result;
   try {
     if (streaming) {
-      // Bridge the engine's float chunk callback to the JS int16 sink.
-      auto engineCb = [&onChunk](
-                          const float* pcm,
-                          std::size_t samples,
-                          int chunkIndex,
-                          bool isLast) {
-        onChunk(pcmFloatToInt16(pcm, samples), chunkIndex, isLast);
-      };
-      result = engine->synthesize(text, engineCb);
+      // Bridge the engine's float chunk callback to the JS int16 sink, running
+      // the seam-free LavaSR stage in between when the enhancer is active.
+      result = engine->synthesize(
+          text,
+          StreamChunkPostProcessor{
+              onChunk,
+              makeStreamingEnhancer(enhancer, rates),
+              streamedSamples});
     } else {
       result = engine->synthesize(text);
     }
@@ -306,9 +507,19 @@ CosyvoiceModel::SynthResult CosyvoiceModel::synthesize(
         std::string("cosyvoice.synthesize: ") + e.what());
   }
 
-  resampleBatchOutput(cfg_, result);
+  if (!streaming) {
+    applyBatchPostProcessing(cfg_, result, denoiser, enhancer);
+  }
   const auto t1 = std::chrono::steady_clock::now();
-  recordSynthesisStats(result, t0, t1);
+
+  // On the streaming+enhancer path chunks are emitted at streamFinalRate while
+  // result.sample_rate stays native; elsewhere result.sample_rate is already
+  // the emitted rate (batch enhance/resample updates it in place).
+  const int emittedRate =
+      (streaming && enhancer) ? rates.streamFinalRate : result.sample_rate;
+  const std::size_t emittedSamples =
+      streaming ? streamedSamples : result.pcm.size();
+  recordSynthesisStats(emittedSamples, emittedRate, result.duration_s, t0, t1);
 
   if (streaming) {
     return {Output{}, true}; // chunks already emitted via onChunk
@@ -317,14 +528,14 @@ CosyvoiceModel::SynthResult CosyvoiceModel::synthesize(
 }
 
 void CosyvoiceModel::recordSynthesisStats(
-    const tts_cpp::cosyvoice::SynthesisResult& result,
+    std::size_t outSamples, int emittedRate, float durationS,
     std::chrono::steady_clock::time_point t0,
     std::chrono::steady_clock::time_point t1) {
-  sampleRate_ = result.sample_rate;
-  totalSamples_ = static_cast<int64_t>(result.pcm.size());
+  sampleRate_ = emittedRate;
+  totalSamples_ = static_cast<int64_t>(outSamples);
   audioDurationMs_ =
-      result.duration_s > 0.0f
-          ? result.duration_s * 1000.0
+      durationS > 0.0f
+          ? durationS * 1000.0
           : (sampleRate_ > 0 ? (static_cast<double>(totalSamples_) * 1000.0 /
                                 static_cast<double>(sampleRate_))
                              : 0.0);
@@ -377,6 +588,10 @@ CosyvoiceModel::runtimeStats() const {
   stats.emplace_back("backendDevice", static_cast<int64_t>(backendDevice_));
   stats.emplace_back("backendId", static_cast<int64_t>(backendId_));
   stats.emplace_back("gpuUnsupported", static_cast<int64_t>(gpuUnsupported_));
+  stats.emplace_back(
+      "enhancerBackendDevice", static_cast<int64_t>(enhancerBackendDevice_));
+  stats.emplace_back(
+      "enhancerBackendId", static_cast<int64_t>(enhancerBackendId_));
   return stats;
 }
 

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.hpp
@@ -19,6 +19,11 @@ class Engine;
 struct SynthesisResult;
 } // namespace tts_cpp::cosyvoice
 
+namespace tts_cpp::lavasr {
+class Enhancer;
+class Denoiser;
+} // namespace tts_cpp::lavasr
+
 namespace qvac::ttsggml::cosyvoice {
 
 class CosyvoiceModel
@@ -77,8 +82,11 @@ private:
     bool wasStreaming = false;
   };
   SynthResult synthesize(const std::string& text, const ChunkCallback& onChunk);
+  // `outSamples` / `emittedRate` describe what actually reached the caller: on
+  // the streaming+enhancer path that is the enhanced stream, not the engine's
+  // native-rate SynthesisResult.
   void recordSynthesisStats(
-      const tts_cpp::cosyvoice::SynthesisResult& result,
+      std::size_t outSamples, int emittedRate, float durationS,
       std::chrono::steady_clock::time_point t0,
       std::chrono::steady_clock::time_point t1);
   static void validateConfig(const CosyvoiceConfig& cfg);
@@ -90,6 +98,14 @@ private:
 
   mutable std::mutex engineMu_;
   std::shared_ptr<tts_cpp::cosyvoice::Engine> engine_;
+  // LavaSR enhancer: loaded alongside the engine when cfg_.enhancerGgufPath is
+  // set; null disables enhancement. Holds only const weights, so it is safe to
+  // share across concurrent enhance() calls.
+  std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer_;
+  // LavaSR denoiser (runs before the enhancer, rate-preserving): loaded when
+  // cfg_.denoiserGgufPath is set; null disables denoising. Batch-only — the
+  // denoiser + streaming combination is rejected in validateConfig.
+  std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser_;
 
   std::atomic_bool jobInProgress_{false};
   mutable std::atomic_bool cancelRequested_{false};
@@ -106,6 +122,13 @@ private:
   int backendId_ = 0;
   bool gpuUnsupported_ = false;
   std::string backendName_ = "CPU";
+
+  // LavaSR enhancer backend, surfaced in runtimeStats so a host / GPU smoke
+  // test can confirm the enhancer network actually engaged the GPU. Device:
+  // -1 = no enhancer loaded, 0 = CPU, 1 = GPU. The id mirrors backendId_ and
+  // uses the same map as backendIdFromName() in BackendUtils.hpp.
+  int enhancerBackendDevice_ = -1;
+  int enhancerBackendId_ = -1;
 };
 
 // Streaming is requested when the config asks for chunked output and the job

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.hpp
@@ -3,6 +3,7 @@
 #include <any>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -142,5 +143,19 @@ bool streamingRequested(const CosyvoiceConfig& cfg, bool hasChunkCallback);
 // unit-testable without weights (see test_cosyvoice_config.cpp).
 void resampleBatchOutput(
     const CosyvoiceConfig& cfg, tts_cpp::cosyvoice::SynthesisResult& result);
+
+// What actually reached the caller, which is not always what the engine's
+// SynthesisResult describes: while streaming with the enhancer, chunks are
+// emitted at the enhancer's final rate but the result stays at the native rate.
+struct EmittedAudio {
+  std::size_t samples = 0;
+  int sampleRate = 0;
+};
+
+// Free function for the same reason as streamingRequested: the stats depend on
+// this choice, and getting it wrong is silent.
+EmittedAudio resolveEmittedAudio(
+    bool streaming, bool enhanced, int streamFinalRate,
+    std::size_t streamedSamples, std::size_t batchSamples, int batchRate);
 
 } // namespace qvac::ttsggml::cosyvoice

--- a/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -54,14 +55,35 @@ CosyvoiceConfig configWithExistingDir() {
   return cfg;
 }
 
-// A file that exists but holds no LavaSR weights. validateConfig only checks
-// for presence, so this is enough to exercise the accept path; an actual
-// Enhancer::load would happen later in load().
-std::string existingFile(const char* name) {
-  auto path = emptyModelDir() / name;
-  std::ofstream(path) << "not-a-real-gguf";
-  return path.string();
+// Placeholder LavaSR GGUFs are staged outside the model dir so the latter keeps
+// matching the "holds no weights" contract above.
+std::filesystem::path lavasrStageDir() {
+  auto dir = std::filesystem::temp_directory_path() /
+             "qvac-tts-ggml-cosyvoice-tests-lavasr";
+  std::filesystem::create_directories(dir);
+  return dir;
 }
+
+// A file that exists but holds no LavaSR weights, removed again when the test
+// ends. validateConfig only checks for presence, so this is enough to exercise
+// the accept path; an actual Enhancer::load would happen later in load().
+class TempGguf {
+public:
+  explicit TempGguf(const char* name) : path_(lavasrStageDir() / name) {
+    std::ofstream(path_) << "not-a-real-gguf";
+  }
+  ~TempGguf() {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+  TempGguf(const TempGguf&) = delete;
+  TempGguf& operator=(const TempGguf&) = delete;
+
+  std::string path() const { return path_.string(); }
+
+private:
+  std::filesystem::path path_;
+};
 
 } // namespace
 
@@ -121,10 +143,11 @@ TEST(CosyvoiceValidate, StreamingNonNativeOutputRateRejected) {
 // The LavaSR enhancer resamples inside its overlap-reprocess window, so it
 // lifts the streaming native-rate restriction above.
 TEST(CosyvoiceValidate, StreamingNonNativeOutputRateAcceptedWithEnhancer) {
+  const TempGguf enhancer("lavasr-enhancer.gguf");
   auto cfg = configWithExistingDir();
   cfg.streamChunkTokens = 25;
   cfg.outputSampleRate = 16000;
-  cfg.enhancerGgufPath = existingFile("lavasr-enhancer.gguf");
+  cfg.enhancerGgufPath = enhancer.path();
   EXPECT_NO_THROW(CosyvoiceModel{cfg});
 }
 
@@ -141,8 +164,9 @@ TEST(CosyvoiceValidate, NonexistentDenoiserGgufRejected) {
 }
 
 TEST(CosyvoiceValidate, EnhancerAcceptedForBatchAndStreaming) {
+  const TempGguf enhancer("lavasr-enhancer.gguf");
   auto base = configWithExistingDir();
-  base.enhancerGgufPath = existingFile("lavasr-enhancer.gguf");
+  base.enhancerGgufPath = enhancer.path();
 
   EXPECT_NO_THROW(CosyvoiceModel{base});
 
@@ -154,8 +178,9 @@ TEST(CosyvoiceValidate, EnhancerAcceptedForBatchAndStreaming) {
 // The UL-UNAS denoiser is one-shot in tts-cpp, so it stays batch-only until a
 // stateful streaming denoiser lands.
 TEST(CosyvoiceValidate, DenoiserAcceptedForBatchButRejectedWhileStreaming) {
+  const TempGguf denoiser("lavasr-denoiser.gguf");
   auto batch = configWithExistingDir();
-  batch.denoiserGgufPath = existingFile("lavasr-denoiser.gguf");
+  batch.denoiserGgufPath = denoiser.path();
   EXPECT_NO_THROW(CosyvoiceModel{batch});
 
   auto streaming = batch;

--- a/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
@@ -28,6 +28,7 @@
 using qvac::ttsggml::cosyvoice::CosyvoiceConfig;
 using qvac::ttsggml::cosyvoice::CosyvoiceModel;
 using qvac::ttsggml::cosyvoice::resampleBatchOutput;
+using qvac::ttsggml::cosyvoice::resolveEmittedAudio;
 using qvac::ttsggml::cosyvoice::streamingRequested;
 using qvac_errors::StatusError;
 
@@ -203,6 +204,42 @@ TEST(CosyvoiceStreaming, StreamingRequestedContract) {
   CosyvoiceConfig cfgZeroChunks;
   cfgZeroChunks.streamChunkTokens = 0;
   EXPECT_FALSE(streamingRequested(cfgZeroChunks, true));
+}
+
+// The stats are read off whatever actually reached the caller. Only the
+// streaming+enhancer path diverges from the engine's SynthesisResult, and
+// getting it wrong understates totalSamples or reports the wrong rate without
+// failing anything, so pin all four combinations.
+TEST(CosyvoiceStreaming, EmittedAudioFollowsWhatTheCallerReceived) {
+  constexpr std::size_t kStreamed = 96000;
+  constexpr std::size_t kBatch = 48000;
+  constexpr int kFinalRate = 16000;
+  constexpr int kBatchRate = 24000;
+
+  const auto batchPlain = resolveEmittedAudio(
+      false, false, kFinalRate, kStreamed, kBatch, kBatchRate);
+  EXPECT_EQ(batchPlain.samples, kBatch);
+  EXPECT_EQ(batchPlain.sampleRate, kBatchRate);
+
+  // Batch enhancement rewrites SynthesisResult in place, so the batch rate is
+  // already the emitted one and the enhancer flag changes nothing.
+  const auto batchEnhanced =
+      resolveEmittedAudio(false, true, kFinalRate, kStreamed, kBatch, 48000);
+  EXPECT_EQ(batchEnhanced.samples, kBatch);
+  EXPECT_EQ(batchEnhanced.sampleRate, 48000);
+
+  const auto streamPlain = resolveEmittedAudio(
+      true, false, kFinalRate, kStreamed, kBatch, kBatchRate);
+  EXPECT_EQ(streamPlain.samples, kStreamed);
+  EXPECT_EQ(streamPlain.sampleRate, kBatchRate)
+      << "unenhanced streaming emits at the engine's native rate";
+
+  const auto streamEnhanced = resolveEmittedAudio(
+      true, true, kFinalRate, kStreamed, kBatch, kBatchRate);
+  EXPECT_EQ(streamEnhanced.samples, kStreamed);
+  EXPECT_EQ(streamEnhanced.sampleRate, kFinalRate)
+      << "the enhanced stream is emitted at the enhancer's final rate, not the "
+         "native rate the SynthesisResult still reports";
 }
 
 TEST(CosyvoiceValidate, ConfigDefaultsAreCpuFriendly) {

--- a/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -51,6 +52,15 @@ CosyvoiceConfig configWithExistingDir() {
   CosyvoiceConfig cfg;
   cfg.modelDir = emptyModelDir().string();
   return cfg;
+}
+
+// A file that exists but holds no LavaSR weights. validateConfig only checks
+// for presence, so this is enough to exercise the accept path; an actual
+// Enhancer::load would happen later in load().
+std::string existingFile(const char* name) {
+  auto path = emptyModelDir() / name;
+  std::ofstream(path) << "not-a-real-gguf";
+  return path.string();
 }
 
 } // namespace
@@ -106,6 +116,51 @@ TEST(CosyvoiceValidate, StreamingNonNativeOutputRateRejected) {
   cfg.streamChunkTokens = 25;
   cfg.outputSampleRate = 16000; // non-native while streaming
   EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+// The LavaSR enhancer resamples inside its overlap-reprocess window, so it
+// lifts the streaming native-rate restriction above.
+TEST(CosyvoiceValidate, StreamingNonNativeOutputRateAcceptedWithEnhancer) {
+  auto cfg = configWithExistingDir();
+  cfg.streamChunkTokens = 25;
+  cfg.outputSampleRate = 16000;
+  cfg.enhancerGgufPath = existingFile("lavasr-enhancer.gguf");
+  EXPECT_NO_THROW(CosyvoiceModel{cfg});
+}
+
+TEST(CosyvoiceValidate, NonexistentEnhancerGgufRejected) {
+  auto cfg = configWithExistingDir();
+  cfg.enhancerGgufPath = "/definitely/does/not/exist/lavasr-enhancer.gguf";
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, NonexistentDenoiserGgufRejected) {
+  auto cfg = configWithExistingDir();
+  cfg.denoiserGgufPath = "/definitely/does/not/exist/lavasr-denoiser.gguf";
+  EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+TEST(CosyvoiceValidate, EnhancerAcceptedForBatchAndStreaming) {
+  auto base = configWithExistingDir();
+  base.enhancerGgufPath = existingFile("lavasr-enhancer.gguf");
+
+  EXPECT_NO_THROW(CosyvoiceModel{base});
+
+  auto streaming = base;
+  streaming.streamChunkTokens = 25;
+  EXPECT_NO_THROW(CosyvoiceModel{streaming});
+}
+
+// The UL-UNAS denoiser is one-shot in tts-cpp, so it stays batch-only until a
+// stateful streaming denoiser lands.
+TEST(CosyvoiceValidate, DenoiserAcceptedForBatchButRejectedWhileStreaming) {
+  auto batch = configWithExistingDir();
+  batch.denoiserGgufPath = existingFile("lavasr-denoiser.gguf");
+  EXPECT_NO_THROW(CosyvoiceModel{batch});
+
+  auto streaming = batch;
+  streaming.streamChunkTokens = 25;
+  EXPECT_THROW(CosyvoiceModel{streaming}, StatusError);
 }
 
 // Ungated coverage of the wasStreaming decision (the double-emit fix):

--- a/packages/tts-ggml/addon/tests/test_streaming_enhancer.cpp
+++ b/packages/tts-ggml/addon/tests/test_streaming_enhancer.cpp
@@ -1,6 +1,6 @@
 // Unit tests for StreamingEnhancer — the stateful wrapper that lets the
-// Chatterbox native chunk-streaming path emit LavaSR-enhanced audio chunk by
-// chunk (overlap-reprocess with look-ahead margin + crossfade).
+// Chatterbox and CosyVoice3 native chunk-streaming paths emit LavaSR-enhanced
+// audio chunk by chunk (overlap-reprocess with look-ahead margin + crossfade).
 //
 // The real enhancer is injected as a transform, so these exercise the
 // streaming bookkeeping (windowing, hold-back, crossfade, compaction) in
@@ -21,6 +21,23 @@
 using qvac::ttsggml::StreamingEnhancer;
 
 namespace {
+
+constexpr int kNativeRate = 24000;
+constexpr int kEnhancedRate = 48000;
+constexpr float kToneHz = 180.0f;
+
+// Hops matching streamChunkTokens 25 and 5 at the CosyVoice3 token rate.
+constexpr std::size_t kOneSecondHop = 24000;
+constexpr std::size_t kFifthSecondHop = 4800;
+
+constexpr float kShortUtteranceSeconds = 5.0f;
+constexpr float kLongUtteranceSeconds = 30.0f;
+
+// Each window re-feeds context + margin + crossfade (8192 + 8192 + 256) around
+// the committed hop, so amplification settles near 1 + 16640/hop.
+constexpr double kMaxAmplificationAtOneSecondHops = 1.8;
+constexpr double kMinAmplificationAtFifthSecondHops = 4.0;
+constexpr double kAmplificationTolerance = 0.05;
 
 // Shift-invariant linear upsample-by-2 (24k -> 48k stand-in). Temporal support
 // is 1 input sample (out[2k+1] reads in[k+1]); the last sample clamps. This is
@@ -82,6 +99,22 @@ std::vector<float> streamChunks(
   const auto tail = se.flush();
   out.insert(out.end(), tail.begin(), tail.end());
   return out;
+}
+
+// Total input the enhancer is handed, divided by the utterance length: the
+// factor by which overlap-reprocess multiplies a single batch pass.
+double reprocessAmplification(float seconds, std::size_t hop) {
+  std::size_t processed = 0;
+  StreamingEnhancer se(
+      [&processed](const std::vector<float>& block) {
+        processed += block.size();
+        return upsample2(block);
+      },
+      kNativeRate,
+      kEnhancedRate);
+  const auto in = sine(kToneHz, seconds, kNativeRate);
+  streamChunks(se, in, hop);
+  return static_cast<double>(processed) / static_cast<double>(in.size());
 }
 
 } // namespace
@@ -211,4 +244,27 @@ TEST(StreamingEnhancer, MemoryStaysBounded) {
   ASSERT_EQ(streamed.size(), batch.size());
   for (std::size_t i = 0; i < batch.size(); ++i)
     ASSERT_FLOAT_EQ(streamed[i], batch[i]) << "mismatch at sample " << i;
+}
+
+TEST(StreamingEnhancer, ReprocessCostDoesNotGrowWithUtteranceLength) {
+  const double shortUtterance =
+      reprocessAmplification(kShortUtteranceSeconds, kOneSecondHop);
+  const double longUtterance =
+      reprocessAmplification(kLongUtteranceSeconds, kOneSecondHop);
+
+  EXPECT_LT(longUtterance, kMaxAmplificationAtOneSecondHops);
+  EXPECT_NEAR(shortUtterance, longUtterance, kAmplificationTolerance)
+      << "overlap-reprocess must cost a constant factor of a batch pass, not "
+         "one that grows with utterance length";
+}
+
+TEST(StreamingEnhancer, ReprocessCostRisesAsHopsShrink) {
+  const double oneSecondHops =
+      reprocessAmplification(kLongUtteranceSeconds, kOneSecondHop);
+  const double fifthSecondHops =
+      reprocessAmplification(kLongUtteranceSeconds, kFifthSecondHop);
+
+  EXPECT_LT(oneSecondHops, kMaxAmplificationAtOneSecondHops);
+  EXPECT_GT(fifthSecondHops, kMinAmplificationAtFifthSecondHops)
+      << "the fixed per-window context + margin dominates once hops are small";
 }

--- a/packages/tts-ggml/examples/cosyvoice-enhanced.js
+++ b/packages/tts-ggml/examples/cosyvoice-enhanced.js
@@ -1,0 +1,132 @@
+'use strict'
+
+/**
+ * CosyVoice3 TTS + LavaSR neural enhancement for @qvac/tts-ggml.
+ *
+ * Synthesizes a single utterance with CosyVoice3, then opts into the LavaSR
+ * enhancer: a lightweight Vocos bandwidth-extension network (ConvNeXt backbone
+ * + ISTFT spec head) that upsamples CosyVoice3's native 24 kHz output to 48 kHz
+ * with a synthesised high band. Output is 48 kHz when enhancement is on.
+ *
+ * Pass a third argument to also run the LavaSR denoiser (UL-UNAS) before the
+ * enhancer; it is rate-preserving and batch-only.
+ *
+ * Usage:
+ *   bare examples/cosyvoice-enhanced.js "text to synthesize" [modelDir] [--denoise]
+ *
+ * Expects:
+ *   models/cosyvoice3/                   (or set COSYVOICE_MODEL_DIR)
+ *   models/lavasr/lavasr-enhancer.gguf   (or set LAVASR_ENHANCER_GGUF)
+ *   models/lavasr/lavasr-denoiser.gguf   (--denoise only; or LAVASR_DENOISER_GGUF)
+ *
+ * Convert the enhancer GGUF from the public LavaSRcpp ONNX release with:
+ *   python scripts/convert-lavasr-enhancer-to-gguf.py \
+ *     --backbone enhancer_backbone.onnx --spec-head enhancer_spec_head.onnx \
+ *     --out models/lavasr/lavasr-enhancer.gguf --ftype f16
+ */
+
+const fs = require('bare-fs')
+const path = require('bare-path')
+const TTSGgml = require('../')
+const { createWav } = require('./wav-helper')
+const { setLogger, releaseLogger } = require('../addonLogging')
+
+const ENHANCED_SAMPLE_RATE = 48000
+
+const argv = global.Bare ? global.Bare.argv : process.argv
+const env = (global.Bare && global.Bare.env) || (typeof process !== 'undefined' && process.env) || {}
+const textArg = argv[2]
+const modelDirArg = argv[3] && argv[3] !== '--denoise' ? argv[3] : undefined
+const denoise = argv.includes('--denoise')
+
+if (!textArg || typeof textArg !== 'string' || textArg.trim().length === 0) {
+  console.error('Usage: cosyvoice-enhanced.js "<text to synthesize>" [modelDir] [--denoise]')
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+}
+
+const pkgRoot = path.join(__dirname, '..')
+const modelDir = path.join(pkgRoot, 'models')
+const cosyvoiceModelDir =
+  modelDirArg || env.COSYVOICE_MODEL_DIR || path.join(modelDir, 'cosyvoice3')
+const enhancerGguf =
+  env.LAVASR_ENHANCER_GGUF || path.join(modelDir, 'lavasr', 'lavasr-enhancer.gguf')
+const denoiserGguf =
+  env.LAVASR_DENOISER_GGUF || path.join(modelDir, 'lavasr', 'lavasr-denoiser.gguf')
+
+const required = [
+  ['cosyvoice3 model dir', cosyvoiceModelDir],
+  ['lavasr enhancer', enhancerGguf]
+]
+if (denoise) required.push(['lavasr denoiser', denoiserGguf])
+
+for (const [label, file] of required) {
+  if (!fs.existsSync(file)) {
+    console.error(`Missing ${label}: ${file}`)
+    console.error('Assemble the model dir with tts-cpp/scripts/assemble-cosyvoice3-model.py,')
+    console.error('and convert the LavaSR GGUFs with the scripts referenced in README.md')
+    console.error('(or set COSYVOICE_MODEL_DIR / LAVASR_ENHANCER_GGUF / LAVASR_DENOISER_GGUF).')
+    if (global.Bare) global.Bare.exit(1)
+    else process.exit(1)
+  }
+}
+
+async function main () {
+  setLogger((priority, message) => {
+    if (priority > 1) return
+    const names = { 0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG', 4: 'OFF' }
+    console.log(`[C++ log] [${names[priority] || 'UNKNOWN'}]: ${message}`)
+  })
+
+  const outputFile = path.join(__dirname, 'cosyvoice-enhanced-output.wav')
+
+  // Supplying the LavaSR GGUFs (files.lavasrEnhancer / files.lavasrDenoiser) is
+  // what turns each stage on — there is no separate on/off flag.
+  const files = { cosyvoiceModelDir, lavasrEnhancer: enhancerGguf }
+  if (denoise) files.lavasrDenoiser = denoiserGguf
+
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_COSYVOICE3,
+    files,
+    config: { language: 'en', useGPU: false },
+    logger: console,
+    opts: { stats: true }
+  })
+
+  try {
+    console.log(`Loading CosyVoice3 + LavaSR enhancer${denoise ? ' + denoiser' : ''}...`)
+    await model.load()
+    console.log(`Running enhanced TTS on: "${textArg}"`)
+
+    const response = await model.run({ input: textArg, type: 'text' })
+
+    let buffer = []
+    let sampleRate = ENHANCED_SAMPLE_RATE
+    await response
+      .onUpdate(data => {
+        if (data && data.outputArray) buffer = buffer.concat(Array.from(data.outputArray))
+        if (data && data.sampleRate) sampleRate = data.sampleRate
+      })
+      .await()
+
+    console.log(`TTS finished! Reported sample rate: ${sampleRate} Hz (expect 48000 with enhancement).`)
+    if (response.stats) {
+      const s = response.stats
+      console.log(`Enhancer ran on backendDevice=${s.enhancerBackendDevice} (-1 none / 0 CPU / 1 GPU)`)
+    }
+    createWav(buffer, sampleRate, outputFile)
+    console.log(`Wrote ${outputFile}`)
+  } catch (err) {
+    console.error('Error during enhanced TTS:', err)
+    throw err
+  } finally {
+    await model.unload()
+    releaseLogger()
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+})

--- a/packages/tts-ggml/examples/cosyvoice-enhanced.js
+++ b/packages/tts-ggml/examples/cosyvoice-enhanced.js
@@ -27,6 +27,7 @@
 
 const fs = require('bare-fs')
 const path = require('bare-path')
+const proc = require('bare-process')
 const TTSGgml = require('../')
 const { createWav } = require('./wav-helper')
 const { setLogger, releaseLogger } = require('../addonLogging')
@@ -34,7 +35,7 @@ const { setLogger, releaseLogger } = require('../addonLogging')
 const ENHANCED_SAMPLE_RATE = 48000
 
 const argv = global.Bare ? global.Bare.argv : process.argv
-const env = (global.Bare && global.Bare.env) || (typeof process !== 'undefined' && process.env) || {}
+const env = proc.env || {}
 const textArg = argv[2]
 const modelDirArg = argv[3] && argv[3] !== '--denoise' ? argv[3] : undefined
 const denoise = argv.includes('--denoise')

--- a/packages/tts-ggml/examples/cosyvoice-tts.js
+++ b/packages/tts-ggml/examples/cosyvoice-tts.js
@@ -25,6 +25,7 @@
 
 const fs = require('bare-fs')
 const path = require('bare-path')
+const proc = require('bare-process')
 const TTSGgml = require('../')
 const { createWav } = require('./wav-helper')
 const { setLogger, releaseLogger } = require('../addonLogging')
@@ -32,7 +33,7 @@ const { setLogger, releaseLogger } = require('../addonLogging')
 const COSYVOICE_SAMPLE_RATE = 24000
 
 const argv = global.Bare ? global.Bare.argv : process.argv
-const env = (global.Bare && global.Bare.env) || (typeof process !== 'undefined' && process.env) || {}
+const env = proc.env || {}
 const textArg = argv[2]
 const modelDirArg = argv[3]
 

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -157,9 +157,13 @@ interface TTSGgmlRuntimeConfig {
     useGPU?: boolean;
     /**
      * Desired output sample rate in Hz (8000-192000); omit to keep the engine's
-     * native rate. Resamples the native output (24 kHz Chatterbox, 44.1 kHz
-     * Supertonic), or the 48 kHz LavaSR-enhanced signal, before emitting.
-     * `TTSOutputChunk.sampleRate` reports the resulting rate.
+     * native rate. Resamples the native output (24 kHz Chatterbox and
+     * CosyVoice3, 44.1 kHz Supertonic), or the 48 kHz LavaSR-enhanced signal,
+     * before emitting. `TTSOutputChunk.sampleRate` reports the resulting rate.
+     *
+     * CosyVoice3 native chunk streaming emits at 24 kHz: a different rate is
+     * only accepted there when the LavaSR enhancer is active, because the
+     * enhancer's overlap-reprocess window resamples without chunk seams.
      */
     outputSampleRate?: number;
     backendsDir?: string;
@@ -300,14 +304,16 @@ interface TTSGgmlOptions extends ParlerDescriptionFields {
     /**
      * LavaSR neural speech enhancement. Opt-in CPU/GGML bandwidth extension to
      * 48 kHz, enabled by a GGUF path here or through `files.lavasrEnhancer`.
-     * Works for both engines, including Chatterbox native chunk streaming.
+     * Supported by Chatterbox, Supertonic and CosyVoice3, including the native
+     * chunk streaming of Chatterbox and CosyVoice3 (Parler is rejected: it
+     * already emits 44.1 kHz).
      */
     enhancer?: LavaSREnhancerOptions;
     /**
      * LavaSR neural speech denoiser (UL-UNAS). Opt-in preprocessing that runs
      * before the enhancer and preserves the sample rate. Enabled by a GGUF path
-     * here or through `files.lavasrDenoiser`; rejected with Chatterbox native
-     * chunk streaming.
+     * here or through `files.lavasrDenoiser`; rejected with native chunk
+     * streaming (batch synthesis only).
      */
     denoiser?: LavaSRDenoiserOptions;
     /** Directory the addon scans for dynamically loaded ggml backends. */

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -495,6 +495,7 @@ declare class TTSGgml {
     private _resolveEngineAndModelPaths;
     private _assignSynthesisOptions;
     private _assertEngineStreamingSupport;
+    private _requestsChunkStreaming;
     private _assertParlerOptionConsistency;
     private _assertCosyvoiceOptionConsistency;
     /**

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -683,15 +683,19 @@ class TTSGgml {
         // streaming guards, matching the pre-migration single-method throw order.
         this._assertParlerOptionConsistency();
         this._assertCosyvoiceOptionConsistency();
-        if (this._denoiserGgufPath &&
-            (this._streamChunkTokens != null ||
-                this._streamFirstChunkTokens != null)) {
+        if (this._denoiserGgufPath && this._requestsChunkStreaming()) {
             throw new Error("tts-ggml: the LavaSR denoiser is not yet supported with " +
                 "native chunk streaming (streamChunkTokens / " +
                 "streamFirstChunkTokens). Use batch synthesis, or drop the " +
                 "denoiser for streaming. Streaming denoise is a planned " +
                 "follow-up (needs a stateful streaming denoiser).");
         }
+    }
+    // A token count of 0 means "no streaming" (same contract the addon's
+    // validateConfig enforces), so only a positive count requests it.
+    _requestsChunkStreaming() {
+        return ((this._streamChunkTokens ?? 0) > 0 ||
+            (this._streamFirstChunkTokens ?? 0) > 0);
     }
     _assertParlerOptionConsistency() {
         if (this._engineType === ENGINE_PARLER) {

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -687,7 +687,7 @@ class TTSGgml {
             (this._streamChunkTokens != null ||
                 this._streamFirstChunkTokens != null)) {
             throw new Error("tts-ggml: the LavaSR denoiser is not yet supported with " +
-                "Chatterbox native chunk streaming (streamChunkTokens / " +
+                "native chunk streaming (streamChunkTokens / " +
                 "streamFirstChunkTokens). Use batch synthesis, or drop the " +
                 "denoiser for streaming. Streaming denoise is a planned " +
                 "follow-up (needs a stateful streaming denoiser).");
@@ -742,15 +742,8 @@ class TTSGgml {
         }
     }
     _assertCosyvoiceOptionConsistency() {
-        if (this._engineType === ENGINE_COSYVOICE3) {
-            // CosyVoice3 outputs no LavaSR-supported signal; reject the enhancer/
-            // denoiser at construction (mirrors the parler rejection).
-            if (this._enhancerGgufPath || this._denoiserGgufPath) {
-                throw new Error("tts-ggml: CosyVoice3 does not support LavaSR enhancement/denoising. " +
-                    "Drop lavasrEnhancer / lavasrDenoiser.");
-            }
+        if (this._engineType === ENGINE_COSYVOICE3)
             return;
-        }
         const cosyvoiceOnly = [];
         const cosyvoiceOnlyFields = {
             instruct: this._instruct,

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -24,6 +24,8 @@
     "example:supertonic-mtl": "bare examples/supertonic-mtl-tts.js \"Hello from the multilingual Supertonic engine.\"",
     "example:supertonic-mtl-sweep": "bare examples/supertonic-mtl-sweep-tts.js",
     "example:supertonic-sentence-stream": "bare examples/supertonic-sentence-stream-tts.js",
+    "example:cosyvoice": "bare examples/cosyvoice-tts.js \"Hello from CosyVoice three.\"",
+    "example:cosyvoice-enhanced": "bare examples/cosyvoice-enhanced.js \"Hello from CosyVoice three.\"",
     "example:parler": "bare examples/parler-tts.js \"Hey, how are you doing today?\"",
     "lint": "npm run lint:js && npm run lint:ts && npm run test:types",
     "lint:js": "prettier --check \"test/**/*.js\" \"binding.js\" && lunte \"test/**/*.js\" \"binding.js\"",

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -1358,11 +1358,7 @@ class TTSGgml {
     // streaming guards, matching the pre-migration single-method throw order.
     this._assertParlerOptionConsistency();
     this._assertCosyvoiceOptionConsistency();
-    if (
-      this._denoiserGgufPath &&
-      (this._streamChunkTokens != null ||
-        this._streamFirstChunkTokens != null)
-    ) {
+    if (this._denoiserGgufPath && this._requestsChunkStreaming()) {
       throw new Error(
         "tts-ggml: the LavaSR denoiser is not yet supported with " +
           "native chunk streaming (streamChunkTokens / " +
@@ -1371,6 +1367,15 @@ class TTSGgml {
           "follow-up (needs a stateful streaming denoiser).",
       );
     }
+  }
+
+  // A token count of 0 means "no streaming" (same contract the addon's
+  // validateConfig enforces), so only a positive count requests it.
+  private _requestsChunkStreaming(): boolean {
+    return (
+      (this._streamChunkTokens ?? 0) > 0 ||
+      (this._streamFirstChunkTokens ?? 0) > 0
+    );
   }
 
   private _assertParlerOptionConsistency(): void {

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -313,9 +313,13 @@ interface TTSGgmlRuntimeConfig {
   useGPU?: boolean;
   /**
    * Desired output sample rate in Hz (8000-192000); omit to keep the engine's
-   * native rate. Resamples the native output (24 kHz Chatterbox, 44.1 kHz
-   * Supertonic), or the 48 kHz LavaSR-enhanced signal, before emitting.
-   * `TTSOutputChunk.sampleRate` reports the resulting rate.
+   * native rate. Resamples the native output (24 kHz Chatterbox and
+   * CosyVoice3, 44.1 kHz Supertonic), or the 48 kHz LavaSR-enhanced signal,
+   * before emitting. `TTSOutputChunk.sampleRate` reports the resulting rate.
+   *
+   * CosyVoice3 native chunk streaming emits at 24 kHz: a different rate is
+   * only accepted there when the LavaSR enhancer is active, because the
+   * enhancer's overlap-reprocess window resamples without chunk seams.
    */
   outputSampleRate?: number;
   backendsDir?: string;
@@ -460,14 +464,16 @@ interface TTSGgmlOptions extends ParlerDescriptionFields {
   /**
    * LavaSR neural speech enhancement. Opt-in CPU/GGML bandwidth extension to
    * 48 kHz, enabled by a GGUF path here or through `files.lavasrEnhancer`.
-   * Works for both engines, including Chatterbox native chunk streaming.
+   * Supported by Chatterbox, Supertonic and CosyVoice3, including the native
+   * chunk streaming of Chatterbox and CosyVoice3 (Parler is rejected: it
+   * already emits 44.1 kHz).
    */
   enhancer?: LavaSREnhancerOptions;
   /**
    * LavaSR neural speech denoiser (UL-UNAS). Opt-in preprocessing that runs
    * before the enhancer and preserves the sample rate. Enabled by a GGUF path
-   * here or through `files.lavasrDenoiser`; rejected with Chatterbox native
-   * chunk streaming.
+   * here or through `files.lavasrDenoiser`; rejected with native chunk
+   * streaming (batch synthesis only).
    */
   denoiser?: LavaSRDenoiserOptions;
   /** Directory the addon scans for dynamically loaded ggml backends. */
@@ -1359,7 +1365,7 @@ class TTSGgml {
     ) {
       throw new Error(
         "tts-ggml: the LavaSR denoiser is not yet supported with " +
-          "Chatterbox native chunk streaming (streamChunkTokens / " +
+          "native chunk streaming (streamChunkTokens / " +
           "streamFirstChunkTokens). Use batch synthesis, or drop the " +
           "denoiser for streaming. Streaming denoise is a planned " +
           "follow-up (needs a stateful streaming denoiser).",
@@ -1426,17 +1432,7 @@ class TTSGgml {
   }
 
   private _assertCosyvoiceOptionConsistency(): void {
-    if (this._engineType === ENGINE_COSYVOICE3) {
-      // CosyVoice3 outputs no LavaSR-supported signal; reject the enhancer/
-      // denoiser at construction (mirrors the parler rejection).
-      if (this._enhancerGgufPath || this._denoiserGgufPath) {
-        throw new Error(
-          "tts-ggml: CosyVoice3 does not support LavaSR enhancement/denoising. " +
-            "Drop lavasrEnhancer / lavasrDenoiser.",
-        );
-      }
-      return;
-    }
+    if (this._engineType === ENGINE_COSYVOICE3) return;
     const cosyvoiceOnly: string[] = [];
     const cosyvoiceOnlyFields: Record<
       string,

--- a/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
+++ b/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
@@ -3,13 +3,13 @@
 // LavaSR enhancer integration + regression tests.
 //
 // The construct-time tests need no models and always run in CI. They pin:
-// enhancer + Chatterbox native chunk streaming is now supported (constructs and
-// forwards both knobs — the addon enhances each chunk seam-free), and a
-// misconfigured enhancer can't silently become a no-op (an unknown
-// enhancer.type throws). The model-backed tests assert the enhanced output is
-// reported as 48 kHz for both engines (incl. Chatterbox native streaming);
-// they are gated on the converted enhancer GGUF being staged, and skip cleanly
-// otherwise.
+// enhancer + native chunk streaming is now supported on Chatterbox and
+// CosyVoice3 (constructs and forwards both knobs — the addon enhances each
+// chunk seam-free), the denoiser stays batch-only, and a misconfigured enhancer
+// can't silently become a no-op (an unknown enhancer.type throws). The
+// model-backed tests assert the enhanced output is reported as 48 kHz for both
+// engines (incl. Chatterbox native streaming); they are gated on the converted
+// enhancer GGUF being staged, and skip cleanly otherwise.
 //
 // Stage the enhancer GGUF via scripts/convert-lavasr-enhancer-to-gguf.py (from
 // the public LavaSRcpp ONNX release) into models/lavasr/lavasr-enhancer.gguf,
@@ -156,6 +156,59 @@ test('Chatterbox: enhancer + streamChunkTokens constructs and forwards both', (t
   )
 })
 
+test('CosyVoice3: enhancer + streamChunkTokens constructs and forwards both', (t) => {
+  // CosyVoice3 used to reject the enhancer outright; it is now supported on the
+  // batch path and on native chunk streaming, so both knobs must reach the
+  // addon together.
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_COSYVOICE3,
+    files: {
+      cosyvoiceModelDir: './models/cosyvoice3',
+      lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
+    },
+    streamChunkTokens: 25,
+    config: { language: 'en' }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.streamChunkTokens, 25, 'streamChunkTokens forwarded')
+  t.is(
+    params.lavasrEnhancerPath,
+    './models/lavasr/lavasr-enhancer.gguf',
+    'enhancer path forwarded alongside streamChunkTokens'
+  )
+})
+
+test('CosyVoice3: denoiser is forwarded for batch but rejected with streaming', (t) => {
+  const batch = new TTSGgml({
+    engine: TTSGgml.ENGINE_COSYVOICE3,
+    files: {
+      cosyvoiceModelDir: './models/cosyvoice3',
+      lavasrDenoiser: './models/lavasr/lavasr-denoiser.gguf'
+    },
+    config: { language: 'en' }
+  })
+  t.is(
+    batch._buildTtsParams().lavasrDenoiserPath,
+    './models/lavasr/lavasr-denoiser.gguf',
+    'denoiser path forwarded on the batch path'
+  )
+
+  t.exception(
+    () =>
+      new TTSGgml({
+        engine: TTSGgml.ENGINE_COSYVOICE3,
+        files: {
+          cosyvoiceModelDir: './models/cosyvoice3',
+          lavasrDenoiser: './models/lavasr/lavasr-denoiser.gguf'
+        },
+        streamChunkTokens: 25,
+        config: { language: 'en' }
+      }),
+    /denoiser is not yet supported with native chunk streaming/,
+    'denoiser + native chunk streaming throws (unlike the enhancer)'
+  )
+})
+
 test('enhancer with an unknown type is rejected at construction', (t) => {
   t.exception(
     () =>
@@ -208,6 +261,14 @@ for (const [engineName, engine, files] of [
     {
       t3Model: './models/chatterbox-t3-turbo.gguf',
       s3genModel: './models/chatterbox-s3gen.gguf',
+      lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
+    }
+  ],
+  [
+    'CosyVoice3',
+    TTSGgml.ENGINE_COSYVOICE3,
+    {
+      cosyvoiceModelDir: './models/cosyvoice3',
       lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
     }
   ]

--- a/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
+++ b/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
@@ -7,9 +7,10 @@
 // CosyVoice3 (constructs and forwards both knobs — the addon enhances each
 // chunk seam-free), the denoiser stays batch-only, and a misconfigured enhancer
 // can't silently become a no-op (an unknown enhancer.type throws). The
-// model-backed tests assert the enhanced output is reported as 48 kHz for both
-// engines (incl. Chatterbox native streaming); they are gated on the converted
-// enhancer GGUF being staged, and skip cleanly otherwise.
+// model-backed tests assert the enhanced output is reported as 48 kHz for
+// Supertonic, Chatterbox and CosyVoice3, covering the native chunk streaming of
+// the two engines that support it; they are gated on the converted enhancer
+// GGUF being staged, and skip cleanly otherwise.
 //
 // Stage the enhancer GGUF via scripts/convert-lavasr-enhancer-to-gguf.py (from
 // the public LavaSRcpp ONNX release) into models/lavasr/lavasr-enhancer.gguf,
@@ -24,12 +25,16 @@ const TTSGgml = require('@qvac/tts-ggml')
 const {
   ensureLavaSREnhancerGguf,
   ensureSupertonicModel,
-  ensureChatterboxModels
+  ensureChatterboxModels,
+  ensureCosyvoiceModel
 } = require('../utils/downloadModel')
 const { resolveRefWavPath } = require('../utils/runChatterboxTTS')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
+// CosyVoice3 segfaults at load/synthesis on the win32-x64 desktop lane; mirrors
+// the skip in cosyvoice3.test.js so the Windows lane stays green.
+const SKIP_COSYVOICE = platform === 'win32'
 // Mirrors gpu-smoke.test.js: CI runners without a real GPU export NO_GPU=true to
 // skip the GPU-gated entries; QVAC_TTS_GPU_SMOKE_RELAX=1 downgrades a GPU->CPU
 // fallback from a failure to a warning (e.g. a Linux host with no Vulkan SDK).
@@ -500,6 +505,115 @@ test(
       t.ok(total > 0, 'streamed enhanced audio produced samples')
       // Every chunk that carries audio must be tagged at the enhanced 48 kHz rate
       // (not the engine's native 24 kHz) — the mislabel this feature prevents.
+      for (const u of updates) {
+        if (u.outputArray.length > 0 && u.sampleRate != null) {
+          t.is(u.sampleRate, 48000, 'streamed enhanced chunk reports 48 kHz')
+        }
+      }
+      const isLastCount = updates.filter((u) => u.isLast === true).length
+      t.ok(isLastCount <= 1, 'at most one isLast=true across streamed chunks')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+// CosyVoice3 is CPU-only in this iteration, and the addon hands the enhancer the
+// engine's *resolved* device, so these also pin that the enhancer really loaded
+// and ran (enhancerBackendDevice=0) rather than silently staying off. Text is
+// kept short to bound CPU LM-decode time in CI, as in cosyvoice3.test.js.
+
+test(
+  'CosyVoice3 + LavaSR enhancer (batch) reports 48 kHz enhanced output',
+  { timeout: 900000, skip: SKIP_COSYVOICE },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
+    })
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
+    }
+    const dl = await ensureCosyvoiceModel({
+      targetDir: path.join(baseDir, 'models', 'cosyvoice3')
+    })
+    if (!dl.success) {
+      t.fail('CosyVoice3 model files not available — registry fetch failed.')
+      return
+    }
+
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_COSYVOICE3,
+      files: { cosyvoiceModelDir: dl.modelDir, lavasrEnhancer: enh.path },
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const r = await runAndCollect(model, 'Hello from CosyVoice.')
+      t.is(r.sampleRate, 48000, 'enhanced cosyvoice3 output reports 48 kHz (native is 24 kHz)')
+      t.ok(r.samples > 0, 'enhanced synthesis produced audio')
+      t.ok(r.stats, 'runtimeStats returned (constructed with stats:true)')
+      t.is(
+        r.stats.enhancerBackendDevice,
+        0,
+        'enhancer loaded and ran on CPU (enhancerBackendDevice=0, not -1 = never loaded)'
+      )
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+test(
+  'CosyVoice3 + LavaSR enhancer + native chunk streaming emits 48 kHz chunks',
+  { timeout: 900000, skip: SKIP_COSYVOICE },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
+    })
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
+    }
+    const dl = await ensureCosyvoiceModel({
+      targetDir: path.join(baseDir, 'models', 'cosyvoice3')
+    })
+    if (!dl.success) {
+      t.fail('CosyVoice3 model files not available — registry fetch failed.')
+      return
+    }
+
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_COSYVOICE3,
+      files: { cosyvoiceModelDir: dl.modelDir, lavasrEnhancer: enh.path },
+      streamChunkTokens: 25, // native chunk streaming + enhancer (the path)
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const updates = []
+      const response = await model.run({ input: 'Hello from CosyVoice.', type: 'text' })
+      await response
+        .onUpdate((d) => {
+          if (d && d.outputArray) updates.push(d)
+        })
+        .await()
+
+      const total = updates.reduce((acc, u) => acc + u.outputArray.length, 0)
+      t.ok(updates.length >= 1, 'streamed at least one chunk event')
+      t.ok(total > 0, 'streamed enhanced audio produced samples')
+      // Every chunk carrying audio must be tagged at the enhanced 48 kHz rate
+      // rather than CosyVoice3's native 24 kHz — the mislabel this path prevents.
       for (const u of updates) {
         if (u.outputArray.length > 0 && u.sampleRate != null) {
           t.is(u.sampleRate, 48000, 'streamed enhanced chunk reports 48 kHz')

--- a/packages/tts-ggml/test/integration/output-sample-rate.test.js
+++ b/packages/tts-ggml/test/integration/output-sample-rate.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
 // Output-sample-rate selection: a requested outputSampleRate is honored
-// end-to-end and reported on the output chunk. Gated on the Supertonic GGUF +
-// a tts-cpp build that supports EngineOptions::output_sample_rate (PR #69);
-// skips/fails cleanly otherwise.
+// end-to-end and reported on the output chunk. The construct-time CosyVoice3
+// test needs no models; the model-backed ones are gated on the Supertonic /
+// Parler GGUFs plus a tts-cpp build that supports
+// EngineOptions::output_sample_rate (PR #69), and skip/fail cleanly otherwise.
 
 const os = require('bare-os')
 const path = require('bare-path')
@@ -31,6 +32,31 @@ async function collect(model, text) {
     .await()
   return { samples, sampleRate }
 }
+
+// CosyVoice3 native chunk streaming emits at its native 24 kHz, so the addon
+// rejects a different outputSampleRate there unless the LavaSR enhancer is on:
+// the enhancer's overlap-reprocess window resamples without leaving chunk
+// seams. That decision lives in CosyvoiceModel::validateConfig; this pins the
+// JS half, which must forward the combination rather than reject it up front.
+test('CosyVoice3: enhancer + streaming forwards a non-native outputSampleRate', (t) => {
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_COSYVOICE3,
+    files: {
+      cosyvoiceModelDir: './models/cosyvoice3',
+      lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
+    },
+    streamChunkTokens: 25,
+    config: { language: 'en', outputSampleRate: 16000 }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.outputSampleRate, 16000, 'requested rate forwarded')
+  t.is(params.streamChunkTokens, 25, 'streaming still requested')
+  t.is(
+    params.lavasrEnhancerPath,
+    './models/lavasr/lavasr-enhancer.gguf',
+    'enhancer forwarded — it is what makes the rate valid while streaming'
+  )
+})
 
 test(
   'Supertonic: outputSampleRate=16000 resamples and reports 16 kHz',

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -373,7 +373,7 @@ test('Chatterbox: denoiser + streamChunkTokens is rejected (streaming denoise is
         streamChunkTokens: 25,
         config: { language: 'en' }
       }),
-    /denoiser is not yet supported with Chatterbox native chunk streaming/,
+    /denoiser is not yet supported with native chunk streaming/,
     'denoiser + native chunk streaming throws (unlike the enhancer, which supports it)'
   )
 })

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -378,6 +378,23 @@ test('Chatterbox: denoiser + streamChunkTokens is rejected (streaming denoise is
   )
 })
 
+test('Chatterbox: denoiser + streamChunkTokens 0 is accepted (0 means no streaming)', (t) => {
+  t.execution(
+    () =>
+      new TTSGgml({
+        files: {
+          t3Model: './models/chatterbox-t3-turbo.gguf',
+          s3genModel: './models/chatterbox-s3gen.gguf',
+          lavasrDenoiser: '/abs/den.gguf'
+        },
+        streamChunkTokens: 0,
+        streamFirstChunkTokens: 0,
+        config: { language: 'en' }
+      }),
+    'an explicit 0 requests batch synthesis, so the denoiser stays allowed'
+  )
+})
+
 test('Chatterbox: denoiser and enhancer forward both paths (denoise before enhance)', (t) => {
   const model = new TTSGgml({
     files: {

--- a/packages/tts-ggml/test/unit/cosyvoice3.inference.test.js
+++ b/packages/tts-ggml/test/unit/cosyvoice3.inference.test.js
@@ -239,6 +239,15 @@ test('CosyVoice3: cosyvoice3-only options on other engines throw', (t) => {
   )
 })
 
+test('CosyVoice3: LavaSR denoiser + streamChunkTokens 0 is accepted', (t) => {
+  const model = createMockedCosyvoiceModel({
+    files: { cosyvoiceModelDir: './models/cv3', lavasrDenoiser: './d.gguf' },
+    extra: { streamChunkTokens: 0 }
+  })
+  const parameters = model._buildTtsParams()
+  t.is(parameters.lavasrDenoiserPath, './d.gguf', '0 tokens means batch, so the denoiser survives')
+})
+
 test('CosyVoice3: streamChunkTokens is NOT rejected (native streaming model)', (t) => {
   // Unlike Supertonic, CosyVoice3 supports native sub-utterance chunk streaming.
   t.execution(

--- a/packages/tts-ggml/test/unit/cosyvoice3.inference.test.js
+++ b/packages/tts-ggml/test/unit/cosyvoice3.inference.test.js
@@ -171,22 +171,38 @@ test('CosyVoice3: invalid instruct value / unknown key rejected', (t) => {
   )
 })
 
-test('CosyVoice3: LavaSR enhancer/denoiser rejected at construction', (t) => {
+test('CosyVoice3: LavaSR enhancer/denoiser accepted and forwarded to the addon', (t) => {
+  const model = createMockedCosyvoiceModel({
+    files: {
+      cosyvoiceModelDir: './models/cv3',
+      lavasrEnhancer: './e.gguf',
+      lavasrDenoiser: './d.gguf'
+    }
+  })
+  const parameters = model._buildTtsParams()
+  t.is(parameters.lavasrEnhancerPath, './e.gguf', 'enhancer path forwarded')
+  t.is(parameters.lavasrDenoiserPath, './d.gguf', 'denoiser path forwarded')
+})
+
+test('CosyVoice3: LavaSR enhancer works with native chunk streaming', (t) => {
+  const model = createMockedCosyvoiceModel({
+    files: { cosyvoiceModelDir: './models/cv3', lavasrEnhancer: './e.gguf' },
+    extra: { streamChunkTokens: 25 }
+  })
+  const parameters = model._buildTtsParams()
+  t.is(parameters.lavasrEnhancerPath, './e.gguf', 'enhancer survives streaming')
+  t.is(parameters.streamChunkTokens, 25, 'streaming still requested')
+})
+
+test('CosyVoice3: LavaSR denoiser rejected with native chunk streaming', (t) => {
   t.exception(
     () =>
       createMockedCosyvoiceModel({
-        files: { cosyvoiceModelDir: './models/cv3', lavasrEnhancer: './e.gguf' }
+        files: { cosyvoiceModelDir: './models/cv3', lavasrDenoiser: './d.gguf' },
+        extra: { streamChunkTokens: 25 }
       }),
-    /LavaSR/,
-    'enhancer rejected at construction'
-  )
-  t.exception(
-    () =>
-      createMockedCosyvoiceModel({
-        files: { cosyvoiceModelDir: './models/cv3', lavasrDenoiser: './d.gguf' }
-      }),
-    /LavaSR/,
-    'denoiser rejected at construction'
+    /denoiser is not yet supported with native chunk streaming/,
+    'denoiser + streaming rejected at construction'
   )
 })
 


### PR DESCRIPTION
Stacked on #3446 — review that one first; this PR targets its branch, not `main`.

## Summary

CosyVoice3 previously rejected the LavaSR enhancer and denoiser at construction, on the grounds that it emitted "no LavaSR-supported signal". That was never a technical limitation: LavaSR consumes 24 kHz, which is exactly CosyVoice3's native output rate. This PR drops the rejection and wires both stages through the same paths Chatterbox and Supertonic already use.

- **Enhancer** works on batch synthesis and on native chunk streaming. Streaming reuses the existing `StreamingEnhancer` (overlap-reprocess plus crossfade), so chunk seams stay inaudible. Output becomes 48 kHz.
- **Denoiser** is batch-only and runs before the enhancer, preserving the sample rate. `tts-cpp` exposes only a one-shot `denoise()`, so pairing it with chunk streaming is rejected in `CosyvoiceModel::validateConfig` rather than silently skipped. A stateful streaming denoiser remains the planned follow-up.
- `enhancerBackendDevice` / `enhancerBackendId` are surfaced in runtime stats, matching the sibling engines.

## Behaviour changes

**`outputSampleRate` while streaming.** CosyVoice3 native chunk streaming used to reject any non-native `outputSampleRate`, because naive per-chunk resampling breaks the seams. It is now accepted when the enhancer is active, since the enhancer's overlap-reprocess window already resamples seam-free. Without the enhancer the native-rate restriction stands unchanged.

**Denoiser rejection message.** The JS-side denoiser-plus-streaming rejection was worded as Chatterbox-specific; it is now engine-neutral, since the same constraint applies to CosyVoice3. `chatterbox.inference.test.js` is updated for the new wording.

**Stats accounting.** `recordSynthesisStats` previously read its sample count and rate off the engine's `SynthesisResult`. On the streaming-plus-enhancer path that struct still reports the native 24 kHz while the caller actually receives the enhanced stream, so the signature now takes the emitted sample count and rate explicitly.

Everything is opt-in through a GGUF path, so behaviour with no enhancer or denoiser configured is unchanged.

## Test plan

- [x] C++ unit tests: 126 pass, 8 skipped (need real model files). 5 new CosyVoice validation tests cover a missing enhancer GGUF, a missing denoiser GGUF, enhancer accepted on both batch and streaming, denoiser accepted on batch but rejected while streaming, and a non-native streaming output rate accepted once the enhancer is on.
- [x] JS unit tests: 198 brittle plus 34 node pass. New CosyVoice tests assert the enhancer and denoiser paths are forwarded to the addon, the enhancer survives streaming, and the denoiser plus streaming combination is rejected.
- [x] Native addon and test binary build clean, no warnings.
- [x] `lint:js`, `lint:ts`, `typecheck`, `test:dts` and `check:generated` all pass.
- [x] `git clang-format` (v19) reports no changes on the touched hunks.
- [ ] Manual run against real weights via `npm run example:cosyvoice-enhanced` (add `--denoise` for the denoiser stage) — needs the CosyVoice3 model dir plus the LavaSR GGUFs.

## Notes for reviewers

The denoiser plus streaming combination is rejected in two places by design: `src/index.ts` catches it early with an actionable message, and `CosyvoiceModel::validateConfig` backstops it for callers reaching the addon directly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217064682127439