### PR TITLE
QVAC-22824 fix: align speech addons on ggml-speech

### DIFF
--- a/packages/asr-ggml/vcpkg-configuration.json
+++ b/packages/asr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "f66882852e7e9a6ae01f995491c74f509936b037",
+    "baseline": "73b3017dd7c7493e9be1b687b706e675df635145",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -62,7 +62,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.9.1",
-      "port-version": 5
+      "port-version": 6
     }
   ]
 }

--- a/packages/bci-whispercpp/vcpkg-configuration.json
+++ b/packages/bci-whispercpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a9d7e924de8cb7133c54c5b1d446e4d9c0508ec8",
+    "baseline": "73b3017dd7c7493e9be1b687b706e675df635145",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -38,7 +38,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.9.1",
-      "port-version": 4
+      "port-version": 6
     }
   ]
 }

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4dbe15d8c3a181d691289739c9531a09d46eae27",
+    "baseline": "73b3017dd7c7493e9be1b687b706e675df635145",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-07-30"
+      "version>=": "2026-08-03"
     }
   ],
   "features": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- ASR, TTS, and BCI currently resolve different `ggml-speech` revisions while packaging backends under the same native library names.
- Co-loading those addons can therefore substitute an incompatible GGML backend and crash mobile E2E consumers.

## 📝 How does it solve it?

- Pins all three addons to registry baseline `73b3017dd7c7493e9be1b687b706e675df635145`, which resolves `ggml-speech` to `2026-07-30`.
- Aligns ASR and BCI on `whisper-cpp` `1.9.1#6` and updates TTS to the stabilized `tts-cpp` `2026-08-03` revision.
- Keeps one shared speech-backend build instead of introducing addon-specific backend filenames and loaders.

## 🧪 How was it tested?

- [x] Parsed all edited vcpkg manifests as JSON
- [x] `git diff --check`
- [x] Repository lint diagnostics
- [ ] Native prebuild and mobile co-load validation in CI

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216917020008328