### PR TITLE
fix[api]: expose ocr-ggml addonLogging named exports

### DIFF
--- a/packages/ocr-ggml/addonLogging.d.ts
+++ b/packages/ocr-ggml/addonLogging.d.ts
@@ -4,4 +4,6 @@ export interface AddonLogging {
     releaseLogger: () => void;
 }
 declare const addonLogging: AddonLogging;
+export declare const setLogger: AddonLogging["setLogger"];
+export declare const releaseLogger: AddonLogging["releaseLogger"];
 export default addonLogging;

--- a/packages/ocr-ggml/addonLogging.js
+++ b/packages/ocr-ggml/addonLogging.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.releaseLogger = exports.setLogger = void 0;
 const addonLogging = {
     get setLogger() {
         // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
@@ -10,5 +11,11 @@ const addonLogging = {
         return require("./binding").releaseLogger;
     },
 };
+// ESM named imports need the top-level `exports.X =` form these emit. They
+// delegate rather than capture, so the binding stays resolved on first call.
+const setLogger = (callback) => addonLogging.setLogger(callback);
+exports.setLogger = setLogger;
+const releaseLogger = () => addonLogging.releaseLogger();
+exports.releaseLogger = releaseLogger;
 exports.default = addonLogging;
 module.exports = addonLogging;

--- a/packages/ocr-ggml/src/addonLogging.ts
+++ b/packages/ocr-ggml/src/addonLogging.ts
@@ -21,6 +21,13 @@ const addonLogging: AddonLogging = {
   },
 };
 
+// ESM named imports need the top-level `exports.X =` form these emit. They
+// delegate rather than capture, so the binding stays resolved on first call.
+export const setLogger: AddonLogging["setLogger"] = (callback) =>
+  addonLogging.setLogger(callback);
+export const releaseLogger: AddonLogging["releaseLogger"] = () =>
+  addonLogging.releaseLogger();
+
 export default addonLogging;
 
 module.exports = addonLogging;

--- a/packages/ocr-ggml/test/unit/addon-logging-exports.test.js
+++ b/packages/ocr-ggml/test/unit/addon-logging-exports.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// cjs-module-lexer discovers a CommonJS module's named exports statically and
+// only detects top-level `exports.X =`; the getter object alone yields none.
+// The binding must still be resolved on first access, not at load.
+
+const test = require('brittle')
+const fs = require('bare-fs')
+const path = require('bare-path')
+
+test('addonLogging emits the top-level assignments the lexer needs', (t) => {
+  const emitted = fs.readFileSync(path.join(__dirname, '..', '..', 'addonLogging.js'), 'utf8')
+
+  t.ok(emitted.includes('exports.setLogger = '), 'setLogger is a top-level exports assignment')
+  t.ok(
+    emitted.includes('exports.releaseLogger = '),
+    'releaseLogger is a top-level exports assignment'
+  )
+  t.ok(
+    emitted.includes('module.exports = addonLogging'),
+    'module.exports stays the bare addonLogging object'
+  )
+})
+
+test('the named exports delegate instead of capturing the binding', (t) => {
+  const emitted = fs.readFileSync(path.join(__dirname, '..', '..', 'addonLogging.js'), 'utf8')
+
+  t.ok(
+    emitted.includes('addonLogging.setLogger(callback)'),
+    'setLogger calls through on invocation, keeping the binding lazy'
+  )
+  t.absent(
+    emitted.includes('exports.setLogger = addonLogging.setLogger'),
+    'the getter is not read at module load'
+  )
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `import { setLogger } from '@qvac/ocr-ggml/addonLogging'` has never linked. cjs-module-lexer only detects top-level `exports.X =`, and this module exports an object of getters, so the lexer reported `get` before the TypeScript migration (#3330) and nothing after it.
- Unlike embed-llamacpp and diffusion-cpp, where the migration lost working named exports, here they never worked. This is a fix rather than a revert to previous behaviour.

## 📝 How does it solve it?

- Exports `setLogger` and `releaseLogger` as functions that call through to the getters rather than reading them at module load. That emits the assignments the lexer scans for while keeping the native binding resolved on first use, which is what the getters were there for.

## 🧪 How was it tested?

- cjs-module-lexer now reports `["setLogger", "releaseLogger", "default"]`; it reported `["get"]` before the migration and `["default"]` on main.
- Loaded the emitted module against a `binding.js` that throws at load: the module still loads, and the throw only surfaces when a logger function is used, so laziness is intact.
- `npm run lint` passes. The unit suite could not run locally because the installed `bare-fs` requires Bare >= 1.28.0 and this machine has 1.26.0, so the new test's assertions were verified directly against the emitted file. CI covers the suite.