### PR TITLE
feat[notask]: add KAT-Coder V2.5 Dev Q8_0 to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8216,5 +8216,16 @@
     "tags": ["generation", "instruct", "moe", "kat-coder"],
     "notes": "",
     "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF/resolve/d8f684f08d2950ea9d2db6a35ef7dada0707858b/Kwaipilot_KAT-Coder-V2.5-Dev-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "KAT-Coder V2.5 Dev 35B-A3B MoE coding model (bartowski GGUF)",
+    "quantization": "q8_0",
+    "params": "35B",
+    "licenseId": "Apache-2.0",
+    "tags": ["generation", "instruct", "moe", "kat-coder"],
+    "notes": "",
+    "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
   }
 ]


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Registry needs a high-fidelity tier for KAT-Coder V2.5 Dev after smaller quants land

## 📝 How does it solve it?

- Register the bartowski Q8_0 GGUF (~34.4 GB) in `models.prod.json`, commit-pinned for ingest on merge
- Stacked after Q4_K_M — merge prior KAT-Coder PRs first, wait for each `sync-staging`, then merge this one

## 🧪 How was it tested?

- Ran `node scripts/validate-models-json.js` locally
- Post-merge: confirm `sync-staging` + smoke test; spot-check with `modelRegistrySearch({ filter: "kat-coder" })`
