### PR TITLE
QVAC-23194 infra: auto-discover all qvac-fabric vcpkg manifests in lockstep check

### DIFF
--- a/.github/actions/verify-qvac-fabric-lockstep/action.yml
+++ b/.github/actions/verify-qvac-fabric-lockstep/action.yml
@@ -14,6 +14,17 @@ runs:
       run: |
         set -euo pipefail
 
+        mapfile -t mentions < <(
+          for file in packages/*/vcpkg.json; do
+            if jq -e '
+              [.. | strings, (objects | .name?) | select(. == "qvac-fabric")]
+              | length > 0
+            ' "${file}" >/dev/null 2>&1; then
+              echo "${file}"
+            fi
+          done | sort
+        )
+
         mapfile -t files < <(
           for file in packages/*/vcpkg.json; do
             if jq -e '
@@ -30,6 +41,24 @@ runs:
 
         if [ "${#files[@]}" -eq 0 ]; then
           echo "No packages/*/vcpkg.json manifests declare qvac-fabric with version>="
+          exit 1
+        fi
+
+        declare -A verified=()
+        for file in "${files[@]}"; do
+          verified["${file}"]=1
+        done
+
+        unverified=()
+        for file in "${mentions[@]}"; do
+          if [ -z "${verified[${file}]+x}" ]; then
+            unverified+=("${file}")
+          fi
+        done
+
+        if [ "${#unverified[@]}" -gt 0 ]; then
+          echo "qvac-fabric is referenced but not lockstep-verified (missing top-level dependency with version>=):"
+          printf '  %s\n' "${unverified[@]}"
           exit 1
         fi
 

--- a/.github/actions/verify-qvac-fabric-lockstep/action.yml
+++ b/.github/actions/verify-qvac-fabric-lockstep/action.yml
@@ -1,5 +1,5 @@
 name: Verify qvac-fabric lockstep
-description: Ensures qvac-fabric dependency version is identical across selected vcpkg manifests.
+description: Ensures qvac-fabric dependency version is identical across all package vcpkg manifests that declare it.
 
 outputs:
   version:
@@ -14,19 +14,27 @@ runs:
       run: |
         set -euo pipefail
 
-        files=(
-          "packages/llm-llamacpp/vcpkg.json"
-          "packages/embed-llamacpp/vcpkg.json"
-          "packages/translation-nmtcpp/vcpkg.json"
+        mapfile -t files < <(
+          for file in packages/*/vcpkg.json; do
+            if jq -e '
+              [
+                .dependencies[]?
+                | objects
+                | select(.name == "qvac-fabric" and (.["version>="] != null))
+              ] | length > 0
+            ' "${file}" >/dev/null; then
+              echo "${file}"
+            fi
+          done | sort
         )
+
+        if [ "${#files[@]}" -eq 0 ]; then
+          echo "No packages/*/vcpkg.json manifests declare qvac-fabric with version>="
+          exit 1
+        fi
 
         versions=()
         for file in "${files[@]}"; do
-          if [ ! -f "${file}" ]; then
-            echo "Missing file: ${file}"
-            exit 1
-          fi
-
           version="$(jq -r '
             [
               .dependencies[]
@@ -55,5 +63,5 @@ runs:
           fi
         done
 
-        echo "qvac-fabric lockstep verified: ${baseline}"
+        echo "qvac-fabric lockstep verified across ${#files[@]} manifests: ${baseline}"
         echo "version=${baseline}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `verify-qvac-fabric-lockstep` only checked three hardcoded manifests (`llm-llamacpp`, `embed-llamacpp`, `translation-nmtcpp`).
- Three other `qvac-fabric` consumers were never validated: `fabric`, `ocr-ggml`, and `vla-ggml` — even though their PR workflows (`on-pr-ocr-ggml`, `on-pr-vla`, etc.) already call the same action.
- A coordinated `qvac-fabric` bump could leave those packages on a different `version>=` without CI catching it.

## 📝 How does it solve it?

- Replace the hardcoded manifest list with auto-discovery: scan every `packages/*/vcpkg.json` that declares a top-level `qvac-fabric` dependency with `version>=`.
- Fail early if no qualifying manifests are found.
- Log how many manifests were verified (currently six: `embed-llamacpp`, `fabric`, `llm-llamacpp`, `ocr-ggml`, `translation-nmtcpp`, `vla-ggml`).
- New `qvac-fabric` consumers are included automatically when they add the dependency to their `vcpkg.json`.

## 🧪 How was it tested?

- Confirmed discovery finds all six current `qvac-fabric` manifests and they share `version>= 9840.1.1`.
- Change is picked up by existing callers: `on-pr-shared-ci-infra` (`fabric-lockstep` job) and per-addon `verify-fabric-lockstep` jobs (`llm-llamacpp`, `embed-llamacpp`, `translation-nmtcpp`, `ocr-ggml`, `vla`).
- Ran on CI: https://github.com/tetherto/qvac/actions/runs/30996167344/job/92273736657