### PR TITLE
QVAC-21988 chore: depend on PyPI bare-rpc and add sdk-python publish WF

### DIFF
--- a/.github/workflows/on-pr-sdk-python-e2e-full.yml
+++ b/.github/workflows/on-pr-sdk-python-e2e-full.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Install (with transport + optional extras)
         run: |
-          "$PYBIN" -m pip install -e ".[gen,dev,bare-rpc,vla,notebook]"
+          "$PYBIN" -m pip install -e ".[gen,dev,vla,notebook]"
 
       - name: Build worker
         run: |

--- a/.github/workflows/on-pr-sdk-python-e2e.yml
+++ b/.github/workflows/on-pr-sdk-python-e2e.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install (with transport + optional extras)
         run: |
           python3 -m venv .venv
-          .venv/bin/pip install --quiet -e ".[gen,dev,bare-rpc,vla,notebook]"
+          .venv/bin/pip install --quiet -e ".[gen,dev,vla,notebook]"
 
       # All-public @qvac deps, no auth — same as the CLI's plain build.
       - name: Build worker

--- a/.github/workflows/pr-checks-sdk-python.yml
+++ b/.github/workflows/pr-checks-sdk-python.yml
@@ -58,10 +58,8 @@ jobs:
           .venv/bin/python3 -m mypy scripts
           .venv/bin/python3 -m mypy tests
 
