### PR TITLE
QVAC-22648 fix: install unified ASR addon in bare-sdk e2e

### DIFF
--- a/.github/workflows/on-pr-bare-sdk-e2e.yml
+++ b/.github/workflows/on-pr-bare-sdk-e2e.yml
@@ -153,7 +153,7 @@ jobs:
       # committed manifest addon-free (enforced by check-no-addon-deps).
       - name: Install addon prebuilds
         working-directory: packages/bare-sdk
-        run: npm install --no-save @qvac/llm-llamacpp @qvac/embed-llamacpp @qvac/translation-nmtcpp @qvac/transcription-whispercpp
+        run: npm install --no-save @qvac/llm-llamacpp @qvac/embed-llamacpp @qvac/translation-nmtcpp @qvac/asr-ggml
 
       - name: Run bare-sdk inference e2e
         working-directory: packages/bare-sdk


### PR DESCRIPTION
## Summary

- Install `@qvac/asr-ggml` instead of the retired Whisper addon in the base-branch bare-sdk e2e workflow.
- Unblock the `pull_request_target` e2e check on #3586, which imports `@qvac/asr-ggml/addonLogging`.

## Test plan

- [x] Confirm the PR contains only the addon install substitution.
- [ ] Merge this PR and rerun the bare-sdk inference e2e check on #3586.

