### PR TITLE
chore[notask]: release @qvac/opencode-plugin 0.1.2

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.1.2
+
+This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.5 and `@qvac/cli` 0.10 so managed local serves pick up the CLI 0.10 / SDK 0.17 runtime.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.5.0` for managed mode
+- `@qvac/cli@^0.10.0` for `qvac serve` (SDK 0.17 runtime)
+
+Plugin behavior is unchanged: the host still starts managed QVAC serve, injects the OpenAI-compatible `qvac` provider, and keeps the existing compatibility shim.
+
 ## [0.1.1]
 
 Release Date: 2026-07-27
@@ -8,12 +23,15 @@ Release Date: 2026-07-27
 
 This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.4 and `@qvac/cli` 0.9 so managed local serves pick up the AI SDK 7 provider and the latest CLI / SDK fixes.
 
-### Requirements
+## Dependency Alignment
 
-- [`@qvac/ai-sdk-provider@^0.4.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for managed mode (AI SDK 7).
-- [`@qvac/cli@^0.9.0`](https://www.npmjs.com/package/@qvac/cli) so the host can run `qvac serve` (SDK 0.16 runtime).
-- `@ai-sdk/openai-compatible@^3.0.0` and `ai@^7.0.0`.
-- Node.js 22 or newer.
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.4.0` for managed mode
+- `@qvac/cli@^0.9.0` for `qvac serve` (SDK 0.16 runtime)
+- `@ai-sdk/openai-compatible@^3.0.0` and `ai@^7.0.0` for the AI SDK 7 peer graph
+
+Node.js 22 or newer is required. Plugin behavior is unchanged: the host still starts managed QVAC serve, injects the OpenAI-compatible `qvac` provider, and keeps the existing compatibility shim.
 
 ## [0.1.0]
 
@@ -23,19 +41,78 @@ Release Date: 2026-06-16
 
 The first public release of `@qvac/opencode-plugin` — a turnkey [OpenCode](https://opencode.ai) plugin that runs a local, fully managed QVAC serve so `opencode` works against on-device models with no second terminal and no manual server.
 
-### Added
+---
 
-- **Zero-config local OpenCode.** Adding `@qvac/opencode-plugin` to a project's `opencode.json` `plugin` array is enough: on startup the plugin brings up a managed `qvac serve`, injects an OpenAI-compatible `qvac` provider pointed at it, sets it as the project default model, and tears the serve down on exit. No `provider` block, no second terminal, no `QVAC_MODEL=` prefix.
-- **Managed serve host process.** The plugin spawns a host child process in a real Node/Bun runtime (OpenCode runs plugins inside its own compiled binary, which cannot spawn the detached managed-mode supervisor). The host runs `createQvac({ mode: 'managed' })` from [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider), which brings up a shared, idle-reaped serve on an auto-allocated port, and ensures the serve is reaped even if OpenCode is killed hard.
-- **Non-blocking startup.** The host starts a small local proxy and reports it is listening before the model finishes downloading, so `opencode run` never trips OpenCode's startup timeout; the model loads in the background and the first turn waits on it.
-- **Shared serve across windows.** Multiple OpenCode windows share one serve (the provider's `reuse` default); the detached runner owns the loaded model and reaps it a few minutes after the last session leaves, so a second window doesn't reload the model.
-- **Friendly model ids.** A models.dev-style id (e.g. `qwen3.5-9b`) flows through OpenCode's model picker and the request `model` field, with the friendly-id → QVAC constant mapping resolved via `@qvac/ai-sdk-provider`'s catalog. Defaults to `qwen3.5-9b`.
-- **Layered configuration.** Options resolve from built-in defaults, a project `qvac.json`, the `opencode.json` plugin-tuple options, and `QVAC_*` environment variables (in increasing precedence): `model`, `ctxSize`, `reasoningBudget`, `tools`, `shim`, `runtime`, `readyTimeoutMs`, `setDefaultModel`, and `debug`.
-- **OpenAI-compatibility shim.** An in-process proxy bridges `@ai-sdk/openai-compatible` and QVAC serve: it flattens array `content` to the string form serve currently accepts, and re-routes inline `<think>…</think>` reasoning to `reasoning_content` so OpenCode renders a collapsed "Thought" block. Disable with `shim: false` / `QVAC_SHIM=0` once serve closes those gaps; the proxy itself remains (it is what lets startup return before the model loads).
-- **Examples.** Minimal and fully-annotated `opencode.json` examples for adding the plugin with and without options.
-- **Explicit static tools mode.** The managed serve config pins `toolsMode: "static"` so the OpenAI-compatible client surface is unambiguous across CLI versions (the invalid `"auto"` value leaves the serve with no loaded model).
+## Introducing `@qvac/opencode-plugin`
 
-### Requirements
+Add the plugin to a project's `opencode.json` and `opencode` brings up a managed `qvac serve` by itself, points OpenCode at it, and tears it down on exit:
 
-- [`@qvac/ai-sdk-provider@^0.2.2`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for managed mode.
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@qvac/opencode-plugin"]
+}
+```
+
+```bash
+opencode          # interactive — uses qvac/qwen3.5-9b by default
+opencode run "…"  # one-shot — works too (no startup race)
+```
+
+No `provider` block, no second terminal, no `QVAC_MODEL=` prefix.
+
+## How it works
+
+1. On startup the plugin spawns a **host** child process in a real Node/Bun runtime. OpenCode runs plugins inside its own compiled binary, whose `process.execPath` is the editor — not a JS runtime — so managed mode cannot spawn its detached supervisor from there. The host provides a real runtime and ensures the serve is reaped even if OpenCode is killed hard.
+2. The host starts a small local proxy and immediately reports it is listening — **before** the model downloads. The plugin injects an OpenAI-compatible `qvac` provider pointed at the proxy and returns, so `opencode run` never trips OpenCode's startup timeout. The model loads in the background; the first turn waits on it (a slow cold turn, not a failure).
+3. The host runs `createQvac({ mode: 'managed' })` from [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider), which brings up a shared, idle-reaped serve on an auto-allocated port.
+
+Multiple OpenCode windows **share one serve** (the provider's `reuse` default): the detached runner owns the loaded model and reaps it a few minutes after the last session leaves, so a second window doesn't reload the model.
+
+## Model ids
+
+You pick a friendly, models.dev-style id (`qwen3.5-9b`) and that exact id flows through the whole stack — OpenCode's model picker (`qvac/qwen3.5-9b`) and the request `model` field. The verbose QVAC constant (`QWEN3_5_9B_MULTIMODAL_Q4_K_M`) stays an internal detail of the serve; the friendly-id → constant mapping lives in `@qvac/ai-sdk-provider`'s catalog.
+
+| models.dev id  | QVAC constant                    |
+| -------------- | -------------------------------- |
+| `qwen3.5-0.8b` | `QWEN3_5_0_8B_MULTIMODAL_Q4_K_M` |
+| `qwen3.5-2b`   | `QWEN3_5_2B_MULTIMODAL_Q4_K_M`   |
+| `qwen3.5-4b`   | `QWEN3_5_4B_MULTIMODAL_Q4_K_M`   |
+| `qwen3.5-9b`   | `QWEN3_5_9B_MULTIMODAL_Q4_K_M`   |
+
+## Configuration
+
+Options resolve from (lowest to highest precedence) built-in defaults, a project `qvac.json`, the `opencode.json` plugin-tuple options, and `QVAC_*` environment variables:
+
+| Option            | Env                      | Default      | Meaning                                                       |
+| ----------------- | ------------------------ | ------------ | ------------------------------------------------------------- |
+| `model`           | `QVAC_MODEL`             | `qwen3.5-9b` | friendly id or a raw QVAC constant                            |
+| `ctxSize`         | `QVAC_CTX_SIZE`          | `32768`      | serve context window                                          |
+| `reasoningBudget` | `QVAC_REASONING_BUDGET`  | `-1`         | `-1` = reasoning on, `0` = off                                |
+| `tools`           | `QVAC_TOOLS`             | `true`       | enable the tool-calling chat template                         |
+| `shim`            | `QVAC_SHIM`              | `true`       | apply the OpenAI-compat transforms                            |
+| `runtime`         | `QVAC_RUNTIME`           | auto         | path to the node/bun runtime that hosts the serve             |
+| `readyTimeoutMs`  | `QVAC_READY_TIMEOUT_MS`  | `1800000`    | budget for the serve to become healthy, incl. a cold download |
+| `setDefaultModel` | `QVAC_SET_DEFAULT_MODEL` | `true`       | force `qvac/<model>` as the project default                   |
+| `debug`           | `QVAC_DEBUG`             | `false`      | mirror host milestones + per-request traces to stderr         |
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [["@qvac/opencode-plugin", { "model": "qwen3.5-2b" }]]
+}
+```
+
+## The `shim` option
+
+`@ai-sdk/openai-compatible` (which OpenCode speaks) and QVAC serve disagree on two points today, so the host runs a small in-process proxy that bridges them:
+
+- **array `content`** — the AI SDK sends `content` as an array of typed parts; serve currently accepts only a string, so the proxy flattens text parts.
+- **reasoning** — with reasoning on, the model emits `<think>…</think>` inline on the content channel; the proxy re-routes that to `reasoning_content` so OpenCode shows a collapsed "Thought" block instead of raw tags.
+
+Both are stopgaps for serve gaps. Set `shim: false` (or `QVAC_SHIM=0`) to turn the transforms off once serve closes those gaps; the proxy itself stays (it is what lets startup return before the model finishes loading).
+
+## Requirements
+
+- [`@qvac/ai-sdk-provider@^0.2.2`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for managed mode (its `^0.6.0 || ^0.7.0` CLI peer range is what unlocks CLI 0.7).
 - [`@qvac/cli@^0.7.0`](https://www.npmjs.com/package/@qvac/cli) so the host can run `qvac serve` (resolved by the provider's managed mode).

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -124,8 +124,8 @@ running `opencode` from the terminal.
 
 ## Requirements
 
-- [`@qvac/ai-sdk-provider@^0.4.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)
+- [`@qvac/ai-sdk-provider@^0.5.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)
   for managed mode (AI SDK 7).
-- [`@qvac/cli@^0.9.0`](https://www.npmjs.com/package/@qvac/cli) available so the
+- [`@qvac/cli@^0.10.0`](https://www.npmjs.com/package/@qvac/cli) available so the
   host can run `qvac serve` (SDK 0.16 runtime).
 - Node.js 22 or newer.

--- a/plugins/opencode/changelog/0.1.2/CHANGELOG.md
+++ b/plugins/opencode/changelog/0.1.2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.1.2
+
+Release Date: 2026-08-07
+
+## Compatibility
+
+- Depends on `@qvac/ai-sdk-provider@^0.5.0` and `@qvac/cli@^0.10.0` so managed OpenCode installs resolve the provider and CLI that track `@qvac/sdk` 0.17.

--- a/plugins/opencode/changelog/0.1.2/CHANGELOG_LLM.md
+++ b/plugins/opencode/changelog/0.1.2/CHANGELOG_LLM.md
@@ -1,0 +1,14 @@
+# QVAC OpenCode Plugin v0.1.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.1.2
+
+This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.5 and `@qvac/cli` 0.10 so managed local serves pick up the CLI 0.10 / SDK 0.17 runtime.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.5.0` for managed mode
+- `@qvac/cli@^0.10.0` for `qvac serve` (SDK 0.17 runtime)
+
+Plugin behavior is unchanged: the host still starts managed QVAC serve, injects the OpenAI-compatible `qvac` provider, and keeps the existing compatibility shim.

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/opencode-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenCode plugin that runs a local, managed QVAC serve so `opencode` works against on-device models with no second terminal",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.0",
-    "@qvac/ai-sdk-provider": "^0.4.0",
-    "@qvac/cli": "^0.9.0",
+    "@qvac/ai-sdk-provider": "^0.5.0",
+    "@qvac/cli": "^0.10.0",
     "ai": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Publishes `@qvac/opencode-plugin` 0.1.2 so OpenCode installs resolve `@qvac/cli` 0.10 / `@qvac/ai-sdk-provider` 0.5 / SDK 0.17.

## 📝 How does it solve it?

- Bumps `plugins/opencode/package.json` from 0.1.1 → 0.1.2.
- Updates dependencies to `@qvac/ai-sdk-provider@^0.5.0` and `@qvac/cli@^0.10.0`.
- Updates README compatibility lines.
- Adds `plugins/opencode/changelog/0.1.2/` and prepends `CHANGELOG.md`.
- Promote/merge after `@qvac/ai-sdk-provider` 0.5.0 is on npm ([draft](https://github.com/tetherto/qvac/pull/3706)).

## 🧪 How was it tested?

- Manual dep-alignment changelog (no feature PRs since 0.1.1).
- Prettier on changelog + package metadata.
- Unit/lint deferred until lower layers are on npm.