### PR TITLE
tmp: QVAC-23114 overlay-port CI validation for ACE-Step on OpenCL -- DO NOT MERGE

### DIFF
--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -16,6 +16,11 @@ find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
 
+# DO NOT MERGE -- overlay pins for on-device CI validation of two unmerged PRs.
+# ggml-speech  -> tetherto/qvac-ext-ggml#52              (ACE-Step OpenCL kernels)
+# audiogen-cpp -> tetherto/qvac-ext-lib-whisper.cpp#126  (whole pipeline on OpenCL)
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/overlay-ports;${VCPKG_OVERLAY_PORTS}")
+
 project(audiogen-ggml CXX C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/packages/audiogen-ggml/overlay-ports/audiogen-cpp/portfile.cmake
+++ b/packages/audiogen-ggml/overlay-ports/audiogen-cpp/portfile.cmake
@@ -1,0 +1,79 @@
+# DO NOT MERGE -- throwaway pin at the head of
+# tetherto/qvac-ext-lib-whisper.cpp#126, so the addon's own CI can exercise it on
+# real devices before it lands on master.
+#
+# That PR runs the whole ACE-Step pipeline on OpenCL: it gives music-cli a
+# --backends-dir (without it a GGML_BACKEND_DL build registers no backend at
+# all), prefers OpenCL over Vulkan on Adreno 700+, materialises two small
+# auxiliary tensors as F32 at load so the graph carries no BF16 mul_mat or
+# quantised cast, stops the VAE synchronising once per node, and extends the
+# stage allowlist so the LM and FSQ detokenizer take the GPU on OpenCL.
+# Depends on the ggml-speech overlay beside it.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF 9a829e4cd3b86e6910e3690d9d48c7372a10856b
+    SHA512 fb85adfbe87f5e267df0a1dc7499e1564af1d236d0f801ab1c021ac7b53d17ee73aebb8a82661808d66a3664cff610e908ad1d890a424bd76a92aab6001d70d4
+    HEAD_REF master
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/engines/audiogen")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "audiogen-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the engines/audiogen/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        cuda    GGML_CUDA
+        opencl  GGML_OPENCL
+)
+
+set(PLATFORM_OPTIONS)
+
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DAUDIOGEN_BUILD_LIBRARY=ON
+        -DAUDIOGEN_BUILD_EXECUTABLES=OFF
+        -DAUDIOGEN_BUILD_TESTS=OFF
+        -DAUDIOGEN_INSTALL=ON
+        -DAUDIOGEN_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DAUDIOGEN_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME audiogen-cpp CONFIG_PATH share/audiogen-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/audiogen-ggml/overlay-ports/audiogen-cpp/vcpkg.json
+++ b/packages/audiogen-ggml/overlay-ports/audiogen-cpp/vcpkg.json
@@ -1,0 +1,81 @@
+{
+  "name": "audiogen-cpp",
+  "version-date": "2026-08-03",
+  "description": "DO NOT MERGE -- throwaway overlay pinned at the head of tetherto/qvac-ext-lib-whisper.cpp#126, so the audiogen-ggml CI can exercise it on real devices before it lands on master. Runs the whole ACE-Step pipeline on OpenCL: music-cli gains a --backends-dir, without which a GGML_BACKEND_DL build registers no backend at all; Adreno 700+ now prefers OpenCL over Vulkan, matching the tier policy engines/tts already ships, and every other platform keeps ggml's existing choice; two small auxiliary tensors -- the FSQ detokenizer's BF16 fsq_proj and its quantised special_tokens, plus the Q4_K_M-only BF16 timbre embed_tokens -- are materialised as F32 at load, which is exact and removes a BF16 mul_mat and a quantised cast from the graph; the VAE stops synchronising once per node to drive a progress bar (a CPU-path win too); and the stage allowlist is extended so the LM and FSQ detokenizer take the GPU on OpenCL. Requires the ggml-speech overlay beside it.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/engines/audiogen",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-08-03"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/audiogen-ggml/overlay-ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/audiogen-ggml/overlay-ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/audiogen-ggml/overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/audiogen-ggml/overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/audiogen-ggml/overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/audiogen-ggml/overlay-ports/ggml-speech/portfile.cmake
@@ -1,0 +1,252 @@
+# DO NOT MERGE -- throwaway pin at the head of tetherto/qvac-ext-ggml#52, so the
+# addon's own CI can exercise it on real devices before it lands on speech.
+#
+# That PR adds the OpenCL ops ACE-Step needs on Adreno (SNAKE, COL2IM_1D, BF16
+# get_rows -- previously a hard ggml_abort inside ggml_cl_compute_forward), fixes
+# a silent-corruption bug in ggml_cl_mul_mat_kq_kqv_adreno (the kernel derives
+# src0's channel stride as nb01*M and never receives nb02, so a strided KV view
+# made every KV head past head 0 read the wrong bytes), and optimises the
+# quantised weight upload and the conv1d GEMM path.
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF d6827a8080bad1cb20cb8a956158c0c608bd0912
+    SHA512 479ff31ccee0bea79fff6828842c8a7060bebaec58ff753dd012fed705adecb00b6a9041abd3e107023f2c8ef8ff7b5696e789b7653df7f7358876510eba019d
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# Desktop aarch64 Linux: same per-arch CPU-variant packaging as Android.
+# This build is not GGML_NATIVE and passes no -march override, so a
+# single-variant CPU backend lands on the compiler's plain armv8-a
+# baseline: the dotprod/fp16/i8mm ARM kernels (incl. the repack GEMM
+# kernels in ggml-cpu/arch/arm/repack.cpp) are compiled out and both
+# f16 and quantized (q4_0/q8_0) GEMMs stay on the slowest generic
+# paths. GGML_CPU_ALL_VARIANTS builds one MODULE .so per ARMv8.x/9.x
+# feature tier and scores them against the running CPU at first use,
+# so the prebuild stays SIGILL-safe on any aarch64 host. The speech
+# addons stage lib/libqvac-speech-ggml-*.so next to their .bare and
+# forward backendsDir to ggml_backend_load_all_from_path(), same as
+# Android. Verified on the Parakeet + Whisper RTF benchmarks (qvac
+# runs 29243365879 / 29333221534): parakeet tdt q4_0 mean RTF
+# 0.2285 -> 0.0612, whisper base f16 0.3316 -> 0.0970.
+set(QVAC_LINUX_ARM64_DL_CPU OFF)
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(QVAC_LINUX_ARM64_DL_CPU ON)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        # The dlopen'd MODULE backends must not carry shared-library
+        # dependencies the host machine doesn't ship. The qvac linux
+        # triplets compile with clang -stdlib=libc++ but only the final
+        # addon binary links libc++ statically; a module with NEEDED
+        # libc++.so.1 / libc++abi.so.1 entries fails to dlopen on a
+        # stock host (no libc++ runtime package) and the registry
+        # loader skips it *silently* -- the CPU backend then simply
+        # never registers ("no CPU device registered"). Link the C++
+        # runtime statically into the modules instead, matching the
+        # addon convention. Composed with the triplet's own
+        # VCPKG_LINKER_FLAGS because a bare -DCMAKE_MODULE_LINKER_FLAGS
+        # would override vcpkg's *_INIT seeding and drop the triplet's
+        # -stdlib=libc++ at link time (under gcc triplets this composes
+        # to plain -static-libstdc++, which is equally valid).
+        "-DCMAKE_MODULE_LINKER_FLAGS=${VCPKG_LINKER_FLAGS} -static-libstdc++"
+    )
+endif()
+
+# The v0.10.2 ggml sync introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+# Desktop Linux MODULE backend pickup. ggml's own install() places the
+# MODULE backends in bin/ (CMAKE_INSTALL_BINDIR) and -- unlike Android,
+# where CMake never versions module filenames -- as versioned files
+# (libqvac-speech-ggml-cpu-armv8.2_1.so.<ver>) plus unversioned .so
+# symlinks. Two problems with leaving them there: the runtime loader
+# only matches the exact `.so` extension, and the speech addons stage
+# backends by file(INSTALL)-ing a glob of lib/libqvac-speech-ggml-*.so,
+# which would copy a symlink without its target. Dereference each
+# unversioned name onto its real file, publish plain .so files in lib/,
+# and drop bin/ (static triplets must not ship a bin/ dir anyway).
+if(QVAC_LINUX_ARM64_DL_CPU)
+    foreach(_cfg "" "/debug")
+        file(GLOB _backend_mods
+            "${CURRENT_PACKAGES_DIR}${_cfg}/bin/libqvac-speech-ggml-*.so")
+        foreach(_mod IN LISTS _backend_mods)
+            get_filename_component(_mod_name "${_mod}" NAME)
+            file(REAL_PATH "${_mod}" _mod_real)
+            file(COPY_FILE "${_mod_real}"
+                 "${CURRENT_PACKAGES_DIR}${_cfg}/lib/${_mod_name}")
+        endforeach()
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}${_cfg}/bin")
+        # Do not ship the SVE-bearing CPU variants. ggml's SVE code
+        # paths are drastically slower than the NEON dotprod/fp16 paths
+        # on the 128-bit-vector cores that make up the desktop
+        # arm64-linux fleet (Neoverse-N2 runners; Apple VMs and
+        # Snapdragon X have no SVE at all): whisper base q8_0 RTF
+        # 0.2224 via armv8.6_2 (SVE) vs 0.0626 via armv8.2_2 (no SVE),
+        # f16 0.2586 vs 0.0938 (qvac A/B runs 29328745233 /
+        # 29332248742) -- and the runtime score would pick the SVE
+        # tiers on SVE hardware. Parakeet is within 3% either way (its
+        # hot GEMMs use the NEON repack kernels). Revisit when the
+        # speech branch grows an SVE-free i8mm tier (the Android
+        # variant list has one) or VL-aware scoring.
+        foreach(_sve_tier armv8.2_3 armv8.6_1 armv8.6_2 armv9.2_1 armv9.2_2)
+            file(REMOVE
+                "${CURRENT_PACKAGES_DIR}${_cfg}/lib/libqvac-speech-ggml-cpu-${_sve_tier}.so")
+        endforeach()
+    endforeach()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/audiogen-ggml/overlay-ports/ggml-speech/usage
+++ b/packages/audiogen-ggml/overlay-ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/audiogen-ggml/overlay-ports/ggml-speech/vcpkg.json
+++ b/packages/audiogen-ggml/overlay-ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-08-03",
+  "description": "DO NOT MERGE -- throwaway overlay pinned at the head of tetherto/qvac-ext-ggml#52, so the audiogen-ggml CI can exercise it on real devices before it lands on speech. Adds the OpenCL ops ACE-Step needs on Adreno -- SNAKE and COL2IM_1D for the Oobleck VAE, and a BF16 get_rows so the 310 MB text-encoder embedding is not widened to F32 -- each of which was previously a hard ggml_abort inside ggml_cl_compute_forward. Fixes a pre-existing silent corruption in ggml_cl_mul_mat_kq_kqv_adreno, which derives src0's channel stride internally as nb01*M and is never passed nb02, so any strided KV view made every KV head past head 0 read the wrong bytes on prefill. Optimises the quantised weight upload (tiled local-memory buffer transposes, reused Q8_0 staging buffer) and adds a swapped-operand xmem GEMM for conv1d, whose operands arrive the other way round from what the weight-stationary kernel wants. Verified against the pristine speech plugin with test-backend-ops -o MUL_MAT -b GPUOpenCL.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/audiogen-ggml/test/mobile/test.cjs
+++ b/packages/audiogen-ggml/test/mobile/test.cjs
@@ -202,7 +202,8 @@ function _makeGen (modelDir) {
     config: {
       inferenceSteps: TURBO_STEPS,
       shift: TURBO_SHIFT,
-      useGPU: false
+      // DO NOT MERGE (overlay branch): exercise OpenCL/Vulkan/Metal on device.
+      useGPU: true
     }
   })
 }
