### PR TITLE
fix[notask]: isolate speech addon GGML backends

### DIFF
--- a/packages/asr-ggml/CMakeLists.txt
+++ b/packages/asr-ggml/CMakeLists.txt
@@ -67,45 +67,17 @@ endif()
 # `android-arm64/qvac__asr-ggml`) and installs the .so / .dll / .dylib
 # backend files there. The runtime resolves the directory via the same
 # shape on the JS side (`path.join(__dirname, 'prebuilds')`), then the
-# engine-config backendsDir is forwarded to the model layer which calls
-# `ggml_backend_load_all_from_path()` against it. The C++ define below
-# tells the addon what relative subdir to scan under that root.
+# engine-config backendsDir is forwarded to the addon-local backend loader. The
+# C++ define below tells it what relative subdir to scan under that root.
 bare_target(bare_target_value)
 bare_module_target("." _unused_target NAME module_name VERSION _unused_version)
 set(BACKENDS_SUBDIR_VALUE "${bare_target_value}/${module_name}")
 message(STATUS "Building asr-ggml with BACKENDS_SUBDIR='${BACKENDS_SUBDIR_VALUE}'")
 
-# Collect every dynamically-loadable ggml backend that the `ggml-speech`
-# port produced, as IMPORTED targets. Both whisper-cpp and parakeet-cpp
-# resolve the single ggml-speech install tree, so one staging pass serves
-# both engines. Two branches:
-#   1. IMPORTED targets that `find_package(ggml)` already surfaced
-#      (CPU on Android, all backends on Linux desktop).
-#   2. Loose `libqvac-speech-ggml-*.so` MODULE files that ggml-config
-#      deliberately omits from GGML_AVAILABLE_BACKENDS' IMPORTED set
-#      (Vulkan + OpenCL on Android — the loader picks them up at
-#      runtime via `ggml_backend_load_all_from_path()`).
-# Hybrid-mode caveat: the ggml-speech vcpkg port builds Android with
-# GGML_BACKEND_DL=ON + GGML_CPU_STATIC=ON, so only the CPU backend
-# ships as a static archive AND as an IMPORTED ggml::ggml-cpu target;
-# the GPU MODULE .so files are staged by the loose-glob below so the
-# engine can select Vulkan/OpenCL per ggml's Adreno-tier policy when
-# useGPU=true; ggml falls back to CPU on devices it can't drive.
-set(BACKEND_DL_LIBS "")
-if((ANDROID OR UNIX) AND NOT APPLE)
-  foreach(_backend ${GGML_AVAILABLE_BACKENDS})
-    if(TARGET ggml::${_backend})
-      list(APPEND BACKEND_DL_LIBS INSTALL TARGET ggml::${_backend})
-    endif()
-  endforeach()
-endif()
-
-# Loose-file pickup for MODULE backends that aren't surfaced as
-# IMPORTED targets by find_package(ggml). Glob runs at configure time —
-# the .so files come from ggml-speech's `file(INSTALL ...)` step in its
-# portfile, which has already completed by the time vcpkg hands control
-# back to us. Apple / Windows static-only configs return an empty list
-# and skip the install rule.
+# Collect every dynamically-loadable backend produced by ggml-speech. Both
+# engines resolve one install tree, so one renamed staging pass serves Whisper
+# and Parakeet. The glob runs after vcpkg has installed the CPU variants and
+# GPU modules into lib/. Apple and Windows static-only builds return no files.
 set(BACKEND_DL_LOOSE_SOS "")
 if((ANDROID OR UNIX) AND NOT APPLE)
   if(NOT VCPKG_INSTALLED_PATH OR NOT EXISTS "${VCPKG_INSTALLED_PATH}/lib")
@@ -122,18 +94,28 @@ if((ANDROID OR UNIX) AND NOT APPLE)
   endif()
 endif()
 
-add_bare_module(asr-ggml EXPORTS ${BACKEND_DL_LIBS})
+add_bare_module(asr-ggml)
 
 # Stage every loose MODULE backend selected above into the same
 # per-host/per-module subdir cmake-bare's INSTALL TARGET branch uses for
-# IMPORTED targets — keeping destinations identical so
-# `ggml_backend_load_all_from_path(backendsDir / BACKENDS_SUBDIR)`
-# discovers IMPORTED-target CPU + loose-file GPU backends in one scan.
+# IMPORTED targets. Give every backend an ASR-specific basename so Android APK
+# packaging cannot overwrite it with tts-ggml's independently built backend.
+# The addon-local BackendLoader loads these exact filenames; the ggml-speech
+# port's compiled-in `qvac-speech-` discovery prefix is intentionally bypassed.
 if(BACKEND_DL_LOOSE_SOS)
