### PR TITLE
QVAC-23032 mod: add DeepSeek V4 Flash registry entries

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8205,5 +8205,38 @@
     "tags": ["generation", "instruct", "moe", "kat-coder"],
     "notes": "",
     "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF/resolve/109848da2469efe1f1aab9e11acea08a065ccd4f/UD-IQ2_M/DeepSeek-V4-Flash-0731-UD-IQ2_M-00001-of-00003.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "DeepSeek V4 Flash 0731 UD-IQ2_M model",
+    "quantization": "UD-IQ2_M",
+    "params": "304B",
+    "licenseId": "MIT",
+    "tags": ["generation", "instruct", "deepseek-v4", "shard"],
+    "notes": "shard 1/3",
+    "link": "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF/resolve/109848da2469efe1f1aab9e11acea08a065ccd4f/UD-IQ2_M/DeepSeek-V4-Flash-0731-UD-IQ2_M-00002-of-00003.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "DeepSeek V4 Flash 0731 UD-IQ2_M model",
+    "quantization": "UD-IQ2_M",
+    "params": "304B",
+    "licenseId": "MIT",
+    "tags": ["generation", "instruct", "deepseek-v4", "shard"],
+    "notes": "shard 2/3",
+    "link": "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF/resolve/109848da2469efe1f1aab9e11acea08a065ccd4f/UD-IQ2_M/DeepSeek-V4-Flash-0731-UD-IQ2_M-00003-of-00003.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "DeepSeek V4 Flash 0731 UD-IQ2_M model",
+    "quantization": "UD-IQ2_M",
+    "params": "304B",
+    "licenseId": "MIT",
+    "tags": ["generation", "instruct", "deepseek-v4", "shard"],
+    "notes": "shard 3/3",
+    "link": "https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF"
   }
 ]


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- There's no DeepSeek model in the registry currently.

## 📝 How does it solve it?

- Adds DeepSeek V4 Flash sharded model to `models.prod.json`

## 🧪 How was it tested?

- Ran `npm run validate:models`.

## 📦 Models

### Added models

```
DeepSeek-V4-Flash-0731-UD-IQ2_M
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217027802865423