### PR TITLE
QVAC-18397 chore: release addon consumers for addon-cpp 1.3.3

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -12,6 +12,18 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 [`docs/WHISPER-CHANGELOG.md`](docs/WHISPER-CHANGELOG.md) and
 [`docs/PARAKEET-CHANGELOG.md`](docs/PARAKEET-CHANGELOG.md).
 
+## [0.2.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.1.1] - 2026-08-03
 
 ### Changed

--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/asr-ggml",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Multi-engine ASR (Whisper + NVIDIA Parakeet) inference addon for qvac on the Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.1.1] - 2026-08-03
 
 ### Changed

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.6.0] - 2026-08-03
 
 ### Changed

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.16.0] - 2026-08-05
 
 This release adds Google FuzzTest coverage for the image preprocessor and wires

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {

--- a/packages/diffusion-cpp/CHANGELOG.md
+++ b/packages/diffusion-cpp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.18.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.17.0] - 2026-07-23
 
 This release adds the validated Wan 2.2 TI2V-5B Turbo Q5_K_S workflow for

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.31.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.30.1] - 2026-07-30
 
 ### Changed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.13.1] - 2026-07-30
 
 ### Changed

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR pipeline on GGUF weights)",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.0] - 2026-08-06
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+- Update the Opus deprecation unit-test mock to the composed inference API used
+  by `@qvac/infer-base` 0.5.x and newer.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [8.3.1] - 2026-08-03
 
 ### Fixed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "8.3.1",
+  "version": "9.0.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-08-06
 
 ### Added
 
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default iOS app memory budget on CPU (map-in-place, mmap-backed weight
   loading plus CosyVoice3 sequential stage loading, via `tts-cpp` `2026-08-04`),
   so they no longer OOM on non-entitled devices. Output is byte-identical.
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3446](https://github.com/tetherto/qvac/pull/3446) - QVAC-22652 feat[api]:
+  add CosyVoice3 engine to @qvac/tts-ggml
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
 
 ## [0.6.2] - 2026-08-03
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - 2026-08-06
+## [Unreleased]
 
 ### Added
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.7.0",
+  "version": "0.6.2",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler engines from tts-cpp)",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler engines from tts-cpp)",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.18.0] - 2026-08-06
+
+### Fixed
+
+- The native binding now treats the shared runtime's optional job id return from
+  `runJob()` as the acceptance signal, fixing the `qvac-lib-inference-addon-cpp`
+  1.3.3 build failure.
+
+### Changed
+
+- Align `@qvac/infer-base` and `qvac-lib-inference-addon-cpp` dependency floors
+  with the shared addon runtime validated across the live addon consumer set.
+
+### Pull Requests
+
+- [#3567](https://github.com/tetherto/qvac/pull/3567) - QVAC-18397 chore[notask]:
+  test addon-cpp 1.3.3 across consumers
+
 ## [0.17.0] - 2026-08-03
 
 ### Added
@@ -22,7 +40,6 @@
 
 ### Fixed
 
-- The native binding now treats the shared runtime's optional job id return from `runJob()` as the acceptance signal, fixing the `qvac-lib-inference-addon-cpp` 1.3.3 build failure.
 - GPU-backend loads no longer read the whole embodiment bank into host RAM to discard it unread. The rank-3 rows are held out of VRAM by giving them a non-null data pointer, which is all the ggml allocator inspects; the bytes were then streamed in anyway even though the selected row is read straight from the file. On a 17-row ship set that removed ~340 MB of disk read, ~340 MB of copying and a ~340 MB transient allocation from every GPU load (roughly double under `--embodiments all`), which matters most on the mobile RAM budgets the q5 build targets.
 - A GGUF carrying rank-3 embodiment weights but no readable `groot.embodiment.stored_cat_ids` table is now a load-time error instead of a clean load followed by a `GGML_ASSERT` process abort on the first `run()`. Relatedly, a `groot.embodiment.*` array that is present but not an int32 array is reported as corruption rather than silently treated as absent, and `groot.embodiment.count` is cross-checked against the table length instead of being written and never read.
 - The pre-transpose refill copied one matrix element per `std::memcpy` call with a runtime element size, which the compiler cannot fold into a move — about 5 million out-of-line calls per refill at `HIDDEN_SIZE` 1024. It is now a typed element copy. This ran at load before, and `setEmbodiment` puts it on a repeatable path.

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary
- Bump the live addon consumers validated by #3567 to their next release versions: `asr-ggml` 0.2.0, `audiogen-ggml` 0.2.0, `bci-whispercpp` 0.7.0, `classification-ggml` 0.17.0, `diffusion-cpp` 0.18.0, `embed-llamacpp` 0.31.0, `ocr-ggml` 0.14.0, `translation-nmtcpp` 9.0.0, `tts-ggml` 0.7.0, and `vla-ggml` 0.18.0.
- Add matching changelog sections for the addon-cpp 1.3.3 / infer-base 0.6.2 consumer sweep from #3567.
- Fold the existing `tts-ggml` unreleased CosyVoice3 notes into the 0.7.0 release block and move the VLA addon-cpp admission fix into its own 0.18.0 release block.

## Test plan
- `node -e 'const fs=require("fs"); const pkgs=["asr-ggml","audiogen-ggml","bci-whispercpp","classification-ggml","diffusion-cpp","embed-llamacpp","ocr-ggml","translation-nmtcpp","tts-ggml","vla-ggml"]; for (const p of pkgs) { const pkg=JSON.parse(fs.readFileSync("packages/"+p+"/package.json","utf8")); const changelog=fs.readFileSync("packages/"+p+"/CHANGELOG.md","utf8"); const heading="## ["+pkg.version+"] - 2026-08-06"; if (!changelog.includes(heading)) throw new Error(p+" missing changelog for "+pkg.version); console.log(p+" "+pkg.version); }'`
- `git diff --check`

---
Generated by Cursor agent using `qv-addon-changelog`.