### PR TITLE
fix: recover DeepSeek V4 checkpoints

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
@@ -99,12 +99,20 @@ void TextLlmContext::initializeCommonState() {
   // predicate is about RoPE-based K-shift (position shifting) and
   // returns `true` for all memory types in fabric today, including
   // recurrent and hybrid. The real architectural property we care
-  // about is "does this model have a recurrent half?", which is
-  // exactly what these two model predicates report.
+  // about is "does this model need full-state replay?" DeepSeek V4 needs that
+  // path as well even though its compressed cache is not reported by either
+  // model predicate.
   const auto* const model = modelCtx_.model;
+  const std::optional<std::string> architecture =
+      qvac_lib_inference_addon_llama::utils::getModelArchitecture(model);
+  const bool isDeepSeekV4 =
+      architecture.has_value() &&
+      qvac_lib_inference_addon_llama::utils::isDeepSeekV4Architecture(
+          architecture.value());
   needsRecurrentSnapshot_ =
       (model != nullptr) &&
-      (llama_model_is_recurrent(model) || llama_model_is_hybrid(model));
+      (llama_model_is_recurrent(model) || llama_model_is_hybrid(model) ||
+       isDeepSeekV4);
   compactor_.setNeedsRecurrentSnapshot(needsRecurrentSnapshot_);
   // EOS-inside-reasoning recovery (close-marker substitution +
   // trailing newlines) is a Qwen3-specific workaround. Gate it on the
@@ -115,13 +123,9 @@ void TextLlmContext::initializeCommonState() {
   // tracking / compaction via `reasoningEnabled_`, just not this
   // recovery.
   {
-    const std::optional<std::string> arch =
-        qvac_lib_inference_addon_llama::utils::getModelArchitecture(
-            modelCtx_.model);
-    isQwen3ReasoningFamily_ =
-        arch.has_value() &&
+    isQwen3ReasoningFamily_ = architecture.has_value() &&
         qvac_lib_inference_addon_llama::utils::
-            isQwen3ReasoningFamilyArchitecture(arch.value());
+            isQwen3ReasoningFamilyArchitecture(architecture.value());
   }
 
   // Precompute the EOG token id set used by the EOS-inside-reasoning recovery
@@ -1107,7 +1111,7 @@ bool TextLlmContext::onGenerationFinished(
   }
   capturePendingThinkClose();
   onSequenceEnd(outputCallback);
-  if (shouldRollbackKnownReasoningCutoff()) {
+  if (shouldRollbackInterruptedReasoning()) {
     return rollbackCurrentRequest(outputCallback);
   }
   if (generationStarted_) {
@@ -1134,14 +1138,16 @@ bool TextLlmContext::onCancel(
   return rollbackCurrentRequest(outputCallback);
 }
 
-bool TextLlmContext::shouldRollbackKnownReasoningCutoff() const {
-  const bool knownTruncation =
-      generationStopReason_ == GenerationStopReason::PredictionLimit ||
-      generationStopReason_ == GenerationStopReason::SequenceLimit;
-  return knownTruncation && needsRecurrentSnapshot_ &&
-         removeThinkingFromContext_ && reasoningEnabled_ &&
-         reasoningState_.inside_reasoning && compactor_.hasOpenSpan() &&
-         !compactor_.hasCapturedCloseSpan();
+bool TextLlmContext::shouldRollbackInterruptedReasoning() const {
+  return qvac_lib_inference_addon_llama::utils::
+      shouldRollbackInterruptedReasoning(
+          generationStopReason_ != GenerationStopReason::None,
+          needsRecurrentSnapshot_,
+          removeThinkingFromContext_,
+          reasoningEnabled_,
+          reasoningState_.inside_reasoning,
+          compactor_.hasOpenSpan(),
+          compactor_.hasCapturedCloseSpan());
 }
 
 bool TextLlmContext::rollbackCurrentRequest(

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
@@ -290,7 +290,7 @@ private:
   void setOpenThinkSpan(llama_pos start);
   void capturePendingThinkClose();
   void compactThinkSpan();
-  [[nodiscard]] bool shouldRollbackKnownReasoningCutoff() const;
+  [[nodiscard]] bool shouldRollbackInterruptedReasoning() const;
   [[nodiscard]] bool rollbackCurrentRequest(
       const std::function<void(const std::string&)>& outputCallback);
   void configureReasoningTags(
@@ -404,12 +404,14 @@ private:
   // this default per model.
   bool removeThinkingFromContext_ = true;
 
-  // True when this context's model is recurrent or hybrid
+  // True when this context's model is recurrent, hybrid, or DeepSeek V4.
   // (`llama_model_is_recurrent || llama_model_is_hybrid`) — Mamba /
   // RWKV pure-recurrent and hybrid SSM + attention families (Qwen3.5,
   // Qwen3-Next, Jamba, Granite-Hybrid, LFM2, Nemotron-H, Kimi-Linear).
   // For these we use the snapshot + replay path: snapshot the full
-  // sequence state at end-of-prefill, restore at end-of-generation,
+  // DeepSeek V4 has the same checkpoint requirement despite not reporting
+  // either predicate. We snapshot the full sequence state at end-of-prefill,
+  // restore at end-of-generation,
   // then batched-replay the captured post-reasoning tokens.
   // Pure-attention models keep the existing
   // `seq_rm + seq_add` path untouched.

--- a/packages/llm-llamacpp/addon/src/utils/ChatTemplateUtils.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/ChatTemplateUtils.cpp
@@ -178,10 +178,15 @@ bool isQwen3ReasoningFamilyArchitecture(std::string_view architecture) {
          QWEN3_REASONING_FAMILY_ARCHES.end();
 }
 
+bool isDeepSeekV4Architecture(std::string_view architecture) {
+  return normalizeArchitecture(architecture) == "deepseek4";
+}
+
 std::optional<ReasoningTags> selectReasoningTagsForArchitecture(
     const std::optional<std::string>& architecture) {
   if (architecture.has_value() &&
-      isQwen3ReasoningFamilyArchitecture(architecture.value())) {
+      (isQwen3ReasoningFamilyArchitecture(architecture.value()) ||
+       isDeepSeekV4Architecture(architecture.value()))) {
     return ReasoningTags{.open = "<think>", .close = "</think>"};
   }
   return std::nullopt;

--- a/packages/llm-llamacpp/addon/src/utils/ChatTemplateUtils.hpp
+++ b/packages/llm-llamacpp/addon/src/utils/ChatTemplateUtils.hpp
@@ -31,8 +31,8 @@ selectReasoningTagsForModel(const ::llama_model* model);
 
 // Architecture-only variant. Covers families identifiable from
 // `general.architecture` alone (Qwen3-family: `qwen3`, `qwen35`,
-// `qwen35moe`, ...). Gemma 4 needs basename and is resolved in
-// `selectReasoningTagsForModel`.
+// `qwen35moe`, and DeepSeek V4: `deepseek4`). Gemma 4 needs basename
+// and is resolved in `selectReasoningTagsForModel`.
 std::optional<ReasoningTags> selectReasoningTagsForArchitecture(
     const std::optional<std::string>& architecture);
 
@@ -65,6 +65,14 @@ std::optional<ReasoningTags> selectReasoningTagSource(
  * (e.g. Gemma 4). Empty / unknown architectures return false.
  */
 bool isQwen3ReasoningFamilyArchitecture(std::string_view architecture);
+
+/**
+ * @brief Returns true when `architecture` is DeepSeek V4 (`deepseek4`).
+ *
+ * DeepSeek V4 uses the same full-state checkpoint/replay lifecycle as hybrid
+ * Qwen3.5 for cancellation and reasoning compaction.
+ */
+bool isDeepSeekV4Architecture(std::string_view architecture);
 
 /**
  * @brief Returns true when the GGUF metadata basename identifies a MedPsy

--- a/packages/llm-llamacpp/addon/src/utils/ReasoningSnapshotPolicy.hpp
+++ b/packages/llm-llamacpp/addon/src/utils/ReasoningSnapshotPolicy.hpp
@@ -68,5 +68,19 @@ recurrentReasoningBoundaryDecision(
          RecurrentReasoningBoundaryDecision::Capture;
 }
 
+// Any terminal generation reason that interrupts an open reasoning span must
+// restore the pre-request checkpoint on the snapshot/replay path. Continuing
+// to compaction without a close marker would wipe the whole sequence instead
+// of preserving the preceding conversation.
+[[nodiscard]] inline bool shouldRollbackInterruptedReasoning(
+    bool hasTerminalReason, bool needsRecurrentSnapshot,
+    bool removeThinkingFromContext, bool reasoningEnabled,
+    bool insideReasoning, bool hasOpenSpan,
+    bool hasCapturedCloseSpan) noexcept {
+  return hasTerminalReason && needsRecurrentSnapshot &&
+         removeThinkingFromContext && reasoningEnabled && insideReasoning &&
+         hasOpenSpan && !hasCapturedCloseSpan;
+}
+
 } // namespace utils
 } // namespace qvac_lib_inference_addon_llama

--- a/packages/llm-llamacpp/test/unit/test_chat_template_utils.cpp
+++ b/packages/llm-llamacpp/test/unit/test_chat_template_utils.cpp
@@ -105,6 +105,23 @@ TEST_F(ChatTemplateUtilsTest, SelectReasoningTagsForArchitectureQwen3Family) {
   }
 }
 
+TEST_F(ChatTemplateUtilsTest, IdentifiesDeepSeekV4Architecture) {
+  EXPECT_TRUE(isDeepSeekV4Architecture("deepseek4"));
+  EXPECT_TRUE(isDeepSeekV4Architecture("DeepSeek4"));
+  EXPECT_FALSE(isDeepSeekV4Architecture("deepseek3"));
+  EXPECT_FALSE(isDeepSeekV4Architecture("qwen35"));
+}
+
+TEST_F(
+    ChatTemplateUtilsTest, SelectReasoningTagsForArchitectureDeepSeekV4) {
+  const std::optional<ReasoningTags> tags =
+      selectReasoningTagsForArchitecture(std::string("deepseek4"));
+  ASSERT_TRUE(tags.has_value());
+  EXPECT_EQ(tags->open, "<think>");
+  EXPECT_EQ(tags->close, "</think>");
+  EXPECT_FALSE(isQwen3ReasoningFamilyArchitecture("deepseek4"));
+}
+
 TEST_F(ChatTemplateUtilsTest, SelectReasoningTagsForArchitectureRejectsOthers) {
   // Unrelated arches.
   EXPECT_FALSE(

--- a/packages/llm-llamacpp/test/unit/test_reasoning_block_compactor.cpp
+++ b/packages/llm-llamacpp/test/unit/test_reasoning_block_compactor.cpp
@@ -18,6 +18,7 @@ using qvac_lib_inference_addon_llama::utils::recurrentReasoningBoundaryDecision;
 using qvac_lib_inference_addon_llama::utils::RecurrentReasoningBoundaryDecision;
 using qvac_lib_inference_addon_llama::utils::
     shouldCaptureRecurrentReasoningBoundary;
+using qvac_lib_inference_addon_llama::utils::shouldRollbackInterruptedReasoning;
 
 // Unit coverage for the hybrid / recurrent reasoning replay seam.
 //
@@ -118,6 +119,47 @@ TEST(ReasoningSnapshotPolicy, RejectsWhenCloseMarkerIsMultiToken) {
           /*thinkingForcedOpen=*/true,
           /*closeMarkerSingleToken=*/false),
       RecurrentReasoningBoundaryDecision::UnsupportedMultiTokenClose);
+}
+
+TEST(ReasoningSnapshotPolicy, RollsBackAnyInterruptedOpenReasoningSpan) {
+  // The caller maps every terminal stop reason (EOG, antiprompt, n_predict,
+  // and sequence limit) to hasTerminalReason=true. A checkpoint-backed
+  // context must restore rather than attempting to compact an unclosed span.
+  EXPECT_TRUE(shouldRollbackInterruptedReasoning(
+      /*hasTerminalReason=*/true,
+      /*needsRecurrentSnapshot=*/true,
+      /*removeThinkingFromContext=*/true,
+      /*reasoningEnabled=*/true,
+      /*insideReasoning=*/true,
+      /*hasOpenSpan=*/true,
+      /*hasCapturedCloseSpan=*/false));
+}
+
+TEST(ReasoningSnapshotPolicy, KeepsCompletedOrNonTerminalReasoning) {
+  EXPECT_FALSE(shouldRollbackInterruptedReasoning(
+      /*hasTerminalReason=*/false,
+      /*needsRecurrentSnapshot=*/true,
+      /*removeThinkingFromContext=*/true,
+      /*reasoningEnabled=*/true,
+      /*insideReasoning=*/true,
+      /*hasOpenSpan=*/true,
+      /*hasCapturedCloseSpan=*/false));
+  EXPECT_FALSE(shouldRollbackInterruptedReasoning(
+      /*hasTerminalReason=*/true,
+      /*needsRecurrentSnapshot=*/true,
+      /*removeThinkingFromContext=*/true,
+      /*reasoningEnabled=*/true,
+      /*insideReasoning=*/false,
+      /*hasOpenSpan=*/true,
+      /*hasCapturedCloseSpan=*/false));
+  EXPECT_FALSE(shouldRollbackInterruptedReasoning(
+      /*hasTerminalReason=*/true,
+      /*needsRecurrentSnapshot=*/true,
+      /*removeThinkingFromContext=*/true,
+      /*reasoningEnabled=*/true,
+      /*insideReasoning=*/true,
+      /*hasOpenSpan=*/true,
+      /*hasCapturedCloseSpan=*/true));
 }
 
 TEST(ReasoningRollbackStateAppend, AppendsRegardlessOfCaptureFlag) {


### PR DESCRIPTION
## Summary
- classify `deepseek4` as requiring the full-state reasoning checkpoint/replay path
- restore interrupted reasoning on terminal generation stops without applying Qwen-only EOS behavior
- add architecture and rollback-policy regression coverage

## Test plan
- [x] `git diff --check`
- [ ] `npm run test:cpp:build` (blocked: `cmake-bare` is unavailable in the clean worktree)