### PR TITLE
QVAC-23279 chore[mod]: add Indic Conformer CTC models to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8323,5 +8323,38 @@
     "tags": ["generation", "instruct", "moe", "kat-coder"],
     "notes": "",
     "link": "https://huggingface.co/bartowski/Kwaipilot_KAT-Coder-V2.5-Dev-GGUF"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/indic_conformer/2026-08-07/indic-conformer-ctc.f16.gguf",
+    "engine": "@qvac/transcription-parakeet",
+    "link": "https://huggingface.co/ai4bharat/indic-conformer",
+    "description": "Indic Conformer CTC 600M multilingual GGUF",
+    "quantization": "f16",
+    "params": "600M",
+    "licenseId": "MIT",
+    "tags": ["transcription", "indic-conformer", "ctc", "ggml", "indic", "multilingual"],
+    "notes": "F16 GGUF conversion of ai4bharat/indic-conformer"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/indic_conformer/2026-08-07/indic-conformer-ctc.q4_0.gguf",
+    "engine": "@qvac/transcription-parakeet",
+    "link": "https://huggingface.co/ai4bharat/indic-conformer",
+    "description": "Indic Conformer CTC 600M multilingual GGUF",
+    "quantization": "q4_0",
+    "params": "600M",
+    "licenseId": "MIT",
+    "tags": ["transcription", "indic-conformer", "ctc", "ggml", "indic", "multilingual"],
+    "notes": "Q4_0 GGUF conversion of ai4bharat/indic-conformer"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/indic_conformer/2026-08-07/indic-conformer-ctc.q8_0.gguf",
+    "engine": "@qvac/transcription-parakeet",
+    "link": "https://huggingface.co/ai4bharat/indic-conformer",
+    "description": "Indic Conformer CTC 600M multilingual GGUF",
+    "quantization": "q8_0",
+    "params": "600M",
+    "licenseId": "MIT",
+    "tags": ["transcription", "indic-conformer", "ctc", "ggml", "indic", "multilingual"],
+    "notes": "Q8_0 GGUF conversion of ai4bharat/indic-conformer"
   }
 ]


### PR DESCRIPTION
## What problem does this PR solve?

- Indic Conformer CTC GGUF artifacts are on S3 but not discoverable via the QVAC model registry.
- Clients cannot search/download `indic-conformer-ctc` (`f16` / `q4_0` / `q8_0`) through the normal registry path.

## How does it solve it?

- Adds three entries to `packages/registry-server/data/models.prod.json`:
  - `indic-conformer-ctc.f16.gguf`
  - `indic-conformer-ctc.q4_0.gguf`
  - `indic-conformer-ctc.q8_0.gguf`
- Sources point at `s3:///qvac_models_compiled/ggml/indic_conformer/2026-08-07/…`
- Engine: `@qvac/transcription-parakeet`; license: `MIT`; link: `https://huggingface.co/ai4bharat/indic-conformer`
- After merge to `main`, registry sync uploads the artifacts and they become queryable via `modelRegistrySearch()`.

## How was it tested?

- Confirmed the three S3 objects under `s3://tether-ai-dev/qvac_models_compiled/ggml/indic_conformer/2026-08-07/`
- Validated JSON structure of the new registry entries (parse + field shape match existing parakeet CTC rows)
- Full `npm run validate:models` should be run in CI with the `verify` label

## Models

### Added models

```
indic-conformer-ctc.f16
indic-conformer-ctc.q4_0
indic-conformer-ctc.q8_0
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217233899679548