@@ -320,8 +321,23 @@ async function testGenerateMusic () {
       item.outputArray.byteOffset,
       item.outputArray.byteOffset + item.outputArray.byteLength)))
   }
-  await response.await()
+  const stats = await response.await()
   const elapsedMs = Date.now() - t0
+
+  // DO NOT MERGE (overlay branch): useGPU:true on its own proves nothing --
+  // the engine falls back to the CPU when no GPU backend initialises. Log which
+  // backend it actually resolved so the Device Farm artifacts can be read for it.
+  // Deliberately NOT asserting backendDevice === 1: CPU is the correct outcome on
+  // a Mali device (the Android GPU allowlist admits Adreno and Xclipse only), so a
+  // hard GPU gate would red-fail the Pixel 9 lane for behaving as designed. Only
+  // a missing field -- i.e. broken stats plumbing -- is a failure here.
+  const _bd = stats && stats.backendDevice
+  const _bi = stats && stats.backendId
+  console.log('[audiogen-mobile] resolved backendDevice=' + _bd + ' backendId=' + _bi +
+              ' (1 = GPU, 0 = CPU fallback)')
+  if (_bd == null || _bi == null) {
+    throw new Error('run stats carry no backendDevice/backendId; cannot tell which backend ran')
+  }
 
   await gen.destroy()
 

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -1,4 +1,6 @@
 {
+  "name": "audiogen-ggml",
+  "version": "0.1.1",
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
**DO NOT MERGE.** Throwaway branch that exists only to run two unmerged PRs through this
addon's own CI on real devices. It will be deleted once the run is read.

| overlay port | pinned at |
|---|---|
| `ggml-speech` | [tetherto/qvac-ext-ggml#52](https://github.com/tetherto/qvac-ext-ggml/pull/52) @ `d6827a80` |
| `audiogen-cpp` | [tetherto/qvac-ext-lib-whisper.cpp#126](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/126) @ `9a829e4c` |

Together they run the whole ACE-Step pipeline on OpenCL (Adreno). Wired through
`VCPKG_OVERLAY_PORTS` in `CMakeLists.txt` rather than an env var, so the entire build sees it.

## Why this run has a real answer

The previous audiogen overlay run
([30899472735](https://github.com/tetherto/qvac/actions/runs/30899472735), the Metal validation
for QVAC-23118) had its **Android lane fail**. Reading its Device Farm artifacts: the Android pool
is a **Samsung Galaxy S25 Ultra (Adreno 830)** and a **Google Pixel 9 (Mali-G715)**. On the S25,
`testLoadModels` passed and `testGenerateMusic` took SIGABRT:

```
#00 abort
#01 ggml_abort+228
#03 ggml_cl_compute_forward(ggml_backend*, ggml_tensor*)+1176
#05 ggml_backend_graph_compute+24
#07 tts_cpp::acestep::Engine::generate(...)
```

That is the OpenCL backend's unimplemented-op abort — exactly what #52's `SNAKE` / `COL2IM_1D` /
BF16 `get_rows` kernels and #126's stage placement exist to fix. The S25 is also the device named
in the ticket.

## Pre-registered reading of the result

| outcome | reading |
|---|---|
| S25 `testGenerateMusic` passes, and the engine's own backend line names OpenCL | fix confirmed |
| S25 still aborts inside `ggml_cl_compute_forward` | refuted — an op is still missing |
| anything before `testGenerateMusic -> start` (download timeout, pool unavailable) | did-not-run, not a verdict |
| Pixel 9 resolves `backendDevice=0` and passes on CPU | expected — Mali is deliberately outside the Android GPU allowlist |

The mobile job is `continue-on-error` and the merge guard treats `success || skipped` as a pass,
so **the job's colour is not evidence**; the Device Farm artifacts are.

## Changes

- `overlay-ports/{ggml-speech,audiogen-cpp}` — pinned to the two PR heads. SHA512s were reproduced
  from the GitHub archive URL vcpkg actually fetches, downloaded to a file and size- + `tar`-checked
  before hashing rather than piped into `shasum`.
- `vcpkg.json` — gains `name` + `version` tracking `package.json`. vcpkg rejects a nameless manifest
  once overlay ports are in play; this cost the QVAC-23118 overlay a full CI round.
- `test/mobile/test.cjs` — `useGPU` was `false`, so the Android lane never constructed a GPU backend
  and could not have exercised OpenCL at all. Flipped to `true`, and the resolved backend is now
  logged. Deliberately **not** asserted to be a GPU: the Android GPU allowlist admits Adreno and
  Xclipse only, so CPU is the correct outcome on the pool's Pixel 9, and a hard `backendDevice === 1`
  gate would red-fail that lane for behaving as designed (which is what happened on the QVAC-23118
  branch). Only absent stats fields fail here.

## Verified locally before spending the run

`vcpkg install --triplet arm64-android` with the overlay: both ports resolve from `overlay-ports`
rather than the registry, as `ggml-speech[core,opencl,vulkan]` and `audiogen-cpp[core,opencl,vulkan]`,
and both build clean against the NDK — `libqvac-speech-ggml-opencl.so` and `libaudiogen-cpp.a` are
produced, 0 compile errors. The fetched sources were checked to carry both PRs.
