### PR TITLE
QVAC-23207 chore: release llm-llamacpp 0.41.0

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.41.0] - 2026-08-07
+
+### Changed
+
+- Migrated the runtime wrapper and type declarations to TypeScript. Sources now
+  live under `src/` and the published root JavaScript entrypoints (`index.js`,
+  `addon.js`, `batchHandler.js`, `addonLogging.js`) and their `.d.ts`
+  declarations are generated from them and committed. Runtime behaviour and the
+  CommonJS export shape are unchanged.
+- The package is exported with `export =` rather than a default export, which
+  gives CommonJS consumers a real construct signature (`import LlmLlamacpp =
+  require('@qvac/llm-llamacpp')` previously failed with TS2351). A consequence
+  is that `import LlmLlamacpp from '@qvac/llm-llamacpp'` now requires
+  `esModuleInterop` or `allowSyntheticDefaultImports`; without either,
+  TypeScript reports TS1259.
+- `addon` is a public member of the published type instead of `protected`. An
+  interface cannot express `protected`, and the property was already public at
+  runtime, so this widens what the declarations support rather than changing
+  behaviour.
+- `BatchResponse.on` accepts the inherited `EventEmitter` event map in addition
+  to the `"output"` overload. Callback types for `"output"` are unchanged, but
+  an unrecognised event name no longer fails to compile.
+- `./addonLogging` additionally exports `setLogger` and `releaseLogger` as named
+  bindings, so ESM named imports resolve. The default export is unchanged.
+
 ## [0.40.0] - 2026-08-06
 
 One model instance can now serve several requests at once. Every `run()` call is

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
Follow-up to #3685, which landed the TypeScript migration without release metadata per the two-PR model.

## 🎯 What problem does this PR solve?

- #3685 changed the published declaration contract but carried no version bump or changelog entry. This is the release half.

## 📝 How does it solve it?

- Bumps `@qvac/llm-llamacpp` to `0.41.0`. Minor, matching how the sibling wrapper migrations released: vla-ggml `0.15.0` to `0.16.0` (#3467) and translation-nmtcpp `8.2.1` to `8.3.0` (#3468).
- Adds the `[0.41.0]` entry. Unlike those two it does not claim the public API is unchanged, because a consumer needs to know:
  - `export =` means a default import now requires `esModuleInterop`, or TypeScript reports TS1259.
  - `addon` is public in the declarations instead of `protected`, which widens what is supported.
  - `BatchResponse.on` accepts the inherited event map, so an unrecognised event name no longer fails to compile.
  - `./addonLogging` gains named `setLogger` / `releaseLogger` bindings, so ESM named imports resolve.

## 🧪 How was it tested?

- `npm run lint` passes.
- Existing changelog entries are untouched: the diff is 26 insertions, 0 deletions. Prettier is deliberately not run over the file, since `lint:js` only covers `.js/.cjs/.mjs` and reformatting would rewrite released entries.

Supersedes #3698, which was opened on a `release-*` branch that the repository ruleset protects, so it could not be rebased after #3685 squash-merged.
