### PR TITLE
infra[notask]: add a bulk approver for fork-ci deployments

### DIFF
--- a/docs/ci/LABELS.md
+++ b/docs/ci/LABELS.md
@@ -17,8 +17,22 @@ Secret-bearing CI on **external fork PRs** is gated by the GitHub Actions **`for
 | **Internal PRs** | Same-repo PRs skip the environment gate (empty environment) and run without an approval prompt. |
 | **Implementation** | `fork-approval` job calls [`.github/workflows/reusable-fork-approval.yml`](../../.github/workflows/reusable-fork-approval.yml) from each privileged workflow. The `authorize` / `resolve-config` job runs **after** `fork-approval`, checks out `authorize-pr` from the **default branch only**, and `authorize-pr` reads the `qvac/fork-verified` status on the current head SHA as belt-and-suspenders. |
 | **Ops verification** | Run `node .github/scripts/verify-fork-ci-environment.mjs` (requires `gh` auth with environments read) to confirm required reviewers are configured on the `fork-ci` environment. |
+| **Bulk approval** | A fork PR spreads across several runs, each with its own prompt. `node scripts/ci/approve-fork-ci.mjs <pr>` approves them in one go — see [Approving several runs at once](#approving-several-runs-at-once). |
 
 There is **no self-service path** for external contributors — a merge/release team member must approve the workflow run.
+
+### Approving several runs at once
+
+GitHub scopes environment approval to a single workflow run, so a fork PR touching several packages puts a separate prompt on each of its runs — 7 is typical here. They all encode the same per-commit decision, so walking them by hand costs minutes and adds nothing.
+
+```bash
+node scripts/ci/approve-fork-ci.mjs <pr-number>          # list what is pending
+node scripts/ci/approve-fork-ci.mjs <pr-number> --sha <commit> --yes
+```
+
+The first form is a dry run: it prints every pending `fork-ci` deployment and hands you the pinned command to run next. `--yes` requires `--sha` naming the commit you reviewed, and refuses if the fork has pushed since — the head SHA is resolved when the command runs, so without that pin a commit that landed mid-review would be approved sight-unseen. It approves all runs or none, so a PR can never end up with some privileged jobs run and others silently skipped.
+
+This only replaces the clicking. GitHub still enforces required-reviewer membership and `prevent_self_review` server-side, so the script can do nothing you could not do by hand in the Actions UI.
 
 ### Ordering matters: approve `fork-ci` **before** applying stage labels
 

--- a/scripts/ci/__tests__/approve-fork-ci.test.mjs
+++ b/scripts/ci/__tests__/approve-fork-ci.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseArgs, checkApprovalPin } from '../approve-fork-ci.mjs'
+
+const HEAD = 'c969e50dde20ea728db8ed6c1f1162fdc7a9dd73'
+
+test('parseArgs: pr number, sha pin and confirmation flag', () => {
+  assert.deepEqual(parseArgs(['3510']), { pr: '3510', sha: null, confirmed: false })
+  assert.deepEqual(parseArgs(['3510', '--sha', HEAD, '--yes']), {
+    pr: '3510',
+    sha: HEAD,
+    confirmed: true,
+  })
+  assert.deepEqual(parseArgs(['--yes', '--sha', HEAD, '3510']), {
+    pr: '3510',
+    sha: HEAD,
+    confirmed: true,
+  })
+})
+
+test('parseArgs: rejects unknown arguments rather than ignoring them', () => {
+  assert.throws(() => parseArgs(['3510', '--force']), /unknown argument: --force/)
+})
+
+test('a dry run needs no pin', () => {
+  assert.equal(
+    checkApprovalPin({ requestedSha: null, currentSha: HEAD, confirmed: false }),
+    null,
+  )
+})
+
+test('approving requires naming the reviewed commit', () => {
+  const error = checkApprovalPin({
+    requestedSha: null,
+    currentSha: HEAD,
+    confirmed: true,
+  })
+  assert.match(error, /--yes requires --sha/)
+})
+
+test('approving a commit that moved since review is refused', () => {
+  // The head SHA is resolved at invocation time. Without this check, a push
+  // landing between review and approval would be approved sight-unseen.
+  const error = checkApprovalPin({
+    requestedSha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    currentSha: HEAD,
+    confirmed: true,
+  })
+  assert.match(error, /does not match the current head/)
+})
+
+test('approving the reviewed commit is allowed, including by short sha', () => {
+  assert.equal(
+    checkApprovalPin({ requestedSha: HEAD, currentSha: HEAD, confirmed: true }),
+    null,
+  )
+  assert.equal(
+    checkApprovalPin({ requestedSha: 'c969e50dd', currentSha: HEAD, confirmed: true }),
+    null,
+  )
+})
+
+test('a short sha must be a prefix, not merely a substring', () => {
+  const error = checkApprovalPin({
+    requestedSha: '969e50dd',
+    currentSha: HEAD,
+    confirmed: true,
+  })
+  assert.match(error, /does not match the current head/)
+})

--- a/scripts/ci/approve-fork-ci.mjs
+++ b/scripts/ci/approve-fork-ci.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Approve every pending `fork-ci` deployment for a fork PR's head commit.
+ *
+ * GitHub scopes environment approval to a single workflow run, and a fork PR
+ * that touches several packages spreads across many runs — 7 is typical here.
+ * All of those encode one decision ("is this commit safe to run with secrets"),
+ * which is per-SHA, so clicking through each run costs the approver minutes and
+ * buys no additional safety.
+ *
+ * This changes only the clicking. GitHub still enforces required-reviewer
+ * membership and prevent_self_review server-side, so this can do nothing the
+ * operator could not do by hand in the Actions UI.
+ *
+ * Dry run by default. `--yes` additionally requires `--sha` naming the commit
+ * you reviewed: the head SHA is resolved at invocation time, so without that
+ * pin a push landing between your review and your approval would be approved
+ * sight-unseen. The dry run prints the exact pinned command to run next.
+ *
+ *   node scripts/ci/approve-fork-ci.mjs 3510
+ *   node scripts/ci/approve-fork-ci.mjs 3510 --sha c969e50dd... --yes
+ */
+import { spawnSync } from 'node:child_process'
+
+const REPO = process.env.QVAC_REPO || 'tetherto/qvac'
+const ENVIRONMENT = 'fork-ci'
+
+export function parseArgs(argv) {
+  const args = { pr: null, sha: null, confirmed: false }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--yes') args.confirmed = true
+    else if (arg === '--sha') args.sha = argv[++i] ?? null
+    else if (/^\d+$/.test(arg)) args.pr = arg
+    else throw new Error(`unknown argument: ${arg}`)
+  }
+  return args
+}
+
+/**
+ * Gate on the operator having named the commit they reviewed. Returns an error
+ * string rather than throwing so the caller can print it alongside context.
+ */
+export function checkApprovalPin({ requestedSha, currentSha, confirmed }) {
+  if (!confirmed) return null
+  if (!requestedSha) {
+    return '--yes requires --sha <commit> naming the commit you reviewed.'
+  }
+  if (!currentSha.startsWith(requestedSha)) {
+    return (
+      `refusing to approve: --sha ${requestedSha} does not match the current head ` +
+      `${currentSha}. The fork pushed after you reviewed it — re-review the new commit.`
+    )
+  }
+  return null
+}
+
+function gh(args) {
+  const res = spawnSync('gh', args, { encoding: 'utf8' })
+  if (res.status !== 0) {
+    throw new Error(`gh ${args.join(' ')} failed: ${res.stderr || res.stdout}`)
+  }
+  return res.stdout.trim()
+}
+
+function ghJson(args) {
+  const out = gh(args)
+  return out ? JSON.parse(out) : null
+}
+
+function collectPending(sha) {
+  const runs =
+    ghJson([
+      'api', `repos/${REPO}/actions/runs?head_sha=${sha}&per_page=100`,
+      '--jq', '[.workflow_runs[] | {id, name}]',
+    ]) ?? []
+
+  const pending = []
+  for (const run of runs) {
+    const deployments =
+      ghJson([
+        'api', `repos/${REPO}/actions/runs/${run.id}/pending_deployments`,
+        '--jq',
+        `[.[] | select(.environment.name == "${ENVIRONMENT}")
+              | {envId: .environment.id, canApprove: .current_user_can_approve}]`,
+      ]) ?? []
+    for (const deployment of deployments) pending.push({ ...run, ...deployment })
+  }
+  return pending
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.pr) {
+    console.error('usage: approve-fork-ci.mjs <pr-number> [--sha <commit>] [--yes]')
+    process.exit(2)
+  }
+
+  const meta = ghJson([
+    'pr', 'view', args.pr, '--repo', REPO,
+    '--json', 'headRefOid,isCrossRepository,headRepositoryOwner,title',
+  ])
+
+  if (!meta.isCrossRepository) {
+    console.log(`PR #${args.pr} is not from a fork — ${ENVIRONMENT} approval does not apply.`)
+    return
+  }
+
+  const sha = meta.headRefOid
+  const pinError = checkApprovalPin({
+    requestedSha: args.sha,
+    currentSha: sha,
+    confirmed: args.confirmed,
+  })
+  if (pinError) {
+    console.error(pinError)
+    process.exit(1)
+  }
+
+  console.log(`PR #${args.pr} — ${meta.title}`)
+  console.log(`fork: ${meta.headRepositoryOwner.login}`)
+  console.log(`head: ${sha}\n`)
+
+  const pending = collectPending(sha)
+  if (pending.length === 0) {
+    console.log(`No pending ${ENVIRONMENT} deployments on this commit — nothing to approve.`)
+    return
+  }
+
+  console.log(`${pending.length} pending ${ENVIRONMENT} deployment(s):`)
+  for (const item of pending) {
+    console.log(`  ${item.canApprove ? '•' : '✗'} ${item.name}  (run ${item.id})`)
+  }
+
+  // Approve all or none: a partial approval leaves the PR in a state where some
+  // privileged jobs ran and some silently did not, which reads as "tested".
+  const blocked = pending.filter((item) => !item.canApprove)
+  if (blocked.length) {
+    console.error(
+      `\n${blocked.length} of these cannot be approved by you — you are not a required ` +
+        'reviewer on fork-ci, or this is your own run (self-review is blocked). Nothing approved.',
+    )
+    process.exit(1)
+  }
+
+  if (!args.confirmed) {
+    console.log(`\nReview the diff first: https://github.com/${REPO}/pull/${args.pr}/files`)
+    console.log('Approval authorises this exact commit to run with secrets on our runners.\n')
+    console.log('Then run:')
+    console.log(`  node scripts/ci/approve-fork-ci.mjs ${args.pr} --sha ${sha} --yes`)
+    return
+  }
+
+  for (const item of pending) {
+    gh([
+      'api', `repos/${REPO}/actions/runs/${item.id}/pending_deployments`,
+      '--method', 'POST',
+      '-F', `environment_ids[]=${item.envId}`,
+      '-f', 'state=approved',
+      '-f', `comment=Approved for ${sha.slice(0, 9)} via approve-fork-ci`,
+    ])
+    console.log(`approved: ${item.name} (run ${item.id})`)
+  }
+
+  console.log(`\nApproved ${pending.length} run(s) for ${sha.slice(0, 9)}.`)
+  console.log('The next push to this PR invalidates the approval and needs a fresh one.')
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main()
+  } catch (e) {
+    console.error(`approve-fork-ci: ${e.message}`)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- GitHub scopes environment approval to a **single workflow run**. A fork PR that touches several packages spreads across many runs, so the approver gets a separate prompt on each one. Measured on live fork PRs: **#3510 and #3404 need 7 approvals each**, across 7 distinct run IDs. There is no PR-level or SHA-level approve in the GitHub UI and no setting that changes this.

- All of those prompts encode **one** decision — "is this commit safe to run with secrets on our runners" — which is per-SHA, not per-run. The extra clicks cost the approver several minutes per fork PR and buy no additional safety. Raised by @dima.

## 📝 How does it solve it?

- `scripts/ci/approve-fork-ci.mjs` approves every pending `fork-ci` deployment on a PR's head commit in one command.

- **It only replaces the clicking.** GitHub still enforces required-reviewer membership and `prevent_self_review` server-side, so the script can do nothing the operator could not do by hand in the Actions UI. No workflow, action, or environment config is touched — the trust gate itself is unchanged.

```bash
node scripts/ci/approve-fork-ci.mjs 3510                      # dry run: list what is pending
node scripts/ci/approve-fork-ci.mjs 3510 --sha c969e50dd --yes
```

Safety properties, each covered by a unit test:

| Property | Why |
|---|---|
| Dry run by default | The default invocation cannot approve anything; it prints the pinned command to run next. |
| `--yes` requires `--sha` | The head SHA is resolved *at invocation time*. Without a pin, a push landing between your review and your approval would be approved sight-unseen. |
| Stale `--sha` is refused | Tells you the fork moved and to re-review, rather than silently approving newer code. |
| Short SHAs must be a **prefix** | A substring match would let an unrelated commit satisfy the pin. |
| All-or-nothing | If any pending deployment is not approvable by you, nothing is approved. A partial approval leaves a PR where some privileged jobs ran and others silently did not — which reads as "tested". |
| No-ops on same-repo PRs | `fork-ci` does not apply to them. |

## 🧪 How was it tested?

- [x] `node --test scripts/ci/__tests__/approve-fork-ci.test.mjs` — 7/7 pass.
- [x] Dry run against the **live** pending deployments on #3510: correctly lists all 5 and emits the pinned follow-up command.
- [x] `--yes` with **no** `--sha` → refused, exit 1.
- [x] `--yes` with a **stale** `--sha` → refused, exit 1, with a re-review message.
- [x] Re-checked after both refusals: all 5 deployments still pending, nothing approved.
- [x] Correctly no-ops on a same-repo PR (#3597).
- [x] `ci-trust-policy.test.mjs` still 51/51 — no workflow or action modified.

## 🛡️ Permissions changes

Not applicable — this is a local operator tool run with the maintainer's own `gh` credentials. No workflow permissions are added or changed.

---

### Deliberately not included

A follow-up idea was to have `reusable-fork-approval.yml` skip the environment when `qvac/fork-verified` already exists on the head SHA. It would not help the case being complained about — all runs start simultaneously and every precheck sees "not approved" before any approval lands, so the initial burst still queues. Its only real benefit is the second wave (approve → add a stage label → approve again), which this script already covers by re-running it. That is not worth editing the sole fork trust gate, where a mistake is a fail-open.
