### PR TITLE
DEMO (do not merge): audiogen-ggml benchmark table on a labelled PR

### DIFF
--- a/packages/audiogen-ggml/benchmarks/manual-results/README.md
+++ b/packages/audiogen-ggml/benchmarks/manual-results/README.md
@@ -75,3 +75,5 @@ node scripts/perf-report/aggregate-audiogen-ggml-rtf.js \
   --manual-dir packages/audiogen-ggml/benchmarks/manual-results \
   --output /tmp/audiogen-ggml-performance-findings.md
 ```
+
+Demo branch: exercising the `run-benchmarks` label. Delete after the run.


### PR DESCRIPTION
Throwaway PR proving the `run-benchmarks` label from #3691 renders the findings table on a PR run.

The base branch carries #3691's workflows, because `pull_request_target` reads the workflow definition from the base. That is the only way to exercise the new PR lane before #3691 merges.

Delete this PR and both branches once the table is visible.