-  install(
-    FILES ${BACKEND_DL_LOOSE_SOS}
-    DESTINATION ${bare_target_value}/${module_name}
-  )
+  foreach(_lib IN LISTS BACKEND_DL_LOOSE_SOS)
+    get_filename_component(_backend_name "${_lib}" NAME)
+    string(REPLACE
+      "libqvac-speech-ggml-"
+      "libqvac-asr-ggml-"
+      _isolated_backend_name
+      "${_backend_name}")
+    install(
+      FILES "${_lib}"
+      DESTINATION ${bare_target_value}/${module_name}
+      RENAME "${_isolated_backend_name}"
+    )
+  endforeach()
 endif()
 
 target_sources(
@@ -141,6 +123,7 @@ target_sources(
   PRIVATE
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/JSAdapter.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BackendLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/StreamingProcessor.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ParakeetStreamingProcessor.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/whisper/WhisperConfig.cpp
@@ -170,9 +153,9 @@ target_link_libraries(
 target_compile_definitions(${asr-ggml} PUBLIC JS_LOGGER)
 # Same value the JS side appends to the host-provided `backendsDir`
 # default (`path.join(__dirname, 'prebuilds', <subdir>)`). The consumers
-# of this define are the `#ifdef BACKENDS_SUBDIR` blocks in
-# WhisperModel.cpp / ParakeetModel.cpp — the define must be present on
-# EVERY target that compiles those translation units (this module target
+# of this define are the `#ifdef BACKENDS_SUBDIR` blocks in BackendLoader.cpp
+# and the engine option builders. The define must be present on EVERY target
+# that compiles those translation units (this module target
 # and asr_ggml_tests below), or the #ifdef silently compiles out and the
 # engine scans the prebuilds root instead of
 # `<backendsDir>/<bare-target>/<module-name>` ("no CPU device registered"
@@ -394,6 +377,7 @@ if(BUILD_TESTING)
     ${PROJECT_SOURCE_DIR}/addon/tests/parakeet_test_config_and_audio.cpp
     ${PROJECT_SOURCE_DIR}/addon/tests/ParakeetAddonCppTest.cpp
     # engine cores recompiled for coverage instrumentation (tts-ggml pattern)
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BackendLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/StreamingProcessor.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ParakeetStreamingProcessor.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/whisper/WhisperConfig.cpp
@@ -420,7 +404,7 @@ if(BUILD_TESTING)
     ggml::ggml
   )
 
-  # asr_ggml_tests recompiles WhisperModel.cpp / ParakeetModel.cpp, whose
+  # asr_ggml_tests recompiles BackendLoader.cpp and the model sources, whose
   # `#ifdef BACKENDS_SUBDIR` blocks must see the same define as the module
   # target — see the note above the module-target define.
   target_compile_definitions(asr_ggml_tests PRIVATE

--- a/packages/asr-ggml/addon/src/model-interface/BackendLoader.cpp
+++ b/packages/asr-ggml/addon/src/model-interface/BackendLoader.cpp
@@ -1,0 +1,167 @@
+#include "model-interface/BackendLoader.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <system_error>
+
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+#include <dlfcn.h>
+#endif
+
+#include <ggml-backend.h>
+
+#include "inference-addon-cpp/Logger.hpp"
+
+namespace qvac::asrggml::backend {
+
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char* BACKEND_PREFIX = "libqvac-asr-ggml-";
+
+fs::path joinBackendsSubdir(const fs::path& root) {
+#ifdef BACKENDS_SUBDIR
+  return (root / fs::path(BACKENDS_SUBDIR)).lexically_normal();
+#else
+  return root;
+#endif
+}
+
+fs::path prebuildsDirFromAddonLocation() {
+  Dl_info info{};
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  const void* selfSymbol =
+      reinterpret_cast<const void*>(&prebuildsDirFromAddonLocation);
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+  if (dladdr(selfSymbol, &info) == 0 || info.dli_fname == nullptr) {
+    return {};
+  }
+
+  std::error_code ec;
+  const fs::path prebuildsDir =
+      fs::path(info.dli_fname).parent_path().parent_path();
+  if (prebuildsDir.empty() || !fs::exists(prebuildsDir, ec)) {
+    return {};
+  }
+  return prebuildsDir;
+}
+
+bool loadBackend(const fs::path& directory, const std::string& name) {
+  const fs::path path = directory / (std::string(BACKEND_PREFIX) + name + ".so");
+  std::error_code ec;
+  if (!fs::exists(path, ec)) {
+    return false;
+  }
+  return ggml_backend_load(path.string().c_str()) != nullptr;
+}
+
+bool hasAdrenoGpu() {
+  for (size_t index = 0; index < ggml_backend_dev_count(); ++index) {
+    ggml_backend_dev_t device = ggml_backend_dev_get(index);
+    if (device == nullptr) {
+      continue;
+    }
+    const char* description = ggml_backend_dev_description(device);
+    if (description == nullptr) {
+      continue;
+    }
+    std::string normalized(description);
+    std::transform(
+        normalized.begin(),
+        normalized.end(),
+        normalized.begin(),
+        [](unsigned char character) {
+          return static_cast<char>(std::tolower(character));
+        });
+    if (normalized.find("adreno") != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool loadCpuBackend(const fs::path& directory) {
+#if defined(__ANDROID__)
+  constexpr std::array<const char*, 7> CPU_VARIANTS = {
+      "cpu-android_armv9.2_2",
+      "cpu-android_armv9.2_1",
+      "cpu-android_armv9.0_1",
+      "cpu-android_armv8.6_1",
+      "cpu-android_armv8.2_2",
+      "cpu-android_armv8.2_1",
+      "cpu-android_armv8.0_1"};
+#else
+  constexpr std::array<const char*, 3> CPU_VARIANTS = {
+      "cpu-armv8.2_2", "cpu-armv8.2_1", "cpu-armv8.0_1"};
+#endif
+
+  for (const char* variant : CPU_VARIANTS) {
+    if (loadBackend(directory, variant)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void loadBackendsFromRoot(const fs::path& root) {
+  const fs::path directory = joinBackendsSubdir(root);
+  QLOG(
+      qvac_lib_inference_addon_cpp::logger::Priority::INFO,
+      std::string("loading isolated ASR ggml backends from: ") +
+          directory.string());
+
+  if (std::getenv("GGML_DISABLE_VULKAN") == nullptr) {
+    loadBackend(directory, "vulkan");
+  }
+  if (hasAdrenoGpu() || std::getenv("GGML_OPENCL_FORCE_LOAD") != nullptr) {
+    loadBackend(directory, "opencl");
+  }
+
+  if (!loadCpuBackend(directory)) {
+    QLOG(
+        qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
+        "No isolated ASR CPU backend was loadable; trying the legacy "
+        "qvac-speech backend prefix.");
+    ggml_backend_load_all_from_path(directory.string().c_str());
+  }
+}
+
+} // namespace
+#endif
+
+void ensureLoaded(const std::string& backendsRoot) {
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+  static std::once_flag flag;
+  std::call_once(flag, [&]() {
+    if (!backendsRoot.empty()) {
+      loadBackendsFromRoot(fs::path(backendsRoot));
+      return;
+    }
+
+    const fs::path selfLocatedRoot = prebuildsDirFromAddonLocation();
+    std::error_code ec;
+    if (!selfLocatedRoot.empty() &&
+        fs::exists(joinBackendsSubdir(selfLocatedRoot), ec)) {
+      loadBackendsFromRoot(selfLocatedRoot);
+      return;
+    }
+
+    QLOG(
+        qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
+        "ASR backendsDir was not set and addon-relative prebuilds could not "
+        "be located; falling back to GGML's default search path.");
+    ggml_backend_load_all();
+  });
+#else
+  static_cast<void>(backendsRoot);
+#endif
+}
+
+} // namespace qvac::asrggml::backend

--- a/packages/asr-ggml/addon/src/model-interface/BackendLoader.cpp
+++ b/packages/asr-ggml/addon/src/model-interface/BackendLoader.cpp
@@ -4,8 +4,11 @@
 #include <array>
 #include <cctype>
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
+#include <limits>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <system_error>
 
@@ -54,37 +57,63 @@ fs::path prebuildsDirFromAddonLocation() {
 }
 
 bool loadBackend(const fs::path& directory, const std::string& name) {
-  const fs::path path = directory / (std::string(BACKEND_PREFIX) + name + ".so");
+  const std::string filename = std::string(BACKEND_PREFIX) + name + ".so";
+  const fs::path path = directory / filename;
   std::error_code ec;
-  if (!fs::exists(path, ec)) {
-    return false;
+  if (fs::exists(path, ec)) {
+    return ggml_backend_load(path.string().c_str()) != nullptr;
   }
-  return ggml_backend_load(path.string().c_str()) != nullptr;
+#if defined(__ANDROID__)
+  // Android may keep native libraries compressed inside the APK. In that
+  // layout there is no filesystem path, but bionic can resolve the uniquely
+  // named library directly from the APK by basename.
+  return ggml_backend_load(filename.c_str()) != nullptr;
+#else
+  return false;
+#endif
 }
 
-bool hasAdrenoGpu() {
-  for (size_t index = 0; index < ggml_backend_dev_count(); ++index) {
-    ggml_backend_dev_t device = ggml_backend_dev_get(index);
-    if (device == nullptr) {
-      continue;
-    }
-    const char* description = ggml_backend_dev_description(device);
-    if (description == nullptr) {
-      continue;
-    }
-    std::string normalized(description);
-    std::transform(
-        normalized.begin(),
-        normalized.end(),
-        normalized.begin(),
-        [](unsigned char character) {
-          return static_cast<char>(std::tolower(character));
-        });
-    if (normalized.find("adreno") != std::string::npos) {
-      return true;
+int adrenoVersionFromDescription(const std::string& description) {
+  std::string normalized = description;
+  std::transform(
+      normalized.begin(),
+      normalized.end(),
+      normalized.begin(),
+      [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+      });
+  if (normalized.find("dreno") == std::string::npos) {
+    return -1;
+  }
+  static const std::regex adrenoRegex(R"(dreno\D*?(\d{3,4}))");
+  std::smatch matches;
+  if (std::regex_search(normalized, matches, adrenoRegex) &&
+      matches.size() > 1) {
+    try {
+      return std::stoi(matches[1].str());
+    } catch (const std::exception&) {
+      return -3;
     }
   }
-  return false;
+  return -3;
+}
+
+int minimumAdrenoVersion(ggml_backend_reg_t backend) {
+  if (backend == nullptr) {
+    return -2;
+  }
+  int minimum = std::numeric_limits<int>::max();
+  for (size_t index = 0; index < ggml_backend_reg_dev_count(backend); ++index) {
+    ggml_backend_dev_t device = ggml_backend_reg_dev_get(backend, index);
+    const char* description =
+        device != nullptr ? ggml_backend_dev_description(device) : nullptr;
+    const int version =
+        adrenoVersionFromDescription(description != nullptr ? description : "");
+    if (version > 0) {
+      minimum = std::min(minimum, version);
+    }
+  }
+  return minimum < std::numeric_limits<int>::max() ? minimum : -1;
 }
 
 bool loadCpuBackend(const fs::path& directory) {
@@ -110,17 +139,36 @@ bool loadCpuBackend(const fs::path& directory) {
   return false;
 }
 
-void loadBackendsFromRoot(const fs::path& root) {
+void loadBackendsFromRoot(
+    const fs::path& root, const std::string& openclCacheDir) {
   const fs::path directory = joinBackendsSubdir(root);
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::INFO,
       std::string("loading isolated ASR ggml backends from: ") +
           directory.string());
 
+  if (!openclCacheDir.empty()) {
+    setenv("GGML_OPENCL_CACHE_DIR", openclCacheDir.c_str(), 1);
+  }
+
+  ggml_backend_reg_t vulkanBackend = nullptr;
   if (std::getenv("GGML_DISABLE_VULKAN") == nullptr) {
     loadBackend(directory, "vulkan");
+    vulkanBackend = ggml_backend_reg_by_name("vulkan");
   }
-  if (hasAdrenoGpu() || std::getenv("GGML_OPENCL_FORCE_LOAD") != nullptr) {
+
+  const int adrenoVersion = minimumAdrenoVersion(vulkanBackend);
+  bool loadOpencl = adrenoVersion > 700;
+  if (adrenoVersion > 0 && adrenoVersion <= 700 &&
+      vulkanBackend != nullptr) {
+    // Match ggml-speech's policy: Adreno 700 and older use CPU because neither
+    // Vulkan nor OpenCL is stable there.
+    ggml_backend_unload(vulkanBackend);
+  }
+  if (std::getenv("GGML_OPENCL_FORCE_LOAD") != nullptr) {
+    loadOpencl = true;
+  }
+  if (loadOpencl) {
     loadBackend(directory, "opencl");
   }
 
@@ -136,12 +184,13 @@ void loadBackendsFromRoot(const fs::path& root) {
 } // namespace
 #endif
 
-void ensureLoaded(const std::string& backendsRoot) {
+void ensureLoaded(
+    const std::string& backendsRoot, const std::string& openclCacheDir) {
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
   static std::once_flag flag;
   std::call_once(flag, [&]() {
     if (!backendsRoot.empty()) {
-      loadBackendsFromRoot(fs::path(backendsRoot));
+      loadBackendsFromRoot(fs::path(backendsRoot), openclCacheDir);
       return;
     }
 
@@ -149,9 +198,14 @@ void ensureLoaded(const std::string& backendsRoot) {
     std::error_code ec;
     if (!selfLocatedRoot.empty() &&
         fs::exists(joinBackendsSubdir(selfLocatedRoot), ec)) {
-      loadBackendsFromRoot(selfLocatedRoot);
+      loadBackendsFromRoot(selfLocatedRoot, openclCacheDir);
       return;
     }
+
+#if defined(__ANDROID__)
+    loadBackendsFromRoot(fs::path{}, openclCacheDir);
+    return;
+#endif
 
     QLOG(
         qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
@@ -161,6 +215,7 @@ void ensureLoaded(const std::string& backendsRoot) {
   });
 #else
   static_cast<void>(backendsRoot);
+  static_cast<void>(openclCacheDir);
 #endif
 }
 

--- a/packages/asr-ggml/addon/src/model-interface/BackendLoader.hpp
+++ b/packages/asr-ggml/addon/src/model-interface/BackendLoader.hpp
@@ -7,7 +7,8 @@ namespace qvac::asrggml::backend {
 
 // Loads this addon's uniquely named dynamic GGML backends once. backendsRoot
 // is the package prebuilds directory; BACKENDS_SUBDIR is appended internally.
-void ensureLoaded(const std::string& backendsRoot);
+void ensureLoaded(
+    const std::string& backendsRoot, const std::string& openclCacheDir = {});
 
 } // namespace qvac::asrggml::backend
 

--- a/packages/asr-ggml/addon/src/model-interface/BackendLoader.hpp
+++ b/packages/asr-ggml/addon/src/model-interface/BackendLoader.hpp
@@ -1,0 +1,14 @@
+#ifndef QVAC_ASRGGML_BACKENDLOADER_HPP
+#define QVAC_ASRGGML_BACKENDLOADER_HPP
+
+#include <string>
+
+namespace qvac::asrggml::backend {
+
+// Loads this addon's uniquely named dynamic GGML backends once. backendsRoot
+// is the package prebuilds directory; BACKENDS_SUBDIR is appended internally.
+void ensureLoaded(const std::string& backendsRoot);
+
+} // namespace qvac::asrggml::backend
+
+#endif // QVAC_ASRGGML_BACKENDLOADER_HPP

--- a/packages/asr-ggml/addon/src/model-interface/parakeet/ParakeetConfig.hpp
+++ b/packages/asr-ggml/addon/src/model-interface/parakeet/ParakeetConfig.hpp
@@ -91,13 +91,12 @@ struct ParakeetConfig {
   // Forwarded to pkt::EngineOptions::backends_dir /
   // opencl_cache_dir. On Android (and any other GGML_BACKEND_DL=ON
   // build) the ggml core is statically linked into this addon's
-  // `.bare` module while the GPU backends ship as separately
-  // dlopen()'d `.so` files (libqvac-speech-ggml-{vulkan,opencl}.so
-  // plus the per-arch CPU variants under
-  // libqvac-speech-ggml-cpu-android_armv*_*.so). The JS layer
-  // resolves `backendsDir` to that prebuild folder at construction
-  // time so `ggml_backend_load_all_from_path()` finds them at
-  // runtime; `openclCacheDir` sets `$GGML_OPENCL_CACHE_DIR` for
+  // `.bare` module while the backends ship as separately dlopen()'d,
+  // addon-isolated `.so` files (libqvac-asr-ggml-{vulkan,opencl}.so plus
+  // libqvac-asr-ggml-cpu-android_armv*_*.so). The JS layer resolves
+  // `backendsDir` to that prebuild folder at construction time so the
+  // addon-local backend loader finds them at runtime; `openclCacheDir` sets
+  // `$GGML_OPENCL_CACHE_DIR` for
   // ggml-opencl's program-binary cache (Android-only, ignored
   // elsewhere). Both default to empty -> let parakeet-cpp fall back
   // to its own resolution (ggml's compile-time default search path

--- a/packages/asr-ggml/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/asr-ggml/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -479,7 +479,8 @@ void ParakeetModel::load() {
   modelLoadMs_ = measureMs([&] {
     const fs::path ggufPath = resolveGgufPath();
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
-    qvac::asrggml::backend::ensureLoaded(cfg_.backendsDir);
+    qvac::asrggml::backend::ensureLoaded(
+        cfg_.backendsDir, cfg_.openclCacheDir);
 #endif
     const pkt::EngineOptions eopts = buildEngineOptions(cfg_, ggufPath);
     std::lock_guard<std::mutex> lk(engine_mutex_);

--- a/packages/asr-ggml/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/asr-ggml/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -21,6 +21,7 @@
 #include "ggml.h"
 #include "inference-addon-cpp/Errors.hpp"
 #include "inference-addon-cpp/Logger.hpp"
+#include "model-interface/BackendLoader.hpp"
 
 namespace qvac::asrggml::parakeet {
 
@@ -477,6 +478,9 @@ void ParakeetModel::load() {
 
   modelLoadMs_ = measureMs([&] {
     const fs::path ggufPath = resolveGgufPath();
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+    qvac::asrggml::backend::ensureLoaded(cfg_.backendsDir);
+#endif
     const pkt::EngineOptions eopts = buildEngineOptions(cfg_, ggufPath);
     std::lock_guard<std::mutex> lk(engine_mutex_);
     engine_ = std::make_unique<pkt::Engine>(eopts);

--- a/packages/asr-ggml/addon/src/model-interface/whisper/WhisperConfig.hpp
+++ b/packages/asr-ggml/addon/src/model-interface/whisper/WhisperConfig.hpp
@@ -39,7 +39,7 @@ struct WhisperConfig {
 
   // Addon prebuilds folder (`configurationParams.backendsDir` from JS).
   // Combined with the compile-time `BACKENDS_SUBDIR` to locate the
-  // per-arch ggml `.so` modules for `ggml_backend_load_all_from_path()`.
+  // addon-isolated, per-arch ggml `.so` modules.
   // Android-only; empty elsewhere.
   std::string backendsDir;
 };

--- a/packages/asr-ggml/addon/src/model-interface/whisper/WhisperModel.cpp
+++ b/packages/asr-ggml/addon/src/model-interface/whisper/WhisperModel.cpp
@@ -15,10 +15,6 @@
 #include <thread>
 #include <utility>
 
-#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
-#include <dlfcn.h>
-#endif
-
 #include <ggml-backend.h>
 
 #include "WhisperConfig.hpp"
@@ -26,6 +22,7 @@
 #include "addon/AsrErrors.hpp"
 #include "inference-addon-cpp/Errors.hpp"
 #include "inference-addon-cpp/Logger.hpp"
+#include "model-interface/BackendLoader.hpp"
 #include "model-interface/WhisperTypes.hpp"
 
 namespace qvac::asrggml::whisper {
@@ -77,95 +74,6 @@ auto WhisperModel::formatCaptionOutput(Transcript& transcript) -> void {
                     "|>" + transcript.text + "<|" +
                     std::to_string(static_cast<int>(transcript.end)) + "|>";
 }
-
-#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
-namespace {
-// Join a prebuilds root with the cmake-bare per-target module subdir
-// (BACKENDS_SUBDIR == "<bare_target>/<module_name>", set in CMakeLists) to get
-// the directory the ggml-speech port staged the dlopenable CPU/GPU `.so`
-// modules into.
-std::filesystem::path joinBackendsSubdir(const std::filesystem::path& root) {
-#ifdef BACKENDS_SUBDIR
-  return (root / std::filesystem::path(BACKENDS_SUBDIR)).lexically_normal();
-#else
-  return root;
-#endif
-}
-
-// Resolve the prebuilds root from the addon's own on-disk location, so a caller
-// that omits configurationParams.backendsDir (e.g. a direct WhisperInterface
-// consumer) still finds the sibling backends. The addon binary lives at
-// <prebuilds>/<bare_target>/<module_name>.bare and the backends install under
-// <prebuilds>/BACKENDS_SUBDIR (== <bare_target>/<module_name>), so the
-// prebuilds root is the addon's grandparent directory. dladdr resolves to this
-// addon because bare loads addons RTLD_LOCAL (mirrors inference-addon-cpp's
-// Pin.hpp). Returns an empty path when the addon can't be located.
-std::filesystem::path prebuildsDirFromAddonLocation() {
-  Dl_info info{};
-  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
-  const void* selfSymbol =
-      reinterpret_cast<const void*>(&prebuildsDirFromAddonLocation);
-  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
-  if (dladdr(selfSymbol, &info) == 0 || info.dli_fname == nullptr) {
-    return {};
-  }
-  std::error_code ec;
-  const std::filesystem::path addonPath(info.dli_fname);
-  const std::filesystem::path prebuildsDir =
-      addonPath.parent_path().parent_path();
-  if (prebuildsDir.empty() || !std::filesystem::exists(prebuildsDir, ec)) {
-    return {};
-  }
-  return prebuildsDir;
-}
-
-void loadBackendsFromRoot(const std::filesystem::path& root) {
-  const std::filesystem::path variantsDir = joinBackendsSubdir(root);
-  QLOG(
-      qvac_lib_inference_addon_cpp::logger::Priority::INFO,
-      std::string("loading ggml backends from: ") + variantsDir.string());
-  ggml_backend_load_all_from_path(variantsDir.string().c_str());
-}
-
-// desktop linux-arm64 -- and Android -- ship ggml with `GGML_BACKEND_DL=ON`
-// (since ggml-speech 2026-07-14), so no backend is statically registered.
-// dlopen the per-arch CPU + GPU `.so` modules once per process before
-// whisper_init; otherwise it aborts on a NULL CPU device. Prefer the
-// runtime-supplied backendsDir; when it is omitted, self-locate the addon's
-// own prebuilds dir before falling back to ggml_backend_load_all() (whose
-// default search path scans the host executable's dir, not the addon's, so it
-// misses the renamed `libqvac-speech-ggml-*.so` modules).
-// Mirrors packages/{diffusion-cpp,llm-llamacpp,classification-ggml,…}.
-void ensureBackendsLoaded(const std::string& backendsDir) {
-  static std::once_flag flag;
-  std::call_once(flag, [&]() {
-    if (!backendsDir.empty()) {
-      loadBackendsFromRoot(std::filesystem::path(backendsDir));
-      return;
-    }
-    const std::filesystem::path selfLocatedRoot =
-        prebuildsDirFromAddonLocation();
-    std::error_code ec;
-    if (!selfLocatedRoot.empty() &&
-        std::filesystem::exists(joinBackendsSubdir(selfLocatedRoot), ec)) {
-      QLOG(
-          qvac_lib_inference_addon_cpp::logger::Priority::INFO,
-          "configurationParams.backendsDir not set; using addon-relative "
-          "prebuilds dir.");
-      loadBackendsFromRoot(selfLocatedRoot);
-      return;
-    }
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
-        "configurationParams.backendsDir not set and the addon could not "
-        "locate its own prebuilds dir; falling back to "
-        "ggml_backend_load_all() (default search path). CPU/Vulkan/OpenCL "
-        "registration may fail inside an APK.");
-    ggml_backend_load_all();
-  });
-}
-} // namespace
-#endif // __ANDROID__ || linux-arm64
 
 namespace {
 std::string toLowerCopy(std::string value) {
@@ -262,7 +170,7 @@ void WhisperModel::load() {
   if (!ctx_) {
 
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
-    ensureBackendsLoaded(cfg_.backendsDir);
+    qvac::asrggml::backend::ensureLoaded(cfg_.backendsDir);
 #endif
 
     whisper_context_params contextParams = toWhisperContextParams(cfg_);

--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -67,49 +67,15 @@ endif()
 # `tts_cpp::{chatterbox,supertonic}::EngineOptions::backends_dir`
 # field (calls `ggml_backend_load_all_from_path()` against it) once
 # the JS / C++ wiring lands. The C++ define below tells the addon
-# what relative subdir to scan under that root.
+# what relative subdir the addon-local backend loader scans under that root.
 bare_target(bare_target_value)
 bare_module_target("." unused_target NAME module_name VERSION unused_version)
 set(BACKENDS_SUBDIR_VALUE "${bare_target_value}/${module_name}")
 message(STATUS "Building tts-ggml with BACKENDS_SUBDIR='${BACKENDS_SUBDIR_VALUE}'")
 
-# Collect every dynamically-loadable ggml backend the ggml-speech port
-# produced ($CURRENT_PACKAGES_DIR/lib/libqvac-speech-ggml-*.so on
-# Android; nothing on Apple/static-only platforms). cmake-bare's
-# `add_bare_module(... EXPORTS INSTALL TARGET <tgt>)` bundles each
-# IMPORTED `ggml::<backend>` target into the per-arch prebuilds folder
-# next to the `.bare` module. Mirrors qvac/packages/transcription-
-# parakeet/CMakeLists.txt's BACKEND_DL_LIBS path.
-#
-# Hybrid-mode caveat: the ggml-speech vcpkg port builds Android with
-# GGML_BACKEND_DL=ON + GGML_CPU_STATIC=ON, so only the CPU backend
-# ships as a static archive AND as an IMPORTED `ggml::ggml-cpu` target;
-# Vulkan / OpenCL get built as MODULE .so files at
-# `${VCPKG_INSTALLED_PATH}/lib/libqvac-speech-ggml-{vulkan,opencl}.so`
-# but ggml-config.cmake.in deliberately leaves them out of
-# `GGML_AVAILABLE_BACKENDS`' IMPORTED set (the loader is expected to
-# find them via `ggml_backend_load_all_from_path()` at runtime). We
-# pick those up with an explicit `install(FILES ...)` below so the
-# runtime scan against BACKENDS_SUBDIR actually finds them next to
-# the .bare module.
-set(BACKEND_DL_LIBS "")
-if((ANDROID OR UNIX) AND NOT APPLE)
-  foreach(_backend ${GGML_AVAILABLE_BACKENDS})
-    if(TARGET ggml::${_backend})
-      list(APPEND BACKEND_DL_LIBS INSTALL TARGET ggml::${_backend})
-    endif()
-  endforeach()
-endif()
-
-# Loose-file pickup for MODULE backends that aren't surfaced as
-# IMPORTED targets by find_package(ggml). On Android this is what
-# actually delivers Vulkan + OpenCL into the prebuilds folder; we
-# do the same on Linux as a fallback for any future hybrid build
-# there. Glob runs at configure time -- the .so files come from
-# ggml-speech's `file(INSTALL ...)` step in its portfile, which has
-# already completed by the time vcpkg hands control back to us. Apple
-# / Windows static-only configs return an empty list and skip the
-# install rule below.
+# Collect every dynamically-loadable backend produced by ggml-speech. The glob
+# runs after vcpkg has installed the CPU variants and GPU modules into lib/.
+# Apple and Windows static-only builds return no files.
 set(BACKEND_DL_LOOSE_SOS "")
 if((ANDROID OR UNIX) AND NOT APPLE)
   if(NOT VCPKG_INSTALLED_PATH OR NOT EXISTS "${VCPKG_INSTALLED_PATH}/lib")
@@ -126,21 +92,28 @@ if((ANDROID OR UNIX) AND NOT APPLE)
   endif()
 endif()
 
-add_bare_module(tts-ggml EXPORTS ${BACKEND_DL_LIBS})
+add_bare_module(tts-ggml)
 
 # Stage every loose MODULE backend (Vulkan / OpenCL on Android, ...)
 # into the same per-host/per-module subdir cmake-bare's INSTALL TARGET
-# branch uses for IMPORTED targets (see cmake-bare.cmake's
-# `DESTINATION ${host}/${name}` -- e.g. `android-arm64/qvac__tts-ggml`).
-# Keeping the destinations identical means
-# `ggml_backend_load_all_from_path(backendsDir / BACKENDS_SUBDIR)`
-# on the C++ side discovers IMPORTED-target CPU and loose-file
-# GPU backends with a single scan.
+# branch uses. Give every backend a TTS-specific basename so Android APK
+# packaging cannot overwrite it with asr-ggml's independently built backend.
+# The addon-local BackendLoader loads these exact filenames; the ggml-speech
+# port's compiled-in `qvac-speech-` discovery prefix is intentionally bypassed.
 if(BACKEND_DL_LOOSE_SOS)
-  install(
-    FILES ${BACKEND_DL_LOOSE_SOS}
-    DESTINATION ${bare_target_value}/${module_name}
-  )
+  foreach(_lib IN LISTS BACKEND_DL_LOOSE_SOS)
+    get_filename_component(_backend_name "${_lib}" NAME)
+    string(REPLACE
+      "libqvac-speech-ggml-"
+      "libqvac-tts-ggml-"
+      _isolated_backend_name
+      "${_backend_name}")
+    install(
+      FILES "${_lib}"
+      DESTINATION ${bare_target_value}/${module_name}
+      RENAME "${_isolated_backend_name}"
+    )
+  endforeach()
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -152,6 +125,7 @@ target_sources(
   PRIVATE
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/JSAdapter.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BackendLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/parler/ParlerModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -323,6 +297,7 @@ if(BUILD_TESTING)
       addon/tests/test_output_resampler.cpp
       addon/tests/test_pcm_conversion.cpp
       addon/tests/AddonCppTest.cpp
+      addon/src/model-interface/BackendLoader.cpp
       addon/src/model-interface/chatterbox/ChatterboxModel.cpp
       addon/src/model-interface/parler/ParlerModel.cpp
       addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -340,6 +315,8 @@ if(BUILD_TESTING)
       GTest::gmock_main
       tts-cpp::tts-cpp
   )
+  target_compile_definitions(tts_ggml_tests PRIVATE
+    BACKENDS_SUBDIR="${BACKENDS_SUBDIR_VALUE}")
   if(ENABLE_COVERAGE)
     # LLVM source-based coverage (clang).  Same flag set parakeet uses.
     target_compile_options(tts_ggml_tests PRIVATE

--- a/packages/tts-ggml/addon/src/model-interface/BackendLoader.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/BackendLoader.cpp
@@ -1,0 +1,167 @@
+#include "model-interface/BackendLoader.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <system_error>
+
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+#include <dlfcn.h>
+#endif
+
+#include <ggml-backend.h>
+
+#include "inference-addon-cpp/Logger.hpp"
+
+namespace qvac::ttsggml::backend {
+
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char* BACKEND_PREFIX = "libqvac-tts-ggml-";
+
+fs::path joinBackendsSubdir(const fs::path& root) {
+#ifdef BACKENDS_SUBDIR
+  return (root / fs::path(BACKENDS_SUBDIR)).lexically_normal();
+#else
+  return root;
+#endif
+}
+
+fs::path prebuildsDirFromAddonLocation() {
+  Dl_info info{};
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  const void* selfSymbol =
+      reinterpret_cast<const void*>(&prebuildsDirFromAddonLocation);
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+  if (dladdr(selfSymbol, &info) == 0 || info.dli_fname == nullptr) {
+    return {};
+  }
+
+  std::error_code ec;
+  const fs::path prebuildsDir =
+      fs::path(info.dli_fname).parent_path().parent_path();
+  if (prebuildsDir.empty() || !fs::exists(prebuildsDir, ec)) {
+    return {};
+  }
+  return prebuildsDir;
+}
+
+bool loadBackend(const fs::path& directory, const std::string& name) {
+  const fs::path path = directory / (std::string(BACKEND_PREFIX) + name + ".so");
+  std::error_code ec;
+  if (!fs::exists(path, ec)) {
+    return false;
+  }
+  return ggml_backend_load(path.string().c_str()) != nullptr;
+}
+
+bool hasAdrenoGpu() {
+  for (size_t index = 0; index < ggml_backend_dev_count(); ++index) {
+    ggml_backend_dev_t device = ggml_backend_dev_get(index);
+    if (device == nullptr) {
+      continue;
+    }
+    const char* description = ggml_backend_dev_description(device);
+    if (description == nullptr) {
+      continue;
+    }
+    std::string normalized(description);
+    std::transform(
+        normalized.begin(),
+        normalized.end(),
+        normalized.begin(),
+        [](unsigned char character) {
+          return static_cast<char>(std::tolower(character));
+        });
+    if (normalized.find("adreno") != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool loadCpuBackend(const fs::path& directory) {
+#if defined(__ANDROID__)
+  constexpr std::array<const char*, 7> CPU_VARIANTS = {
+      "cpu-android_armv9.2_2",
+      "cpu-android_armv9.2_1",
+      "cpu-android_armv9.0_1",
+      "cpu-android_armv8.6_1",
+      "cpu-android_armv8.2_2",
+      "cpu-android_armv8.2_1",
+      "cpu-android_armv8.0_1"};
+#else
+  constexpr std::array<const char*, 3> CPU_VARIANTS = {
+      "cpu-armv8.2_2", "cpu-armv8.2_1", "cpu-armv8.0_1"};
+#endif
+
+  for (const char* variant : CPU_VARIANTS) {
+    if (loadBackend(directory, variant)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void loadBackendsFromRoot(const fs::path& root) {
+  const fs::path directory = joinBackendsSubdir(root);
+  QLOG(
+      qvac_lib_inference_addon_cpp::logger::Priority::INFO,
+      std::string("loading isolated TTS ggml backends from: ") +
+          directory.string());
+
+  if (std::getenv("GGML_DISABLE_VULKAN") == nullptr) {
+    loadBackend(directory, "vulkan");
+  }
+  if (hasAdrenoGpu() || std::getenv("GGML_OPENCL_FORCE_LOAD") != nullptr) {
+    loadBackend(directory, "opencl");
+  }
+
+  if (!loadCpuBackend(directory)) {
+    QLOG(
+        qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
+        "No isolated TTS CPU backend was loadable; trying the legacy "
+        "qvac-speech backend prefix.");
+    ggml_backend_load_all_from_path(directory.string().c_str());
+  }
+}
+
+} // namespace
+#endif
+
+void ensureLoaded(const std::string& backendsRoot) {
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+  static std::once_flag flag;
+  std::call_once(flag, [&]() {
+    if (!backendsRoot.empty()) {
+      loadBackendsFromRoot(fs::path(backendsRoot));
+      return;
+    }
+
+    const fs::path selfLocatedRoot = prebuildsDirFromAddonLocation();
+    std::error_code ec;
+    if (!selfLocatedRoot.empty() &&
+        fs::exists(joinBackendsSubdir(selfLocatedRoot), ec)) {
+      loadBackendsFromRoot(selfLocatedRoot);
+      return;
+    }
+
+    QLOG(
+        qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
+        "TTS backendsDir was not set and addon-relative prebuilds could not "
+        "be located; falling back to GGML's default search path.");
+    ggml_backend_load_all();
+  });
+#else
+  static_cast<void>(backendsRoot);
+#endif
+}
+
+} // namespace qvac::ttsggml::backend

--- a/packages/tts-ggml/addon/src/model-interface/BackendLoader.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/BackendLoader.cpp
@@ -4,8 +4,11 @@
 #include <array>
 #include <cctype>
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
+#include <limits>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <system_error>
 
@@ -54,37 +57,63 @@ fs::path prebuildsDirFromAddonLocation() {
 }
 
 bool loadBackend(const fs::path& directory, const std::string& name) {
-  const fs::path path = directory / (std::string(BACKEND_PREFIX) + name + ".so");
+  const std::string filename = std::string(BACKEND_PREFIX) + name + ".so";
+  const fs::path path = directory / filename;
   std::error_code ec;
-  if (!fs::exists(path, ec)) {
-    return false;
+  if (fs::exists(path, ec)) {
+    return ggml_backend_load(path.string().c_str()) != nullptr;
   }
-  return ggml_backend_load(path.string().c_str()) != nullptr;
+#if defined(__ANDROID__)
+  // Android may keep native libraries compressed inside the APK. In that
+  // layout there is no filesystem path, but bionic can resolve the uniquely
+  // named library directly from the APK by basename.
+  return ggml_backend_load(filename.c_str()) != nullptr;
+#else
+  return false;
+#endif
 }
 
-bool hasAdrenoGpu() {
-  for (size_t index = 0; index < ggml_backend_dev_count(); ++index) {
-    ggml_backend_dev_t device = ggml_backend_dev_get(index);
-    if (device == nullptr) {
-      continue;
-    }
-    const char* description = ggml_backend_dev_description(device);
-    if (description == nullptr) {
-      continue;
-    }
-    std::string normalized(description);
-    std::transform(
-        normalized.begin(),
-        normalized.end(),
-        normalized.begin(),
-        [](unsigned char character) {
-          return static_cast<char>(std::tolower(character));
-        });
-    if (normalized.find("adreno") != std::string::npos) {
-      return true;
+int adrenoVersionFromDescription(const std::string& description) {
+  std::string normalized = description;
+  std::transform(
+      normalized.begin(),
+      normalized.end(),
+      normalized.begin(),
+      [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+      });
+  if (normalized.find("dreno") == std::string::npos) {
+    return -1;
+  }
+  static const std::regex adrenoRegex(R"(dreno\D*?(\d{3,4}))");
+  std::smatch matches;
+  if (std::regex_search(normalized, matches, adrenoRegex) &&
+      matches.size() > 1) {
+    try {
+      return std::stoi(matches[1].str());
+    } catch (const std::exception&) {
+      return -3;
     }
   }
-  return false;
+  return -3;
+}
+
+int minimumAdrenoVersion(ggml_backend_reg_t backend) {
+  if (backend == nullptr) {
+    return -2;
+  }
+  int minimum = std::numeric_limits<int>::max();
+  for (size_t index = 0; index < ggml_backend_reg_dev_count(backend); ++index) {
+    ggml_backend_dev_t device = ggml_backend_reg_dev_get(backend, index);
+    const char* description =
+        device != nullptr ? ggml_backend_dev_description(device) : nullptr;
+    const int version =
+        adrenoVersionFromDescription(description != nullptr ? description : "");
+    if (version > 0) {
+      minimum = std::min(minimum, version);
+    }
+  }
+  return minimum < std::numeric_limits<int>::max() ? minimum : -1;
 }
 
 bool loadCpuBackend(const fs::path& directory) {
@@ -110,17 +139,36 @@ bool loadCpuBackend(const fs::path& directory) {
   return false;
 }
 
-void loadBackendsFromRoot(const fs::path& root) {
+void loadBackendsFromRoot(
+    const fs::path& root, const std::string& openclCacheDir) {
   const fs::path directory = joinBackendsSubdir(root);
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::INFO,
       std::string("loading isolated TTS ggml backends from: ") +
           directory.string());
 
+  if (!openclCacheDir.empty()) {
+    setenv("GGML_OPENCL_CACHE_DIR", openclCacheDir.c_str(), 1);
+  }
+
+  ggml_backend_reg_t vulkanBackend = nullptr;
   if (std::getenv("GGML_DISABLE_VULKAN") == nullptr) {
     loadBackend(directory, "vulkan");
+    vulkanBackend = ggml_backend_reg_by_name("vulkan");
   }
-  if (hasAdrenoGpu() || std::getenv("GGML_OPENCL_FORCE_LOAD") != nullptr) {
+
+  const int adrenoVersion = minimumAdrenoVersion(vulkanBackend);
+  bool loadOpencl = adrenoVersion > 700;
+  if (adrenoVersion > 0 && adrenoVersion <= 700 &&
+      vulkanBackend != nullptr) {
+    // Match ggml-speech's policy: Adreno 700 and older use CPU because neither
+    // Vulkan nor OpenCL is stable there.
+    ggml_backend_unload(vulkanBackend);
+  }
+  if (std::getenv("GGML_OPENCL_FORCE_LOAD") != nullptr) {
+    loadOpencl = true;
+  }
+  if (loadOpencl) {
     loadBackend(directory, "opencl");
   }
 
@@ -136,12 +184,13 @@ void loadBackendsFromRoot(const fs::path& root) {
 } // namespace
 #endif
 
-void ensureLoaded(const std::string& backendsRoot) {
+void ensureLoaded(
+    const std::string& backendsRoot, const std::string& openclCacheDir) {
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
   static std::once_flag flag;
   std::call_once(flag, [&]() {
     if (!backendsRoot.empty()) {
-      loadBackendsFromRoot(fs::path(backendsRoot));
+      loadBackendsFromRoot(fs::path(backendsRoot), openclCacheDir);
       return;
     }
 
@@ -149,9 +198,14 @@ void ensureLoaded(const std::string& backendsRoot) {
     std::error_code ec;
     if (!selfLocatedRoot.empty() &&
         fs::exists(joinBackendsSubdir(selfLocatedRoot), ec)) {
-      loadBackendsFromRoot(selfLocatedRoot);
+      loadBackendsFromRoot(selfLocatedRoot, openclCacheDir);
       return;
     }
+
+#if defined(__ANDROID__)
+    loadBackendsFromRoot(fs::path{}, openclCacheDir);
+    return;
+#endif
 
     QLOG(
         qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
@@ -161,6 +215,7 @@ void ensureLoaded(const std::string& backendsRoot) {
   });
 #else
   static_cast<void>(backendsRoot);
+  static_cast<void>(openclCacheDir);
 #endif
 }
 

--- a/packages/tts-ggml/addon/src/model-interface/BackendLoader.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/BackendLoader.hpp
@@ -7,7 +7,8 @@ namespace qvac::ttsggml::backend {
 
 // Loads this addon's uniquely named dynamic GGML backends once. backendsRoot
 // is the package prebuilds directory; BACKENDS_SUBDIR is appended internally.
-void ensureLoaded(const std::string& backendsRoot);
+void ensureLoaded(
+    const std::string& backendsRoot, const std::string& openclCacheDir = {});
 
 } // namespace qvac::ttsggml::backend
 

--- a/packages/tts-ggml/addon/src/model-interface/BackendLoader.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/BackendLoader.hpp
@@ -1,0 +1,14 @@
+#ifndef QVAC_TTSGGML_BACKENDLOADER_HPP
+#define QVAC_TTSGGML_BACKENDLOADER_HPP
+
+#include <string>
+
+namespace qvac::ttsggml::backend {
+
+// Loads this addon's uniquely named dynamic GGML backends once. backendsRoot
+// is the package prebuilds directory; BACKENDS_SUBDIR is appended internally.
+void ensureLoaded(const std::string& backendsRoot);
+
+} // namespace qvac::ttsggml::backend
+
+#endif // QVAC_TTSGGML_BACKENDLOADER_HPP

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -18,6 +18,7 @@
 
 #include "addon/TTSErrors.hpp"
 #include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/BackendLoader.hpp"
 #include "model-interface/BackendUtils.hpp"
 #include "model-interface/EnhancerLoader.hpp"
 #include "model-interface/OutputResampler.hpp"
@@ -67,6 +68,9 @@ constexpr int DEFAULT_N_CTX = 4096;
 constexpr const char* DEFAULT_KV_CACHE_TYPE = "f16";
 
 tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) {
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir);
+#endif
   tts_cpp::chatterbox::EngineOptions opts;
   opts.t3_gguf_path    = cfg.t3ModelPath;
   opts.s3gen_gguf_path = cfg.s3genModelPath;

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -69,7 +69,7 @@ constexpr const char* DEFAULT_KV_CACHE_TYPE = "f16";
 
 tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) {
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
-  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir);
+  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir, cfg.openclCacheDir);
 #endif
   tts_cpp::chatterbox::EngineOptions opts;
   opts.t3_gguf_path    = cfg.t3ModelPath;

--- a/packages/tts-ggml/addon/src/model-interface/parler/ParlerModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/parler/ParlerModel.cpp
@@ -16,6 +16,7 @@
 
 #include "addon/TTSErrors.hpp"
 #include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/BackendLoader.hpp"
 #include "model-interface/BackendUtils.hpp"
 #include "model-interface/OutputResampler.hpp"
 
@@ -48,6 +49,9 @@ tts_cpp::parler::DescriptionSpec toSpec(const ParlerDescriptionFields& d) {
 }
 
 tts_cpp::parler::EngineOptions toEngineOptions(const ParlerConfig& cfg) {
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir);
+#endif
   tts_cpp::parler::EngineOptions opts;
   opts.model_gguf_path = cfg.modelGgufPath;
   opts.default_description = ParlerModel::resolveDescription(cfg.desc);

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -46,7 +46,7 @@ namespace general_error = qvac_errors::general_error;
 
 tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) {
 #if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
-  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir);
+  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir, cfg.openclCacheDir);
 #endif
   tts_cpp::supertonic::EngineOptions opts;
   opts.model_gguf_path = cfg.modelGgufPath;

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -17,6 +17,7 @@
 
 #include "addon/TTSErrors.hpp"
 #include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/BackendLoader.hpp"
 #include "model-interface/BackendUtils.hpp"
 #include "model-interface/EnhancerLoader.hpp"
 #include "model-interface/OutputResampler.hpp"
@@ -44,6 +45,9 @@ using qvac_errors::tts_error::TTSErrorCode;
 namespace general_error = qvac_errors::general_error;
 
 tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) {
+#if defined(__ANDROID__) || (defined(__linux__) && defined(__aarch64__))
+  qvac::ttsggml::backend::ensureLoaded(cfg.backendsDir);
+#endif
   tts_cpp::supertonic::EngineOptions opts;
   opts.model_gguf_path = cfg.modelGgufPath;
   opts.voice           = cfg.voice;


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- ASR and TTS independently package GGML backends using identical `libqvac-speech-ggml-*` filenames.
- Android packaging can replace one addon's backend with another incompatible build, causing native crashes when speech addons are co-loaded.
- Includes the addon-version alignment changes from [#3588](https://github.com/tetherto/qvac/pull/3588), which align the Fabric-based SDK addons.

## 📝 How does it solve it?

- Packages ASR backends as `libqvac-asr-ggml-*` and TTS backends as `libqvac-tts-ggml-*`.
- Adds addon-local loaders that select the correct CPU and GPU libraries while supporting compressed Android APKs.
- Preserves GGML's Adreno Vulkan/OpenCL safety policy and configures the OpenCL cache before initialization.
- Keeps the SDK addon versions aligned with the Fabric compatibility updates.

## 🧪 How was it tested?

- [x] Repository lint diagnostics
- [x] `git diff --check`
- [x] Targeted runtime and packaging review
- [ ] Android build and speech co-load validation in CI