### PR TITLE
QVAC-23053 fix[mod]: point multi-embodiment GR00T registry entries at the base build

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -7734,25 +7734,25 @@
     "link": "https://huggingface.co/nvidia/GR00T-N1.7-LIBERO"
   },
   {
-    "source": "s3:///qvac_models_compiled/vla/groot-n1.7-3b-multi/2026-07-23/groot-q8_vf16.gguf",
+    "source": "s3:///qvac_models_compiled/vla/groot-n1.7-3b-multi/2026-08-04/groot-q8_vf16.gguf",
     "engine": "@qvac/vla-ggml",
     "description": "NVIDIA GR00T N1.7-3B vision-language-action model, multi-embodiment. Single GGUF carrying every trained embodiment head of the base checkpoint (17 stored rows, default libero_sim); select at load or switch at runtime by tag or cat_id, no reload. Same architecture as the LIBERO model: Qwen3-VL backbone, VL fusion, 32-layer AlternateVLDiT action head, 4-step Euler flow-matching. Camera count and action dims follow the selected embodiment. Desktop multi-embodiment model of record.",
     "quantization": "q8_vf16",
     "params": "groot-n1.7-3b-multi",
     "licenseId": "nvidia-open-model-license",
     "tags": ["vla", "groot", "multi-embodiment", "robotics"],
-    "notes": "q8_vf16 profile: Q8_0 text / DiT / VL-fusion / action-head linears, F16 vision tower + embodiment bank, F32 norms. Requires @qvac/vla-ggml >= 0.17.0 (older loaders reject the rank-3 embodiment.* tensors). Per-embodiment parity vs the PyTorch oracle on selected rows: libero_sim cos 0.999995, oxe_droid cos 0.999993, real_r1_pro cos 0.999941 (see qvac PR #3427). Converted from nvidia/GR00T-N1.7-3B via convert_groot_dit_to_gguf.py multi-embodiment mode.",
+    "notes": "q8_vf16 profile: Q8_0 non-vision linears, F16 vision tower + embodiment bank, F32 norms. Requires @qvac/vla-ggml >= 0.17.0. Base-checkpoint conversion (nvidia/GR00T-N1.7-3B, 2026-08-04) — replaces the withdrawn 2026-07-23 LIBERO-post-trained build, whose finetuned trunk skewed every non-libero row (DROID cos 0.881 vs 0.999993 base-derived). Parity vs the base oracle: libero_sim cos 0.999995, oxe_droid 0.999993, real_r1_pro 0.999941 (PR #3427). For LIBERO-only use, prefer groot-n1.7-3b-libero.",
     "link": "https://huggingface.co/nvidia/GR00T-N1.7-3B"
   },
   {
-    "source": "s3:///qvac_models_compiled/vla/groot-n1.7-3b-multi/2026-07-23/groot-q5_vf16.gguf",
+    "source": "s3:///qvac_models_compiled/vla/groot-n1.7-3b-multi/2026-08-04/groot-q5_vf16.gguf",
     "engine": "@qvac/vla-ggml",
     "description": "NVIDIA GR00T N1.7-3B vision-language-action model, multi-embodiment. Mobile profile of the desktop multi-embodiment groot-q8_vf16 model: same architecture and embodiment bank (17 stored rows, default libero_sim), smaller action-head quant so the model file fits the on-device memory budget. Active embodiment selected at load or switched at runtime by tag or cat_id.",
     "quantization": "q5_vf16",
     "params": "groot-n1.7-3b-multi",
     "licenseId": "nvidia-open-model-license",
     "tags": ["vla", "groot", "multi-embodiment", "robotics", "mobile"],
-    "notes": "q5_vf16 profile: Q5_0 non-vision linears, F16 vision tower + embodiment bank, F32 norms. Q5_0 is required — legacy Q4_0 is too coarse for the DiT action head, and K-quants are not supported by the qvac-fabric gguf packer. Requires @qvac/vla-ggml >= 0.17.0. Converted from nvidia/GR00T-N1.7-3B via convert_groot_dit_to_gguf.py multi-embodiment mode.",
+    "notes": "q5_vf16 profile: Q5_0 non-vision linears, F16 vision tower + embodiment bank, F32 norms. Q5_0 is required — legacy Q4_0 is too coarse for the DiT action head, and K-quants are not supported by the qvac-fabric gguf packer. Requires @qvac/vla-ggml >= 0.17.0. Base-checkpoint conversion (nvidia/GR00T-N1.7-3B, 2026-08-04) — replaces the withdrawn 2026-07-23 LIBERO-post-trained build, whose finetuned trunk skewed every non-libero row. For LIBERO-only use, prefer the groot-n1.7-3b-libero entries.",
     "link": "https://huggingface.co/nvidia/GR00T-N1.7-3B"
   },
   {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The multi-embodiment GR00T GGUFs registered in #3632 (`2026-07-23`) were converted from the **LIBERO-post-trained** checkpoint. LIBERO post-training only trains the `libero_sim` row, but the shared trunk (backbone / vision / DiT) is finetuned — so every non-libero embodiment served from that file is off: selecting DROID on it measures **cos 0.881 / rel 0.83** against the base DROID oracle, versus **cos 0.999993** on a base-derived build.
- A base-checkpoint conversion has been uploaded to S3 under `qvac_models_compiled/vla/groot-n1.7-3b-multi/2026-08-04/` (q8_vf16 4.07 GB, q5_vf16 3.05 GB).

## 📝 How does it solve it?

- Repoints both `groot-n1.7-3b-multi` entries at the `2026-08-04` base-derived files. On sync the old `2026-07-23` registry paths are auto-deprecated and the new ones uploaded.
- Notes now record the withdrawal reason, the per-embodiment parity numbers vs the base oracle (which the #3427 table actually measured on a base-derived build), and that the `groot-n1.7-3b-libero` entries remain the model of record for LIBERO-only use.

## 🧪 How was it tested?

- `npm run validate:models` passes (757 models); prettier clean.
- Parity measurements by @rita (addon side): shipped 2026-07-23 file DROID cos 0.881 vs base-derived cos 0.999993.
- After merge + sync, the SDK constants on #3625 will be refreshed to the new registry paths/blob pointers.
