### PR TITLE
QVAC-18397 chore: bump llm-llamacpp to 0.40.0 for the multi-job queue

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## [0.40.0] - 2026-08-06
+
+One model instance can now serve several requests at once. Every `run()` call is
+admitted as its own job by a native multi-job scheduler and decodes alongside
+whatever else is in flight, so concurrent callers share the batch engine instead
+of queueing behind each other. Terminal stats become per-job, cancellation
+becomes per-job, and a new admission policy lets a caller choose between failing
+fast and being queued.
+
+### Added
+
+- Concurrent top-level `run()` calls on one instance at `parallel >= 2`. Each
+  call streams to its own response, routed by the job id minted at admission; a
+  batch `run([...])` is admitted as one job whose prompts occupy up to N slots.
+- `rejectWhenBusy`, the admission policy, as `opts.rejectWhenBusy` per instance
+  and `runOptions.rejectWhenBusy` per call. A refusal throws an `Error` carrying
+  `code === 'RUN_BUSY'`, so callers branch on the code rather than matching the
+  message. The default follows `parallel`: `true` at `1`, preserving the
+  sequential fail-fast behaviour, `false` at `>= 2`. A batch derives ONE group
+  policy from its items — items that disagree are refused with a `TypeError`.
+- `activeSlots()` on the addon surface, reporting the requests occupying or
+  waiting for a continuous-batching slot. Slots, not jobs, are the currency
+  admission is measured in: one batch job of N prompts consumes up to N of them,
+  so a job count alone under-reports a full pool.
+- Per-job terminal stats. A job's `JobEnded` now overrides `TTFT`, `TPS`,
+  `generatedTokens` and `promptTokens` with that job's own observed figures,
+  while `ppTPS`, `CacheTokens`, `contextSlides`, `thinkingBlockDiscards`,
+  `avgConcurrentSeq` and `backendDevice` stay model-level.
+- `stopReason` for a single prompt that runs through the batch engine, which
+  previously omitted the key that the sequential path always reported.
+- Targeted cancellation: `response.cancel()` stops only that call's job or
+  group and leaves concurrent jobs decoding. A cancel that arrives while the
+  group's prompts are still queued settles it immediately instead of waiting for
+  an unrelated job to free a slot.
+
+### Changed
+
+- `parallel` now accepts `1..256` instead of `1..1024`. 256 is the engine's own
+  `LLAMA_MAX_SEQ`; a larger value used to spawn the whole eager thread pool and
+  only then fail the model load, where llama.cpp swallows the real reason into a
+  log line.
+- `parallel` also sizes the scheduler's worker pool one-to-one, and those OS
+  threads are created eagerly at load and held for the model's lifetime. A large
+  `parallel` is a standing resource commitment even while idle.
+- A `parallel` too large for `ctx_size` to leave room per slot — or a
+  `batch_size` smaller than `parallel` — is now refused as an `InvalidArgument`
+  naming the knobs involved, instead of escaping the load as an unmapped
+  `std::invalid_argument`.
+- A prefill-only request without `saveCacheToDisk` and a `cacheKey` is rejected
+  with `InvalidArgument` on a parallel model: its warmed state lives in a
+  context concurrent jobs cannot reach. Load with `parallel: 1` for live-only
+  cache warming.
+- `qvac-lib-inference-addon-cpp` dependency floor moves `1.2.4` -> `1.3.3` for
+  the multi-job scheduler.
+
+### Pull Requests
+
+- [#3445](https://github.com/tetherto/qvac/pull/3445) - Multi-job queue at
+  addon-cpp and LLM (Needed for LLM Continuous Batching Optimizations)
+
 ## [0.39.4] - 2026-08-04
 
 Internal refactor of how JS configuration is parsed into C++. Generation,

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.39.4",
+  "version": "0.40.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 Problem

PR #3445 (QVAC-18397) merged the native multi-job scheduler into
`packages/llm-llamacpp`, but `main` still carries `0.39.4` — which is exactly what
npm publishes as `latest`. The feature is on `main` and unreleasable: `/release`
validates the bump and stops, and `/addon-changelog` refuses to bump.

It is the only change to this package since `llamacpp-llm-v0.39.4`. I checked all
20 commits between that tag and `main` against the GitHub API rather than local
git — the local clone is shallow, and its path-filtered log wrongly attributes
the whole package tree to an unrelated CosyVoice3 commit that happens to sit on
the shallow boundary. #3446 touches 0 files here and is therefore not listed.

## 📝 How

Two files, nothing else:

- `package.json`: `0.39.4` -> `0.40.0`, version field only.
- `CHANGELOG.md`: a `## [0.40.0] - 2026-08-06` entry describing the merged
  behaviour — concurrent `run()` calls, the `rejectWhenBusy` policy and its
  `RUN_BUSY` code, `activeSlots()`, per-job terminal stats, `stopReason` on the
  concurrent path, targeted cancellation, the `1..256` `parallel` ceiling, the
  eager worker pool, and the `qvac-lib-inference-addon-cpp` floor moving
  `1.2.4` -> `1.3.3`.

Minor rather than patch: new public surface, a changed default (`rejectWhenBusy`
follows `parallel`), a narrowed accepted range for `parallel`, and a dependency
floor bump. On a 0.x package a minor bump is this repo's breaking-change signal.

Every changelog claim was read out of the merged code in `origin/main`
(`index.d.ts`, `ParallelLimits.hpp`, `vcpkg.json`), not paraphrased from commit
messages.

## 🧪 Tested

No source changed, so there is nothing to build or run. What I did verify:

- `grep -nE "^## \[0\.40\.0\]"` matches at line 3 — this is the same regex the
  release-body extractor uses in `.github/actions/verify-changelog-notes`, and an
  unbracketed heading is the usual way this task fails later instead of now.
- `git diff --stat origin/main` shows exactly two files, and the `package.json`
  diff is the single `version` line. No `vcpkg.json`, no
  `vcpkg-configuration.json` baseline.
- `package.json` version equals the changelog heading version.
- `origin/main` and `npm view @qvac/llm-llamacpp dist-tags.latest` were both
  `0.39.4` before this change, so `0.40.0` is free.

## ⚠️ Breaking changes

None in this PR — it only bumps a version and adds a changelog entry.

Worth flagging about the release it enables: `parallel` values in `257..1024`
were accepted before #3445 and are now rejected at construction. In practice
they never worked — the engine's `LLAMA_MAX_SEQ` is 256, so such a value spawned
the whole eager thread pool and then failed the model load with a generic
message — but a caller passing one will now see an `InvalidArgument` at a
different point.
