### PR TITLE
chore[bc|notask]: release @qvac/ai-sdk-provider 0.5.0

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.5.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.5.0
+
+This release aligns managed mode with `@qvac/cli` 0.10 / `@qvac/sdk` 0.17 and drops the retired ONNX OCR plugin path from provider-facing guidance in favor of ggml OCR.
+
+## Breaking Changes
+
+### Managed mode requires CLI 0.10
+
+The optional `@qvac/cli` peer for managed mode is now `^0.10.0`. Older CLI minors are no longer accepted, so managed installs resolve the CLI 0.10 / SDK 0.17 runtime.
+
+**Before:**
+
+```json
+{ "peerDependencies": { "@qvac/cli": "^0.9.0" } }
+```
+
+**After:**
+
+```json
+{ "peerDependencies": { "@qvac/cli": "^0.10.0" } }
+```
+
+### OCR plugin path
+
+Configs that still reference the retired ONNX OCR plugin must switch to ggml OCR.
+
+**Before:**
+
+```json
+{ "plugins": ["@qvac/sdk/onnx-ocr/plugin"] }
+```
+
+**After:**
+
+```json
+{ "plugins": ["@qvac/sdk/ggml-ocr/plugin"] }
+```
+
+## Dependency Alignment
+
+Promote this release after `@qvac/cli` 0.10.0 is on npm.
+
 ## [0.4.0]
 
 Release Date: 2026-07-27

--- a/packages/ai-sdk-provider/changelog/0.5.0/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.5.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.5.0
+
+Release Date: 2026-08-07
+
+## 🧹 Chores
+
+- Remove retired ocr-onnx addon from the monorepo. (see PR [#3466](https://github.com/tetherto/qvac/pull/3466)) - See [breaking changes](./breaking.md)

--- a/packages/ai-sdk-provider/changelog/0.5.0/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.5.0/CHANGELOG_LLM.md
@@ -1,0 +1,43 @@
+# QVAC AI SDK Provider v0.5.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.5.0
+
+This release aligns managed mode with `@qvac/cli` 0.10 / `@qvac/sdk` 0.17 and drops the retired ONNX OCR plugin path from provider-facing guidance in favor of ggml OCR.
+
+## Breaking Changes
+
+### Managed mode requires CLI 0.10
+
+The optional `@qvac/cli` peer for managed mode is now `^0.10.0`. Older CLI minors are no longer accepted, so managed installs resolve the CLI 0.10 / SDK 0.17 runtime.
+
+**Before:**
+
+```json
+{ "peerDependencies": { "@qvac/cli": "^0.9.0" } }
+```
+
+**After:**
+
+```json
+{ "peerDependencies": { "@qvac/cli": "^0.10.0" } }
+```
+
+### OCR plugin path
+
+Configs that still reference the retired ONNX OCR plugin must switch to ggml OCR.
+
+**Before:**
+
+```json
+{ "plugins": ["@qvac/sdk/onnx-ocr/plugin"] }
+```
+
+**After:**
+
+```json
+{ "plugins": ["@qvac/sdk/ggml-ocr/plugin"] }
+```
+
+## Dependency Alignment
+
+Promote this release after `@qvac/cli` 0.10.0 is on npm.

--- a/packages/ai-sdk-provider/changelog/0.5.0/breaking.md
+++ b/packages/ai-sdk-provider/changelog/0.5.0/breaking.md
@@ -1,0 +1,24 @@
+# 💥 Breaking Changes v0.5.0
+
+## Remove retired ocr-onnx addon from the monorepo
+
+PR: [#3466](https://github.com/tetherto/qvac/pull/3466)
+
+**BEFORE:**
+
+```typescript
+// qvac.config.json — documented but broken since @qvac/sdk 0.15.0
+{ "plugins": ["@qvac/sdk/onnx-ocr/plugin"] }
+```
+
+**AFTER:**
+
+```typescript
+{ "plugins": ["@qvac/sdk/ggml-ocr/plugin"] }
+```
+
+---
+
+Related: QVAC-22515 · companion PRs: #3465 (registry deprecation, merged), #3469 (CI retirement, merged). After the registry sync, regenerate the model catalogs (`bun run update-models` in `packages/sdk` and `packages/ai-sdk-provider`) so the 19 dead OCR entries drop out.
+
+---

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^3.0",
-    "@qvac/cli": "^0.9.0",
+    "@qvac/cli": "^0.10.0",
     "ai": "^7.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Publishes `@qvac/ai-sdk-provider` 0.5.0 so managed mode and plugins resolve `@qvac/cli` 0.10 / `@qvac/sdk` 0.17.

## 📝 How does it solve it?

- Bumps `packages/ai-sdk-provider/package.json` from 0.4.0 → 0.5.0.
- Raises `peerDependencies["@qvac/cli"]` from `^0.9.0` → `^0.10.0`.
- Adds `packages/ai-sdk-provider/changelog/0.5.0/` and prepends `CHANGELOG.md`.
- Breaking: OCR configs must use `@qvac/sdk/ggml-ocr/plugin` (monorepo removal #3466).
- Promote/merge after `@qvac/cli` 0.10.0 is on npm ([draft](https://github.com/tetherto/qvac/pull/3704)).

## 🧪 How was it tested?

- Changelog generated with `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=ai-sdk-provider`.
- Prettier on changelog + package metadata.
- Full provider test suite deferred until CLI 0.10.0 is on npm.

## 💥 Breaking Changes

**BEFORE:**
```json
{ "peerDependencies": { "@qvac/cli": "^0.9.0" }, "plugins": ["@qvac/sdk/onnx-ocr/plugin"] }
```

**AFTER:**
```json
{ "peerDependencies": { "@qvac/cli": "^0.10.0" }, "plugins": ["@qvac/sdk/ggml-ocr/plugin"] }
```