### PR TITLE
feat[notask]: add KAT-Coder V2.5 Dev IQ2_XXS to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8205,27 +8205,5 @@
     "tags": ["generation", "instruct", "moe", "kat-coder", "coding"],
     "notes": "",
     "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
-  },
-  {
-    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-Q4_K_M.gguf",
-    "engine": "@qvac/llm-llamacpp",
-    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
-    "quantization": "q4_k_m",
-    "params": "35B",
-    "licenseId": "Apache-2.0",
-    "tags": ["generation", "instruct", "moe", "kat-coder", "coding"],
-    "notes": "",
-    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
-  },
-  {
-    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-Q8_0.gguf",
-    "engine": "@qvac/llm-llamacpp",
-    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
-    "quantization": "q8_0",
-    "params": "35B",
-    "licenseId": "Apache-2.0",
-    "tags": ["generation", "instruct", "moe", "kat-coder", "coding"],
-    "notes": "",
-    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
   }
 ]

--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8194,5 +8194,38 @@
     "tags": ["tts", "cosyvoice", "cosyvoice3", "voice", "zh", "female", "gguf"],
     "notes": "",
     "link": "https://huggingface.co/FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+  },
+  {
+    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-IQ2_XXS.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
+    "quantization": "iq2_xxs",
+    "params": "35B",
+    "licenseId": "Apache-2.0",
+    "tags": ["generation", "instruct", "moe", "kat-coder", "coding"],
+    "notes": "",
+    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-Q4_K_M.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
+    "quantization": "q4_k_m",
+    "params": "35B",
+    "licenseId": "Apache-2.0",
+    "tags": ["generation", "instruct", "moe", "kat-coder", "coding"],
+    "notes": "",
+    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
+    "quantization": "q8_0",
+    "params": "35B",
+    "licenseId": "Apache-2.0",
+    "tags": ["generation", "instruct", "moe", "kat-coder", "coding"],
+    "notes": "",
+    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
   }
 ]


### PR DESCRIPTION
## Summary
- Add **IQ2_XXS** (~9.1 GB) bartowski GGUF of [Kwaipilot/KAT-Coder-V2.5-Dev](https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF) to `models.prod.json`
- Engine `@qvac/llm-llamacpp`, license `Apache-2.0`, params `35B` (35B-A3B MoE, `qwen35moe`)
- Source pinned to HF commit `d8f684f08d2950ea9d2db6a35ef7dada0707858b`

## Follow-ups (separate PRs after this sync lands)
- Q4_K_M (~19.9 GB)
- Q8_0 (~34.4 GB)
- SDK constants via `/qv-sdk-update-models` once desired quants are live

## Test plan
- [x] `node scripts/validate-models-json.js` — Valid: 750 models
- [ ] CI `validate-json` on this PR
- [ ] After merge: confirm `sync-staging` + smoke test succeed
- [ ] Spot-check via `modelRegistrySearch({ filter: "kat-coder" })`