### PR TITLE
QVAC-22492 chore: bump vla-ggml to 0.17.0 + changelog

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.17.0] - 2026-08-03
 
 ### Added
 
@@ -26,6 +26,10 @@
 - A GGUF carrying rank-3 embodiment weights but no readable `groot.embodiment.stored_cat_ids` table is now a load-time error instead of a clean load followed by a `GGML_ASSERT` process abort on the first `run()`. Relatedly, a `groot.embodiment.*` array that is present but not an int32 array is reported as corruption rather than silently treated as absent, and `groot.embodiment.count` is cross-checked against the table length instead of being written and never read.
 - The pre-transpose refill copied one matrix element per `std::memcpy` call with a runtime element size, which the compiler cannot fold into a move — about 5 million out-of-line calls per refill at `HIDDEN_SIZE` 1024. It is now a typed element copy. This ran at load before, and `setEmbodiment` puts it on a repeatable path.
 - The v1 converter path no longer stamps `num_cameras = 2` when the default embodiment's view count is unknown; it fails and names `--embodiment-cameras TAG=N`, matching what multi mode already did. A wrong count fails silently at inference, so guessing it at conversion time only moved the guess. A v1 GGUF bakes one tag, so when that tag's `cat_id` is shared by rigs that disagree, the tag's own count is used rather than the row's 0 — a `cat_id` with no single answer does not make the one tag being converted ambiguous. Multi mode is unchanged there, since its per-row count would still be 0 and rescuing only the top-level key would desync the two. `--embodiments all` also reports a checkpoint whose category bank is smaller than the expected 32 rows, instead of raising a bare `IndexError`.
+
+### Pull Requests
+
+- [#3427](https://github.com/tetherto/qvac/pull/3427) - QVAC-22492 feat[api]: GR00T multi-embodiment support in vla-ggml
 
 ## [0.16.2] - 2026-07-31
 

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 Problem

The GR00T multi-embodiment work merged to `main` in #3427, but `packages/vla-ggml/package.json` still carries `0.16.2` — the same version already published to npm as `latest`. The feature is therefore on `main` and unreleasable: `/release` refuses to cut a release branch without a bump, and `release-merge-guard` requires `package.json` to match the version in the release branch name.

#3427 also left its notes in a `## [Unreleased]` changelog block, which no release can extract.

## 📝 How

Minor bump `0.16.2` → `0.17.0`, and promote the existing `## [Unreleased]` block to a dated `## [0.17.0] - 2026-08-03` entry with a `### Pull Requests` list. The changelog prose is unchanged — it was written by #3427 alongside the code.

Minor rather than patch because the release adds public API surface:

- `VlaModel.setEmbodiment(selector)` — switch a loaded multi-embodiment GR00T model to another embodiment in the same GGUF.
- A new optional load config key, `config.embodiment` (tag, numeric `cat_id`, or `{ catId | tag, numCameras }`).
- New hparams fields `selectedEmbodimentTag` / `selectedEmbodimentCatId`.

Two files change and nothing else — no `vcpkg.json`, no `vcpkg-configuration.json` baseline.

## 🧪 Tested

- `origin/main` and `npm view @qvac/vla-ggml dist-tags.latest` both read `0.16.2`, so no bump was already pending.
- `git log vla-v0.16.2..origin/main -- packages/vla-ggml/` returns exactly one commit (`717a9ee39`, #3427), which is the work this version documents.
- Spot-checked the promoted changelog text against the merged source rather than against the commit message: `setEmbodiment` (`src/index.ts:745`, `index.d.ts:42`), `grootCheckV1EmbodimentRank` (`addon/src/model-interface/groot.cpp:773`), `selectedEmbodimentCatId` (`index.d.ts:120`), `--embodiment-cameras` (`scripts/convert_groot_dit_to_gguf.py:321`).
- `grep -nE "^## \[0\.17\.0\]" packages/vla-ggml/CHANGELOG.md` matches — this is the regex `.github/actions/verify-changelog-notes` uses, and an unbracketed heading would only fail later at release time.
- `git diff --stat origin/main` shows exactly `packages/vla-ggml/package.json` and `packages/vla-ggml/CHANGELOG.md`.

No source changes, so there is nothing new to build or test here; #3427 carried the cpp, desktop and mobile coverage for the feature itself.

## ⚠️ Breaking changes

None in this PR — it is a version bump plus changelog.

Worth knowing about the release it enables, both already documented in the promoted entry:

- A multi-embodiment GGUF is **not** loadable by `0.16.1` or earlier. Those loaders have no row-slicing code, so they load the file cleanly and then abort the process on `GGML_ASSERT` at the first `run()`. `0.17.0` turns that into a catchable load error. Multi files ship under their own `groot-n1.7-3b-multi/` S3 family and the registry entries a released addon resolves still point at `groot-n1.7-3b-libero/`, so a pinned older addon is never served one.
- `setEmbodiment()` now rejects a single-embodiment GGUF unconditionally, including a request naming the tag that GGUF bakes in; that case used to resolve as a silent no-op.

Follow-up this entry commits us to: the changelog states that SDK exposure of `config.embodiment` lands with the SDK's `@qvac/vla-ggml` range bump to this version, so the SDK-side range bump is still outstanding.
