### PR TITLE
QVAC-23105 chore: bump @qvac/bci-whispercpp to ^0.6.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -202,7 +202,7 @@
     "changelog:generate": "node ../../scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk && prettier --write changelog"
   },
   "dependencies": {
-    "@qvac/bci-whispercpp": "^0.5.0",
+    "@qvac/bci-whispercpp": "^0.6.0",
     "@qvac/classification-ggml": "^0.15.1",
     "@qvac/decoder-audio": "^0.5.0",
     "@qvac/diffusion-cpp": "^0.17.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The SDK pins `@qvac/bci-whispercpp` at `^0.5.0`, missing the `0.6.0` release that
aligns `ggml-speech` version.

## 📝 How does it solve it?

- Bump the `@qvac/bci-whispercpp` dependency range from `^0.5.0` to `^0.6.0` in
  `packages/sdk/package.json`.