-      # Fast leg: mocked unit tests only. The real-worker tests (transport, poc,
-      # conformance corpus, orchestrate tool loop, disconnect) skip themselves
-      # here — no worker is built and bare-rpc isn't installed — and run in the
-      # test-e2e-smoke-gated on-pr-sdk-python-e2e.yml instead, which is long (it
-      # downloads models).
+      # Fast leg: mocked unit tests + transport unit tests that do not need a
+      # worker. Real-worker tests skip themselves here (no worker built) and run
+      # in the test-e2e-smoke-gated on-pr-sdk-python-e2e.yml instead.
       - name: Test (unit)
         run: .venv/bin/python3 -m pytest tests/ -v

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -1,0 +1,85 @@
+# Publish tetherto-qvac-sdk via PyPI Trusted Publisher (OIDC).
+# Configure publisher on PyPI: workflow publish-sdk-python.yml, env pypi.
+# Tags: sdk-python-vX.Y.Z
+
+name: Publish SDK Python
+
+on:
+  push:
+    tags:
+      - "sdk-python-v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload to PyPI (requires Trusted Publisher)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-sdk-python-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: packages/sdk-python
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
+        with:
+          python-version: "3.10"
+
+      - name: Install build tooling
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install --quiet -U pip
+          .venv/bin/pip install --quiet build twine
+          .venv/bin/pip install --quiet -e ".[gen]"
+
+      - name: Contract check
+        run: .venv/bin/python3 scripts/generate.py --check
+
+      - name: Build
+        run: .venv/bin/python3 -m build --sdist --wheel --outdir dist/
+
+      - name: Check metadata
+        run: .venv/bin/python3 -m twine check dist/*
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: tetherto-qvac-sdk-dist
+          path: packages/sdk-python/dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: >-
+      github.repository == 'tetherto/qvac' &&
+      (startsWith(github.ref, 'refs/tags/sdk-python-v') ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish == true))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tetherto-qvac-sdk
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: tetherto-qvac-sdk-dist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -17,14 +17,11 @@ anything to run**.
 **1. Install the package**
 
 ```bash
-pip install "tetherto-qvac-sdk[bare-rpc]"
+pip install tetherto-qvac-sdk
 ```
 
-The `bare-rpc` extra is **required** — it's the wire transport (`bare-rpc-python`)
-the client speaks to the worker. It's an extra only because its dependencies are
-git-only for now; it folds into the base install once they're on PyPI. Genuinely
-optional extras: `vla` (numpy), `notebook` (numpy + pandas). (`langdetect` is no
-longer needed — source-language detection moved into the worker.)
+That pulls the wire transport (`bare-rpc`, `compact-encoding`) from PyPI.
+Optional extras: `vla` (numpy), `notebook` (numpy + pandas).
 
 **2. Install the worker** (one time) — either route works; both need Node.js:
 
@@ -112,7 +109,7 @@ models in `tetherto.qvac_sdk.schemas`, if you prefer the explicit modules.
 For notebooks and REPLs, `tetherto.qvac_sdk.notebook.SyncClient` runs the async
 client on a background thread so every call is plain and blocking (no `await`),
 with numpy/pandas returns and live in-cell streaming. Needs the `notebook`
-extra (`pip install "tetherto-qvac-sdk[notebook,bare-rpc]"`):
+extra (`pip install "tetherto-qvac-sdk[notebook]"`):
 
 ```python
 from tetherto.qvac_sdk.notebook import SyncClient
@@ -186,7 +183,7 @@ than trusted to match.
 
 ```bash
 python3 -m venv .venv
-.venv/bin/pip install -e ".[gen,dev,bare-rpc]"
+.venv/bin/pip install -e ".[gen,dev]"
 .venv/bin/python3 scripts/generate.py          # regenerate from ../sdk/contract
 .venv/bin/python3 -m pytest                     # unit + (with a built worker) real-model e2e
 ```

--- a/packages/sdk-python/examples/notebook.ipynb
+++ b/packages/sdk-python/examples/notebook.ipynb
@@ -12,7 +12,7 @@
     "Install the `notebook` extra:\n",
     "\n",
     "```bash\n",
-    "pip install \"tetherto-qvac-sdk[notebook,bare-rpc]\"\n",
+    "pip install \"tetherto-qvac-sdk[notebook]\"\n",
     "```\n",
     "\n",
     "A worker must be available (see the docs' \"Install the worker\" step); against a source checkout, set `QVAC_SDK_DIR` or pass `SyncClient(sdk_dir=...)`."

--- a/packages/sdk-python/examples/notebook.py
+++ b/packages/sdk-python/examples/notebook.py
@@ -6,7 +6,7 @@ numpy/pandas-native returns and live in-cell streaming. It's the ergonomic way
 to drive QVAC from a Jupyter notebook or a REPL.
 
 Needs the `notebook` extra (numpy + pandas):
-    pip install "tetherto-qvac-sdk[notebook,bare-rpc]"
+    pip install "tetherto-qvac-sdk[notebook]"
 
 RUN: python examples/notebook.py
 """

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -12,7 +12,11 @@ description = "Generated Python client for the QVAC SDK worker RPC"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
-dependencies = ["pydantic>=2.6,<3"]
+dependencies = [
+  "pydantic>=2.6,<3",
+  "bare-rpc>=0.0.1",
+  "compact-encoding>=0.0.1",
+]
 
 [tool.hatch.version]
 path = "src/tetherto/qvac_sdk/_generated/sdk_version.py"
@@ -38,19 +42,6 @@ vla = ["numpy>=1.26"]
 notebook = ["numpy>=1.26", "pandas>=2.2"]
 # scripts/build_wheel.py: the self-contained per-platform wheel build.
 release = ["build>=1.2"]
-# The wire transport -- REQUIRED for the default experience, not truly optional.
-# It's an extra only because neither dep is on PyPI yet (both v0.0.1, git-only)
-# and PyPI rejects direct git references in a package's required dependencies.
-# Fold this into `dependencies` above once both are published. Pinned to their
-# current HEAD commits for reproducibility while unreleased.
-bare-rpc = [
-  "bare-rpc-python @ git+https://github.com/holepunchto/bare-rpc-python.git@5219c528866678553cb9716f80a199c9accfe8c1",
-  "compact-encoding-python @ git+https://github.com/holepunchto/compact-encoding-python.git@e7e1f080eb413c6ea06f8c6400a9716857c67266",
-]
-
-[tool.hatch.metadata]
-# QVAC-21806 PoC: bare-rpc-python/compact-encoding-python aren't on PyPI yet.
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 # PEP 420 namespace package: ship the whole `tetherto/` tree (no
@@ -107,7 +98,5 @@ disable_error_code = ["assignment"]
 
 [[tool.mypy.overrides]]
 module = ["bare_rpc", "compact_encoding"]
-# The bare-rpc extra is optional and git-only (no PyPI release, no py.typed
-# marker), so it's absent from the default install CI type-checks against.
-# bare_rpc_transport.py already guards the import at runtime.
+# Upstream wheels ship without py.typed.
 ignore_missing_imports = true

--- a/packages/sdk-python/src/tetherto/qvac_sdk/bare_rpc_transport.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/bare_rpc_transport.py
@@ -38,8 +38,8 @@ BARE_RPC_AVAILABLE = bare_rpc is not None
 class BareRpcNotInstalledError(ImportError):
     def __init__(self) -> None:
         super().__init__(
-            "bare_rpc is not installed -- install the 'bare-rpc' extra "
-            "(`pip install tetherto-qvac-sdk[bare-rpc]`) to use BareRpcTransport"
+            "bare_rpc is not installed -- reinstall tetherto-qvac-sdk "
+            "(depends on bare-rpc from PyPI) to use BareRpcTransport"
         )
 
 

--- a/packages/sdk-python/src/tetherto/qvac_sdk/bare_rpc_transport.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/bare_rpc_transport.py
@@ -25,22 +25,12 @@ import os
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from typing import Any
 
+import bare_rpc
+
 from .errors import reconstruct_error
 
-try:
-    import bare_rpc
-except ImportError:
-    bare_rpc = None
-
-BARE_RPC_AVAILABLE = bare_rpc is not None
-
-
-class BareRpcNotInstalledError(ImportError):
-    def __init__(self) -> None:
-        super().__init__(
-            "bare_rpc is not installed -- reinstall tetherto-qvac-sdk "
-            "(depends on bare-rpc from PyPI) to use BareRpcTransport"
-        )
+# Required dependency (see pyproject.toml). Kept for existing test skipifs.
+BARE_RPC_AVAILABLE = True
 
 
 def _json_or_raise(data: bytes) -> Any:
@@ -98,8 +88,6 @@ class BareRpcTransport:
         home_dir: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> None:
-        if bare_rpc is None:
-            raise BareRpcNotInstalledError()
         self._command = list(command)
         # QVAC_HOME_DIR lets CI/tests pin the worker's storage root (models,
         # registry) to a cacheable, per-OS-explicit path instead of the

--- a/packages/sdk-python/tests/test_bare_rpc_connect_cleanup.py
+++ b/packages/sdk-python/tests/test_bare_rpc_connect_cleanup.py
@@ -1,8 +1,6 @@
 """Unit coverage for BareRpcTransport.connect() cleanup on spawn failure.
 
-Does not need a built worker — only the bare_rpc extra — so it runs in the
-fast PR check once that extra is installed, and locally with `pip install -e
-'.[bare-rpc]'`.
+Does not need a built worker — only bare_rpc — so it runs in the fast PR check.
 """
 
 from __future__ import annotations
@@ -20,8 +18,8 @@ pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(
         not BARE_RPC_AVAILABLE,
-        reason="bare_rpc not installed -- install the 'bare-rpc' extra "
-        "(`pip install -e '.[bare-rpc]'`) to run these tests",
+        reason="bare_rpc not installed -- reinstall tetherto-qvac-sdk "
+        "(depends on bare-rpc from PyPI) to run these tests",
     ),
 ]
 

--- a/packages/sdk-python/tests/test_bare_rpc_transport.py
+++ b/packages/sdk-python/tests/test_bare_rpc_transport.py
@@ -55,8 +55,8 @@ pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(
         not BARE_RPC_AVAILABLE,
-        reason="bare_rpc not installed -- install the 'bare-rpc' extra "
-        "(`pip install -e '.[bare-rpc]'`) to run these tests",
+        reason="bare_rpc not installed -- reinstall tetherto-qvac-sdk "
+        "(depends on bare-rpc from PyPI) to run these tests",
     ),
     pytest.mark.skipif(
         not WORKER_AVAILABLE,

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -160,7 +160,7 @@ def test_client_raises_when_resolved_paths_do_not_exist(monkeypatch) -> None:
 
 @pytest.mark.skipif(
     not BARE_RPC_AVAILABLE,
-    reason="Client() constructs a BareRpcTransport -- needs the 'bare-rpc' extra",
+    reason="Client() constructs a BareRpcTransport -- needs bare-rpc installed",
 )
 def test_client_transport_property_requires_connect() -> None:
     # __init__ only checks these paths exist, not that they're a real worker --
@@ -172,8 +172,8 @@ def test_client_transport_property_requires_connect() -> None:
 
 @pytest.mark.skipif(
     not BARE_RPC_AVAILABLE,
-    reason="bare_rpc not installed -- install the 'bare-rpc' extra "
-    "(`pip install -e '.[bare-rpc]'`) to run these tests",
+    reason="bare_rpc not installed -- reinstall tetherto-qvac-sdk "
+    "(depends on bare-rpc from PyPI) to run these tests",
 )
 @pytest.mark.skipif(
     not WORKER_AVAILABLE,

--- a/packages/sdk-python/tests/test_conformance.py
+++ b/packages/sdk-python/tests/test_conformance.py
@@ -5,7 +5,7 @@ Python client against a locally-built worker, asserting the same expectations
 the JS runner (packages/sdk/e2e/conformance/run.mjs) checks. One source of
 cases for both clients, so they cannot drift on the covered behaviour.
 
-Gated like test_e2e_sdk_parity: needs the bare-rpc extra and a built SDK worker.
+Gated like test_e2e_sdk_parity: needs bare_rpc and a built SDK worker.
 """
 
 from __future__ import annotations
@@ -50,7 +50,7 @@ def _load_cases() -> list[dict]:
 CASES = _load_cases()
 
 pytestmark = [
-    pytest.mark.skipif(not BARE_RPC_AVAILABLE, reason="bare-rpc extra not installed"),
+    pytest.mark.skipif(not BARE_RPC_AVAILABLE, reason="bare_rpc not installed"),
     pytest.mark.skipif(
         not WORKER_AVAILABLE,
         reason=f"no built SDK worker + Bare runtime (worker={WORKER_PATH!r}, bare={BARE_BIN!r})",

--- a/packages/sdk-python/tests/test_e2e_sdk_parity.py
+++ b/packages/sdk-python/tests/test_e2e_sdk_parity.py
@@ -4,7 +4,7 @@ same prompts, same models, same output expectations as the JS smoke suite,
 so the Python client is held to the JS client's output bar, not a loose
 "non-empty" check.
 
-Gated exactly like test_bare_rpc_transport.py: needs the bare-rpc extra and a
+Gated exactly like test_bare_rpc_transport.py: needs bare_rpc and a
 built SDK worker (`bun run build` in packages/sdk). Models are the SDK e2e's
 own smoke resources; all are commonly cached, and fetch over P2P otherwise.
 """
@@ -38,7 +38,7 @@ WORKER_PATH = os.path.join(SDK_DIR, "dist", "server", "worker.js")
 IMAGES = os.path.join(SDK_DIR, "e2e", "assets", "images")
 
 pytestmark = [
-    pytest.mark.skipif(not BARE_RPC_AVAILABLE, reason="bare-rpc extra not installed"),
+    pytest.mark.skipif(not BARE_RPC_AVAILABLE, reason="bare_rpc not installed"),
     pytest.mark.skipif(
         not WORKER_AVAILABLE,
         reason=f"no built SDK worker + Bare runtime (worker={WORKER_PATH!r}, bare={BARE_BIN!r})",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Transport deps (`bare-rpc`, `compact-encoding`) were git-only extras, so a normal PyPI install of `tetherto-qvac-sdk` was blocked.
- No publish path existed for cutting `tetherto-qvac-sdk` once the org PyPI Trusted Publisher is ready.

## 📝 How does it solve it?

- Make `bare-rpc>=0.0.1` and `compact-encoding>=0.0.1` required dependencies (PyPI); drop git extras and `allow-direct-references`.
- Add `.github/workflows/publish-sdk-python.yml` (OIDC Trusted Publisher on tags `sdk-python-v*` / optional `workflow_dispatch`).
- Update install docs, CI install lines, and skip/error messages that still referred to the `bare-rpc` extra.

## 🧪 How was it tested?

- `pip install -e ".[gen,dev,vla,notebook]"` from PyPI `bare-rpc` / `compact-encoding` 0.0.1
- `scripts/generate.py --check`, ruff
- `pytest -m "not heavy"` against a built `@qvac/sdk` worker: **150 passed**, 2 heavy deselected
- `python -m build` + `twine check` (Requires-Dist includes `bare-rpc` / `compact-encoding`)
