### PR TITLE
fix[api]: restore embed-llamacpp addonLogging named exports

### DIFF
--- a/packages/embed-llamacpp/addonLogging.d.ts
+++ b/packages/embed-llamacpp/addonLogging.d.ts
@@ -13,4 +13,6 @@ export interface AddonLogging {
     releaseLogger(this: void): void;
 }
 declare const addonLogging: AddonLogging;
+export declare const setLogger: (this: void, callback: (priority: number, message: string) => void) => void;
+export declare const releaseLogger: (this: void) => void;
 export default addonLogging;

--- a/packages/embed-llamacpp/addonLogging.js
+++ b/packages/embed-llamacpp/addonLogging.js
@@ -1,10 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.releaseLogger = exports.setLogger = void 0;
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved from package prebuilds.
 const binding = require("./binding");
 const addonLogging = {
     setLogger: binding.setLogger,
     releaseLogger: binding.releaseLogger,
 };
+// ESM named imports need the top-level `exports.X =` form these emit.
+exports.setLogger = addonLogging.setLogger;
+exports.releaseLogger = addonLogging.releaseLogger;
 exports.default = addonLogging;
 module.exports = addonLogging;

--- a/packages/embed-llamacpp/src/addonLogging.ts
+++ b/packages/embed-llamacpp/src/addonLogging.ts
@@ -21,6 +21,10 @@ const addonLogging: AddonLogging = {
   releaseLogger: binding.releaseLogger,
 };
 
+// ESM named imports need the top-level `exports.X =` form these emit.
+export const setLogger = addonLogging.setLogger;
+export const releaseLogger = addonLogging.releaseLogger;
+
 export default addonLogging;
 
 module.exports = addonLogging;

--- a/packages/embed-llamacpp/test/unit/addon-logging-exports.test.js
+++ b/packages/embed-llamacpp/test/unit/addon-logging-exports.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// cjs-module-lexer discovers a CommonJS module's named exports statically and
+// only detects top-level `exports.X =`; any other form links with none.
+
+const test = require('brittle')
+const fs = require('bare-fs')
+const path = require('bare-path')
+
+test('addonLogging emits the top-level assignments the lexer needs', (t) => {
+  const emitted = fs.readFileSync(path.join(__dirname, '..', '..', 'addonLogging.js'), 'utf8')
+
+  t.ok(emitted.includes('exports.setLogger = '), 'setLogger is a top-level exports assignment')
+  t.ok(
+    emitted.includes('exports.releaseLogger = '),
+    'releaseLogger is a top-level exports assignment'
+  )
+  t.ok(
+    emitted.includes('module.exports = addonLogging'),
+    'module.exports stays the bare addonLogging object'
+  )
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `import { setLogger } from '@qvac/embed-llamacpp/addonLogging'` fails to link with `SyntaxError: Named export 'setLogger' not found`, on Node and on Bare.
- The TypeScript migration (#3433) replaced the `module.exports = { setLogger, releaseLogger }` object literal with a const assigned to `module.exports`. cjs-module-lexer only detects top-level `exports.X =`, so it now reports no named exports where it previously reported them.

## 📝 How does it solve it?

- Exports the two bindings explicitly from `src/addonLogging.ts`, which emits the assignments the lexer scans for. The default export and the CommonJS runtime shape are unchanged.
- Adds a unit test asserting the emitted form, since a type-level test cannot observe lexer visibility.

## 🧪 How was it tested?

- Ran cjs-module-lexer over the emitted file before and after: it reports `["setLogger", "releaseLogger", "default"]` where it previously reported `["default"]`.
- Confirmed the same names are reported for the pre-migration file, so this restores the original surface rather than adding to it.
- `npm run lint` and the unit suite pass.

Same fix is going to the other affected packages. ocr-ggml has the same symptom but was never working, so it is handled separately.