### PR TITLE
infra[notask]: consolidate prebuilds-<pkg>.yml into prebuilds-nx.yml + shared nx-affected action

### DIFF
--- a/.github/actions/nx-affected/action.yml
+++ b/.github/actions/nx-affected/action.yml
@@ -1,12 +1,5 @@
 name: 'Nx affected matrix'
-description: >
-  Shared nx-affected matrix computation for the *-nx.yml consolidated
-  workflows. Checks out the repo, installs deps, resolves base/head (real
-  merge-base via nrwl/nx-set-shas on a real pull_request event, otherwise the
-  base-ref/head-ref inputs from a workflow_dispatch/workflow_call caller),
-  computes the transitive nx-affected package set, and intersects it with the
-  caller's own YAML config table. Single source of truth — do NOT inline this
-  per workflow.
+description: 'Shared nx-affected matrix computation for the *-nx.yml consolidated workflows.'
 
 inputs:
   config:

--- a/.github/actions/nx-affected/action.yml
+++ b/.github/actions/nx-affected/action.yml
@@ -1,0 +1,68 @@
+name: 'Nx affected matrix'
+description: >
+  Shared nx-affected matrix computation for the *-nx.yml consolidated
+  workflows. Checks out the repo, installs deps, resolves base/head (real
+  merge-base via nrwl/nx-set-shas on a real pull_request event, otherwise the
+  base-ref/head-ref inputs from a workflow_dispatch/workflow_call caller),
+  computes the transitive nx-affected package set, and intersects it with the
+  caller's own YAML config table. Single source of truth — do NOT inline this
+  per workflow.
+
+inputs:
+  config:
+    description: 'YAML list of per-package config objects; must include a `package` key on each entry'
+    required: true
+  base-ref:
+    description: 'Base ref for nx affected when not resolvable from a pull_request event'
+    required: false
+    default: 'main'
+  head-ref:
+    description: 'Head ref for nx affected when not resolvable from a pull_request event'
+    required: false
+    default: 'HEAD'
+
+outputs:
+  matrix:
+    description: 'JSON array: config entries whose `package` is in the nx-affected set'
+    value: ${{ steps.compute.outputs.matrix }}
+  any:
+    description: '"true" if the matrix is non-empty, else "false"'
+    value: ${{ steps.compute.outputs.any }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+      with:
+        node-version: lts/*
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    - shell: bash
+      run: pnpm install --frozen-lockfile
+    - if: github.event_name == 'pull_request'
+      uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5
+    - id: compute
+      shell: bash
+      env:
+        NX_CONFIG: ${{ inputs.config }}
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        INPUT_HEAD_REF: ${{ inputs.head-ref }}
+      run: |
+        set -euo pipefail
+        BASE="${NX_BASE:-$INPUT_BASE_REF}"
+        HEAD="${NX_HEAD:-$INPUT_HEAD_REF}"
+
+        AFFECTED=$(pnpm exec nx show projects --affected --base="$BASE" --head="$HEAD" --json \
+          | tail -n1 \
+          | jq -c 'map(sub("^@qvac/"; ""))')
+        echo "Affected (transitive): $AFFECTED"
+
+        CONFIG_JSON=$(yq -o=json -I=0 e '.' <<< "$NX_CONFIG")
+
+        MATRIX=$(jq -c --argjson affected "$AFFECTED" '[.[] | select(.package as $p | $affected | index($p) != null)]' <<< "$CONFIG_JSON")
+        echo "Matrix (config ∩ affected): $MATRIX"
+        echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+        echo "any=$([ "$MATRIX" != "[]" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"

--- a/.github/actions/nx-project-matrix/action.yml
+++ b/.github/actions/nx-project-matrix/action.yml
@@ -1,24 +1,5 @@
 name: 'Nx project.json-driven matrix'
-description: >
-  Generic replacement for a hand-typed per-workflow YAML config table. Computes the nx-affected
-  set for a given target (same base/head resolution as ./nx-affected), then for each affected
-  project reads that target's `options.ci` block directly from each package's own project.json —
-  read from the BASE branch's committed content, never the PR head — and flattens
-  `options.ci.platforms[]` into one matrix row per (package, platform), adding `workdir` from the
-  project's own top-level `root` (never hand-authored in `options.ci` — it's already known to nx).
-  Emits the same `matrix`/`any` output shape ./nx-affected already does, so a consuming workflow's
-  `matrix` job is a drop-in swap.
-
-  SECURITY: project.json is a file a PR author fully controls. Reading options.ci from the PR head
-  would let a PR redirect its OWN run onto a different runner/matrix in the same PR — this action
-  always resolves options.ci via `git show <base>:packages/<pkg>/project.json`, never the checked-
-  out working tree at head. Verified fork-PR safe: `git show` here only ever reads already-fetched
-  base-repo history (fetch-depth 0 on the base repo, which is all `actions/checkout` ever touches
-  for a `pull_request` event — the fork's repo is never fetched), so this has no fork-specific
-  code path at all, unlike detect-native-changes which must special-case fork fetches because it
-  diffs head content. A package added in the same PR (no project.json on base yet) is skipped with
-  a warning, not treated as affected-with-no-config — see the two-step onboarding note in the
-  migration plan.
+description: 'Builds the matrix from each affected package''s project.json options.ci (read from base only, never PR head).'
 
 inputs:
   target:

--- a/.github/actions/nx-project-matrix/action.yml
+++ b/.github/actions/nx-project-matrix/action.yml
@@ -4,9 +4,10 @@ description: >
   set for a given target (same base/head resolution as ./nx-affected), then for each affected
   project reads that target's `options.ci` block directly from each package's own project.json —
   read from the BASE branch's committed content, never the PR head — and flattens
-  `options.ci.platforms[]` into one matrix row per (package, platform). Emits the same
-  `matrix`/`any` output shape ./nx-affected already does, so a consuming workflow's `matrix` job
-  is a drop-in swap.
+  `options.ci.platforms[]` into one matrix row per (package, platform), adding `workdir` from the
+  project's own top-level `root` (never hand-authored in `options.ci` — it's already known to nx).
+  Emits the same `matrix`/`any` output shape ./nx-affected already does, so a consuming workflow's
+  `matrix` job is a drop-in swap.
 
   SECURITY: project.json is a file a PR author fully controls. Reading options.ci from the PR head
   would let a PR redirect its OWN run onto a different runner/matrix in the same PR — this action
@@ -90,11 +91,12 @@ runs:
           if [ -z "$CI" ] || [ "$CI" = "null" ]; then
             continue
           fi
-          PKG_ROWS=$(echo "$CI" | jq -c --arg pkg "$pkg" '
+          ROOT=$(echo "$PROJECT_JSON" | jq -r '.root')
+          PKG_ROWS=$(echo "$CI" | jq -c --arg pkg "$pkg" --arg workdir "$ROOT" '
             (.platforms // [{}]) as $platforms
             | (del(.platforms)) as $rest
             | $platforms
-            | map({package: $pkg} + $rest + .)
+            | map({package: $pkg, workdir: $workdir} + $rest + .)
           ')
           ROWS=$(jq -c --argjson new "$PKG_ROWS" '. + $new' <<< "$ROWS")
         done

--- a/.github/actions/nx-project-matrix/action.yml
+++ b/.github/actions/nx-project-matrix/action.yml
@@ -1,5 +1,5 @@
 name: 'Nx project.json-driven matrix'
-description: 'Builds the matrix from each affected package''s project.json options.ci (read from base only, never PR head).'
+description: 'Builds the matrix from each affected package''s project.json options.ci (read from base only, never PR head), with optional per-run overrides validated against each package''s own declared fields.'
 
 inputs:
   target:
@@ -13,6 +13,10 @@ inputs:
     description: 'Head ref for nx affected when not resolvable from a pull_request event'
     required: false
     default: 'HEAD'
+  overrides:
+    description: 'JSON object of {package: {ciField: value}} to override per-run. Each field must already exist in that package''s own options.ci for this target.'
+    required: false
+    default: '{}'
 
 outputs:
   matrix:
@@ -43,6 +47,7 @@ runs:
         INPUT_TARGET: ${{ inputs.target }}
         INPUT_BASE_REF: ${{ inputs.base-ref }}
         INPUT_HEAD_REF: ${{ inputs.head-ref }}
+        INPUT_OVERRIDES: ${{ inputs.overrides }}
       run: |
         set -euo pipefail
         TARGET="$INPUT_TARGET"
@@ -81,6 +86,37 @@ runs:
           ')
           ROWS=$(jq -c --argjson new "$PKG_ROWS" '. + $new' <<< "$ROWS")
         done
+
+        # Per-run overrides: a key is valid only if it already exists as a
+        # field on that package's own row (i.e. was declared in its
+        # options.ci for this target). Applied uniformly across every row
+        # belonging to that package. Comes from the dispatch/call input, same
+        # trust level as any other free-form workflow input — never sourced
+        # from PR-head project.json.
+        OVERRIDES="$INPUT_OVERRIDES"
+        echo "$OVERRIDES" | jq -e 'type == "object"' >/dev/null || {
+          echo "::error::overrides must be a JSON object, got: $OVERRIDES"
+          exit 1
+        }
+
+        for pkg in $(echo "$OVERRIDES" | jq -r 'keys[]'); do
+          PKG_ROW_COUNT=$(echo "$ROWS" | jq --arg p "$pkg" '[.[] | select(.package == $p)] | length')
+          if [ "$PKG_ROW_COUNT" -eq 0 ]; then
+            echo "::error::overrides references package '$pkg', which is not affected or has no $TARGET options.ci"
+            exit 1
+          fi
+          for key in $(echo "$OVERRIDES" | jq -r --arg p "$pkg" '.[$p] | keys[]'); do
+            KEY_EXISTS=$(echo "$ROWS" | jq --arg p "$pkg" --arg k "$key" '[.[] | select(.package == $p) | has($k)] | any')
+            if [ "$KEY_EXISTS" != "true" ]; then
+              echo "::error::overrides key '$key' for package '$pkg' is not a declared options.ci field for target $TARGET"
+              exit 1
+            fi
+          done
+        done
+
+        ROWS=$(jq -c --argjson overrides "$OVERRIDES" '
+          map(. as $row | $row * ($overrides[$row.package] // {}))
+        ' <<< "$ROWS")
 
         echo "Matrix ($TARGET): $ROWS"
         echo "matrix=$ROWS" >> "$GITHUB_OUTPUT"

--- a/.github/actions/nx-project-matrix/action.yml
+++ b/.github/actions/nx-project-matrix/action.yml
@@ -25,6 +25,9 @@ outputs:
   any:
     description: '"true" if the matrix is non-empty, else "false"'
     value: ${{ steps.compute.outputs.any }}
+  carveouts:
+    description: 'JSON array of affected package short-names whose options.ci is flagged carveOut:true (routed to their own bespoke reusable by the caller, not the generic matrix job)'
+    value: ${{ steps.compute.outputs.carveouts }}
 
 runs:
   using: composite
@@ -118,6 +121,14 @@ runs:
           map(. as $row | $row * ($overrides[$row.package] // {}))
         ' <<< "$ROWS")
 
+        # Partition: rows flagged carveOut are routed by the caller to their own
+        # bespoke reusable (they have no platforms/generic config), so keep them
+        # out of the generic matrix and surface just their package names.
+        CARVEOUTS=$(echo "$ROWS" | jq -c '[.[] | select(.carveOut == true) | .package] | unique')
+        ROWS=$(echo "$ROWS" | jq -c '[.[] | select(.carveOut != true)]')
+
         echo "Matrix ($TARGET): $ROWS"
+        echo "Carve-outs ($TARGET): $CARVEOUTS"
         echo "matrix=$ROWS" >> "$GITHUB_OUTPUT"
         echo "any=$([ "$ROWS" != "[]" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        echo "carveouts=$CARVEOUTS" >> "$GITHUB_OUTPUT"

--- a/.github/actions/nx-project-matrix/action.yml
+++ b/.github/actions/nx-project-matrix/action.yml
@@ -1,0 +1,104 @@
+name: 'Nx project.json-driven matrix'
+description: >
+  Generic replacement for a hand-typed per-workflow YAML config table. Computes the nx-affected
+  set for a given target (same base/head resolution as ./nx-affected), then for each affected
+  project reads that target's `options.ci` block directly from each package's own project.json —
+  read from the BASE branch's committed content, never the PR head — and flattens
+  `options.ci.platforms[]` into one matrix row per (package, platform). Emits the same
+  `matrix`/`any` output shape ./nx-affected already does, so a consuming workflow's `matrix` job
+  is a drop-in swap.
+
+  SECURITY: project.json is a file a PR author fully controls. Reading options.ci from the PR head
+  would let a PR redirect its OWN run onto a different runner/matrix in the same PR — this action
+  always resolves options.ci via `git show <base>:packages/<pkg>/project.json`, never the checked-
+  out working tree at head. Verified fork-PR safe: `git show` here only ever reads already-fetched
+  base-repo history (fetch-depth 0 on the base repo, which is all `actions/checkout` ever touches
+  for a `pull_request` event — the fork's repo is never fetched), so this has no fork-specific
+  code path at all, unlike detect-native-changes which must special-case fork fetches because it
+  diffs head content. A package added in the same PR (no project.json on base yet) is skipped with
+  a warning, not treated as affected-with-no-config — see the two-step onboarding note in the
+  migration plan.
+
+inputs:
+  target:
+    description: 'nx target name whose options.ci to extract, e.g. test:cpp'
+    required: true
+  base-ref:
+    description: 'Base ref for nx affected + the trusted options.ci source, when not resolvable from a pull_request event'
+    required: false
+    default: 'main'
+  head-ref:
+    description: 'Head ref for nx affected when not resolvable from a pull_request event'
+    required: false
+    default: 'HEAD'
+
+outputs:
+  matrix:
+    description: 'JSON array of flattened (package, platform) rows, sourced from each affected project''s options.ci'
+    value: ${{ steps.compute.outputs.matrix }}
+  any:
+    description: '"true" if the matrix is non-empty, else "false"'
+    value: ${{ steps.compute.outputs.any }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+      with:
+        node-version: lts/*
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+    - shell: bash
+      run: pnpm install --frozen-lockfile
+    - if: github.event_name == 'pull_request'
+      uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5
+    - id: compute
+      shell: bash
+      env:
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        INPUT_HEAD_REF: ${{ inputs.head-ref }}
+      run: |
+        set -euo pipefail
+        TARGET="$INPUT_TARGET"
+        BASE="${NX_BASE:-$INPUT_BASE_REF}"
+        HEAD="${NX_HEAD:-$INPUT_HEAD_REF}"
+
+        AFFECTED=$(pnpm exec nx show projects --affected -t "$TARGET" --base="$BASE" --head="$HEAD" --json \
+          | tail -n1 \
+          | jq -c 'map(sub("^@qvac/"; ""))')
+        echo "Affected ($TARGET, transitive): $AFFECTED"
+
+        # Resolve a git-showable ref for BASE: try it as-is, fall back to
+        # origin/<ref> (nx accepts bare branch names like "main" for --base,
+        # but `git show` needs a ref that actually resolves locally).
+        show_base() {
+          local path="$1"
+          git show "${BASE}:${path}" 2>/dev/null || git show "origin/${BASE}:${path}" 2>/dev/null
+        }
+
+        ROWS='[]'
+        for pkg in $(echo "$AFFECTED" | jq -r '.[]'); do
+          PROJECT_JSON=$(show_base "packages/${pkg}/project.json") || {
+            echo "::warning::packages/${pkg}/project.json not found on base ref '${BASE}' — skipping (new package needs onboarding to base first, see plan)"
+            continue
+          }
+          CI=$(echo "$PROJECT_JSON" | jq -c --arg t "$TARGET" '.targets[$t].options.ci // empty')
+          if [ -z "$CI" ] || [ "$CI" = "null" ]; then
+            continue
+          fi
+          PKG_ROWS=$(echo "$CI" | jq -c --arg pkg "$pkg" '
+            (.platforms // [{}]) as $platforms
+            | (del(.platforms)) as $rest
+            | $platforms
+            | map({package: $pkg} + $rest + .)
+          ')
+          ROWS=$(jq -c --argjson new "$PKG_ROWS" '. + $new' <<< "$ROWS")
+        done
+
+        echo "Matrix ($TARGET): $ROWS"
+        echo "matrix=$ROWS" >> "$GITHUB_OUTPUT"
+        echo "any=$([ "$ROWS" != "[]" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prebuilds-nx.yml
+++ b/.github/workflows/prebuilds-nx.yml
@@ -41,103 +41,84 @@ jobs:
     name: Determine affected packages + build matrix (nx affected, transitive)
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-      any: ${{ steps.matrix.outputs.any }}
-    env:
-      # Config keys are camelCase (not kebab-case) - GHA expressions parse
-      # `matrix.artifact-name-prefix` as subtraction, not property access.
-      # Kebab-case is only used in the final `with:` block below, where the
-      # reusable workflow requires it.
-      PREBUILDS_CONFIG: |
-        - package: asr-ggml
-          workdir: packages/asr-ggml
-          artifactNamePrefix: asr-ggml-
-          linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev libopenblas-dev liblapack-dev libfftw3-dev
-          setupPythonOnWindows: true
-          includeVulkanSdk: true
-        - package: audiogen-ggml
-          workdir: packages/audiogen-ggml
-          artifactNamePrefix: audiogen-ggml-
-          linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
-          includeVulkanSdk: true
-        - package: bci-whispercpp
-          workdir: packages/bci-whispercpp
-          artifactNamePrefix: bci-whispercpp-
-          linuxExtraPackages: libopenblas-dev liblapack-dev libfftw3-dev
-          macBrewPackages: openblas lapack fftw
-          includeVulkanSdk: true
-          extraCmakeDefines: -D WHISPER_USE_CUDA=OFF -D WHISPER_USE_OPENVINO=OFF
-          platformCmakeDefines: |
-            darwin: -D WHISPER_USE_METAL=ON
-            ios: -D WHISPER_USE_METAL=ON
-            linux: -D WHISPER_USE_METAL=OFF
-            android: -D WHISPER_USE_METAL=OFF
-            win32: -D WHISPER_USE_METAL=OFF
-        - package: classification-ggml
-          workdir: packages/classification-ggml
-          artifactNamePrefix: classification-ggml-
-          includeVulkanSdk: true
-        - package: diffusion-cpp
-          workdir: packages/diffusion-cpp
-          artifactNamePrefix: sd-cpp-
-          includeVulkanSdk: true
-        - package: embed-llamacpp
-          workdir: packages/embed-llamacpp
-          artifactNamePrefix: llama-cpp-
-          includeVulkanSdk: true
-        - package: fabric
-          workdir: packages/fabric
-          artifactNamePrefix: fabric-
-          includeVulkanSdk: true
-        - package: llm-llamacpp
-          workdir: packages/llm-llamacpp
-          artifactNamePrefix: llama-cpp-
-          includeVulkanSdk: true
-        - package: ocr-ggml
-          workdir: packages/ocr-ggml
-          artifactNamePrefix: ggml-ocr-
-          includeVulkanSdk: true
-        - package: onnx
-          workdir: packages/onnx
-          artifactNamePrefix: onnx-
-        - package: translation-nmtcpp
-          workdir: packages/translation-nmtcpp
-          includeVulkanSdk: true
-        - package: tts-ggml
-          workdir: packages/tts-ggml
-          artifactNamePrefix: tts-ggml-
-          linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
-          includeVulkanSdk: true
-        - package: vla-ggml
-          workdir: packages/vla-ggml
-          artifactNamePrefix: vla-
-          linuxExtraPackages: libxi-dev libxtst-dev libxrandr-dev
-          includeVulkanSdk: true
-          includeRocm: true
+      matrix: ${{ steps.compute.outputs.matrix }}
+      any: ${{ steps.compute.outputs.any }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+      - id: compute
+        uses: ./.github/actions/nx-affected
         with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: lts/*
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - run: pnpm install --frozen-lockfile
-      - id: matrix
-        shell: bash
-        run: |
-          set -euo pipefail
-          AFFECTED=$(nx show projects --affected --base="${{ inputs.base-ref }}" --head="${{ inputs.head-ref }}" --json \
-            | jq -c 'map(sub("^@qvac/"; ""))')
-          echo "Affected (transitive): $AFFECTED"
-
-          CONFIG_JSON=$(yq -o=json -I=0 e '.' <<< "$PREBUILDS_CONFIG")
-
-          MATRIX=$(jq -c --argjson affected "$AFFECTED" '[.[] | select(.package as $p | $affected | index($p) != null)]' <<< "$CONFIG_JSON")
-          echo "Matrix (config ∩ affected): $MATRIX"
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "any=$([ "$MATRIX" != "[]" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          base-ref: ${{ inputs.base-ref }}
+          head-ref: ${{ inputs.head-ref }}
+          # Config keys are camelCase (not kebab-case) - GHA expressions parse
+          # `matrix.artifact-name-prefix` as subtraction, not property access.
+          # Kebab-case is only used in the final `with:` block below, where
+          # the reusable workflow requires it.
+          config: |
+            - package: asr-ggml
+              workdir: packages/asr-ggml
+              artifactNamePrefix: asr-ggml-
+              linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev libopenblas-dev liblapack-dev libfftw3-dev
+              setupPythonOnWindows: true
+              includeVulkanSdk: true
+            - package: audiogen-ggml
+              workdir: packages/audiogen-ggml
+              artifactNamePrefix: audiogen-ggml-
+              linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
+              includeVulkanSdk: true
+            - package: bci-whispercpp
+              workdir: packages/bci-whispercpp
+              artifactNamePrefix: bci-whispercpp-
+              linuxExtraPackages: libopenblas-dev liblapack-dev libfftw3-dev
+              macBrewPackages: openblas lapack fftw
+              includeVulkanSdk: true
+              extraCmakeDefines: -D WHISPER_USE_CUDA=OFF -D WHISPER_USE_OPENVINO=OFF
+              platformCmakeDefines: |
+                darwin: -D WHISPER_USE_METAL=ON
+                ios: -D WHISPER_USE_METAL=ON
+                linux: -D WHISPER_USE_METAL=OFF
+                android: -D WHISPER_USE_METAL=OFF
+                win32: -D WHISPER_USE_METAL=OFF
+            - package: classification-ggml
+              workdir: packages/classification-ggml
+              artifactNamePrefix: classification-ggml-
+              includeVulkanSdk: true
+            - package: diffusion-cpp
+              workdir: packages/diffusion-cpp
+              artifactNamePrefix: sd-cpp-
+              includeVulkanSdk: true
+            - package: embed-llamacpp
+              workdir: packages/embed-llamacpp
+              artifactNamePrefix: llama-cpp-
+              includeVulkanSdk: true
+            - package: fabric
+              workdir: packages/fabric
+              artifactNamePrefix: fabric-
+              includeVulkanSdk: true
+            - package: llm-llamacpp
+              workdir: packages/llm-llamacpp
+              artifactNamePrefix: llama-cpp-
+              includeVulkanSdk: true
+            - package: ocr-ggml
+              workdir: packages/ocr-ggml
+              artifactNamePrefix: ggml-ocr-
+              includeVulkanSdk: true
+            - package: onnx
+              workdir: packages/onnx
+              artifactNamePrefix: onnx-
+            - package: translation-nmtcpp
+              workdir: packages/translation-nmtcpp
+              includeVulkanSdk: true
+            - package: tts-ggml
+              workdir: packages/tts-ggml
+              artifactNamePrefix: tts-ggml-
+              linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
+              includeVulkanSdk: true
+            - package: vla-ggml
+              workdir: packages/vla-ggml
+              artifactNamePrefix: vla-
+              linuxExtraPackages: libxi-dev libxtst-dev libxrandr-dev
+              includeVulkanSdk: true
+              includeRocm: true
 
   prebuild:
     name: Prebuild (${{ matrix.package }})

--- a/.github/workflows/prebuilds-nx.yml
+++ b/.github/workflows/prebuilds-nx.yml
@@ -41,6 +41,7 @@ jobs:
       matrix: ${{ steps.compute.outputs.matrix }}
       any: ${{ steps.compute.outputs.any }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - id: compute
         uses: ./.github/actions/nx-project-matrix
         with:

--- a/.github/workflows/prebuilds-nx.yml
+++ b/.github/workflows/prebuilds-nx.yml
@@ -1,9 +1,4 @@
-# Consolidates the 13 prebuilds-<pkg>.yml files (all thin wrappers around
-# reusable-prebuilds.yml, differing only in `with:` data). Matrix rows come
-# from each package's own project.json (targets["build"].options.ci), not a
-# hand-typed table - see .github/actions/nx-project-matrix. Matrix is
-# pre-filtered to nx-affected packages before the job runs - a job calling a
-# reusable workflow can't reference `matrix` in its own `if:`. Additive only.
+# Consolidates the 13 prebuilds-<pkg>.yml files.
 name: "Prebuilds (nx)"
 
 on:

--- a/.github/workflows/prebuilds-nx.yml
+++ b/.github/workflows/prebuilds-nx.yml
@@ -1,0 +1,167 @@
+# Consolidates the 13 prebuilds-<pkg>.yml files (all thin wrappers around
+# reusable-prebuilds.yml, differing only in `with:` data). Matrix is
+# pre-filtered to nx-affected packages before the job runs - a job calling a
+# reusable workflow can't reference `matrix` in its own `if:`. Additive only.
+name: "Prebuilds (nx)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        required: false
+        type: string
+        default: "main"
+      head-ref:
+        required: false
+        type: string
+        default: "HEAD"
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+      repository:
+        type: string
+        required: false
+        default: "tetherto/qvac"
+      base-ref:
+        required: false
+        type: string
+        default: "main"
+      head-ref:
+        required: false
+        type: string
+        default: "HEAD"
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    name: Determine affected packages + build matrix (nx affected, transitive)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      any: ${{ steps.matrix.outputs.any }}
+    env:
+      # Config keys are camelCase (not kebab-case) - GHA expressions parse
+      # `matrix.artifact-name-prefix` as subtraction, not property access.
+      # Kebab-case is only used in the final `with:` block below, where the
+      # reusable workflow requires it.
+      PREBUILDS_CONFIG: |
+        - package: asr-ggml
+          workdir: packages/asr-ggml
+          artifactNamePrefix: asr-ggml-
+          linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev libopenblas-dev liblapack-dev libfftw3-dev
+          setupPythonOnWindows: true
+          includeVulkanSdk: true
+        - package: audiogen-ggml
+          workdir: packages/audiogen-ggml
+          artifactNamePrefix: audiogen-ggml-
+          linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
+          includeVulkanSdk: true
+        - package: bci-whispercpp
+          workdir: packages/bci-whispercpp
+          artifactNamePrefix: bci-whispercpp-
+          linuxExtraPackages: libopenblas-dev liblapack-dev libfftw3-dev
+          macBrewPackages: openblas lapack fftw
+          includeVulkanSdk: true
+          extraCmakeDefines: -D WHISPER_USE_CUDA=OFF -D WHISPER_USE_OPENVINO=OFF
+          platformCmakeDefines: |
+            darwin: -D WHISPER_USE_METAL=ON
+            ios: -D WHISPER_USE_METAL=ON
+            linux: -D WHISPER_USE_METAL=OFF
+            android: -D WHISPER_USE_METAL=OFF
+            win32: -D WHISPER_USE_METAL=OFF
+        - package: classification-ggml
+          workdir: packages/classification-ggml
+          artifactNamePrefix: classification-ggml-
+          includeVulkanSdk: true
+        - package: diffusion-cpp
+          workdir: packages/diffusion-cpp
+          artifactNamePrefix: sd-cpp-
+          includeVulkanSdk: true
+        - package: embed-llamacpp
+          workdir: packages/embed-llamacpp
+          artifactNamePrefix: llama-cpp-
+          includeVulkanSdk: true
+        - package: fabric
+          workdir: packages/fabric
+          artifactNamePrefix: fabric-
+          includeVulkanSdk: true
+        - package: llm-llamacpp
+          workdir: packages/llm-llamacpp
+          artifactNamePrefix: llama-cpp-
+          includeVulkanSdk: true
+        - package: ocr-ggml
+          workdir: packages/ocr-ggml
+          artifactNamePrefix: ggml-ocr-
+          includeVulkanSdk: true
+        - package: onnx
+          workdir: packages/onnx
+          artifactNamePrefix: onnx-
+        - package: translation-nmtcpp
+          workdir: packages/translation-nmtcpp
+          includeVulkanSdk: true
+        - package: tts-ggml
+          workdir: packages/tts-ggml
+          artifactNamePrefix: tts-ggml-
+          linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
+          includeVulkanSdk: true
+        - package: vla-ggml
+          workdir: packages/vla-ggml
+          artifactNamePrefix: vla-
+          linuxExtraPackages: libxi-dev libxtst-dev libxrandr-dev
+          includeVulkanSdk: true
+          includeRocm: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - run: pnpm install --frozen-lockfile
+      - id: matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          AFFECTED=$(nx show projects --affected --base="${{ inputs.base-ref }}" --head="${{ inputs.head-ref }}" --json \
+            | jq -c 'map(sub("^@qvac/"; ""))')
+          echo "Affected (transitive): $AFFECTED"
+
+          CONFIG_JSON=$(yq -o=json -I=0 e '.' <<< "$PREBUILDS_CONFIG")
+
+          MATRIX=$(jq -c --argjson affected "$AFFECTED" '[.[] | select(.package as $p | $affected | index($p) != null)]' <<< "$CONFIG_JSON")
+          echo "Matrix (config ∩ affected): $MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "any=$([ "$MATRIX" != "[]" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+  prebuild:
+    name: Prebuild (${{ matrix.package }})
+    needs: matrix
+    if: needs.matrix.outputs.any == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.matrix || '[]') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/reusable-prebuilds.yml
+    with:
+      workdir: ${{ matrix.workdir }}
+      ref: ${{ inputs.ref }}
+      repository: ${{ inputs.repository || 'tetherto/qvac' }}
+      artifact-name-prefix: ${{ matrix.artifactNamePrefix }}
+      linux-extra-packages: ${{ matrix.linuxExtraPackages }}
+      mac-brew-packages: ${{ matrix.macBrewPackages }}
+      setup-python-on-windows: ${{ matrix.setupPythonOnWindows == true }}
+      include-vulkan-sdk: ${{ matrix.includeVulkanSdk == true }}
+      include-rocm: ${{ matrix.includeRocm == true }}
+      extra-cmake-defines: ${{ matrix.extraCmakeDefines }}
+      platform-cmake-defines: ${{ matrix.platformCmakeDefines }}
+    secrets: inherit

--- a/.github/workflows/prebuilds-nx.yml
+++ b/.github/workflows/prebuilds-nx.yml
@@ -1,5 +1,7 @@
 # Consolidates the 13 prebuilds-<pkg>.yml files (all thin wrappers around
-# reusable-prebuilds.yml, differing only in `with:` data). Matrix is
+# reusable-prebuilds.yml, differing only in `with:` data). Matrix rows come
+# from each package's own project.json (targets["build"].options.ci), not a
+# hand-typed table - see .github/actions/nx-project-matrix. Matrix is
 # pre-filtered to nx-affected packages before the job runs - a job calling a
 # reusable workflow can't reference `matrix` in its own `if:`. Additive only.
 name: "Prebuilds (nx)"
@@ -38,87 +40,18 @@ permissions:
 
 jobs:
   matrix:
-    name: Determine affected packages + build matrix (nx affected, transitive)
+    name: Determine affected packages (nx project.json, transitive)
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}
       any: ${{ steps.compute.outputs.any }}
     steps:
       - id: compute
-        uses: ./.github/actions/nx-affected
+        uses: ./.github/actions/nx-project-matrix
         with:
+          target: build
           base-ref: ${{ inputs.base-ref }}
           head-ref: ${{ inputs.head-ref }}
-          # Config keys are camelCase (not kebab-case) - GHA expressions parse
-          # `matrix.artifact-name-prefix` as subtraction, not property access.
-          # Kebab-case is only used in the final `with:` block below, where
-          # the reusable workflow requires it.
-          config: |
-            - package: asr-ggml
-              workdir: packages/asr-ggml
-              artifactNamePrefix: asr-ggml-
-              linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev libopenblas-dev liblapack-dev libfftw3-dev
-              setupPythonOnWindows: true
-              includeVulkanSdk: true
-            - package: audiogen-ggml
-              workdir: packages/audiogen-ggml
-              artifactNamePrefix: audiogen-ggml-
-              linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
-              includeVulkanSdk: true
-            - package: bci-whispercpp
-              workdir: packages/bci-whispercpp
-              artifactNamePrefix: bci-whispercpp-
-              linuxExtraPackages: libopenblas-dev liblapack-dev libfftw3-dev
-              macBrewPackages: openblas lapack fftw
-              includeVulkanSdk: true
-              extraCmakeDefines: -D WHISPER_USE_CUDA=OFF -D WHISPER_USE_OPENVINO=OFF
-              platformCmakeDefines: |
-                darwin: -D WHISPER_USE_METAL=ON
-                ios: -D WHISPER_USE_METAL=ON
-                linux: -D WHISPER_USE_METAL=OFF
-                android: -D WHISPER_USE_METAL=OFF
-                win32: -D WHISPER_USE_METAL=OFF
-            - package: classification-ggml
-              workdir: packages/classification-ggml
-              artifactNamePrefix: classification-ggml-
-              includeVulkanSdk: true
-            - package: diffusion-cpp
-              workdir: packages/diffusion-cpp
-              artifactNamePrefix: sd-cpp-
-              includeVulkanSdk: true
-            - package: embed-llamacpp
-              workdir: packages/embed-llamacpp
-              artifactNamePrefix: llama-cpp-
-              includeVulkanSdk: true
-            - package: fabric
-              workdir: packages/fabric
-              artifactNamePrefix: fabric-
-              includeVulkanSdk: true
-            - package: llm-llamacpp
-              workdir: packages/llm-llamacpp
-              artifactNamePrefix: llama-cpp-
-              includeVulkanSdk: true
-            - package: ocr-ggml
-              workdir: packages/ocr-ggml
-              artifactNamePrefix: ggml-ocr-
-              includeVulkanSdk: true
-            - package: onnx
-              workdir: packages/onnx
-              artifactNamePrefix: onnx-
-            - package: translation-nmtcpp
-              workdir: packages/translation-nmtcpp
-              includeVulkanSdk: true
-            - package: tts-ggml
-              workdir: packages/tts-ggml
-              artifactNamePrefix: tts-ggml-
-              linuxExtraPackages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
-              includeVulkanSdk: true
-            - package: vla-ggml
-              workdir: packages/vla-ggml
-              artifactNamePrefix: vla-
-              linuxExtraPackages: libxi-dev libxtst-dev libxrandr-dev
-              includeVulkanSdk: true
-              includeRocm: true
 
   prebuild:
     name: Prebuild (${{ matrix.package }})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The repo has one `prebuilds-<pkg>.yml` per native addon (13 near-identical wrappers around `reusable-prebuilds.yml`, differing only in `with:` data). Adding or changing a package's prebuild means hand-editing yet another copy, and there is no single place that knows "which packages actually changed on this PR."

This is the first per-stage consolidation in the pnpm+nx migration stack (bases on the foundation PR #3543).

## 🛠️ How does it solve it?

- Adds a shared composite action `.github/actions/nx-affected/action.yml` that every consolidated `*-nx.yml` workflow reuses: checkout → setup-node → pnpm install → resolve base/head (`nrwl/nx-set-shas` on a real `pull_request`, else the `base-ref`/`head-ref` inputs) → `nx show projects --affected --json` → intersect with the caller's own YAML config table → emit a `matrix` JSON + `any` flag. Removes ~30-40 lines of duplicated boilerplate from every consumer.
- Adds `.github/workflows/prebuilds-nx.yml` consolidating the 13 `prebuilds-<pkg>.yml` into one nx-affected-driven matrix. Per-package data (artifact prefix, linux/mac extra packages, cmake defines, vulkan/rocm toggles) lives in one config table; the `prebuild` job maps it to `reusable-prebuilds.yml`'s `with:` inputs.

Additive only — no legacy `prebuilds-<pkg>.yml` file is deleted in this PR. Legacy removal is a separate follow-up once real-CI parity is proven.

## 🔐 Action pinning

No new or bumped third-party actions. All `uses:` pins are carried over verbatim from the legacy `prebuilds-<pkg>.yml` / existing composites:

- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` # 6.0.2
- `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` # 6.3.0
- `pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda` # v4.1.0
- `nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1` # v5 (resolved from the `v5` tag)

## ✅ How was it tested?

- `actionlint` clean (only pre-existing `[shellcheck]` style findings, identical to the legacy files).
- `act -n` structural dry-run: `matrix` job resolves and succeeds; the `prebuild` job depends on the matrix's runtime output (expected `skipped` under dry-run).
- nx-affected sanity: `nx show projects --affected --base=pnpm-monorepo-foundation --head=HEAD --json` → `[]` (no package source changed, only workflow files), confirming the affected filter is wired correctly.

## 📝 Notes for reviewers

- Draft, base = `feature-prebuilds-nx`'s parent in the migration waterfall (foundation). Stacked on PR #3543.
- Interim safety: uses `pull_request` (not `pull_request_target`) while these files are unproven drafts. Revert to `pull_request_target` (matching legacy) is a tracked follow-up before go-live.
