### PR TITLE
fix[notask]: set up Node before the LLM mobile validate step

### DIFF
--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -198,6 +198,15 @@ jobs:
           path: addon
           fetch-depth: 0
 
+      # node/npm is job-managed on the self-hosted runners (installed per runner
+      # user via setup-node, not globally), so npm is only on PATH after this
+      # step runs. The validate step below invokes npm, so it must be set up
+      # first — matches the lts/* used by the setup composite action.
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
       # Hard-fails on purpose. This covers both the generated mobile test list
       # and test/mobile/model-manifest.json — an incomplete pre-stage map does
       # not fail loudly on-device, it silently sends the phone to


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `Validate mobile tests are up-to-date` step in `integration-mobile-test-llm-llamacpp.yml` runs `npm run test:mobile:validate`, but on the self-hosted Hetzner runners **node/npm is job-managed** — provisioned per runner user via `actions/setup-node`, not installed globally (runners handbook §4.1; global root-owned installs caused the 2026-05-19 `bare-make` exit-1 incident, and the up-to-16 users per host would race on a shared prefix).
- `npm` is therefore only on `PATH` after `setup-node` runs, which previously happened later, inside the `Setup mobile test environment` composite. Since #3561 dropped the `|| true` that was silently swallowing the error, the step now **hard-fails with `npm: command not found`** on any runner without a residual node on `PATH`.
- Reported in #devops-help; both observed failures are the **same step on different hosts**: [runs/30630405942](https://github.com/tetherto/qvac/actions/runs/30630405942/job/91210772112) (`qvac-ubuntu2204-x64`, runner6) and [runs/30909171443](https://github.com/tetherto/qvac/actions/runs/30909171443/job/91993749049) (`qvac-ubuntu2204-x64-2`, runner14, PR #3491).

## 📝 How does it solve it?

- Adds a SHA-pinned `actions/setup-node` step **before** the validate step, using `node-version: lts/*` to match the version the `run-mobile-integration-tests/setup` composite already provisions — so validation runs under the same node as the rest of the job.
- Keeps the hard-fail (no `|| true`): with node set up first, a failure now genuinely means a stale mobile test list / manifest, not a missing-npm false alarm.
- Runner-side install of a global npm was deliberately **not** used — see handbook §4.1 and the May incident; per-job `setup-node` caches into each user's `hostedtoolcache` (warm on persistent runners) and keeps the node version controlled in-repo.

## 🧪 How was it tested?

- Local YAML parse clean (`yaml.safe_load`); single-step insertion verified via `git diff` (one file, +9 lines, correct ordering: Setup Node → validate → setup composite).
- Pending on this PR's CI: a run of the LLM mobile lane confirming the `Validate mobile tests are up-to-date` step resolves `npm` and passes on both `qvac-ubuntu2204-x64` and `qvac-ubuntu2204-x64-2`.

## 🔐 Action pinning

- `actions/setup-node`: newly added, pinned to `53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0` — the same SHA already used by `.github/actions/run-mobile-integration-tests/setup/action.yml`, keeping the pin consistent across this workflow family.
