### PR TITLE
feat[notask]: add KAT-Coder V2.5 Dev Q4_K_M to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8205,5 +8205,16 @@
     "tags": ["generation", "instruct", "moe", "kat-coder"],
     "notes": "",
     "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-Q4_K_M.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
+    "quantization": "q4_k_m",
+    "params": "35B",
+    "licenseId": "Apache-2.0",
+    "tags": ["generation", "instruct", "moe", "kat-coder"],
+    "notes": "",
+    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
   }
 ]


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Registry needs a mid-size quality tier for KAT-Coder V2.5 Dev after the IQ2_XXS entry lands

## 📝 How does it solve it?

- Register the bartowski Q4_K_M GGUF (~19.9 GB) in `models.prod.json`, commit-pinned for ingest on merge
- Stacked on the IQ2_XXS PR — merge that first, wait for `sync-staging`, then merge this one

## 🧪 How was it tested?

- Ran `node scripts/validate-models-json.js` locally
- Post-merge: confirm `sync-staging` + smoke test; spot-check with `modelRegistrySearch({ filter: "kat-coder" })`
