### PR TITLE
QVAC-23199 feat[mod]: add the Audio8 TTS engine to @qvac/tts-ggml

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -34,6 +34,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `files.lavasrDenoiser` / `denoiser` stage runs before it on the batch path.
   `enhancerBackendDevice` / `enhancerBackendId` are reported in runtime stats,
   matching the other engines.
+- **Audio8 engine (QVAC-23199).** Fifth engine family under the same
+  `TTSGgml` surface: a DualAR model (24-layer semantic transformer +
+  4-layer acoustic head over 8 codebooks) with a DAC-style codec, native
+  44.1 kHz, CPU-only in this release. Detection via `engine: 'audio8'`,
+  `files.audio8Lm` / `files.audio8CodecDecoder`, or a `modelDir` containing
+  `audio8-lm[-<quant>].gguf` (q8_0 > f16 > q4_0 > f32 within a role). It
+  ships as three GGUFs rather than one because they have different
+  lifetimes: the language model and the codec's synthesis half are needed
+  for every synthesis, the codec's analysis half only to enrol a voice, so
+  a text-only deployment can omit `files.audio8CodecEncoder` entirely.
+- **Audio8 voice cloning, fully in-process.** `referenceAudio` plus
+  `referenceText` (what the recording says) enrol a speaker; the codec's
+  analysis half encodes the recording to codes inside the addon, with no
+  Python side-car and no pre-baked profile. The transcript is required, not
+  optional — the model conditions on it as the turn the reference answers,
+  so a missing one degrades the clone silently. Both fields are also
+  accepted **per call** (`run({ input, referenceAudio, referenceText })`,
+  `runStream`/`runStreaming` options), and the engine caches the codes for
+  the most recent reference, so repeating one across calls skips the
+  encoder.
+- **Audio8 sampling/generation knobs.** `temperature`, `topK`, `topP`,
+  `maxFrames`, `greedy`, `seed`, `threads`, `config.outputSampleRate`
+  (engine-side resample from the native 44.1 kHz), all optional with the
+  engine's own defaults. Sampling is repetition-aware: a token repeated
+  from the recent window is re-drawn under a narrower nucleus.
+  `temperature`/`topK`/`topP`/`maxFrames` are now shared with Parler rather
+  than Parler-only, so the "parler-only" rejection for those four names
+  reads "parler/audio8-only". Requires a `tts-cpp` pin that ships the
+  audio8 engine (qvac-ext-lib-whisper.cpp
+  [PR #128](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/128)).
+  New `examples/audio8-tts.js`, JS unit suite, and C++ config tests.
 
 ### Fixed
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `files.lavasrDenoiser` / `denoiser` stage runs before it on the batch path.
   `enhancerBackendDevice` / `enhancerBackendId` are reported in runtime stats,
   matching the other engines.
-- **Audio8 engine (QVAC-23199).** Fifth engine family under the same
+- **Audio8 engine.** Fifth engine family under the same
   `TTSGgml` surface: a DualAR model (24-layer semantic transformer +
   4-layer acoustic head over 8 codebooks) with a DAC-style codec, native
   44.1 kHz, CPU-only in this release. Detection via `engine: 'audio8'`,
@@ -61,8 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the recent window is re-drawn under a narrower nucleus.
   `temperature`/`topK`/`topP`/`maxFrames` are now shared with Parler rather
   than Parler-only, so the "parler-only" rejection for those four names
-  reads "parler/audio8-only". New `examples/audio8-tts.js`, JS unit suite,
-  and C++ config tests.
+  reads "parler/audio8-only". `response.stats.tokensPerSecond` counts codec
+  frames per second on this engine, not characters per second.
 
 ### Fixed
 
@@ -97,15 +97,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-native rate; it is now accepted while streaming when the LavaSR enhancer
   is active, because the enhancer resamples inside its overlap-reprocess window
   without introducing chunk seams.
-- `tts-cpp` pin `2026-08-06` → `2026-08-07#1` (registry PR
-  [#291](https://github.com/tetherto/qvac-registry-vcpkg/pull/291)), which
-  ships the audio8 engine (qvac-ext-lib-whisper.cpp
-  [PR #128](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/128)).
-  No existing engine changes shape: the only other commits in the range touch
-  the ACE-Step smoke executables, which this package does not build. The
-  `ggml-speech` floor moves from `2026-08-04` to `2026-08-07` (Vulkan matmul
-  src0 binding fix, OpenCL im2col rewrite). Registry baseline unchanged: the
-  `version>=` floor resolves the new port on its own.
+- `tts-cpp` pin `2026-08-06` → `2026-08-07#1`, which ships the audio8 engine.
+  No existing engine changes shape. The `ggml-speech` floor moves from
+  `2026-08-04` to `2026-08-07` (Vulkan matmul src0 binding fix, OpenCL im2col
+  rewrite).
 
 ### Pull Requests
 
@@ -115,6 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test addon-cpp 1.3.3 across consumers
 - [#3692](https://github.com/tetherto/qvac/pull/3692) - consume the LavaSR ARM
   Mali Vulkan release
+- [#3722](https://github.com/tetherto/qvac/pull/3722) - add the Audio8 TTS
+  engine to @qvac/tts-ggml
 
 ## [0.6.2] - 2026-08-03
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -61,10 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the recent window is re-drawn under a narrower nucleus.
   `temperature`/`topK`/`topP`/`maxFrames` are now shared with Parler rather
   than Parler-only, so the "parler-only" rejection for those four names
-  reads "parler/audio8-only". Requires a `tts-cpp` pin that ships the
-  audio8 engine (qvac-ext-lib-whisper.cpp
-  [PR #128](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/128)).
-  New `examples/audio8-tts.js`, JS unit suite, and C++ config tests.
+  reads "parler/audio8-only". New `examples/audio8-tts.js`, JS unit suite,
+  and C++ config tests.
 
 ### Fixed
 
@@ -99,6 +97,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-native rate; it is now accepted while streaming when the LavaSR enhancer
   is active, because the enhancer resamples inside its overlap-reprocess window
   without introducing chunk seams.
+- `tts-cpp` pin `2026-08-06` → `2026-08-07#1` (registry PR
+  [#291](https://github.com/tetherto/qvac-registry-vcpkg/pull/291)), which
+  ships the audio8 engine (qvac-ext-lib-whisper.cpp
+  [PR #128](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/128)).
+  No existing engine changes shape: the only other commits in the range touch
+  the ACE-Step smoke executables, which this package does not build. The
+  `ggml-speech` floor moves from `2026-08-04` to `2026-08-07` (Vulkan matmul
+  src0 binding fix, OpenCL im2col rewrite). Registry baseline unchanged: the
+  `version>=` floor resolves the new port on its own.
 
 ### Pull Requests
 

--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -152,6 +152,7 @@ target_sources(
   PRIVATE
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/JSAdapter.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/audio8/Audio8Model.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/parler/ParlerModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -315,6 +316,7 @@ if(BUILD_TESTING)
   # outside the bare module link.
   add_executable(
     tts_ggml_tests
+      addon/tests/test_audio8_config.cpp
       addon/tests/test_backend_utils.cpp
       addon/tests/test_chatterbox_config.cpp
       addon/tests/test_parler_config.cpp
@@ -325,6 +327,7 @@ if(BUILD_TESTING)
       addon/tests/test_output_resampler.cpp
       addon/tests/test_pcm_conversion.cpp
       addon/tests/AddonCppTest.cpp
+      addon/src/model-interface/audio8/Audio8Model.cpp
       addon/src/model-interface/chatterbox/ChatterboxModel.cpp
       addon/src/model-interface/parler/ParlerModel.cpp
       addon/src/model-interface/supertonic/SupertonicModel.cpp

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -272,6 +272,12 @@ await model.run({
 })
 ```
 
+A per-call `referenceText` on its own corrects the transcript of the
+configured recording.  A per-call `referenceAudio` replaces the voice
+outright and must bring its own transcript — the configured one describes a
+different recording, so it is not inherited — and a recording passed without
+one is rejected before the job is queued.
+
 The engine caches the codes for the most recent reference, so repeating one
 across calls skips the encoder.  Per-call fields also ride on the
 `runStream` / `runStreaming` options, pinned for the whole response so the

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -4,8 +4,9 @@ Text-to-speech Bare addon backed by the [`qvac-tts.cpp`][qvac-tts-cpp]
 GGML library.  Wraps multiple engines under one package: **Chatterbox**
 (Turbo English + multilingual), **Supertonic** (v1 English, v2, and
 v3 31-language), **Parler** (mini/large English + indic 21-language,
-description-conditioned with voice/emotion templates), and **CosyVoice3**
-(Fun-CosyVoice3-0.5B, instruct-conditioned, 24 kHz, CPU), plus optional
+description-conditioned with voice/emotion templates), **CosyVoice3**
+(Fun-CosyVoice3-0.5B, instruct-conditioned, 24 kHz, CPU), and **Audio8**
+(DualAR + neural codec, in-process voice cloning, CPU-only), plus optional
 LavaSR neural denoise + 48 kHz bandwidth-extension enhancement.
 
 Runs in-process with a persistent native engine — the GGUFs, the S3Gen
@@ -30,7 +31,9 @@ Android paths, including Vulkan on ARM Mali (see
   flows out of the C++ engine chunk-by-chunk as T3 tokens produce
   S3Gen+HiFT output; sub-second first-audio-out inside a single
   utterance.
-- **Voice cloning** from a reference wav (or a pre-baked profile dir).
+- **Voice cloning** from a reference wav (or a pre-baked profile dir);
+  on Audio8 the reference is encoded in-process and can be switched per
+  call.
 - **CPU by default**, GPU (Metal / Vulkan / OpenCL) opt-in via
   `config.useGPU: true` on GPU-capable hosts — including Android, where
   `tts-cpp` selects the GPU backend per its per-vendor allowlist (see
@@ -56,8 +59,8 @@ platform has no prebuild the package falls back to a local build via
 
 ## Model files
 
-Four engine families are wrapped (Chatterbox, Supertonic, Parler,
-CosyVoice3), each with its own GGUF layout under `models/`:
+Five engine families are wrapped (Chatterbox, Supertonic, Parler,
+CosyVoice3, Audio8), each with its own GGUF layout under `models/`:
 
 ```
 # Chatterbox turbo (English)
@@ -93,6 +96,12 @@ cosyvoice3/
   cosyvoice3-hift-*.gguf   (~83 MB f32 — CausalHiFT vocoder)
   voice.gguf               (baked default voice: timbre + prompt tensors)
   vocab.json  merges.txt   (Qwen2 BPE tokenizer)
+
+# Audio8 (Audio8-AI/Audio8_TTS; 44.1 kHz, DualAR + neural codec) — three
+# GGUFs, published per quant tier; the encoder is only needed to clone a voice
+audio8-lm-q8_0.gguf              (~0.6 GB; also -f16 / -q4_0 / -f32)
+audio8-codec-decoder-q8_0.gguf   (~110 MB; also -f16 / -f32)
+audio8-codec-encoder-q8_0.gguf   (~120 MB; also -f16 / -f32; cloning only)
 ```
 
 The package converts these from upstream Resemble Chatterbox / Supertone
@@ -109,12 +118,19 @@ npm run setup:venv
 npm run convert-models
 ```
 
+The Audio8 GGUFs are produced by the converters in
+qvac-ext-lib-whisper.cpp (`engines/tts/scripts/convert-audio8-lm-to-gguf.py`
+and `convert-audio8-codec-to-gguf.py`) until they are published to the model
+registry alongside the other engines.
+
 Point the addon at a custom location via `files.modelDir` (engine
 auto-detected from the gguf filenames present), or pass explicit
 `files.t3Model` + `files.s3genModel` (Chatterbox) /
 `files.supertonicModel` (Supertonic) / `files.parlerModel` (Parler) /
 `files.cosyvoiceModelDir` (CosyVoice3 — a directory, see
-[CosyVoice3 instruct](#cosyvoice3-instruct)).
+[CosyVoice3 instruct](#cosyvoice3-instruct)) /
+`files.audio8Lm` + `files.audio8CodecDecoder` (+ `files.audio8CodecEncoder`
+to clone) (Audio8).
 
 ## Quick start
 
@@ -202,6 +218,8 @@ Full runnable demo (with gapless playback via `sox` or `ffplay`):
 
 ## Voice cloning
 
+### Chatterbox
+
 Pass a mono wav ≥ 5 s of clean speech — the engine does the loudness
 normalisation (−27 LUFS), resampling, and all conditioning (VoiceEncoder,
 CAMPPlus, S3TokenizerV2, mel extraction) natively at `load()` time:
@@ -227,6 +245,37 @@ new TTSGgml({
 
 When both are supplied, missing tensors in `voiceDir` are backfilled
 from `referenceAudio`.
+
+### Audio8
+
+Audio8 clones from the recording plus **what is said in it**.  The codec's
+analysis half (`files.audio8CodecEncoder`) encodes the recording to codes
+inside the addon, and the model continues that speaker; the transcript is
+what the reference turn *answers*, so a missing or wrong one degrades the
+clone rather than failing loudly.  Both fields are therefore required
+together, and cloning without the encoder GGUF is rejected at construction.
+
+```js
+const model = new TTSGgml({
+  engine: TTSGgml.ENGINE_AUDIO8,
+  files: { modelDir: './models' }, // needs audio8-codec-encoder-*.gguf present
+  referenceAudio: './voices/me.wav',
+  referenceText: 'Exactly what the recording says, verbatim.'
+})
+await model.load()
+
+// per-call override: a different speaker, or just a corrected transcript
+await model.run({
+  input: 'Spoken in a third voice.',
+  referenceAudio: './voices/someone-else.wav',
+  referenceText: 'What that recording says.'
+})
+```
+
+The engine caches the codes for the most recent reference, so repeating one
+across calls skips the encoder.  Per-call fields also ride on the
+`runStream` / `runStreaming` options, pinned for the whole response so the
+cache stays hot across chunks.
 
 ## Speech enhancement (LavaSR)
 
@@ -452,6 +501,42 @@ Other CosyVoice3-only options: `promptText` (reference transcript for the baked
 voice) and `streamLeftContextTokens` (native chunk-streaming left context).
 CosyVoice3 runs on **CPU** and emits native **24 kHz**.
 
+## Audio8
+
+Audio8 is a **DualAR** model: a 24-layer autoregressive transformer picks one
+semantic token per 46 ms frame, a 4-layer head fills the seven acoustic
+codebooks under it, and a DAC-style neural codec turns the eight codes back
+into 44.1 kHz audio.  It ships as three GGUFs because they have different
+lifetimes — the language model and the codec's synthesis half run on every
+synthesis, the analysis half only to enrol a voice — so a text-only
+deployment can omit `files.audio8CodecEncoder` entirely.
+
+```js
+const model = new TTSGgml({
+  engine: TTSGgml.ENGINE_AUDIO8,
+  files: { modelDir: './models' },
+  temperature: 0.7,
+  topP: 0.9,
+  opts: { stats: true }
+})
+await model.load()
+await model.run({ input: 'Hello from a fully on-device pipeline.' })
+```
+
+Sampling is **repetition-aware**: a semantic token that repeats one from the
+recent window is re-drawn under a narrower nucleus at a higher temperature,
+which is what keeps the model out of the babble attractor that pure top-p
+falls into.  `greedy: true` takes the argmax instead and ignores
+`temperature` / `topK` / `topP`; it is reproducible but noticeably flatter.
+`maxFrames` caps generation in codec frames (~21.5/s of audio).
+
+Audio8 is **CPU-only** in this release.  `useGPU` / `nGpuLayers` are accepted
+and warn rather than failing, so callers do not have to special-case the
+engine; `response.stats.gpuUnsupported` reports when GPU was asked for and
+the CPU ran it.  Expect a real-time factor slightly above 1 on a desktop CPU
+for text-only synthesis, plus a one-off encode when a new reference voice is
+enrolled.
+
 ## API overview
 
 ### Constructor — `new TTSGgml(options)`
@@ -465,10 +550,14 @@ CosyVoice3 runs on **CPU** and emits native **24 kHz**.
 | `files.parlerModel`       | string     | —          | Parler GGUF — mini/large/indic variant (overrides `modelDir`) |
 | `files.cosyvoiceModelDir` | string     | —          | CosyVoice3 model directory (`cosyvoice3-{llm,flow,hift}-*.gguf` + `voice.gguf` + `vocab.json` + `merges.txt`); routes to CosyVoice3 |
 | `files.cosyvoiceLlmModelPath` / `cosyvoiceFlowModelPath` / `cosyvoiceHiftModelPath` | string | — | Per-component overrides for the CosyVoice3 model dir |
+| `files.audio8Lm`          | string     | —          | Audio8 DualAR language model GGUF (overrides `modelDir`) |
+| `files.audio8CodecDecoder`| string     | —          | Audio8 codec synthesis half — codes to wav (overrides `modelDir`) |
+| `files.audio8CodecEncoder`| string     | —          | Audio8 codec analysis half — wav to codes; only needed to clone a voice |
 | `files.lavasrEnhancer`    | string     | —          | LavaSR enhancer GGUF — supplying it turns on 48 kHz enhancement |
 | `files.lavasrDenoiser`    | string     | —          | LavaSR denoiser GGUF — supplying it turns on denoising (batch only) |
-| `engine`                  | string     | auto       | Force `'chatterbox'`, `'supertonic'`, `'parler'` or `'cosyvoice3'` (`TTSGgml.ENGINE_CHATTERBOX` / `ENGINE_SUPERTONIC` / `ENGINE_PARLER` / `ENGINE_COSYVOICE3`); auto-detected from the GGUFs present otherwise |
-| `referenceAudio`          | string     | —          | Mono wav ≥ 5 s for voice cloning |
+| `engine`                  | string     | auto       | Force `'chatterbox'`, `'supertonic'`, `'cosyvoice3'`, `'parler'` or `'audio8'` (`TTSGgml.ENGINE_CHATTERBOX` / `ENGINE_SUPERTONIC` / `ENGINE_COSYVOICE3` / `ENGINE_PARLER` / `ENGINE_AUDIO8`); auto-detected from the GGUFs present otherwise |
+| `referenceAudio`          | string     | —          | Mono wav for voice cloning (Chatterbox: ≥ 5 s; Audio8: also needs `referenceText`).  Audio8 accepts it per call too |
+| `referenceText`           | string     | —          | Audio8-only: what `referenceAudio` says, verbatim.  Required whenever a reference is set; accepted per call |
 | `voiceDir`                | string     | —          | Pre-baked voice profile |
 | `seed`                    | number     | 42         | RNG seed (CFM noise + sampling) |
 | `nGpuLayers`              | number     | 0          | Layers offloaded to GPU (mirrors `useGPU`; pass `99` to offload all) |
@@ -484,8 +573,9 @@ CosyVoice3 runs on **CPU** and emits native **24 kHz**.
 | `noiseNpyPath`            | string     | —          | Supertonic: optional fixed CFM noise `.npy` for reproducibility |
 | `description` / `voiceDescription` | string | fallback caption | Parler-only: full free-text voice description (mutually exclusive with the template fields) |
 | `emotion`, `pitch`, `pace`, `expressivity`, `noise`, `reverb`, `quality` | string | — | Parler-only template fields (see [Parler descriptions & emotions](#parler-descriptions--emotions)); invalid values error listing the valid set |
-| `temperature` / `topK` / `topP` | number | GGUF defaults | Parler-only sampling knobs (`0`/omit = the GGUF's defaults: temp 1.0, top-k 50; `topP` in `(0, 1]`) |
-| `maxFrames`               | number     | GGUF max (~30 s) | Parler-only generation cap in decoder steps (~86/s of audio); `0` = model default, 1–9 rejected |
+| `temperature` / `topK` / `topP` | number | engine defaults | Parler + Audio8 sampling knobs (omit for the engine's own defaults — Parler temp 1.0 / top-k 50, Audio8 temp 0.7 / top-k 50 / top-p 0.9; `topP` in `(0, 1]`) |
+| `maxFrames`               | number     | engine max | Parler + Audio8 generation cap in frames (Parler ~86/s of audio, Audio8 ~21.5/s); `0` = model default, Parler rejects 1–9 |
+| `greedy`                  | boolean    | `false`    | Audio8-only: take the argmax instead of sampling; ignores `temperature` / `topK` / `topP` |
 | `minNewTokens`            | number     | GGUF default | Parler-only minimum tokens before EOS (`-1` = model default) |
 | `normalizeNumbers`        | boolean    | `true`     | Parler-only: expand digits before tokenization (English words; script-native digits on indic) — parler voices raw digits badly |
 | `instruct`                | object \| string | —    | CosyVoice3-only: instruction controls (`dialect` / `emotion` / `speed` / `volume` / `style`, resolved by precedence in that order) or a raw instruction string; an unknown key or invalid value throws (see [CosyVoice3 instruct](#cosyvoice3-instruct)) |
@@ -497,8 +587,8 @@ CosyVoice3 runs on **CPU** and emits native **24 kHz**.
 | `openclCacheDir`          | string     | unset      | Android-only: directory where the OpenCL backend persists its compiled program-binary cache.  Setting it across runs avoids re-JITing the kernels on every fresh process |
 | `vulkanCacheDir`          | string     | unset      | Supertonic + `useGPU: true` only: writable directory where the Vulkan backend persists its compiled pipeline cache (`GGML_VK_PIPELINE_CACHE_DIR`).  Moves the one-time first-dispatch pipeline-compile cost (seconds on Mali) off the first `run()` — paid once per install instead of once per process — and enables a load-time pre-warm.  Fully opt-in: unset -> no cross-process cache, no pre-warm, behaviour unchanged |
 | `config.language`         | string     | `"en"`     | Chatterbox MTL accepts `es/fr/de/pt/it/zh/ja/ko/...`; turbo & Supertonic are English |
-| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / Vulkan / CUDA / OpenCL if available. Honored for Chatterbox/Supertonic on GPU-capable hosts (including Android, per `tts-cpp`'s per-vendor allowlist); Parler is validated on Apple/Metal and Android/ARM Mali Vulkan. Unsupported backends fall back to CPU. See [Backends & GPU acceleration](#backends--gpu-acceleration) |
-| `config.outputSampleRate` | number     | — (engine-native) | Resample the output to this rate (8000–192000 Hz). Omit to keep the engine-native rate (Chatterbox 24 kHz, Supertonic/Parler 44.1 kHz, CosyVoice3 24 kHz, enhancer 48 kHz). Parler native chunk streaming accepts a non-native rate only with the enhancer active |
+| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / Vulkan / CUDA / OpenCL if available. Honored for Chatterbox/Supertonic on GPU-capable hosts (including Android, per `tts-cpp`'s per-vendor allowlist); Parler is validated on Apple/Metal and Android/ARM Mali Vulkan; Audio8 is CPU-only. Unsupported backends fall back to CPU. See [Backends & GPU acceleration](#backends--gpu-acceleration) |
+| `config.outputSampleRate` | number     | — (engine-native) | Resample the output to this rate (8000–192000 Hz). Omit to keep the engine-native rate (Chatterbox 24 kHz, Supertonic / Parler / Audio8 44.1 kHz, CosyVoice3 24 kHz, enhancer 48 kHz). Parler native chunk streaming accepts a non-native rate only with the enhancer active |
 | `opts.stats`              | boolean    | `false`    | Populate `response.stats` with RTF, `backendDevice` (0=CPU, 1=GPU), `backendId` (0=CPU, 1=Metal, 2=CUDA, 3=Vulkan, 4=OpenCL, 99=other), and — when an enhancer is active — `enhancerBackendDevice` / `enhancerBackendId` |
 | `exclusiveRun`            | boolean    | `false`    | **Top-level** option (not under `opts`): serialize overlapping streaming runs |
 
@@ -535,7 +625,7 @@ All `run*` methods return a `QvacResponse` (from `@qvac/infer-base`):
 ```js
 response.onUpdate(data => {
   data.outputArray   // Int16Array — mono PCM
-  data.sampleRate    // actual rate: Chatterbox 24000, Supertonic/Parler 44100, enhancer 48000
+  data.sampleRate    // actual rate: Chatterbox 24000, Supertonic/Parler/Audio8 44100, enhancer 48000
   data.chunkIndex    // present on sentence-streaming events only
   data.sentenceChunk // present on sentence-streaming events only
 })
@@ -576,6 +666,7 @@ Runnable demos under `examples/`:
 | `parler-enhanced.js` | Parler + LavaSR 48 kHz enhancement. `bare examples/parler-enhanced.js "Hello" Laura happy` |
 | `cosyvoice-tts.js` | CosyVoice3 instruct-conditioned batch synth (24 kHz, CPU). `bare examples/cosyvoice-tts.js "Hello"` |
 | `cosyvoice-enhanced.js` | CosyVoice3 + LavaSR 48 kHz enhancement (add `--denoise` for the denoiser). `bare examples/cosyvoice-enhanced.js "Hello"` |
+| `audio8-tts.js` | Audio8 batch synth, optionally cloning a reference. `bare examples/audio8-tts.js "Hello" voice.wav "What it says."` |
 
 The two streaming examples feed PCM into a single long-running
 `sox play` / `ffplay` process so chunks play back-to-back without any

--- a/packages/tts-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/tts-ggml/addon/src/addon/AddonJs.hpp
@@ -18,6 +18,7 @@
 
 #include "js-interface/JSAdapter.hpp"
 #include "model-interface/EnhancerLoader.hpp"
+#include "model-interface/audio8/Audio8Model.hpp"
 #include "model-interface/chatterbox/ChatterboxModel.hpp"
 #include "model-interface/cosyvoice/CosyvoiceModel.hpp"
 #include "model-interface/parler/ParlerModel.hpp"
@@ -27,6 +28,7 @@ namespace qvac::ttsggml::addon_js {
 
 namespace js = qvac_lib_inference_addon_cpp::js;
 
+using audio8::Audio8Model;
 using chatterbox::ChatterboxModel;
 using cosyvoice::CosyvoiceModel;
 using parler::ParlerModel;
@@ -129,6 +131,12 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
         outSr > 0 ? outSr
                   : (enhanced ? kLavasrEnhancedSampleRate : ptm->sampleRate());
     model = std::move(ptm);
+  } else if (engineType == EngineType::Audio8) {
+    auto cfg = adapter.buildAudio8Config(configurationParams, env);
+    const int outSr = cfg.outputSampleRate.value_or(0);
+    auto atm = make_unique<Audio8Model>(std::move(cfg));
+    sampleRate = outSr > 0 ? outSr : atm->sampleRate();
+    model = std::move(atm);
   } else {
     auto cfg = adapter.buildChatterboxConfig(configurationParams, env);
     const bool enhanced = !cfg.enhancerGgufPath.empty();
@@ -187,6 +195,17 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
           StreamingPcmChunk chunk{std::move(pcm), chunkIndex, isLast};
           outputQueue->queueResult(std::any(std::move(chunk)));
         };
+    return instance.runJob(std::any(std::move(modelInput)));
+  }
+
+  if (dynamic_cast<Audio8Model*>(&instance.addonCpp->model.get())) {
+    Audio8Model::AnyInput modelInput;
+    modelInput.text = js::String(env, jsInput).as<std::string>(env);
+    // Per-call referenceAudio/referenceText are siblings of `input` on the job
+    // object; all-empty means "use the constructor config".
+    JSAdapter adapter;
+    modelInput.voice =
+        adapter.readAudio8Voice(args.getJsObject(1, "inputObj"), env);
     return instance.runJob(std::any(std::move(modelInput)));
   }
 
@@ -279,6 +298,22 @@ inline js_value_t* reload(js_env_t* env, js_callback_info_t* info) try {
           }
           cvm->setConfig(std::move(newCfg));
           cvm->reload();
+        });
+  }
+
+  if (dynamic_cast<Audio8Model*>(&instance.addonCpp->model.get())) {
+    auto newCfg = adapter.buildAudio8Config(configurationParams, env);
+    return js::JsAsyncTask::run(
+        env,
+        [addonCpp = instance.addonCpp, newCfg = std::move(newCfg)]() mutable {
+          auto* atm = dynamic_cast<Audio8Model*>(&addonCpp->model.get());
+          if (atm == nullptr) {
+            throw qvac_errors::StatusError(
+                qvac_errors::general_error::InternalError,
+                "reload: model is not an Audio8Model");
+          }
+          atm->setConfig(std::move(newCfg));
+          atm->reload();
         });
   }
 

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -85,11 +85,13 @@ EngineType JSAdapter::readEngineType(
     return EngineType::Cosyvoice;
   if (explicitType == "parler")
     return EngineType::Parler;
+  if (explicitType == "audio8")
+    return EngineType::Audio8;
   if (!explicitType.empty()) {
     throw qvac_errors::StatusError(
         general_error::InvalidArgument,
-        "engineType must be 'chatterbox', 'supertonic', 'cosyvoice3' or "
-        "'parler' (got '" +
+        "engineType must be 'chatterbox', 'supertonic', 'cosyvoice3', 'parler' "
+        "or 'audio8' (got '" +
             explicitType + "')");
   }
 
@@ -111,6 +113,11 @@ EngineType JSAdapter::readEngineType(
       readOptionalString(configurationParams, env, "parlerModelPath");
   if (!parlerPath.empty())
     return EngineType::Parler;
+
+  const std::string audio8Path =
+      readOptionalString(configurationParams, env, "audio8LmPath");
+  if (!audio8Path.empty())
+    return EngineType::Audio8;
 
   const std::string t3Path =
       readOptionalString(configurationParams, env, "t3ModelPath");
@@ -209,6 +216,41 @@ JSAdapter::buildParlerConfig(js::Object configurationParams, js_env_t* env) {
       readOptionalString(configurationParams, env, "lavasrEnhancerPath");
   cfg.denoiserGgufPath =
       readOptionalString(configurationParams, env, "lavasrDenoiserPath");
+  return cfg;
+}
+
+audio8::Audio8Model::VoiceOverride
+JSAdapter::readAudio8Voice(js::Object obj, js_env_t* env) {
+  audio8::Audio8Model::VoiceOverride voice;
+  voice.referenceAudio = readOptionalString(obj, env, "referenceAudio");
+  voice.referenceText = readOptionalString(obj, env, "referenceText");
+  return voice;
+}
+
+audio8::Audio8Config
+JSAdapter::buildAudio8Config(js::Object configurationParams, js_env_t* env) {
+  audio8::Audio8Config cfg;
+  cfg.lmModelPath =
+      readOptionalString(configurationParams, env, "audio8LmPath");
+  cfg.codecDecoderPath =
+      readOptionalString(configurationParams, env, "audio8CodecDecoderPath");
+  cfg.codecEncoderPath =
+      readOptionalString(configurationParams, env, "audio8CodecEncoderPath");
+  const auto voice = readAudio8Voice(configurationParams, env);
+  cfg.referenceAudio = voice.referenceAudio;
+  cfg.referenceText = voice.referenceText;
+  cfg.greedy = readOptionalBool(configurationParams, env, "greedy");
+  cfg.seed = readOptionalInt(configurationParams, env, "seed");
+  cfg.threads = readOptionalInt(configurationParams, env, "threads");
+  cfg.temperature = readOptionalFloat(configurationParams, env, "temperature");
+  cfg.topK = readOptionalInt(configurationParams, env, "topK");
+  cfg.topP = readOptionalFloat(configurationParams, env, "topP");
+  cfg.maxFrames = readOptionalInt(configurationParams, env, "maxFrames");
+  cfg.outputSampleRate =
+      readOptionalInt(configurationParams, env, "outputSampleRate");
+  cfg.nGpuLayers = readOptionalInt(configurationParams, env, "nGpuLayers");
+  cfg.useGpu = readOptionalBool(configurationParams, env, "useGPU");
+  cfg.backendsDir = readOptionalString(configurationParams, env, "backendsDir");
   return cfg;
 }
 

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.hpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.hpp
@@ -5,6 +5,8 @@
 #include <inference-addon-cpp/JsUtils.hpp>
 #include <js.h>
 
+#include "model-interface/audio8/Audio8Config.hpp"
+#include "model-interface/audio8/Audio8Model.hpp"
 #include "model-interface/chatterbox/ChatterboxConfig.hpp"
 #include "model-interface/cosyvoice/CosyvoiceConfig.hpp"
 #include "model-interface/parler/ParlerConfig.hpp"
@@ -17,6 +19,7 @@ enum class EngineType {
   Supertonic,
   Cosyvoice,
   Parler,
+  Audio8,
 };
 
 class JSAdapter {
@@ -43,10 +46,19 @@ public:
       qvac_lib_inference_addon_cpp::js::Object configurationParams,
       js_env_t* env);
 
+  audio8::Audio8Config buildAudio8Config(
+      qvac_lib_inference_addon_cpp::js::Object configurationParams,
+      js_env_t* env);
+
   // Shared by buildParlerConfig and the per-call runJob path (the same
   // description/template properties are legal on both objects).
   parler::ParlerDescriptionFields readParlerDescriptionFields(
       qvac_lib_inference_addon_cpp::js::Object obj, js_env_t* env);
+
+  // Shared by buildAudio8Config and the per-call runJob path (a caller may
+  // name a different recording per call).
+  audio8::Audio8Model::VoiceOverride
+  readAudio8Voice(qvac_lib_inference_addon_cpp::js::Object obj, js_env_t* env);
 };
 
 }

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Config.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Config.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace qvac::ttsggml::audio8 {
+
+/**
+ * Audio8 splits into three GGUFs because they have different lifetimes: the
+ * language model and the codec's synthesis half are needed for every
+ * synthesis, the codec's analysis half only to enrol a voice from a
+ * recording. A text-only deployment can leave codecEncoderPath empty.
+ */
+struct Audio8Config {
+  std::string lmModelPath;
+  std::string codecDecoderPath;
+  std::string codecEncoderPath;
+  /**
+   * Voice cloning: a reference recording and what is said in it. The
+   * transcript is not optional in practice -- the model conditions on it as
+   * the turn the reference answers, and a wrong one degrades the clone.
+   * Cloning needs codecEncoderPath.
+   */
+  std::string referenceAudio;
+  std::string referenceText;
+  /** Take the argmax instead of sampling; ignores temperature/topK/topP. */
+  std::optional<bool> greedy;
+  std::optional<int> seed;
+  std::optional<int> threads;
+  /** Sampling knobs; unset defers to the engine's defaults. */
+  std::optional<float> temperature;
+  std::optional<int> topK;
+  std::optional<float> topP;
+  /** Generation length cap in codec frames (~21.5/s); 0 = engine default. */
+  std::optional<int> maxFrames;
+  /**
+   * Desired output sample rate in Hz (8000-192000), or unset/0 to keep the
+   * codec's native 44100. The engine resamples, so no addon-side pass.
+   */
+  std::optional<int> outputSampleRate;
+  // GPU offload. The engine is CPU-only today and warns on a positive value;
+  // the knobs are here so callers do not have to special-case this engine.
+  // nGpuLayers wins; else useGpu true->99 / false->0.
+  std::optional<int> nGpuLayers;
+  std::optional<bool> useGpu;
+  std::string backendsDir;
+};
+
+} // namespace qvac::ttsggml::audio8

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.cpp
@@ -245,8 +245,9 @@ void Audio8Model::cancel() const {
     e->cancel();
 }
 
-// Per-call fields win over the constructor config, one at a time, so a caller
-// can correct just the transcript of a configured recording.
+// A per-call recording replaces both halves -- it cannot inherit a transcript
+// that describes a different recording -- while a per-call transcript alone
+// corrects the configured one.
 Audio8Model::VoiceOverride
 Audio8Model::resolveVoice(const VoiceOverride& perCall) const {
   VoiceOverride voice{cfg_.referenceAudio, cfg_.referenceText};
@@ -279,7 +280,6 @@ Audio8Model::Output Audio8Model::synthesize(const AnyInput& input) {
   }
 
   const VoiceOverride voice = resolveVoice(input.voice);
-  textLength_ = input.text.size();
 
   const auto t0 = std::chrono::steady_clock::now();
   tts_cpp::audio8::SynthesisResult result;

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.cpp
@@ -1,0 +1,354 @@
+#include "model-interface/audio8/Audio8Model.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <tts-cpp/audio8/engine.h>
+
+#include "addon/TTSErrors.hpp"
+#include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/BackendUtils.hpp"
+#include "model-interface/PcmConversion.hpp"
+
+namespace qvac::ttsggml::audio8 {
+
+namespace {
+
+using qvac_errors::createTTSError;
+using qvac_errors::StatusError;
+using qvac_errors::tts_error::TTSErrorCode;
+namespace general_error = qvac_errors::general_error;
+
+constexpr int kMinOutputSampleRate = 8000;
+constexpr int kMaxOutputSampleRate = 192000;
+
+void requireFile(const std::string& path, const char* what, TTSErrorCode code) {
+  if (!std::filesystem::exists(path)) {
+    throw createTTSError(code, std::string(what) + " not found: " + path);
+  }
+}
+
+std::filesystem::path resolveBackendsDir(const std::string& configured) {
+  std::filesystem::path dir(configured);
+#ifdef BACKENDS_SUBDIR
+  dir = (dir / std::filesystem::path(BACKENDS_SUBDIR)).lexically_normal();
+#endif
+  return dir;
+}
+
+tts_cpp::audio8::EngineOptions toEngineOptions(const Audio8Config& cfg) {
+  tts_cpp::audio8::EngineOptions opts;
+  opts.lm_gguf_path = cfg.lmModelPath;
+  opts.codec_decoder_gguf_path = cfg.codecDecoderPath;
+  opts.codec_encoder_gguf_path = cfg.codecEncoderPath;
+  if (cfg.greedy.has_value())
+    opts.greedy = *cfg.greedy;
+  if (cfg.seed.has_value())
+    opts.seed = *cfg.seed;
+  if (cfg.threads.has_value())
+    opts.n_threads = *cfg.threads;
+  if (cfg.temperature.has_value())
+    opts.temperature = *cfg.temperature;
+  if (cfg.topK.has_value())
+    opts.top_k = *cfg.topK;
+  if (cfg.topP.has_value())
+    opts.top_p = *cfg.topP;
+  if (cfg.maxFrames.has_value())
+    opts.max_frames = *cfg.maxFrames;
+  if (cfg.outputSampleRate.has_value())
+    opts.output_sample_rate = *cfg.outputSampleRate;
+  // Mirrors ParlerModel::toEngineOptions: explicit nGpuLayers wins; else the
+  // useGpu switch maps true->99 (offload all) / false->0 (CPU).
+  if (cfg.nGpuLayers.has_value()) {
+    opts.n_gpu_layers = *cfg.nGpuLayers;
+  } else if (cfg.useGpu.has_value()) {
+    opts.n_gpu_layers = *cfg.useGpu ? kOffloadAllGpuLayers : 0;
+  }
+  if (!cfg.backendsDir.empty()) {
+    opts.backends_dir = resolveBackendsDir(cfg.backendsDir).string();
+  }
+  return opts;
+}
+
+void validateModelPaths(const Audio8Config& cfg) {
+  if (cfg.lmModelPath.empty()) {
+    throw StatusError(
+        general_error::InvalidArgument, "audio8LmPath is required");
+  }
+  if (cfg.codecDecoderPath.empty()) {
+    throw StatusError(
+        general_error::InvalidArgument, "audio8CodecDecoderPath is required");
+  }
+  requireFile(
+      cfg.lmModelPath,
+      "audio8 language model",
+      TTSErrorCode::ModelFileNotFound);
+  requireFile(
+      cfg.codecDecoderPath,
+      "audio8 codec decoder",
+      TTSErrorCode::ModelFileNotFound);
+  if (!cfg.codecEncoderPath.empty()) {
+    requireFile(
+        cfg.codecEncoderPath,
+        "audio8 codec encoder",
+        TTSErrorCode::ModelFileNotFound);
+  }
+}
+
+void validateSampling(const Audio8Config& cfg) {
+  if (cfg.temperature.has_value() && *cfg.temperature < 0.0f) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "temperature must be >= 0 (0 = greedy)");
+  }
+  if (cfg.topK.has_value() && *cfg.topK < 0) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "topK must be >= 0 (0 = no top-k cutoff)");
+  }
+  if (cfg.topP.has_value() && (*cfg.topP <= 0.0f || *cfg.topP > 1.0f)) {
+    throw StatusError(general_error::InvalidArgument, "topP must be in (0, 1]");
+  }
+  if (cfg.maxFrames.has_value() && *cfg.maxFrames < 0) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "maxFrames must be >= 0 (0 = engine default)");
+  }
+  if (cfg.outputSampleRate.has_value() && *cfg.outputSampleRate != 0 &&
+      (*cfg.outputSampleRate < kMinOutputSampleRate ||
+       *cfg.outputSampleRate > kMaxOutputSampleRate)) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "outputSampleRate must be 0 or in [8000, 192000]");
+  }
+}
+
+// Defense-in-depth (JS runs the same check first): reject useGPU/nGpuLayers
+// conflicts so callers can't silently get the opposite backend they asked for.
+void validateGpuIntent(const Audio8Config& cfg) {
+  if (!cfg.useGpu.has_value() || !cfg.nGpuLayers.has_value())
+    return;
+  const bool wantsGpuFlag = *cfg.useGpu;
+  const int layers = *cfg.nGpuLayers;
+  if (wantsGpuFlag == (layers != 0))
+    return;
+  throw StatusError(
+      general_error::InvalidArgument,
+      std::string("Audio8Model: useGPU=") + (wantsGpuFlag ? "true" : "false") +
+          " conflicts with nGpuLayers=" + std::to_string(layers) +
+          ". Either drop one of the two, or make them agree "
+          "(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).");
+}
+
+} // namespace
+
+Audio8Model::Audio8Model(Audio8Config config) : cfg_(std::move(config)) {
+  validateConfig(cfg_);
+  // load() is deferred to waitForLoadInitialization(); see ChatterboxModel.
+}
+
+Audio8Model::~Audio8Model() noexcept = default;
+
+void Audio8Model::validateConfig(const Audio8Config& cfg) {
+  validateModelPaths(cfg);
+  validateVoice(cfg.referenceAudio, cfg.referenceText, cfg.codecEncoderPath);
+  validateSampling(cfg);
+  validateGpuIntent(cfg);
+}
+
+void Audio8Model::validateVoice(
+    const std::string& audio, const std::string& text,
+    const std::string& encoderPath) {
+  if (audio.empty() && text.empty())
+    return;
+  if (audio.empty()) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "referenceText needs a referenceAudio to transcribe");
+  }
+  if (encoderPath.empty()) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "voice cloning needs audio8CodecEncoderPath, which was not configured");
+  }
+  // The model conditions on the transcript as the turn the reference answers,
+  // so a missing one degrades the clone silently. Reject instead.
+  if (text.empty()) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "referenceAudio needs a referenceText saying what the recording says");
+  }
+  requireFile(audio, "audio8 reference audio", TTSErrorCode::ModelFileNotFound);
+}
+
+void Audio8Model::setConfig(Audio8Config config) {
+  validateConfig(config);
+  cfg_ = std::move(config);
+}
+
+void Audio8Model::load() {
+  std::lock_guard lk(engineMu_);
+  loadLocked();
+}
+
+void Audio8Model::unload() {
+  std::lock_guard lk(engineMu_);
+  unloadLocked();
+}
+
+void Audio8Model::reload() {
+  std::lock_guard lk(engineMu_);
+  unloadLocked();
+  loadLocked();
+}
+
+void Audio8Model::loadLocked() {
+  if (engine_)
+    return;
+
+  try {
+    engine_ = std::make_shared<tts_cpp::audio8::Engine>(toEngineOptions(cfg_));
+  } catch (const std::exception& e) {
+    engine_.reset();
+    throw createTTSError(
+        TTSErrorCode::InitializationFailed,
+        std::string("Audio8Model::load: ") + e.what());
+  }
+
+  sampleRate_ = engine_->sample_rate();
+  backendName_ = engine_->backend_name();
+  backendDevice_ = backendDeviceCode(engine_->backend_device());
+  backendId_ = backendIdFromName(backendName_);
+  // The engine is CPU-only today, so GPU intent always resolves to the CPU
+  // device; report it the way ParlerModel derives the same signal.
+  const bool wantsGpu = cfg_.nGpuLayers.has_value()
+                            ? (*cfg_.nGpuLayers != 0)
+                            : cfg_.useGpu.value_or(false);
+  gpuUnsupported_ = wantsGpu && backendDevice_ == kBackendDeviceCpu;
+}
+
+void Audio8Model::unloadLocked() { engine_.reset(); }
+
+void Audio8Model::cancel() const {
+  cancelRequested_.store(true, std::memory_order_relaxed);
+  std::shared_ptr<tts_cpp::audio8::Engine> e;
+  {
+    std::lock_guard lk(engineMu_);
+    e = engine_;
+  }
+  if (e)
+    e->cancel();
+}
+
+// Per-call fields win over the constructor config, one at a time, so a caller
+// can correct just the transcript of a configured recording.
+Audio8Model::VoiceOverride
+Audio8Model::resolveVoice(const VoiceOverride& perCall) const {
+  VoiceOverride voice{cfg_.referenceAudio, cfg_.referenceText};
+  if (!perCall.referenceAudio.empty()) {
+    voice.referenceAudio = perCall.referenceAudio;
+    voice.referenceText = perCall.referenceText;
+  }
+  if (!perCall.referenceText.empty()) {
+    voice.referenceText = perCall.referenceText;
+  }
+  validateVoice(
+      voice.referenceAudio, voice.referenceText, cfg_.codecEncoderPath);
+  return voice;
+}
+
+Audio8Model::Output Audio8Model::synthesize(const AnyInput& input) {
+  std::shared_ptr<tts_cpp::audio8::Engine> engine;
+  {
+    std::lock_guard lk(engineMu_);
+    engine = engine_;
+  }
+  if (!engine) {
+    throw createTTSError(
+        TTSErrorCode::InitializationFailed,
+        "Audio8Model::synthesize: engine not loaded");
+  }
+  if (cancelRequested_.load(std::memory_order_relaxed)) {
+    throw createTTSError(
+        TTSErrorCode::SynthesisFailed, "synthesis cancelled before it started");
+  }
+
+  const VoiceOverride voice = resolveVoice(input.voice);
+  textLength_ = input.text.size();
+
+  const auto t0 = std::chrono::steady_clock::now();
+  tts_cpp::audio8::SynthesisResult result;
+  try {
+    // The engine caches the codes for the most recent voice prompt, so
+    // repeating the same reference across calls skips the codec encoder.
+    result = voice.referenceAudio.empty()
+                 ? engine->synthesize(input.text)
+                 : engine->synthesize(
+                       input.text,
+                       tts_cpp::audio8::load_voice_prompt(
+                           voice.referenceAudio, voice.referenceText));
+  } catch (const std::exception& e) {
+    throw createTTSError(
+        TTSErrorCode::SynthesisFailed,
+        std::string("audio8.synthesize: ") + e.what());
+  }
+  const auto t1 = std::chrono::steady_clock::now();
+
+  sampleRate_ = result.sample_rate;
+  generatedFrames_ = result.frames;
+  totalSamples_ = static_cast<int64_t>(result.pcm.size());
+  audioDurationMs_ = static_cast<double>(result.duration_s) * 1000.0;
+  totalTime_ = std::chrono::duration<double>(t1 - t0).count();
+  realTimeFactor_ =
+      audioDurationMs_ > 0.0 ? (totalTime_ * 1000.0) / audioDurationMs_ : 0.0;
+  tokensPerSecond_ = totalTime_ > 0.0
+                         ? static_cast<double>(generatedFrames_) / totalTime_
+                         : 0.0;
+
+  return pcmFloatToInt16(result.pcm);
+}
+
+std::any Audio8Model::process(const std::any& input) {
+  const auto* anyInput = std::any_cast<AnyInput>(&input);
+  if (!anyInput) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "Audio8Model::process: input must be AnyInput");
+  }
+
+  bool expected = false;
+  if (!jobInProgress_.compare_exchange_strong(
+          expected, true, std::memory_order_acq_rel)) {
+    throw StatusError(
+        general_error::InternalError,
+        "Audio8Model::process: job already in progress");
+  }
+  struct InProgressGuard {
+    std::atomic_bool& flag;
+    ~InProgressGuard() { flag.store(false, std::memory_order_release); }
+  } guard{jobInProgress_};
+
+  cancelRequested_.store(false, std::memory_order_relaxed);
+  return std::any(synthesize(*anyInput));
+}
+
+qvac_lib_inference_addon_cpp::RuntimeStats Audio8Model::runtimeStats() const {
+  qvac_lib_inference_addon_cpp::RuntimeStats stats;
+  stats.emplace_back("totalTime", totalTime_);
+  stats.emplace_back("tokensPerSecond", tokensPerSecond_);
+  stats.emplace_back("realTimeFactor", realTimeFactor_);
+  stats.emplace_back("audioDurationMs", audioDurationMs_);
+  stats.emplace_back("totalSamples", totalSamples_);
+  stats.emplace_back("generatedFrames", static_cast<int64_t>(generatedFrames_));
+  stats.emplace_back("backendDevice", static_cast<int64_t>(backendDevice_));
+  stats.emplace_back("backendId", static_cast<int64_t>(backendId_));
+  stats.emplace_back("gpuUnsupported", static_cast<int64_t>(gpuUnsupported_));
+  return stats;
+}
+
+} // namespace qvac::ttsggml::audio8

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <any>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "inference-addon-cpp/ModelInterfaces.hpp"
+#include "inference-addon-cpp/RuntimeStats.hpp"
+#include "model-interface/audio8/Audio8Config.hpp"
+
+namespace tts_cpp::audio8 {
+class Engine;
+}
+
+namespace qvac::ttsggml::audio8 {
+
+inline constexpr int kAudio8NativeSampleRate = 44100;
+
+class Audio8Model
+    : public qvac_lib_inference_addon_cpp::model::IModel,
+      public qvac_lib_inference_addon_cpp::model::IModelCancel,
+      public qvac_lib_inference_addon_cpp::model::IModelAsyncLoad {
+public:
+  using Input = std::string;
+  using Output = std::vector<int16_t>;
+
+  // Per-call overrides of the constructor's reference recording. Empty means
+  // "keep the configured voice"; an audio path with no text is rejected.
+  struct VoiceOverride {
+    std::string referenceAudio;
+    std::string referenceText;
+
+    bool empty() const {
+      return referenceAudio.empty() && referenceText.empty();
+    }
+  };
+
+  struct AnyInput {
+    std::string text;
+    VoiceOverride voice;
+  };
+
+  explicit Audio8Model(Audio8Config config);
+  ~Audio8Model() noexcept override;
+
+  std::string getName() const override { return "Audio8Model"; }
+  std::any process(const std::any& input) override;
+  qvac_lib_inference_addon_cpp::RuntimeStats runtimeStats() const override;
+
+  void cancel() const override;
+
+  void load();
+  void unload();
+  void reload();
+  bool isLoaded() const {
+    std::lock_guard lk(engineMu_);
+    return static_cast<bool>(engine_);
+  }
+
+  // IModelAsyncLoad — see the equivalent comment on ChatterboxModel.
+  void waitForLoadInitialization() override { load(); }
+  void setWeightsForFile(
+      const std::string&,
+      std::unique_ptr<std::basic_streambuf<char>>&&) override {}
+
+  void setConfig(Audio8Config config);
+  const Audio8Config& config() const { return cfg_; }
+
+  int sampleRate() const { return sampleRate_; }
+
+  static void validateConfig(const Audio8Config& cfg);
+  // Shared by validateConfig and the per-call path, which can name a
+  // different recording. An encoder GGUF and a transcript are both required
+  // as soon as either voice field is set.
+  static void validateVoice(
+      const std::string& audio, const std::string& text,
+      const std::string& encoderPath);
+
+private:
+  VoiceOverride resolveVoice(const VoiceOverride& perCall) const;
+  Output synthesize(const AnyInput& input);
+
+  void loadLocked();
+  void unloadLocked();
+
+  Audio8Config cfg_;
+
+  mutable std::mutex engineMu_;
+  std::shared_ptr<tts_cpp::audio8::Engine> engine_;
+
+  std::atomic_bool jobInProgress_{false};
+
+  // Mirrors SupertonicModel::cancelRequested_ (see that header).
+  mutable std::atomic_bool cancelRequested_{false};
+
+  double totalTime_ = 0.0;
+  double audioDurationMs_ = 0.0;
+  int64_t totalSamples_ = 0;
+  double realTimeFactor_ = 0.0;
+  double tokensPerSecond_ = 0.0;
+  size_t textLength_ = 0;
+  int generatedFrames_ = 0;
+  int sampleRate_ = kAudio8NativeSampleRate;
+
+  int backendDevice_ = 0;
+  int backendId_ = 0;
+  std::string backendName_ = "CPU";
+  bool gpuUnsupported_ = false;
+};
+
+} // namespace qvac::ttsggml::audio8

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.hpp
@@ -33,10 +33,6 @@ public:
   struct VoiceOverride {
     std::string referenceAudio;
     std::string referenceText;
-
-    bool empty() const {
-      return referenceAudio.empty() && referenceText.empty();
-    }
   };
 
   struct AnyInput {
@@ -79,9 +75,11 @@ public:
   static void validateVoice(
       const std::string& audio, const std::string& text,
       const std::string& encoderPath);
+  // The voice a call synthesizes with, merging the per-call override over the
+  // configured one. Public so the merge rule is directly testable.
+  VoiceOverride resolveVoice(const VoiceOverride& perCall) const;
 
 private:
-  VoiceOverride resolveVoice(const VoiceOverride& perCall) const;
   Output synthesize(const AnyInput& input);
 
   void loadLocked();
@@ -101,8 +99,9 @@ private:
   double audioDurationMs_ = 0.0;
   int64_t totalSamples_ = 0;
   double realTimeFactor_ = 0.0;
+  // Frames per second, not characters per second as on the text-paced
+  // engines: Audio8 generates on a fixed 46 ms codec frame grid.
   double tokensPerSecond_ = 0.0;
-  size_t textLength_ = 0;
   int generatedFrames_ = 0;
   int sampleRate_ = kAudio8NativeSampleRate;
 

--- a/packages/tts-ggml/addon/tests/test_audio8_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_audio8_config.cpp
@@ -101,7 +101,7 @@ TEST(Audio8Validate, ReferenceAudioNeedsEncoder) {
 
 TEST(Audio8Validate, ReferenceAudioNeedsTranscript) {
   // The model conditions on the transcript as the turn the reference answers,
-  // so an empty one degrades the clone rather than failing loudly.
+  // so an empty one would degrade the clone silently. Reject it instead.
   auto cfg = cloningStubConfig();
   cfg.referenceText.clear();
   EXPECT_THROW(Audio8Model{cfg}, StatusError);
@@ -222,6 +222,40 @@ TEST(Audio8Voice, PerCallAudioWithoutTranscriptRejected) {
       StatusError);
 }
 
+TEST(Audio8Voice, NoPerCallFieldsKeepTheConfiguredVoice) {
+  const auto cfg = cloningStubConfig();
+  const Audio8Model model{cfg};
+  const Audio8Model::VoiceOverride perCall;
+  const auto voice = model.resolveVoice(perCall);
+  EXPECT_EQ(voice.referenceAudio, cfg.referenceAudio);
+  EXPECT_EQ(voice.referenceText, cfg.referenceText);
+}
+
+TEST(Audio8Voice, PerCallTranscriptKeepsTheConfiguredRecording) {
+  const auto cfg = cloningStubConfig();
+  const Audio8Model model{cfg};
+  Audio8Model::VoiceOverride perCall;
+  perCall.referenceText = "A corrected transcript.";
+  const auto voice = model.resolveVoice(perCall);
+  EXPECT_EQ(voice.referenceAudio, cfg.referenceAudio);
+  EXPECT_EQ(voice.referenceText, perCall.referenceText);
+}
+
+TEST(Audio8Voice, PerCallRecordingReplacesBothHalves) {
+  const Audio8Model model{cloningStubConfig()};
+  Audio8Model::VoiceOverride perCall;
+  perCall.referenceAudio = stubFile("audio8-other-reference-stub.wav");
+  // The configured transcript describes the configured recording, so a new
+  // recording arriving without its own transcript is rejected rather than
+  // silently cloned against the wrong text.
+  EXPECT_THROW(model.resolveVoice(perCall), StatusError);
+
+  perCall.referenceText = "What the other one says.";
+  const auto voice = model.resolveVoice(perCall);
+  EXPECT_EQ(voice.referenceAudio, perCall.referenceAudio);
+  EXPECT_EQ(voice.referenceText, perCall.referenceText);
+}
+
 TEST(Audio8RealGguf, TextOnlySynthesisRoundTrip) {
   const std::string lm = envOrEmpty("QVAC_TEST_AUDIO8_LM_GGUF");
   const std::string decoder = envOrEmpty("QVAC_TEST_AUDIO8_DECODER_GGUF");
@@ -245,5 +279,5 @@ TEST(Audio8RealGguf, TextOnlySynthesisRoundTrip) {
   const auto pcm =
       std::any_cast<Audio8Model::Output>(model.process(std::any(input)));
   EXPECT_FALSE(pcm.empty());
-  EXPECT_EQ(model.sampleRate(), 44100);
+  EXPECT_EQ(model.sampleRate(), qvac::ttsggml::audio8::kAudio8NativeSampleRate);
 }

--- a/packages/tts-ggml/addon/tests/test_audio8_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_audio8_config.cpp
@@ -1,0 +1,249 @@
+// Constructor-validation tests for Audio8Model. Same shape as
+// test_parler_config.cpp: validateConfig is driven via the public
+// constructor, and the GGUF parse is deferred to load() so stub files are
+// enough to exercise every branch that does not touch weights.
+//
+// Real-GGUF round-trip is gated behind QVAC_TEST_AUDIO8_LM_GGUF.
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/audio8/Audio8Config.hpp"
+#include "model-interface/audio8/Audio8Model.hpp"
+
+using qvac::ttsggml::audio8::Audio8Config;
+using qvac::ttsggml::audio8::Audio8Model;
+using qvac_errors::StatusError;
+
+namespace {
+
+std::filesystem::path tempPath(const std::string& suffix) {
+  auto dir =
+      std::filesystem::temp_directory_path() / "qvac-tts-ggml-audio8-tests";
+  std::filesystem::create_directories(dir);
+  return dir / suffix;
+}
+
+std::string stubFile(const std::string& name) {
+  const auto path = tempPath(name);
+  std::ofstream(path, std::ios::binary) << "stub";
+  return path.string();
+}
+
+std::string envOrEmpty(const char* name) {
+  if (const char* v = std::getenv(name))
+    return v;
+  return "";
+}
+
+Audio8Config minimallyValidStubConfig() {
+  Audio8Config cfg;
+  cfg.lmModelPath = stubFile("audio8-lm-stub.gguf");
+  cfg.codecDecoderPath = stubFile("audio8-decoder-stub.gguf");
+  return cfg;
+}
+
+Audio8Config cloningStubConfig() {
+  Audio8Config cfg = minimallyValidStubConfig();
+  cfg.codecEncoderPath = stubFile("audio8-encoder-stub.gguf");
+  cfg.referenceAudio = stubFile("audio8-reference-stub.wav");
+  cfg.referenceText = "What the recording says.";
+  return cfg;
+}
+
+} // namespace
+
+TEST(Audio8Validate, EmptyLmPathRejected) {
+  Audio8Config cfg;
+  cfg.codecDecoderPath = stubFile("audio8-decoder-stub.gguf");
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, EmptyDecoderPathRejected) {
+  Audio8Config cfg;
+  cfg.lmModelPath = stubFile("audio8-lm-stub.gguf");
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, NonexistentPathsRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.lmModelPath = "/definitely/does/not/exist/audio8-lm.gguf";
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+
+  cfg = minimallyValidStubConfig();
+  cfg.codecDecoderPath = "/definitely/does/not/exist/audio8-decoder.gguf";
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+
+  cfg = minimallyValidStubConfig();
+  cfg.codecEncoderPath = "/definitely/does/not/exist/audio8-encoder.gguf";
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, TextOnlyConfigAccepted) {
+  EXPECT_NO_THROW(Audio8Model{minimallyValidStubConfig()});
+}
+
+TEST(Audio8Validate, CloningConfigAccepted) {
+  EXPECT_NO_THROW(Audio8Model{cloningStubConfig()});
+}
+
+TEST(Audio8Validate, ReferenceAudioNeedsEncoder) {
+  auto cfg = cloningStubConfig();
+  cfg.codecEncoderPath.clear();
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, ReferenceAudioNeedsTranscript) {
+  // The model conditions on the transcript as the turn the reference answers,
+  // so an empty one degrades the clone rather than failing loudly.
+  auto cfg = cloningStubConfig();
+  cfg.referenceText.clear();
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, ReferenceTextWithoutAudioRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.referenceText = "Nothing to attach this to.";
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, NonexistentReferenceAudioRejected) {
+  auto cfg = cloningStubConfig();
+  cfg.referenceAudio = "/definitely/does/not/exist/voice.wav";
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, NegativeTemperatureRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.temperature = -0.1f;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, NegativeTopKRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.topK = -1;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, TopPOutOfRangeRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.topP = 0.0f;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+  cfg.topP = 1.5f;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+  cfg.topP = 0.9f;
+  EXPECT_NO_THROW(Audio8Model{cfg});
+}
+
+TEST(Audio8Validate, MaxFramesNonNegative) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.maxFrames = -1;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+  cfg.maxFrames = 0; // engine default
+  EXPECT_NO_THROW(Audio8Model{cfg});
+  cfg.maxFrames = 128;
+  EXPECT_NO_THROW(Audio8Model{cfg});
+}
+
+TEST(Audio8Validate, OutputSampleRateBand) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.outputSampleRate = 4000;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+  cfg.outputSampleRate = 0; // native rate
+  EXPECT_NO_THROW(Audio8Model{cfg});
+  cfg.outputSampleRate = 16000;
+  EXPECT_NO_THROW(Audio8Model{cfg});
+}
+
+TEST(Audio8Validate, UseGpuNGpuLayersConflictRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.useGpu = true;
+  cfg.nGpuLayers = 0;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+  cfg.useGpu = false;
+  cfg.nGpuLayers = 99;
+  EXPECT_THROW(Audio8Model{cfg}, StatusError);
+}
+
+TEST(Audio8Validate, GpuIntentAcceptedAtConstruction) {
+  // The engine is CPU-only today and warns rather than failing, so GPU intent
+  // must not be rejected here.
+  auto cfg = minimallyValidStubConfig();
+  cfg.useGpu = true;
+  EXPECT_NO_THROW(Audio8Model{cfg});
+  cfg.useGpu.reset();
+  cfg.nGpuLayers = 99;
+  EXPECT_NO_THROW(Audio8Model{cfg});
+}
+
+TEST(Audio8Validate, LoadIsDeferredAndStubFailsToParse) {
+  auto cfg = minimallyValidStubConfig();
+  std::unique_ptr<Audio8Model> m;
+  EXPECT_NO_THROW(m = std::make_unique<Audio8Model>(cfg));
+  ASSERT_NE(m, nullptr);
+  EXPECT_FALSE(m->isLoaded());
+  EXPECT_THROW(m->load(), StatusError);
+  EXPECT_FALSE(m->isLoaded());
+}
+
+TEST(Audio8Validate, ConfigDefaultsAllUnset) {
+  Audio8Config cfg;
+  EXPECT_FALSE(cfg.greedy.has_value());
+  EXPECT_FALSE(cfg.seed.has_value());
+  EXPECT_FALSE(cfg.threads.has_value());
+  EXPECT_FALSE(cfg.temperature.has_value());
+  EXPECT_FALSE(cfg.topK.has_value());
+  EXPECT_FALSE(cfg.topP.has_value());
+  EXPECT_FALSE(cfg.maxFrames.has_value());
+  EXPECT_FALSE(cfg.outputSampleRate.has_value());
+  EXPECT_FALSE(cfg.nGpuLayers.has_value());
+  EXPECT_FALSE(cfg.useGpu.has_value());
+}
+
+TEST(Audio8Voice, PerCallTranscriptOverridesConfigured) {
+  Audio8Model model{cloningStubConfig()};
+  EXPECT_NO_THROW(
+      Audio8Model::validateVoice(
+          model.config().referenceAudio,
+          "A corrected transcript.",
+          model.config().codecEncoderPath));
+}
+
+TEST(Audio8Voice, PerCallAudioWithoutTranscriptRejected) {
+  const auto cfg = cloningStubConfig();
+  EXPECT_THROW(
+      Audio8Model::validateVoice(cfg.referenceAudio, "", cfg.codecEncoderPath),
+      StatusError);
+}
+
+TEST(Audio8RealGguf, TextOnlySynthesisRoundTrip) {
+  const std::string lm = envOrEmpty("QVAC_TEST_AUDIO8_LM_GGUF");
+  const std::string decoder = envOrEmpty("QVAC_TEST_AUDIO8_DECODER_GGUF");
+  if (lm.empty() || decoder.empty()) {
+    GTEST_SKIP() << "set QVAC_TEST_AUDIO8_LM_GGUF and "
+                    "QVAC_TEST_AUDIO8_DECODER_GGUF to run this";
+  }
+
+  Audio8Config cfg;
+  cfg.lmModelPath = lm;
+  cfg.codecDecoderPath = decoder;
+  cfg.greedy = true;
+  cfg.maxFrames = 16;
+
+  Audio8Model model{cfg};
+  ASSERT_NO_THROW(model.load());
+  ASSERT_TRUE(model.isLoaded());
+
+  Audio8Model::AnyInput input;
+  input.text = "Hello from a fully on-device C plus plus pipeline.";
+  const auto pcm =
+      std::any_cast<Audio8Model::Output>(model.process(std::any(input)));
+  EXPECT_FALSE(pcm.empty());
+  EXPECT_EQ(model.sampleRate(), 44100);
+}

--- a/packages/tts-ggml/examples/audio8-tts.js
+++ b/packages/tts-ggml/examples/audio8-tts.js
@@ -1,0 +1,145 @@
+'use strict'
+
+/**
+ * Audio8 batch synthesis for @qvac/tts-ggml.
+ *
+ * Audio8 is a DualAR model: a 24-layer autoregressive transformer picks a
+ * semantic token per 46 ms frame, a 4-layer head fills the seven acoustic
+ * codebooks under it, and a DAC-style codec turns the eight codes back into
+ * 44.1 kHz audio.  It ships as three GGUFs -- the language model, the codec's
+ * synthesis half, and the codec's analysis half -- because they have different
+ * lifetimes: text-only synthesis never touches the analysis half.
+ *
+ * Voice cloning is fully in-process.  Pass a reference recording plus the
+ * transcript of what is said in it; the analysis half encodes the recording to
+ * codes and the model continues that speaker.  The transcript is not optional
+ * in practice: the model conditions on it as the turn the reference answers,
+ * and a wrong one degrades the clone.
+ *
+ * Usage:
+ *   bare examples/audio8-tts.js "text to synthesize" [reference.wav] [reference text]
+ *
+ * Examples:
+ *   bare examples/audio8-tts.js "Hello from a fully on-device pipeline."
+ *   bare examples/audio8-tts.js "Cloned speech." voice.wav "What the recording says."
+ *
+ * Expects the Audio8 GGUFs (audio8-lm-q8_0.gguf,
+ * audio8-codec-decoder-q8_0.gguf, and, to clone,
+ * audio8-codec-encoder-q8_0.gguf) under:
+ *   models/
+ * Produce them with the converters in qvac-ext-lib-whisper.cpp
+ * (engines/tts/scripts/convert-audio8-{lm,codec}-to-gguf.py) until they are
+ * published to the model registry.
+ *
+ * NOTE: Audio8 is CPU-only in this release; useGPU / nGpuLayers are accepted
+ * and warn rather than failing.
+ */
+
+const path = require('bare-path')
+const TTSGgml = require('../')
+const { createWav } = require('./wav-helper')
+const { setLogger, releaseLogger } = require('../addonLogging')
+
+const AUDIO8_SAMPLE_RATE = 44100
+
+const argv = global.Bare ? global.Bare.argv : process.argv
+const textArg = argv[2]
+const referenceAudioArg = argv[3]
+const referenceTextArg = argv[4]
+
+function fail(message) {
+  console.error(message)
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+}
+
+if (!textArg || typeof textArg !== 'string' || textArg.trim().length === 0) {
+  fail('Usage: audio8-tts.js "<text to synthesize>" [reference.wav] [reference text]')
+}
+
+if (referenceAudioArg && !referenceTextArg) {
+  fail('A reference recording needs the transcript of what it says as the next argument.')
+}
+
+const pkgRoot = path.join(__dirname, '..')
+const modelDir = path.join(pkgRoot, 'models')
+
+function buildModel() {
+  const voice = referenceAudioArg
+    ? { referenceAudio: path.resolve(referenceAudioArg), referenceText: referenceTextArg }
+    : {}
+  return new TTSGgml({
+    engine: TTSGgml.ENGINE_AUDIO8,
+    files: { modelDir },
+    ...voice,
+    logger: console,
+    opts: { stats: true }
+  })
+}
+
+function reportStats(stats) {
+  if (!stats) return
+  console.log(
+    `Inference stats: totalTime=${stats.totalTime.toFixed(2)}s, ` +
+      `framesPerSecond=${stats.tokensPerSecond.toFixed(2)}, ` +
+      `realTimeFactor=${stats.realTimeFactor.toFixed(3)}, ` +
+      `audioDuration=${stats.audioDurationMs}ms, totalSamples=${stats.totalSamples}`
+  )
+}
+
+async function collectPcm(response) {
+  let buffer = []
+  await response
+    .onUpdate((data) => {
+      if (data && data.outputArray) {
+        buffer = buffer.concat(Array.from(data.outputArray))
+      }
+    })
+    .await()
+  return buffer
+}
+
+async function main() {
+  setLogger((priority, message) => {
+    if (priority > 1) return
+    const names = { 0: 'ERROR', 1: 'WARNING', 2: 'INFO', 3: 'DEBUG', 4: 'OFF' }
+    const name = names[priority] || 'UNKNOWN'
+    console.log(`[${new Date().toISOString()}] [C++ log] [${name}]: ${message}`)
+  })
+
+  const outputFile = path.join(__dirname, 'audio8-output.wav')
+  const model = buildModel()
+
+  try {
+    console.log('Loading Audio8 TTS model...')
+    await model.load()
+    console.log('Model loaded.')
+
+    const how = referenceAudioArg ? `cloning ${referenceAudioArg}` : 'default speaker'
+    console.log(`Running TTS on: "${textArg}" (${how})`)
+
+    const response = await model.run({ input: textArg, type: 'text' })
+    const buffer = await collectPcm(response)
+
+    console.log('TTS finished!')
+    reportStats(response.stats)
+
+    console.log('\nWriting to .wav file...')
+    createWav(buffer, AUDIO8_SAMPLE_RATE, outputFile)
+    console.log(`Finished writing to ${outputFile}`)
+  } catch (err) {
+    console.error('Error during TTS processing:', err)
+    throw err
+  } finally {
+    console.log('Unloading model...')
+    await model.unload()
+    console.log('Model unloaded.')
+    releaseLogger()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  if (global.Bare) global.Bare.exit(1)
+  else process.exit(1)
+})

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -554,10 +554,15 @@ declare class TTSGgml {
      */
     private _resolveParlerJobFields;
     /**
+     * The voice a per-call override actually synthesizes with. Mirrors
+     * Audio8Model::resolveVoice: a per-call recording replaces both halves, so
+     * it cannot inherit the configured transcript, which describes a different
+     * recording; a per-call transcript alone corrects the configured one.
+     */
+    private _mergeAudio8Voice;
+    /**
      * Extract + validate the per-call Audio8 voice fields from a run input or
-     * streaming options. Returns undefined when none are present. A per-call
-     * transcript alone corrects the configured recording's transcript; a
-     * per-call recording replaces both.
+     * streaming options. Returns undefined when none are present.
      */
     private _resolveAudio8JobFields;
     /** The per-call fields of whichever engine is loaded, if any are set. */

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -4,6 +4,7 @@ declare const ENGINE_CHATTERBOX = "chatterbox";
 declare const ENGINE_SUPERTONIC = "supertonic";
 declare const ENGINE_COSYVOICE3 = "cosyvoice3";
 declare const ENGINE_PARLER = "parler";
+declare const ENGINE_AUDIO8 = "audio8";
 declare const COSYVOICE_DIALECTS: {
     readonly cantonese: "广东话";
     readonly northeastern: "东北话";
@@ -57,7 +58,7 @@ interface CosyvoiceInstruct {
     /** Playful style preset. */
     style?: keyof typeof COSYVOICE_STYLES;
 }
-type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC | typeof ENGINE_COSYVOICE3 | typeof ENGINE_PARLER;
+type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC | typeof ENGINE_COSYVOICE3 | typeof ENGINE_PARLER | typeof ENGINE_AUDIO8;
 /**
  * Model file paths for the GGML TTS backend. Engine is auto-detected
  * from these fields (Chatterbox vs Supertonic) unless overridden via
@@ -88,6 +89,18 @@ interface TTSGgmlFiles {
     parlerModel?: string;
     parlerModelPath?: string;
     parler?: string;
+    /** Audio8 DualAR language model GGUF path. Overrides `modelDir`. */
+    audio8Lm?: string;
+    audio8LmPath?: string;
+    /** Audio8 codec synthesis half (codes to 44.1 kHz wav). Overrides `modelDir`. */
+    audio8CodecDecoder?: string;
+    audio8CodecDecoderPath?: string;
+    /**
+     * Audio8 codec analysis half (wav to codes). Only needed to clone a voice
+     * from a recording; a text-only deployment can leave it out.
+     */
+    audio8CodecEncoder?: string;
+    audio8CodecEncoderPath?: string;
     /**
      * CosyVoice3 model directory holding the sub-model GGUFs
      * (`cosyvoice3-{llm,flow,hift}-*.gguf`) plus `voice.gguf`, `vocab.json` and
@@ -209,19 +222,32 @@ interface ParlerDescriptionFields {
     reverb?: string;
     quality?: string;
 }
-interface TTSGgmlOptions extends ParlerDescriptionFields {
+/**
+ * Voice cloning reference. Audio8's codec encoder turns `referenceAudio` into
+ * codes and they are prepended to the prompt as the speaker's own history, so
+ * no speaker encoder and no enrolment step are involved. `referenceText` is
+ * required alongside it there: the model conditions on it as the turn the
+ * recording answers, and a wrong one degrades the clone. Accepted at
+ * construction, on `reload()`, and per call (Audio8 only).
+ */
+interface Audio8VoiceFields {
+    /**
+     * Chatterbox: voice-cloning reference audio path (wav). CosyVoice3: reserved
+     * / not yet effective — zero-shot cloning needs the native S3 tokenizer +
+     * CAM++ (not ported yet), so the engine falls back to the baked voice.
+     * Audio8: the recording to clone, with `referenceText` alongside it.
+     */
+    referenceAudio?: string;
+    /** Audio8: what `referenceAudio` says. Required when cloning. */
+    referenceText?: string;
+}
+interface TTSGgmlOptions extends ParlerDescriptionFields, Audio8VoiceFields {
     files?: TTSGgmlFiles;
     config?: TTSGgmlRuntimeConfig;
     logger?: object;
     lazySessionLoading?: boolean;
     /** Explicit engine selection. Auto-detected from `files` when omitted. */
     engine?: EngineType;
-    /**
-     * Chatterbox: voice-cloning reference audio path (wav). CosyVoice3: reserved
-     * / not yet effective — zero-shot cloning needs the native S3 tokenizer +
-     * CAM++ (not ported yet), so the engine falls back to the baked voice.
-     */
-    referenceAudio?: string;
     /** Chatterbox: directory of baked voice-conditioning tensors. */
     voiceDir?: string;
     /** RNG seed for Chatterbox CFM/SineGen or Supertonic latent generation. */
@@ -331,14 +357,21 @@ interface TTSGgmlOptions extends ParlerDescriptionFields {
     /** Chatterbox MTL Cangjie TSV path for Chinese. */
     cangjieTsvPath?: string;
     /**
-     * Parler sampling / generation knobs; each unset defers to the GGUF's
-     * generation defaults (temperature 1.0, top-k 50, ~30 s max length).
+     * Parler and Audio8 sampling knobs; each unset defers to the engine's own
+     * defaults (Parler: temperature 1.0, top-k 50; Audio8: temperature 0.7,
+     * top-k 50, top-p 0.9). Audio8 filters by top-k/top-p on the raw logits and
+     * only then applies the temperature, following its reference.
      */
     temperature?: number;
     topK?: number;
     topP?: number;
-    /** Parler generation-length cap in decoder steps (~86/s); 0 = model default. */
+    /**
+     * Generation-length cap in decoder frames; 0 = engine default. Parler runs
+     * ~86 frames/s, Audio8 ~21.5.
+     */
     maxFrames?: number;
+    /** Audio8: take the argmax instead of sampling. */
+    greedy?: boolean;
     minNewTokens?: number;
     /** Parler prompt digit expansion (engine default: enabled). */
     normalizeNumbers?: boolean;
@@ -382,13 +415,13 @@ interface SentenceStreamChunkMeta {
      */
     isLast?: boolean;
 }
-interface SentenceStreamOptions extends ParlerDescriptionFields {
+interface SentenceStreamOptions extends ParlerDescriptionFields, Audio8VoiceFields {
     /** BCP-47 locale for `Intl.Segmenter` when available. */
     locale?: string;
     /** Maximum graphemes per chunk; defaults to 300, or 120 for Korean. */
     maxChunkScalars?: number;
 }
-interface RunStreamingOptions extends ParlerDescriptionFields {
+interface RunStreamingOptions extends ParlerDescriptionFields, Audio8VoiceFields {
     accumulateSentences?: boolean;
     sentenceDelimiter?: RegExp;
     sentenceDelimiterPreset?: SentenceDelimiterPreset;
@@ -397,7 +430,7 @@ interface RunStreamingOptions extends ParlerDescriptionFields {
 }
 /** Input accepted by `runStreaming`. */
 type TextStreamInput = string | string[] | Iterable<string> | AsyncIterable<string>;
-interface TTSRunInput extends ParlerDescriptionFields {
+interface TTSRunInput extends ParlerDescriptionFields, Audio8VoiceFields {
     type?: string;
     input: string;
     streamOutput?: boolean;
@@ -428,6 +461,7 @@ declare class TTSGgml {
     static readonly ENGINE_SUPERTONIC = "supertonic";
     static readonly ENGINE_COSYVOICE3 = "cosyvoice3";
     static readonly ENGINE_PARLER = "parler";
+    static readonly ENGINE_AUDIO8 = "audio8";
     opts: object;
     exclusiveRun: boolean;
     logger: object;
@@ -477,6 +511,11 @@ declare class TTSGgml {
     private _openclCacheDir?;
     private _vulkanCacheDir?;
     private _parlerModelPath?;
+    private _audio8LmPath?;
+    private _audio8CodecDecoderPath?;
+    private _audio8CodecEncoderPath?;
+    private _referenceText?;
+    private _greedy?;
     private _description?;
     private _emotion?;
     private _pitch?;
@@ -493,10 +532,19 @@ declare class TTSGgml {
     private _normalizeNumbers?;
     constructor(options?: TTSGgmlOptions);
     private _resolveEngineAndModelPaths;
+    private _resolveAudio8ModelPaths;
     private _assignSynthesisOptions;
     private _assertEngineStreamingSupport;
     private _requestsChunkStreaming;
     private _assertParlerOptionConsistency;
+    private _assertSamplerOptionSupport;
+    private _assertAudio8OptionConsistency;
+    /**
+     * A recording without its transcript is accepted by the model but degrades
+     * the clone silently, and a transcript alone has nothing to attach to, so
+     * both halves have to arrive together.
+     */
+    private _assertAudio8VoiceConsistent;
     private _assertCosyvoiceOptionConsistency;
     /**
      * Extract + validate the per-call parler description/template fields from a
@@ -505,6 +553,15 @@ declare class TTSGgml {
      * free-text description.
      */
     private _resolveParlerJobFields;
+    /**
+     * Extract + validate the per-call Audio8 voice fields from a run input or
+     * streaming options. Returns undefined when none are present. A per-call
+     * transcript alone corrects the configured recording's transcript; a
+     * per-call recording replaces both.
+     */
+    private _resolveAudio8JobFields;
+    /** The per-call fields of whichever engine is loaded, if any are set. */
+    private _resolveJobFields;
     getEngineType(): EngineType;
     getApiDefinition(): string;
     getState(): InferenceState;
@@ -543,6 +600,14 @@ declare class TTSGgml {
     private _buildChatterboxParams;
     private _buildSupertonicParams;
     private _buildParlerParams;
+    private _buildAudio8Params;
+    /** The knobs every engine in SAMPLING_ENGINES reads. */
+    private _assignSamplingParams;
+    /**
+     * Backend and output plumbing for the engines that take no `language`,
+     * where `_assignCommonNativeParams` would be the wrong shape.
+     */
+    private _assignBackendParams;
     private _assignCommonNativeParams;
     /** LavaSR post-processing paths, shared by every engine that supports them. */
     private _assignLavasrParams;
@@ -561,6 +626,12 @@ declare class TTSGgml {
     cancel(): Promise<void>;
     private _failAndClearActiveResponse;
     reload(newConfig?: Record<string, unknown>): Promise<void>;
+    /**
+     * Audio8 voice + sampling knobs are reloadable; they rebuild the engine's
+     * sampler and speaker history. _buildAudio8Params re-validates, so a
+     * half-specified voice still throws.
+     */
+    private _applyAudio8Reload;
     static getModelKey(_params?: unknown): string;
     private _requireAddon;
     private _optionalAddon;

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -19,6 +19,7 @@ const ENGINE_SUPERTONIC = "supertonic";
 // `files.cosyvoiceModelDir`) routes here.
 const ENGINE_COSYVOICE3 = "cosyvoice3";
 const ENGINE_PARLER = "parler";
+const ENGINE_AUDIO8 = "audio8";
 const MIN_OUTPUT_SAMPLE_RATE = 8000;
 const MAX_OUTPUT_SAMPLE_RATE = 192000;
 const CHATTERBOX_T3_TURBO = "chatterbox-t3-turbo.gguf";
@@ -147,6 +148,16 @@ const PARLER_FIELD_KEYS = [
     ...PARLER_DESCRIPTION_KEYS,
     ...PARLER_TEMPLATE_KEYS,
 ];
+// Audio8 ships three GGUFs per quant tier, with the tier in the filename
+// (`audio8-lm-q8_0.gguf`); a bare `audio8-lm.gguf` matches too, as
+// forward-compat with a single-tier release.
+const AUDIO8_LM_RE = /^audio8-lm(-[a-z0-9_]+)?\.gguf$/i;
+const AUDIO8_DECODER_RE = /^audio8-codec-decoder(-[a-z0-9_]+)?\.gguf$/i;
+const AUDIO8_ENCODER_RE = /^audio8-codec-encoder(-[a-z0-9_]+)?\.gguf$/i;
+const AUDIO8_QUANT_ORDER = ["q8_0", "f16", "q4_0", "f32"];
+const AUDIO8_VOICE_KEYS = ["referenceAudio", "referenceText"];
+/** Engines that draw tokens, and so accept temperature / topK / topP / maxFrames. */
+const SAMPLING_ENGINES = [ENGINE_PARLER, ENGINE_AUDIO8];
 function normalizeError(error) {
     return typeof error === "string"
         ? error
@@ -248,6 +259,61 @@ function findParlerInDir(modelDir) {
     matches.sort((left, right) => rank(left) - rank(right));
     return path.join(modelDir, matches[0]);
 }
+/** Names of the entries that carry a value, for "wrong engine" messages. */
+function setOptionNames(options) {
+    return Object.entries(options)
+        .filter(([, value]) => value != null)
+        .map(([name]) => name);
+}
+function readDirSafe(modelDir) {
+    if (!modelDir)
+        return [];
+    try {
+        return fs.readdirSync(modelDir);
+    }
+    catch {
+        return [];
+    }
+}
+function audio8QuantRank(name, pattern) {
+    const match = name.match(pattern);
+    if (!match)
+        return Number.MAX_SAFE_INTEGER;
+    if (!match[1])
+        return 0;
+    const index = AUDIO8_QUANT_ORDER.indexOf(match[1].slice(1).toLowerCase());
+    return index === -1 ? AUDIO8_QUANT_ORDER.length + 1 : index + 1;
+}
+/**
+ * Find one Audio8 GGUF in `modelDir`, preferring the quant tier that reads
+ * best for its size (q8_0 > f16 > q4_0 > f32).
+ */
+function findAudio8InDir(modelDir, pattern) {
+    const matches = readDirSafe(modelDir).filter((name) => pattern.test(name));
+    if (matches.length === 0)
+        return undefined;
+    matches.sort((left, right) => audio8QuantRank(left, pattern) - audio8QuantRank(right, pattern));
+    return path.join(modelDir, matches[0]);
+}
+/**
+ * Collect the Audio8 voice-cloning properties present on `source` (a run
+ * input, streaming options, or constructor options). Returns undefined when
+ * none are set.
+ */
+function pickAudio8VoiceFields(source) {
+    if (source == null || typeof source !== "object")
+        return undefined;
+    const out = {};
+    let any = false;
+    for (const key of AUDIO8_VOICE_KEYS) {
+        const value = source[key];
+        if (value != null && value !== "") {
+            out[key] = String(value);
+            any = true;
+        }
+    }
+    return any ? out : undefined;
+}
 /**
  * Collect the Parler description/template properties present on `source`
  * (a run input, streaming options, or constructor options). Returns undefined
@@ -298,6 +364,9 @@ function normalizeGgmlFiles(files) {
         cosyvoiceS3tokModel: firstNonEmpty(files.cosyvoiceS3tokModel, files.cosyvoiceS3tokModelPath),
         cosyvoiceCampplusModel: firstNonEmpty(files.cosyvoiceCampplusModel, files.cosyvoiceCampplusModelPath),
         parlerModel: firstNonEmpty(files.parlerModel, files.parlerModelPath, files.parler),
+        audio8Lm: firstNonEmpty(files.audio8Lm, files.audio8LmPath),
+        audio8CodecDecoder: firstNonEmpty(files.audio8CodecDecoder, files.audio8CodecDecoderPath),
+        audio8CodecEncoder: firstNonEmpty(files.audio8CodecEncoder, files.audio8CodecEncoderPath),
         voicesDir: firstNonEmpty(files.voicesDir),
         lavasrEnhancer: firstNonEmpty(files.lavasrEnhancer),
         lavasrDenoiser: firstNonEmpty(files.lavasrDenoiser),
@@ -309,12 +378,13 @@ function detectEngineType(engine, files) {
     if (engine === ENGINE_CHATTERBOX ||
         engine === ENGINE_SUPERTONIC ||
         engine === ENGINE_COSYVOICE3 ||
-        engine === ENGINE_PARLER) {
+        engine === ENGINE_PARLER ||
+        engine === ENGINE_AUDIO8) {
         return engine;
     }
     if (engine != null && engine !== "") {
         throw new Error("tts-ggml: 'engine' option must be 'chatterbox', 'supertonic', " +
-            `'cosyvoice3' or 'parler' (got '${String(engine)}')`);
+            `'cosyvoice3', 'parler' or 'audio8' (got '${String(engine)}')`);
     }
     // Explicit CosyVoice3 files/dir take precedence over shared-modelDir sniffing.
     if (files.cosyvoiceModelDir || files.cosyvoiceLlmModel) {
@@ -326,6 +396,8 @@ function detectEngineType(engine, files) {
         return ENGINE_SUPERTONIC;
     if (files.parlerModel)
         return ENGINE_PARLER;
+    if (files.audio8Lm || files.audio8CodecDecoder)
+        return ENGINE_AUDIO8;
     if (files.modelDir) {
         if (dirHasCosyvoice3(files.modelDir))
             return ENGINE_COSYVOICE3;
@@ -340,6 +412,8 @@ function detectEngineType(engine, files) {
             return ENGINE_SUPERTONIC;
         if (findParlerInDir(files.modelDir))
             return ENGINE_PARLER;
+        if (findAudio8InDir(files.modelDir, AUDIO8_LM_RE))
+            return ENGINE_AUDIO8;
     }
     return ENGINE_CHATTERBOX;
 }
@@ -491,6 +565,7 @@ class TTSGgml {
     static ENGINE_SUPERTONIC = ENGINE_SUPERTONIC;
     static ENGINE_COSYVOICE3 = ENGINE_COSYVOICE3;
     static ENGINE_PARLER = ENGINE_PARLER;
+    static ENGINE_AUDIO8 = ENGINE_AUDIO8;
     opts;
     exclusiveRun;
     logger;
@@ -540,6 +615,11 @@ class TTSGgml {
     _openclCacheDir;
     _vulkanCacheDir;
     _parlerModelPath;
+    _audio8LmPath;
+    _audio8CodecDecoderPath;
+    _audio8CodecEncoderPath;
+    _referenceText;
+    _greedy;
     _description;
     _emotion;
     _pitch;
@@ -619,6 +699,10 @@ class TTSGgml {
             this._parlerModelPath = firstNonEmpty(files.parlerModel, files.modelDir ? findParlerInDir(files.modelDir) : undefined);
             return;
         }
+        if (this._engineType === ENGINE_AUDIO8) {
+            this._resolveAudio8ModelPaths(files);
+            return;
+        }
         if (files.modelDir) {
             const resolved = resolveChatterboxModelDirPaths(files.modelDir);
             this._t3ModelPath = firstNonEmpty(files.t3Model, resolved.t3);
@@ -629,8 +713,15 @@ class TTSGgml {
             this._s3genModelPath = files.s3genModel;
         }
     }
+    _resolveAudio8ModelPaths(files) {
+        this._audio8LmPath = firstNonEmpty(files.audio8Lm, findAudio8InDir(files.modelDir, AUDIO8_LM_RE));
+        this._audio8CodecDecoderPath = firstNonEmpty(files.audio8CodecDecoder, findAudio8InDir(files.modelDir, AUDIO8_DECODER_RE));
+        this._audio8CodecEncoderPath = firstNonEmpty(files.audio8CodecEncoder, findAudio8InDir(files.modelDir, AUDIO8_ENCODER_RE));
+    }
     _assignSynthesisOptions(options) {
         this._referenceAudio = options.referenceAudio;
+        this._referenceText = options.referenceText;
+        this._greedy = options.greedy;
         this._voiceDir = options.voiceDir;
         this._seed = options.seed;
         this._nGpuLayers = options.nGpuLayers;
@@ -679,10 +770,19 @@ class TTSGgml {
                 "use sentence-level streaming via the engine-agnostic " +
                 "runStream() / runStreaming() / run({ streamOutput: true }) APIs.");
         }
+        if (this._engineType === ENGINE_AUDIO8 &&
+            (this._streamChunkTokens != null ||
+                this._streamFirstChunkTokens != null)) {
+            throw new Error("tts-ggml: streamChunkTokens / streamFirstChunkTokens are not " +
+                "supported by the audio8 engine, which synthesizes a whole " +
+                "utterance at a time. Use sentence-level streaming via " +
+                "runStream() / runStreaming() / run({ streamOutput: true }).");
+        }
         // Runs before the denoiser guard so a Parler description/template conflict
         // is reported ahead of the engine-agnostic streaming constraints.
         this._assertParlerOptionConsistency();
         this._assertCosyvoiceOptionConsistency();
+        this._assertAudio8OptionConsistency();
         if (this._denoiserGgufPath && this._requestsChunkStreaming()) {
             throw new Error("tts-ggml: the LavaSR denoiser is not yet supported with " +
                 "native chunk streaming (streamChunkTokens > 0). Use batch " +
@@ -716,7 +816,9 @@ class TTSGgml {
         if (this._description != null) {
             parlerOnly.push("description/voiceDescription");
         }
-        const parlerOnlyFields = {
+        // temperature / topK / topP / maxFrames are deliberately absent: audio8
+        // samples too, so SAMPLING_ENGINES decides who may set them.
+        parlerOnly.push(...setOptionNames({
             emotion: this._emotion,
             pitch: this._pitch,
             pace: this._pace,
@@ -724,20 +826,70 @@ class TTSGgml {
             noise: this._noise,
             reverb: this._reverb,
             quality: this._quality,
+            minNewTokens: this._minNewTokens,
+            normalizeNumbers: this._normalizeNumbers,
+        }));
+        if (parlerOnly.length > 0) {
+            throw new Error(`tts-ggml: ${parlerOnly.join(", ")} are parler-only options ` +
+                `(engine is ${this._engineType})`);
+        }
+        this._assertSamplerOptionSupport();
+    }
+    _assertSamplerOptionSupport() {
+        if (SAMPLING_ENGINES.includes(this._engineType))
+            return;
+        const sampling = setOptionNames({
             temperature: this._temperature,
             topK: this._topK,
             topP: this._topP,
             maxFrames: this._maxFrames,
-            minNewTokens: this._minNewTokens,
-            normalizeNumbers: this._normalizeNumbers,
-        };
-        for (const [key, value] of Object.entries(parlerOnlyFields)) {
-            if (value != null)
-                parlerOnly.push(key);
+        });
+        if (sampling.length === 0)
+            return;
+        throw new Error(`tts-ggml: ${sampling.join(", ")} are parler/audio8-only options ` +
+            `(engine is ${this._engineType})`);
+    }
+    _assertAudio8OptionConsistency() {
+        if (this._engineType === ENGINE_AUDIO8) {
+            if (this._enhancerGgufPath || this._denoiserGgufPath) {
+                throw new Error("tts-ggml: the LavaSR enhancer/denoiser are not supported with " +
+                    "the audio8 engine (native 44.1 kHz output needs no bandwidth " +
+                    "extension). Drop lavasrEnhancer / lavasrDenoiser.");
+            }
+            this._assertAudio8VoiceConsistent({
+                referenceAudio: this._referenceAudio,
+                referenceText: this._referenceText,
+            }, "constructor");
+            return;
         }
-        if (parlerOnly.length > 0) {
-            throw new Error(`tts-ggml: ${parlerOnly.join(", ")} are parler-only options ` +
+        const audio8Only = setOptionNames({
+            referenceText: this._referenceText,
+            greedy: this._greedy,
+        });
+        if (audio8Only.length > 0) {
+            throw new Error(`tts-ggml: ${audio8Only.join(", ")} are audio8-only options ` +
                 `(engine is ${this._engineType})`);
+        }
+    }
+    /**
+     * A recording without its transcript is accepted by the model but degrades
+     * the clone silently, and a transcript alone has nothing to attach to, so
+     * both halves have to arrive together.
+     */
+    _assertAudio8VoiceConsistent(voice, where) {
+        if (!voice.referenceAudio && !voice.referenceText)
+            return;
+        if (!voice.referenceAudio) {
+            throw new Error(`tts-ggml: ${where}: referenceText needs a referenceAudio to ` +
+                "transcribe");
+        }
+        if (!voice.referenceText) {
+            throw new Error(`tts-ggml: ${where}: referenceAudio needs a referenceText saying ` +
+                "what the recording says");
+        }
+        if (!this._audio8CodecEncoderPath) {
+            throw new Error(`tts-ggml: ${where}: voice cloning needs the audio8 codec encoder ` +
+                "GGUF (files.audio8CodecEncoder)");
         }
     }
     _assertCosyvoiceOptionConsistency() {
@@ -781,6 +933,34 @@ class TTSGgml {
         }
         return fields;
     }
+    /**
+     * Extract + validate the per-call Audio8 voice fields from a run input or
+     * streaming options. Returns undefined when none are present. A per-call
+     * transcript alone corrects the configured recording's transcript; a
+     * per-call recording replaces both.
+     */
+    _resolveAudio8JobFields(source, where) {
+        const fields = pickAudio8VoiceFields(source);
+        if (!fields)
+            return undefined;
+        if (this._engineType !== ENGINE_AUDIO8) {
+            throw new Error(`tts-ggml: ${where}: per-call referenceAudio/referenceText are ` +
+                `audio8-only (engine is ${this._engineType})`);
+        }
+        this._assertAudio8VoiceConsistent({
+            referenceAudio: fields.referenceAudio ?? this._referenceAudio,
+            referenceText: fields.referenceText ?? this._referenceText,
+        }, where);
+        return fields;
+    }
+    /** The per-call fields of whichever engine is loaded, if any are set. */
+    _resolveJobFields(source, where) {
+        const parler = this._resolveParlerJobFields(source, where);
+        const audio8 = this._resolveAudio8JobFields(source, where);
+        if (!parler && !audio8)
+            return undefined;
+        return { ...(parler ?? {}), ...(audio8 ?? {}) };
+    }
     getEngineType() {
         return this._engineType;
     }
@@ -817,11 +997,11 @@ class TTSGgml {
                     adds: "run with streamOutput: non-empty string `input` is required",
                 });
             }
-            const parlerFields = this._resolveParlerJobFields(input, "run");
+            const jobFields = this._resolveJobFields(input, "run");
             const runStream = () => this._runStreamOrchestrator(input.input, {
                 locale: input.locale,
                 maxChunkScalars: input.maxChunkScalars,
-            }, parlerFields);
+            }, jobFields);
             return this.exclusiveRun
                 ? this._enqueueExclusiveTtsResponse(runStream)
                 : runStream();
@@ -840,6 +1020,7 @@ class TTSGgml {
             locale: normalized.locale,
             maxChunkScalars: normalized.maxChunkScalars,
             ...(pickParlerDescFields(normalized) ?? {}),
+            ...(pickAudio8VoiceFields(normalized) ?? {}),
         });
     }
     /**
@@ -850,7 +1031,7 @@ class TTSGgml {
      * small streamed fragments are coalesced.
      */
     async runStreaming(textStream, options = {}) {
-        const parlerFields = this._resolveParlerJobFields(options, "runStreaming");
+        const jobFields = this._resolveJobFields(options, "runStreaming");
         const streamOptions = this._resolveRunStreamingOptions(textStream, options);
         let normalized = this._normalizeTextStream(textStream);
         if (streamOptions.accumulateSentences) {
@@ -862,7 +1043,7 @@ class TTSGgml {
                 language: this._config.language,
             });
         }
-        const runStream = () => this._runTextStreamOrchestrator(normalized, parlerFields);
+        const runStream = () => this._runTextStreamOrchestrator(normalized, jobFields);
         return this.exclusiveRun
             ? this._enqueueExclusiveTtsResponse(runStream)
             : runStream();
@@ -939,7 +1120,7 @@ class TTSGgml {
             adds: "runStreaming: expected string, array of strings, Iterable, or AsyncIterable",
         });
     }
-    _runTextStreamOrchestrator(source, parlerFields) {
+    _runTextStreamOrchestrator(source, jobFields) {
         const response = this._job.start();
         this._sentenceStreamCtx = {
             textStreamMode: true,
@@ -948,7 +1129,7 @@ class TTSGgml {
             chunkIdx: 0,
             acc: { totalTime: 0, audioDurationMs: 0, totalSamples: 0 },
             chunkResolver: null,
-            parlerFields,
+            jobFields,
         };
         void this._sentenceStreamTextIterableDrive().catch((error) => {
             this._rejectActiveChunk(error);
@@ -977,7 +1158,7 @@ class TTSGgml {
                 await this._requireAddon().runJob({
                     type: "text",
                     input: text,
-                    ...(context.parlerFields ?? {}),
+                    ...(context.jobFields ?? {}),
                 });
                 await done;
             }
@@ -1006,7 +1187,7 @@ class TTSGgml {
             }
             : computeSentenceStreamStats(chunks, accumulator));
     }
-    _runStreamOrchestrator(text, options, parlerFields) {
+    _runStreamOrchestrator(text, options, jobFields) {
         const chunks = (0, textChunker_1.splitTtsText)(String(text), {
             language: this._config.language,
             locale: options.locale,
@@ -1024,7 +1205,7 @@ class TTSGgml {
             chunkIdx: 0,
             acc: { totalTime: 0, audioDurationMs: 0, totalSamples: 0 },
             chunkResolver: null,
-            parlerFields,
+            jobFields,
         };
         void this._sentenceStreamDriveBody().catch((error) => {
             this._rejectActiveChunk(error);
@@ -1045,7 +1226,7 @@ class TTSGgml {
             await this._requireAddon().runJob({
                 type: "text",
                 input: context.chunks[index],
-                ...(context.parlerFields ?? {}),
+                ...(context.jobFields ?? {}),
             });
             await done;
         }
@@ -1077,6 +1258,9 @@ class TTSGgml {
         }
         if (this._engineType === ENGINE_PARLER) {
             return this._buildParlerParams();
+        }
+        if (this._engineType === ENGINE_AUDIO8) {
+            return this._buildAudio8Params();
         }
         return this._buildChatterboxParams();
     }
@@ -1232,20 +1416,7 @@ class TTSGgml {
         if (this._quality != null) {
             parameters.quality = String(this._quality);
         }
-        if (this._seed != null)
-            parameters.seed = this._seed | 0;
-        if (this._threads != null)
-            parameters.threads = this._threads | 0;
-        if (this._temperature != null) {
-            parameters.temperature = Number(this._temperature);
-        }
-        if (this._topK != null)
-            parameters.topK = this._topK | 0;
-        if (this._topP != null)
-            parameters.topP = Number(this._topP);
-        if (this._maxFrames != null) {
-            parameters.maxFrames = this._maxFrames | 0;
-        }
+        this._assignSamplingParams(parameters);
         if (this._minNewTokens != null) {
             parameters.minNewTokens = this._minNewTokens | 0;
         }
@@ -1256,11 +1427,63 @@ class TTSGgml {
             parameters.streamFirstChunkTokens =
                 this._streamFirstChunkTokens | 0;
         }
-        if (this._outputSampleRate != null) {
-            parameters.outputSampleRate = this._outputSampleRate | 0;
-        }
         if (this._normalizeNumbers != null) {
             parameters.normalizeNumbers = !!this._normalizeNumbers;
+        }
+        this._assignBackendParams(parameters);
+        return parameters;
+    }
+    _buildAudio8Params() {
+        // Re-checked here (not only in the constructor) so reload({...}) cannot
+        // smuggle in a half-specified voice.
+        this._assertAudio8VoiceConsistent({
+            referenceAudio: this._referenceAudio,
+            referenceText: this._referenceText,
+        }, "reload");
+        const parameters = {
+            engineType: ENGINE_AUDIO8,
+            audio8LmPath: this._audio8LmPath || "",
+            audio8CodecDecoderPath: this._audio8CodecDecoderPath || "",
+        };
+        if (this._audio8CodecEncoderPath) {
+            parameters.audio8CodecEncoderPath = this._audio8CodecEncoderPath;
+        }
+        if (this._referenceAudio != null) {
+            parameters.referenceAudio = this._referenceAudio;
+        }
+        if (this._referenceText != null) {
+            parameters.referenceText = this._referenceText;
+        }
+        if (this._greedy != null)
+            parameters.greedy = !!this._greedy;
+        this._assignSamplingParams(parameters);
+        this._assignBackendParams(parameters);
+        return parameters;
+    }
+    /** The knobs every engine in SAMPLING_ENGINES reads. */
+    _assignSamplingParams(parameters) {
+        if (this._temperature != null) {
+            parameters.temperature = Number(this._temperature);
+        }
+        if (this._topK != null)
+            parameters.topK = this._topK | 0;
+        if (this._topP != null)
+            parameters.topP = Number(this._topP);
+        if (this._maxFrames != null) {
+            parameters.maxFrames = this._maxFrames | 0;
+        }
+    }
+    /**
+     * Backend and output plumbing for the engines that take no `language`,
+     * where `_assignCommonNativeParams` would be the wrong shape.
+     */
+    _assignBackendParams(parameters) {
+        if (this._seed != null)
+            parameters.seed = this._seed | 0;
+        if (this._threads != null)
+            parameters.threads = this._threads | 0;
+        if (this._outputSampleRate != null) {
+            parameters.outputSampleRate = this._outputSampleRate | 0;
         }
         if (this._nGpuLayers != null) {
             parameters.nGpuLayers = this._nGpuLayers | 0;
@@ -1272,7 +1495,6 @@ class TTSGgml {
         if (this._backendsDir) {
             parameters.backendsDir = this._backendsDir;
         }
-        return parameters;
     }
     _assignCommonNativeParams(parameters) {
         if (this._seed != null)
@@ -1324,7 +1546,7 @@ class TTSGgml {
         this.state.destroyed = true;
     }
     async _runInternal(input) {
-        const parlerFields = this._resolveParlerJobFields(input, "run");
+        const jobFields = this._resolveJobFields(input, "run");
         const response = this._job.start({
             signal: input?.signal,
         });
@@ -1334,7 +1556,7 @@ class TTSGgml {
             await this._requireAddon().runJob({
                 type: input.type || "text",
                 input: input.input,
-                ...(parlerFields ?? {}),
+                ...(jobFields ?? {}),
             });
         }
         catch (error) {
@@ -1463,6 +1685,7 @@ class TTSGgml {
         if (runtimeConfig.outputSampleRate !== undefined) {
             this._outputSampleRate = runtimeConfig.outputSampleRate;
         }
+        this._applyAudio8Reload(newConfig);
         // Parler description/template + sampling knobs are reloadable; they rebuild
         // the engine's default description / sampler. _buildParlerParams re-validates
         // so a wrong-engine reload still throws.
@@ -1526,6 +1749,38 @@ class TTSGgml {
             await existingAddon.destroyInstance();
         this.addon = this._createAddon(parameters, this._addonOutputCallback.bind(this));
         await this._requireAddon().activate();
+    }
+    /**
+     * Audio8 voice + sampling knobs are reloadable; they rebuild the engine's
+     * sampler and speaker history. _buildAudio8Params re-validates, so a
+     * half-specified voice still throws.
+     */
+    _applyAudio8Reload(newConfig) {
+        if (this._engineType !== ENGINE_AUDIO8)
+            return;
+        const config = newConfig;
+        if (config.referenceAudio !== undefined) {
+            this._referenceAudio = config.referenceAudio;
+        }
+        if (config.referenceText !== undefined) {
+            this._referenceText = config.referenceText;
+        }
+        if (config.greedy !== undefined)
+            this._greedy = config.greedy;
+        if (config.temperature !== undefined) {
+            this._temperature = config.temperature;
+        }
+        if (config.topK !== undefined)
+            this._topK = config.topK;
+        if (config.topP !== undefined)
+            this._topP = config.topP;
+        if (config.maxFrames !== undefined) {
+            this._maxFrames = config.maxFrames;
+        }
+        if (config.seed !== undefined)
+            this._seed = config.seed;
+        if (config.threads !== undefined)
+            this._threads = config.threads;
     }
     static getModelKey(_params) {
         void _params;

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -289,6 +289,8 @@ function audio8QuantRank(name, pattern) {
  * best for its size (q8_0 > f16 > q4_0 > f32).
  */
 function findAudio8InDir(modelDir, pattern) {
+    if (!modelDir)
+        return undefined;
     const matches = readDirSafe(modelDir).filter((name) => pattern.test(name));
     if (matches.length === 0)
         return undefined;
@@ -934,10 +936,26 @@ class TTSGgml {
         return fields;
     }
     /**
+     * The voice a per-call override actually synthesizes with. Mirrors
+     * Audio8Model::resolveVoice: a per-call recording replaces both halves, so
+     * it cannot inherit the configured transcript, which describes a different
+     * recording; a per-call transcript alone corrects the configured one.
+     */
+    _mergeAudio8Voice(fields) {
+        if (fields.referenceAudio) {
+            return {
+                referenceAudio: fields.referenceAudio,
+                referenceText: fields.referenceText,
+            };
+        }
+        return {
+            referenceAudio: this._referenceAudio,
+            referenceText: fields.referenceText ?? this._referenceText,
+        };
+    }
+    /**
      * Extract + validate the per-call Audio8 voice fields from a run input or
-     * streaming options. Returns undefined when none are present. A per-call
-     * transcript alone corrects the configured recording's transcript; a
-     * per-call recording replaces both.
+     * streaming options. Returns undefined when none are present.
      */
     _resolveAudio8JobFields(source, where) {
         const fields = pickAudio8VoiceFields(source);
@@ -947,10 +965,7 @@ class TTSGgml {
             throw new Error(`tts-ggml: ${where}: per-call referenceAudio/referenceText are ` +
                 `audio8-only (engine is ${this._engineType})`);
         }
-        this._assertAudio8VoiceConsistent({
-            referenceAudio: fields.referenceAudio ?? this._referenceAudio,
-            referenceText: fields.referenceText ?? this._referenceText,
-        }, where);
+        this._assertAudio8VoiceConsistent(this._mergeAudio8Voice(fields), where);
         return fields;
     }
     /** The per-call fields of whichever engine is loaded, if any are set. */

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qvac/tts-ggml",
   "version": "0.6.2",
-  "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler engines from tts-cpp)",
+  "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + audio8 engines from tts-cpp)",
   "addon": true,
   "engines": {
     "bare": ">=1.19.0"
@@ -27,6 +27,7 @@
     "example:cosyvoice": "bare examples/cosyvoice-tts.js \"Hello from CosyVoice three.\"",
     "example:cosyvoice-enhanced": "bare examples/cosyvoice-enhanced.js \"Hello from CosyVoice three.\"",
     "example:parler": "bare examples/parler-tts.js \"Hey, how are you doing today?\"",
+    "example:audio8": "bare examples/audio8-tts.js \"Audio eight speaks on the CPU.\"",
     "lint": "npm run lint:js && npm run lint:ts && npm run test:types",
     "lint:js": "prettier --check \"test/**/*.js\" \"binding.js\" && lunte \"test/**/*.js\" \"binding.js\"",
     "lint:ts": "eslint \"src/**/*.ts\" --max-warnings=0",

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -841,13 +841,14 @@ function findAudio8InDir(
   modelDir: string | undefined,
   pattern: RegExp,
 ): string | undefined {
+  if (!modelDir) return undefined;
   const matches = readDirSafe(modelDir).filter((name) => pattern.test(name));
   if (matches.length === 0) return undefined;
   matches.sort(
     (left, right) =>
       audio8QuantRank(left, pattern) - audio8QuantRank(right, pattern),
   );
-  return path.join(modelDir as string, matches[0]);
+  return path.join(modelDir, matches[0]);
 }
 
 /**
@@ -1732,10 +1733,29 @@ class TTSGgml {
   }
 
   /**
+   * The voice a per-call override actually synthesizes with. Mirrors
+   * Audio8Model::resolveVoice: a per-call recording replaces both halves, so
+   * it cannot inherit the configured transcript, which describes a different
+   * recording; a per-call transcript alone corrects the configured one.
+   */
+  private _mergeAudio8Voice(
+    fields: Audio8VoiceFieldsResolved,
+  ): Audio8VoiceFields {
+    if (fields.referenceAudio) {
+      return {
+        referenceAudio: fields.referenceAudio,
+        referenceText: fields.referenceText,
+      };
+    }
+    return {
+      referenceAudio: this._referenceAudio,
+      referenceText: fields.referenceText ?? this._referenceText,
+    };
+  }
+
+  /**
    * Extract + validate the per-call Audio8 voice fields from a run input or
-   * streaming options. Returns undefined when none are present. A per-call
-   * transcript alone corrects the configured recording's transcript; a
-   * per-call recording replaces both.
+   * streaming options. Returns undefined when none are present.
    */
   private _resolveAudio8JobFields(
     source: Audio8VoiceFields | null | undefined,
@@ -1750,10 +1770,7 @@ class TTSGgml {
       );
     }
     this._assertAudio8VoiceConsistent(
-      {
-        referenceAudio: fields.referenceAudio ?? this._referenceAudio,
-        referenceText: fields.referenceText ?? this._referenceText,
-      },
+      this._mergeAudio8Voice(fields),
       where,
     );
     return fields;

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -39,6 +39,7 @@ const ENGINE_SUPERTONIC = "supertonic";
 // `files.cosyvoiceModelDir`) routes here.
 const ENGINE_COSYVOICE3 = "cosyvoice3";
 const ENGINE_PARLER = "parler";
+const ENGINE_AUDIO8 = "audio8";
 const MIN_OUTPUT_SAMPLE_RATE = 8000;
 const MAX_OUTPUT_SAMPLE_RATE = 192000;
 const CHATTERBOX_T3_TURBO = "chatterbox-t3-turbo.gguf";
@@ -207,11 +208,31 @@ const PARLER_FIELD_KEYS = [
 type ParlerFieldKey = (typeof PARLER_FIELD_KEYS)[number];
 type ParlerDescFields = Partial<Record<ParlerFieldKey, string>>;
 
+// Audio8 ships three GGUFs per quant tier, with the tier in the filename
+// (`audio8-lm-q8_0.gguf`); a bare `audio8-lm.gguf` matches too, as
+// forward-compat with a single-tier release.
+const AUDIO8_LM_RE = /^audio8-lm(-[a-z0-9_]+)?\.gguf$/i;
+const AUDIO8_DECODER_RE =
+  /^audio8-codec-decoder(-[a-z0-9_]+)?\.gguf$/i;
+const AUDIO8_ENCODER_RE =
+  /^audio8-codec-encoder(-[a-z0-9_]+)?\.gguf$/i;
+const AUDIO8_QUANT_ORDER = ["q8_0", "f16", "q4_0", "f32"];
+const AUDIO8_VOICE_KEYS = ["referenceAudio", "referenceText"] as const;
+type Audio8VoiceKey = (typeof AUDIO8_VOICE_KEYS)[number];
+type Audio8VoiceFieldsResolved = Partial<Record<Audio8VoiceKey, string>>;
+
+/** Per-call engine fields forwarded verbatim onto the native job object. */
+type JobFields = ParlerDescFields & Audio8VoiceFieldsResolved;
+
+/** Engines that draw tokens, and so accept temperature / topK / topP / maxFrames. */
+const SAMPLING_ENGINES: readonly string[] = [ENGINE_PARLER, ENGINE_AUDIO8];
+
 type EngineType =
   | typeof ENGINE_CHATTERBOX
   | typeof ENGINE_SUPERTONIC
   | typeof ENGINE_COSYVOICE3
-  | typeof ENGINE_PARLER;
+  | typeof ENGINE_PARLER
+  | typeof ENGINE_AUDIO8;
 
 /**
  * Model file paths for the GGML TTS backend. Engine is auto-detected
@@ -243,6 +264,18 @@ interface TTSGgmlFiles {
   parlerModel?: string;
   parlerModelPath?: string;
   parler?: string;
+  /** Audio8 DualAR language model GGUF path. Overrides `modelDir`. */
+  audio8Lm?: string;
+  audio8LmPath?: string;
+  /** Audio8 codec synthesis half (codes to 44.1 kHz wav). Overrides `modelDir`. */
+  audio8CodecDecoder?: string;
+  audio8CodecDecoderPath?: string;
+  /**
+   * Audio8 codec analysis half (wav to codes). Only needed to clone a voice
+   * from a recording; a text-only deployment can leave it out.
+   */
+  audio8CodecEncoder?: string;
+  audio8CodecEncoderPath?: string;
   /**
    * CosyVoice3 model directory holding the sub-model GGUFs
    * (`cosyvoice3-{llm,flow,hift}-*.gguf`) plus `voice.gguf`, `vocab.json` and
@@ -369,19 +402,35 @@ interface ParlerDescriptionFields {
   quality?: string;
 }
 
-interface TTSGgmlOptions extends ParlerDescriptionFields {
+/**
+ * Voice cloning reference. Audio8's codec encoder turns `referenceAudio` into
+ * codes and they are prepended to the prompt as the speaker's own history, so
+ * no speaker encoder and no enrolment step are involved. `referenceText` is
+ * required alongside it there: the model conditions on it as the turn the
+ * recording answers, and a wrong one degrades the clone. Accepted at
+ * construction, on `reload()`, and per call (Audio8 only).
+ */
+interface Audio8VoiceFields {
+  /**
+   * Chatterbox: voice-cloning reference audio path (wav). CosyVoice3: reserved
+   * / not yet effective — zero-shot cloning needs the native S3 tokenizer +
+   * CAM++ (not ported yet), so the engine falls back to the baked voice.
+   * Audio8: the recording to clone, with `referenceText` alongside it.
+   */
+  referenceAudio?: string;
+  /** Audio8: what `referenceAudio` says. Required when cloning. */
+  referenceText?: string;
+}
+
+interface TTSGgmlOptions
+  extends ParlerDescriptionFields,
+    Audio8VoiceFields {
   files?: TTSGgmlFiles;
   config?: TTSGgmlRuntimeConfig;
   logger?: object;
   lazySessionLoading?: boolean;
   /** Explicit engine selection. Auto-detected from `files` when omitted. */
   engine?: EngineType;
-  /**
-   * Chatterbox: voice-cloning reference audio path (wav). CosyVoice3: reserved
-   * / not yet effective — zero-shot cloning needs the native S3 tokenizer +
-   * CAM++ (not ported yet), so the engine falls back to the baked voice.
-   */
-  referenceAudio?: string;
   /** Chatterbox: directory of baked voice-conditioning tensors. */
   voiceDir?: string;
   /** RNG seed for Chatterbox CFM/SineGen or Supertonic latent generation. */
@@ -491,14 +540,21 @@ interface TTSGgmlOptions extends ParlerDescriptionFields {
   /** Chatterbox MTL Cangjie TSV path for Chinese. */
   cangjieTsvPath?: string;
   /**
-   * Parler sampling / generation knobs; each unset defers to the GGUF's
-   * generation defaults (temperature 1.0, top-k 50, ~30 s max length).
+   * Parler and Audio8 sampling knobs; each unset defers to the engine's own
+   * defaults (Parler: temperature 1.0, top-k 50; Audio8: temperature 0.7,
+   * top-k 50, top-p 0.9). Audio8 filters by top-k/top-p on the raw logits and
+   * only then applies the temperature, following its reference.
    */
   temperature?: number;
   topK?: number;
   topP?: number;
-  /** Parler generation-length cap in decoder steps (~86/s); 0 = model default. */
+  /**
+   * Generation-length cap in decoder frames; 0 = engine default. Parler runs
+   * ~86 frames/s, Audio8 ~21.5.
+   */
   maxFrames?: number;
+  /** Audio8: take the argmax instead of sampling. */
+  greedy?: boolean;
   minNewTokens?: number;
   /** Parler prompt digit expansion (engine default: enabled). */
   normalizeNumbers?: boolean;
@@ -518,6 +574,9 @@ interface NormalizedFiles {
   cosyvoiceS3tokModel?: string;
   cosyvoiceCampplusModel?: string;
   parlerModel?: string;
+  audio8Lm?: string;
+  audio8CodecDecoder?: string;
+  audio8CodecEncoder?: string;
   voicesDir?: string;
   lavasrEnhancer?: string;
   lavasrDenoiser?: string;
@@ -578,14 +637,18 @@ interface SentenceStreamChunkMeta {
   isLast?: boolean;
 }
 
-interface SentenceStreamOptions extends ParlerDescriptionFields {
+interface SentenceStreamOptions
+  extends ParlerDescriptionFields,
+    Audio8VoiceFields {
   /** BCP-47 locale for `Intl.Segmenter` when available. */
   locale?: string;
   /** Maximum graphemes per chunk; defaults to 300, or 120 for Korean. */
   maxChunkScalars?: number;
 }
 
-interface RunStreamingOptions extends ParlerDescriptionFields {
+interface RunStreamingOptions
+  extends ParlerDescriptionFields,
+    Audio8VoiceFields {
   accumulateSentences?: boolean;
   sentenceDelimiter?: RegExp;
   sentenceDelimiterPreset?: SentenceDelimiterPreset;
@@ -600,7 +663,7 @@ type TextStreamInput =
   | Iterable<string>
   | AsyncIterable<string>;
 
-interface TTSRunInput extends ParlerDescriptionFields {
+interface TTSRunInput extends ParlerDescriptionFields, Audio8VoiceFields {
   type?: string;
   input: string;
   streamOutput?: boolean;
@@ -632,9 +695,10 @@ interface SentenceStreamContext {
   chunkIdx: number;
   acc: StreamAccumulator;
   chunkResolver: ChunkResolver | null;
-  // Parler per-response description/template fields, replayed on every chunk's
-  // jobData so the native T5 cross-KV cache stays hot across the stream.
-  parlerFields?: ParlerDescFields;
+  // Per-response engine fields (Parler description/template, Audio8 voice),
+  // replayed on every chunk's jobData so the native caches they key -- the T5
+  // cross-KV, the encoded reference voice -- stay hot across the stream.
+  jobFields?: JobFields;
 }
 
 type ExclusiveRunner = <T>(fn: () => Promise<T>) => Promise<T>;
@@ -743,6 +807,70 @@ function findParlerInDir(modelDir?: string): string | undefined {
   return path.join(modelDir, matches[0]);
 }
 
+/** Names of the entries that carry a value, for "wrong engine" messages. */
+function setOptionNames(
+  options: Record<string, string | number | boolean | undefined>,
+): string[] {
+  return Object.entries(options)
+    .filter(([, value]) => value != null)
+    .map(([name]) => name);
+}
+
+function readDirSafe(modelDir?: string): string[] {
+  if (!modelDir) return [];
+  try {
+    return fs.readdirSync(modelDir);
+  } catch {
+    return [];
+  }
+}
+
+function audio8QuantRank(name: string, pattern: RegExp): number {
+  const match = name.match(pattern);
+  if (!match) return Number.MAX_SAFE_INTEGER;
+  if (!match[1]) return 0;
+  const index = AUDIO8_QUANT_ORDER.indexOf(match[1].slice(1).toLowerCase());
+  return index === -1 ? AUDIO8_QUANT_ORDER.length + 1 : index + 1;
+}
+
+/**
+ * Find one Audio8 GGUF in `modelDir`, preferring the quant tier that reads
+ * best for its size (q8_0 > f16 > q4_0 > f32).
+ */
+function findAudio8InDir(
+  modelDir: string | undefined,
+  pattern: RegExp,
+): string | undefined {
+  const matches = readDirSafe(modelDir).filter((name) => pattern.test(name));
+  if (matches.length === 0) return undefined;
+  matches.sort(
+    (left, right) =>
+      audio8QuantRank(left, pattern) - audio8QuantRank(right, pattern),
+  );
+  return path.join(modelDir as string, matches[0]);
+}
+
+/**
+ * Collect the Audio8 voice-cloning properties present on `source` (a run
+ * input, streaming options, or constructor options). Returns undefined when
+ * none are set.
+ */
+function pickAudio8VoiceFields(
+  source: Audio8VoiceFields | null | undefined,
+): Audio8VoiceFieldsResolved | undefined {
+  if (source == null || typeof source !== "object") return undefined;
+  const out: Audio8VoiceFieldsResolved = {};
+  let any = false;
+  for (const key of AUDIO8_VOICE_KEYS) {
+    const value = source[key];
+    if (value != null && value !== "") {
+      out[key] = String(value);
+      any = true;
+    }
+  }
+  return any ? out : undefined;
+}
+
 /**
  * Collect the Parler description/template properties present on `source`
  * (a run input, streaming options, or constructor options). Returns undefined
@@ -836,6 +964,15 @@ function normalizeGgmlFiles(
       files.parlerModelPath,
       files.parler,
     ),
+    audio8Lm: firstNonEmpty(files.audio8Lm, files.audio8LmPath),
+    audio8CodecDecoder: firstNonEmpty(
+      files.audio8CodecDecoder,
+      files.audio8CodecDecoderPath,
+    ),
+    audio8CodecEncoder: firstNonEmpty(
+      files.audio8CodecEncoder,
+      files.audio8CodecEncoderPath,
+    ),
     voicesDir: firstNonEmpty(files.voicesDir),
     lavasrEnhancer: firstNonEmpty(files.lavasrEnhancer),
     lavasrDenoiser: firstNonEmpty(files.lavasrDenoiser),
@@ -858,14 +995,15 @@ function detectEngineType(
     engine === ENGINE_CHATTERBOX ||
     engine === ENGINE_SUPERTONIC ||
     engine === ENGINE_COSYVOICE3 ||
-    engine === ENGINE_PARLER
+    engine === ENGINE_PARLER ||
+    engine === ENGINE_AUDIO8
   ) {
     return engine;
   }
   if (engine != null && engine !== "") {
     throw new Error(
       "tts-ggml: 'engine' option must be 'chatterbox', 'supertonic', " +
-        `'cosyvoice3' or 'parler' (got '${String(engine)}')`,
+        `'cosyvoice3', 'parler' or 'audio8' (got '${String(engine)}')`,
     );
   }
   // Explicit CosyVoice3 files/dir take precedence over shared-modelDir sniffing.
@@ -875,6 +1013,7 @@ function detectEngineType(
   if (files.t3Model || files.s3genModel) return ENGINE_CHATTERBOX;
   if (files.supertonicModel) return ENGINE_SUPERTONIC;
   if (files.parlerModel) return ENGINE_PARLER;
+  if (files.audio8Lm || files.audio8CodecDecoder) return ENGINE_AUDIO8;
   if (files.modelDir) {
     if (dirHasCosyvoice3(files.modelDir)) return ENGINE_COSYVOICE3;
     const hasChatterbox =
@@ -887,6 +1026,7 @@ function detectEngineType(
     if (hasChatterbox) return ENGINE_CHATTERBOX;
     if (hasSupertonic) return ENGINE_SUPERTONIC;
     if (findParlerInDir(files.modelDir)) return ENGINE_PARLER;
+    if (findAudio8InDir(files.modelDir, AUDIO8_LM_RE)) return ENGINE_AUDIO8;
   }
   return ENGINE_CHATTERBOX;
 }
@@ -1099,6 +1239,7 @@ class TTSGgml {
   static readonly ENGINE_SUPERTONIC = ENGINE_SUPERTONIC;
   static readonly ENGINE_COSYVOICE3 = ENGINE_COSYVOICE3;
   static readonly ENGINE_PARLER = ENGINE_PARLER;
+  static readonly ENGINE_AUDIO8 = ENGINE_AUDIO8;
 
   opts: object;
   exclusiveRun: boolean;
@@ -1150,6 +1291,11 @@ class TTSGgml {
   private _openclCacheDir?: string;
   private _vulkanCacheDir?: string;
   private _parlerModelPath?: string;
+  private _audio8LmPath?: string;
+  private _audio8CodecDecoderPath?: string;
+  private _audio8CodecEncoderPath?: string;
+  private _referenceText?: string;
+  private _greedy?: boolean;
   private _description?: string;
   private _emotion?: string;
   private _pitch?: string;
@@ -1280,6 +1426,10 @@ class TTSGgml {
       );
       return;
     }
+    if (this._engineType === ENGINE_AUDIO8) {
+      this._resolveAudio8ModelPaths(files);
+      return;
+    }
     if (files.modelDir) {
       const resolved = resolveChatterboxModelDirPaths(files.modelDir);
       this._t3ModelPath = firstNonEmpty(files.t3Model, resolved.t3);
@@ -1293,8 +1443,25 @@ class TTSGgml {
     }
   }
 
+  private _resolveAudio8ModelPaths(files: NormalizedFiles): void {
+    this._audio8LmPath = firstNonEmpty(
+      files.audio8Lm,
+      findAudio8InDir(files.modelDir, AUDIO8_LM_RE),
+    );
+    this._audio8CodecDecoderPath = firstNonEmpty(
+      files.audio8CodecDecoder,
+      findAudio8InDir(files.modelDir, AUDIO8_DECODER_RE),
+    );
+    this._audio8CodecEncoderPath = firstNonEmpty(
+      files.audio8CodecEncoder,
+      findAudio8InDir(files.modelDir, AUDIO8_ENCODER_RE),
+    );
+  }
+
   private _assignSynthesisOptions(options: TTSGgmlOptions): void {
     this._referenceAudio = options.referenceAudio;
+    this._referenceText = options.referenceText;
+    this._greedy = options.greedy;
     this._voiceDir = options.voiceDir;
     this._seed = options.seed;
     this._nGpuLayers = options.nGpuLayers;
@@ -1354,10 +1521,23 @@ class TTSGgml {
           "runStream() / runStreaming() / run({ streamOutput: true }) APIs.",
       );
     }
+    if (
+      this._engineType === ENGINE_AUDIO8 &&
+      (this._streamChunkTokens != null ||
+        this._streamFirstChunkTokens != null)
+    ) {
+      throw new Error(
+        "tts-ggml: streamChunkTokens / streamFirstChunkTokens are not " +
+          "supported by the audio8 engine, which synthesizes a whole " +
+          "utterance at a time. Use sentence-level streaming via " +
+          "runStream() / runStreaming() / run({ streamOutput: true }).",
+      );
+    }
     // Runs before the denoiser guard so a Parler description/template conflict
     // is reported ahead of the engine-agnostic streaming constraints.
     this._assertParlerOptionConsistency();
     this._assertCosyvoiceOptionConsistency();
+    this._assertAudio8OptionConsistency();
     if (this._denoiserGgufPath && this._requestsChunkStreaming()) {
       throw new Error(
         "tts-ggml: the LavaSR denoiser is not yet supported with " +
@@ -1398,31 +1578,101 @@ class TTSGgml {
     if (this._description != null) {
       parlerOnly.push("description/voiceDescription");
     }
-    const parlerOnlyFields: Record<
-      string,
-      string | number | boolean | undefined
-    > = {
-      emotion: this._emotion,
-      pitch: this._pitch,
-      pace: this._pace,
-      expressivity: this._expressivity,
-      noise: this._noise,
-      reverb: this._reverb,
-      quality: this._quality,
-      temperature: this._temperature,
-      topK: this._topK,
-      topP: this._topP,
-      maxFrames: this._maxFrames,
-      minNewTokens: this._minNewTokens,
-      normalizeNumbers: this._normalizeNumbers,
-    };
-    for (const [key, value] of Object.entries(parlerOnlyFields)) {
-      if (value != null) parlerOnly.push(key);
-    }
+    // temperature / topK / topP / maxFrames are deliberately absent: audio8
+    // samples too, so SAMPLING_ENGINES decides who may set them.
+    parlerOnly.push(
+      ...setOptionNames({
+        emotion: this._emotion,
+        pitch: this._pitch,
+        pace: this._pace,
+        expressivity: this._expressivity,
+        noise: this._noise,
+        reverb: this._reverb,
+        quality: this._quality,
+        minNewTokens: this._minNewTokens,
+        normalizeNumbers: this._normalizeNumbers,
+      }),
+    );
     if (parlerOnly.length > 0) {
       throw new Error(
         `tts-ggml: ${parlerOnly.join(", ")} are parler-only options ` +
           `(engine is ${this._engineType})`,
+      );
+    }
+    this._assertSamplerOptionSupport();
+  }
+
+  private _assertSamplerOptionSupport(): void {
+    if (SAMPLING_ENGINES.includes(this._engineType)) return;
+    const sampling = setOptionNames({
+      temperature: this._temperature,
+      topK: this._topK,
+      topP: this._topP,
+      maxFrames: this._maxFrames,
+    });
+    if (sampling.length === 0) return;
+    throw new Error(
+      `tts-ggml: ${sampling.join(", ")} are parler/audio8-only options ` +
+        `(engine is ${this._engineType})`,
+    );
+  }
+
+  private _assertAudio8OptionConsistency(): void {
+    if (this._engineType === ENGINE_AUDIO8) {
+      if (this._enhancerGgufPath || this._denoiserGgufPath) {
+        throw new Error(
+          "tts-ggml: the LavaSR enhancer/denoiser are not supported with " +
+            "the audio8 engine (native 44.1 kHz output needs no bandwidth " +
+            "extension). Drop lavasrEnhancer / lavasrDenoiser.",
+        );
+      }
+      this._assertAudio8VoiceConsistent(
+        {
+          referenceAudio: this._referenceAudio,
+          referenceText: this._referenceText,
+        },
+        "constructor",
+      );
+      return;
+    }
+    const audio8Only = setOptionNames({
+      referenceText: this._referenceText,
+      greedy: this._greedy,
+    });
+    if (audio8Only.length > 0) {
+      throw new Error(
+        `tts-ggml: ${audio8Only.join(", ")} are audio8-only options ` +
+          `(engine is ${this._engineType})`,
+      );
+    }
+  }
+
+  /**
+   * A recording without its transcript is accepted by the model but degrades
+   * the clone silently, and a transcript alone has nothing to attach to, so
+   * both halves have to arrive together.
+   */
+  private _assertAudio8VoiceConsistent(
+    voice: Audio8VoiceFields,
+    where: string,
+  ): void {
+    if (!voice.referenceAudio && !voice.referenceText) return;
+    if (!voice.referenceAudio) {
+      throw new Error(
+        `tts-ggml: ${where}: referenceText needs a referenceAudio to ` +
+          "transcribe",
+      );
+    }
+    if (!voice.referenceText) {
+      throw new Error(
+        `tts-ggml: ${where}: referenceAudio needs a referenceText saying ` +
+          "what the recording says",
+      );
+    }
+    if (!this._audio8CodecEncoderPath) {
+      throw new Error(
+        `tts-ggml: ${where}: voice cloning needs the audio8 codec encoder ` +
+          "GGUF (files.audio8CodecEncoder)",
       );
     }
   }
@@ -1479,6 +1729,45 @@ class TTSGgml {
       );
     }
     return fields;
+  }
+
+  /**
+   * Extract + validate the per-call Audio8 voice fields from a run input or
+   * streaming options. Returns undefined when none are present. A per-call
+   * transcript alone corrects the configured recording's transcript; a
+   * per-call recording replaces both.
+   */
+  private _resolveAudio8JobFields(
+    source: Audio8VoiceFields | null | undefined,
+    where: string,
+  ): Audio8VoiceFieldsResolved | undefined {
+    const fields = pickAudio8VoiceFields(source);
+    if (!fields) return undefined;
+    if (this._engineType !== ENGINE_AUDIO8) {
+      throw new Error(
+        `tts-ggml: ${where}: per-call referenceAudio/referenceText are ` +
+          `audio8-only (engine is ${this._engineType})`,
+      );
+    }
+    this._assertAudio8VoiceConsistent(
+      {
+        referenceAudio: fields.referenceAudio ?? this._referenceAudio,
+        referenceText: fields.referenceText ?? this._referenceText,
+      },
+      where,
+    );
+    return fields;
+  }
+
+  /** The per-call fields of whichever engine is loaded, if any are set. */
+  private _resolveJobFields(
+    source: (ParlerDescriptionFields & Audio8VoiceFields) | null | undefined,
+    where: string,
+  ): JobFields | undefined {
+    const parler = this._resolveParlerJobFields(source, where);
+    const audio8 = this._resolveAudio8JobFields(source, where);
+    if (!parler && !audio8) return undefined;
+    return { ...(parler ?? {}), ...(audio8 ?? {}) };
   }
 
   getEngineType(): EngineType {
@@ -1542,7 +1831,7 @@ class TTSGgml {
             "run with streamOutput: non-empty string `input` is required",
         });
       }
-      const parlerFields = this._resolveParlerJobFields(input, "run");
+      const jobFields = this._resolveJobFields(input, "run");
       const runStream = () =>
         this._runStreamOrchestrator(
           input.input,
@@ -1550,7 +1839,7 @@ class TTSGgml {
             locale: input.locale,
             maxChunkScalars: input.maxChunkScalars,
           },
-          parlerFields,
+          jobFields,
         );
       return this.exclusiveRun
         ? this._enqueueExclusiveTtsResponse(runStream)
@@ -1577,6 +1866,7 @@ class TTSGgml {
       locale: normalized.locale,
       maxChunkScalars: normalized.maxChunkScalars,
       ...(pickParlerDescFields(normalized) ?? {}),
+      ...(pickAudio8VoiceFields(normalized) ?? {}),
     });
   }
 
@@ -1593,7 +1883,7 @@ class TTSGgml {
   ): Promise<
     QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta>
   > {
-    const parlerFields = this._resolveParlerJobFields(
+    const jobFields = this._resolveJobFields(
       options,
       "runStreaming",
     );
@@ -1613,7 +1903,7 @@ class TTSGgml {
       });
     }
     const runStream = () =>
-      this._runTextStreamOrchestrator(normalized, parlerFields);
+      this._runTextStreamOrchestrator(normalized, jobFields);
     return this.exclusiveRun
       ? this._enqueueExclusiveTtsResponse(runStream)
       : runStream();
@@ -1736,7 +2026,7 @@ class TTSGgml {
 
   private _runTextStreamOrchestrator(
     source: AsyncIterable<string>,
-    parlerFields?: ParlerDescFields,
+    jobFields?: JobFields,
   ): QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta> {
     const response = this._job.start() as QvacResponse<
       TTSOutputChunk & SentenceStreamChunkMeta
@@ -1748,7 +2038,7 @@ class TTSGgml {
       chunkIdx: 0,
       acc: { totalTime: 0, audioDurationMs: 0, totalSamples: 0 },
       chunkResolver: null,
-      parlerFields,
+      jobFields,
     };
     void this._sentenceStreamTextIterableDrive().catch(
       (error: unknown) => {
@@ -1781,7 +2071,7 @@ class TTSGgml {
         await this._requireAddon().runJob({
           type: "text",
           input: text,
-          ...(context.parlerFields ?? {}),
+          ...(context.jobFields ?? {}),
         });
         await done;
       }
@@ -1815,7 +2105,7 @@ class TTSGgml {
   private _runStreamOrchestrator(
     text: string,
     options: SentenceStreamOptions,
-    parlerFields?: ParlerDescFields,
+    jobFields?: JobFields,
   ): QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta> {
     const chunks = splitTtsText(String(text), {
       language: this._config.language,
@@ -1836,7 +2126,7 @@ class TTSGgml {
       chunkIdx: 0,
       acc: { totalTime: 0, audioDurationMs: 0, totalSamples: 0 },
       chunkResolver: null,
-      parlerFields,
+      jobFields,
     };
     void this._sentenceStreamDriveBody().catch((error: unknown) => {
       this._rejectActiveChunk(error);
@@ -1857,7 +2147,7 @@ class TTSGgml {
       await this._requireAddon().runJob({
         type: "text",
         input: context.chunks[index],
-        ...(context.parlerFields ?? {}),
+        ...(context.jobFields ?? {}),
       });
       await done;
     }
@@ -1894,6 +2184,9 @@ class TTSGgml {
     }
     if (this._engineType === ENGINE_PARLER) {
       return this._buildParlerParams();
+    }
+    if (this._engineType === ENGINE_AUDIO8) {
+      return this._buildAudio8Params();
     }
     return this._buildChatterboxParams();
   }
@@ -2041,16 +2334,7 @@ class TTSGgml {
     if (this._quality != null) {
       parameters.quality = String(this._quality);
     }
-    if (this._seed != null) parameters.seed = this._seed | 0;
-    if (this._threads != null) parameters.threads = this._threads | 0;
-    if (this._temperature != null) {
-      parameters.temperature = Number(this._temperature);
-    }
-    if (this._topK != null) parameters.topK = this._topK | 0;
-    if (this._topP != null) parameters.topP = Number(this._topP);
-    if (this._maxFrames != null) {
-      parameters.maxFrames = this._maxFrames | 0;
-    }
+    this._assignSamplingParams(parameters);
     if (this._minNewTokens != null) {
       parameters.minNewTokens = this._minNewTokens | 0;
     }
@@ -2061,11 +2345,68 @@ class TTSGgml {
       parameters.streamFirstChunkTokens =
         this._streamFirstChunkTokens | 0;
     }
-    if (this._outputSampleRate != null) {
-      parameters.outputSampleRate = this._outputSampleRate | 0;
-    }
     if (this._normalizeNumbers != null) {
       parameters.normalizeNumbers = !!this._normalizeNumbers;
+    }
+    this._assignBackendParams(parameters);
+    return parameters;
+  }
+
+  private _buildAudio8Params(): TTSConfigurationParams {
+    // Re-checked here (not only in the constructor) so reload({...}) cannot
+    // smuggle in a half-specified voice.
+    this._assertAudio8VoiceConsistent(
+      {
+        referenceAudio: this._referenceAudio,
+        referenceText: this._referenceText,
+      },
+      "reload",
+    );
+    const parameters: TTSConfigurationParams = {
+      engineType: ENGINE_AUDIO8,
+      audio8LmPath: this._audio8LmPath || "",
+      audio8CodecDecoderPath: this._audio8CodecDecoderPath || "",
+    };
+    if (this._audio8CodecEncoderPath) {
+      parameters.audio8CodecEncoderPath = this._audio8CodecEncoderPath;
+    }
+    if (this._referenceAudio != null) {
+      parameters.referenceAudio = this._referenceAudio;
+    }
+    if (this._referenceText != null) {
+      parameters.referenceText = this._referenceText;
+    }
+    if (this._greedy != null) parameters.greedy = !!this._greedy;
+    this._assignSamplingParams(parameters);
+    this._assignBackendParams(parameters);
+    return parameters;
+  }
+
+  /** The knobs every engine in SAMPLING_ENGINES reads. */
+  private _assignSamplingParams(
+    parameters: TTSConfigurationParams,
+  ): void {
+    if (this._temperature != null) {
+      parameters.temperature = Number(this._temperature);
+    }
+    if (this._topK != null) parameters.topK = this._topK | 0;
+    if (this._topP != null) parameters.topP = Number(this._topP);
+    if (this._maxFrames != null) {
+      parameters.maxFrames = this._maxFrames | 0;
+    }
+  }
+
+  /**
+   * Backend and output plumbing for the engines that take no `language`,
+   * where `_assignCommonNativeParams` would be the wrong shape.
+   */
+  private _assignBackendParams(
+    parameters: TTSConfigurationParams,
+  ): void {
+    if (this._seed != null) parameters.seed = this._seed | 0;
+    if (this._threads != null) parameters.threads = this._threads | 0;
+    if (this._outputSampleRate != null) {
+      parameters.outputSampleRate = this._outputSampleRate | 0;
     }
     if (this._nGpuLayers != null) {
       parameters.nGpuLayers = this._nGpuLayers | 0;
@@ -2077,7 +2418,6 @@ class TTSGgml {
     if (this._backendsDir) {
       parameters.backendsDir = this._backendsDir;
     }
-    return parameters;
   }
 
   private _assignCommonNativeParams(
@@ -2139,7 +2479,7 @@ class TTSGgml {
   private async _runInternal(
     input: TTSRunInput,
   ): Promise<QvacResponse<TTSOutputChunk>> {
-    const parlerFields = this._resolveParlerJobFields(input, "run");
+    const jobFields = this._resolveJobFields(input, "run");
     const response = this._job.start({
       signal: input?.signal,
     }) as QvacResponse<TTSOutputChunk>;
@@ -2148,7 +2488,7 @@ class TTSGgml {
       await this._requireAddon().runJob({
         type: input.type || "text",
         input: input.input,
-        ...(parlerFields ?? {}),
+        ...(jobFields ?? {}),
       });
     } catch (error) {
       this._job.fail(normalizeError(error));
@@ -2313,6 +2653,7 @@ class TTSGgml {
     if (runtimeConfig.outputSampleRate !== undefined) {
       this._outputSampleRate = runtimeConfig.outputSampleRate;
     }
+    this._applyAudio8Reload(newConfig);
     // Parler description/template + sampling knobs are reloadable; they rebuild
     // the engine's default description / sampler. _buildParlerParams re-validates
     // so a wrong-engine reload still throws.
@@ -2391,6 +2732,41 @@ class TTSGgml {
       this._addonOutputCallback.bind(this),
     );
     await this._requireAddon().activate();
+  }
+
+  /**
+   * Audio8 voice + sampling knobs are reloadable; they rebuild the engine's
+   * sampler and speaker history. _buildAudio8Params re-validates, so a
+   * half-specified voice still throws.
+   */
+  private _applyAudio8Reload(newConfig: Record<string, unknown>): void {
+    if (this._engineType !== ENGINE_AUDIO8) return;
+    const config = newConfig as Audio8VoiceFields & {
+      greedy?: boolean;
+      temperature?: number;
+      topK?: number;
+      topP?: number;
+      maxFrames?: number;
+      seed?: number;
+      threads?: number;
+    };
+    if (config.referenceAudio !== undefined) {
+      this._referenceAudio = config.referenceAudio;
+    }
+    if (config.referenceText !== undefined) {
+      this._referenceText = config.referenceText;
+    }
+    if (config.greedy !== undefined) this._greedy = config.greedy;
+    if (config.temperature !== undefined) {
+      this._temperature = config.temperature;
+    }
+    if (config.topK !== undefined) this._topK = config.topK;
+    if (config.topP !== undefined) this._topP = config.topP;
+    if (config.maxFrames !== undefined) {
+      this._maxFrames = config.maxFrames;
+    }
+    if (config.seed !== undefined) this._seed = config.seed;
+    if (config.threads !== undefined) this._threads = config.threads;
   }
 
   static getModelKey(_params?: unknown): string {

--- a/packages/tts-ggml/src/tts.ts
+++ b/packages/tts-ggml/src/tts.ts
@@ -22,6 +22,10 @@ export interface TTSJobData {
   noise?: string;
   reverb?: string;
   quality?: string;
+  // Audio8 per-call voice cloning (siblings of `input`), read by
+  // JSAdapter::readAudio8Voice. Ignored by other engines.
+  referenceAudio?: string;
+  referenceText?: string;
 }
 
 export interface TTSWeightData {

--- a/packages/tts-ggml/test/unit/audio8.inference.test.js
+++ b/packages/tts-ggml/test/unit/audio8.inference.test.js
@@ -1,0 +1,362 @@
+'use strict'
+
+const test = require('brittle')
+const path = require('bare-path')
+const TTSGgml = require('../../index.js')
+const { TTSInterface } = require('../../tts.js')
+const MockedBinding = require('../mock/MockedBinding.js')
+const process = require('bare-process')
+
+global.process = process
+
+const LM = './models/audio8-lm-q8_0.gguf'
+const DECODER = './models/audio8-codec-decoder-q8_0.gguf'
+const ENCODER = './models/audio8-codec-encoder-q8_0.gguf'
+
+/** MockedBinding that records every runJob payload (per-call field checks). */
+class RecordingBinding extends MockedBinding {
+  constructor(opts) {
+    super(opts)
+    this.jobs = []
+  }
+
+  runJob(handle, data) {
+    this.jobs.push(data)
+    return super.runJob(handle, data)
+  }
+}
+
+function createMockedAudio8Model({
+  onOutput = () => {},
+  binding,
+  files,
+  exclusiveRun = false,
+  extra = {}
+} = {}) {
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_AUDIO8,
+    files: files || { audio8Lm: LM, audio8CodecDecoder: DECODER },
+    opts: { stats: true },
+    exclusiveRun,
+    ...extra
+  })
+
+  model._createAddon = (configurationParams, outputCb) => {
+    const _binding = binding || new MockedBinding()
+    const addon = new TTSInterface(_binding, configurationParams, outputCb)
+    if (_binding.setBaseInferenceCallback) {
+      _binding.setBaseInferenceCallback(onOutput)
+    }
+    return addon
+  }
+  return model
+}
+
+function withTempDir(name, body) {
+  const fs = require('bare-fs')
+  const os = require('bare-os')
+  const root = path.join(os.tmpdir(), `${name}-${Date.now()}`)
+  fs.mkdirSync(root, { recursive: true })
+  try {
+    return body(root, fs)
+  } finally {
+    try {
+      fs.rmSync(root, { recursive: true, force: true })
+    } catch (_e) {}
+  }
+}
+
+test('Audio8: explicit engine option routes to audio8', (t) => {
+  const model = createMockedAudio8Model()
+  t.is(model.getEngineType(), TTSGgml.ENGINE_AUDIO8, 'engine: audio8 detected')
+  t.is(model._audio8LmPath, LM)
+  t.is(model._audio8CodecDecoderPath, DECODER)
+  t.absent(model._t3ModelPath, 'no t3 path on audio8')
+  t.absent(model._parlerModelPath, 'no parler path on audio8')
+  t.absent(model._supertonicModelPath, 'no supertonic path on audio8')
+})
+
+test('Audio8: audio8Lm file path alone routes to audio8', (t) => {
+  const model = new TTSGgml({ files: { audio8Lm: LM } })
+  t.is(model.getEngineType(), TTSGgml.ENGINE_AUDIO8, 'audio8Lm file detected')
+})
+
+test('Audio8: modelDir auto-detect picks each half at the best quant tier', (t) => {
+  withTempDir('tts-ggml-audio8-detect', (root, fs) => {
+    fs.writeFileSync(path.join(root, 'audio8-lm-f32.gguf'), 'lm-f32')
+    fs.writeFileSync(path.join(root, 'audio8-lm-q8_0.gguf'), 'lm-q8')
+    fs.writeFileSync(path.join(root, 'audio8-codec-decoder-f16.gguf'), 'dec-f16')
+    fs.writeFileSync(path.join(root, 'audio8-codec-encoder-q8_0.gguf'), 'enc-q8')
+
+    const model = new TTSGgml({ files: { modelDir: root } })
+    t.is(model.getEngineType(), TTSGgml.ENGINE_AUDIO8, 'modelDir with audio8 GGUFs detected')
+    t.is(model._audio8LmPath, path.join(root, 'audio8-lm-q8_0.gguf'), 'q8_0 beats f32')
+    t.is(
+      model._audio8CodecDecoderPath,
+      path.join(root, 'audio8-codec-decoder-f16.gguf'),
+      'the only decoder tier present is used'
+    )
+    t.is(
+      model._audio8CodecEncoderPath,
+      path.join(root, 'audio8-codec-encoder-q8_0.gguf'),
+      'the encoder is picked up when present'
+    )
+  })
+})
+
+test('Audio8: existing engines keep precedence in a shared modelDir', (t) => {
+  withTempDir('tts-ggml-audio8-precedence', (root, fs) => {
+    fs.writeFileSync(path.join(root, 'supertonic.gguf'), 'super-marker')
+    fs.writeFileSync(path.join(root, 'audio8-lm-q8_0.gguf'), 'audio8-marker')
+
+    const model = new TTSGgml({ files: { modelDir: root } })
+    t.is(model.getEngineType(), TTSGgml.ENGINE_SUPERTONIC, 'supertonic still wins')
+  })
+})
+
+test('Audio8: ttsParams shape forwards the full config surface', (t) => {
+  const model = createMockedAudio8Model({
+    files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER },
+    extra: {
+      referenceAudio: '/abs/voice.wav',
+      referenceText: 'What the recording says.',
+      greedy: false,
+      seed: 7,
+      threads: 2,
+      temperature: 0.8,
+      topK: 40,
+      topP: 0.95,
+      maxFrames: 256,
+      config: { outputSampleRate: 16000 }
+    }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.engineType, TTSGgml.ENGINE_AUDIO8)
+  t.is(params.audio8LmPath, LM)
+  t.is(params.audio8CodecDecoderPath, DECODER)
+  t.is(params.audio8CodecEncoderPath, ENCODER)
+  t.is(params.referenceAudio, '/abs/voice.wav')
+  t.is(params.referenceText, 'What the recording says.')
+  t.is(params.greedy, false)
+  t.is(params.seed, 7)
+  t.is(params.threads, 2)
+  t.is(params.temperature, 0.8)
+  t.is(params.topK, 40)
+  t.is(params.topP, 0.95)
+  t.is(params.maxFrames, 256)
+  t.is(params.outputSampleRate, 16000)
+  t.is(params.useGPU, false, 'useGPU defaults to false (opt-in) and forwards')
+  t.absent(params.language, 'no language key (audio8 reads it from the prompt)')
+})
+
+test('Audio8: a text-only config omits the encoder and the voice', (t) => {
+  const params = createMockedAudio8Model()._buildTtsParams()
+  t.absent(params.audio8CodecEncoderPath, 'no encoder key when none is configured')
+  t.absent(params.referenceAudio, 'no reference audio key')
+  t.absent(params.referenceText, 'no reference text key')
+})
+
+test('Audio8: constructor guards reject a half-specified voice', (t) => {
+  t.exception(
+    () =>
+      createMockedAudio8Model({
+        files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER },
+        extra: { referenceAudio: '/abs/voice.wav' }
+      }),
+    /referenceAudio needs a referenceText/,
+    'a recording without its transcript throws'
+  )
+  t.exception(
+    () => createMockedAudio8Model({ extra: { referenceText: 'Orphan transcript.' } }),
+    /referenceText needs a referenceAudio/,
+    'a transcript with nothing to attach to throws'
+  )
+  t.exception(
+    () =>
+      createMockedAudio8Model({
+        extra: { referenceAudio: '/abs/voice.wav', referenceText: 'Says this.' }
+      }),
+    /codec encoder/,
+    'cloning without the encoder GGUF throws'
+  )
+})
+
+test('Audio8: constructor rejects unsupported companions', (t) => {
+  t.exception(
+    () =>
+      createMockedAudio8Model({
+        files: { audio8Lm: LM, audio8CodecDecoder: DECODER, lavasrEnhancer: '/abs/enh.gguf' }
+      }),
+    /not supported with the audio8 engine/,
+    'enhancer throws'
+  )
+  t.exception(
+    () => createMockedAudio8Model({ extra: { streamChunkTokens: 40 } }),
+    /not supported by the audio8 engine/,
+    'native chunk streaming throws'
+  )
+})
+
+test('Audio8: audio8-only options on other engines throw', (t) => {
+  t.exception(
+    () =>
+      new TTSGgml({
+        engine: TTSGgml.ENGINE_SUPERTONIC,
+        files: { supertonicModel: './models/supertonic.gguf' },
+        referenceText: 'Says this.'
+      }),
+    /audio8-only/,
+    'referenceText on supertonic throws'
+  )
+  t.exception(
+    () =>
+      new TTSGgml({
+        engine: TTSGgml.ENGINE_CHATTERBOX,
+        files: { t3Model: './models/t3.gguf', s3genModel: './models/s3gen.gguf' },
+        greedy: true
+      }),
+    /audio8-only/,
+    'greedy on chatterbox throws'
+  )
+})
+
+test('Audio8: GPU options forward to params', (t) => {
+  const gpu = createMockedAudio8Model({ extra: { config: { useGPU: true } } })
+  t.is(gpu._buildTtsParams().useGPU, true, 'useGPU:true forwards to params')
+
+  const layers = createMockedAudio8Model({ extra: { nGpuLayers: 99 } })
+  t.is(layers._buildTtsParams().nGpuLayers, 99, 'nGpuLayers forwards to params')
+
+  t.exception(
+    () => createMockedAudio8Model({ extra: { config: { useGPU: false }, nGpuLayers: 99 } }),
+    /conflicts/,
+    'useGPU:false + nGpuLayers:99 conflict rejects'
+  )
+})
+
+test('Audio8: per-call voice fields land on the jobData', async (t) => {
+  const binding = new RecordingBinding()
+  const model = createMockedAudio8Model({
+    binding,
+    files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER },
+    extra: {
+      referenceAudio: '/abs/configured.wav',
+      referenceText: 'The configured transcript.'
+    }
+  })
+  await model.load()
+
+  const r1 = await model.run({
+    type: 'text',
+    input: 'A different speaker.',
+    referenceAudio: '/abs/other.wav',
+    referenceText: 'What the other recording says.'
+  })
+  await r1.await()
+  t.is(binding.jobs.length, 1, 'one job ran')
+  t.is(binding.jobs[0].referenceAudio, '/abs/other.wav', 'per-call audio rides on jobData')
+  t.is(binding.jobs[0].referenceText, 'What the other recording says.')
+
+  const r2 = await model.run({
+    type: 'text',
+    input: 'Same speaker, corrected transcript.',
+    referenceText: 'A corrected transcript.'
+  })
+  await r2.await()
+  t.is(binding.jobs[1].referenceText, 'A corrected transcript.')
+  t.absent(binding.jobs[1].referenceAudio, 'the configured recording is not re-sent')
+
+  const r3 = await model.run({ type: 'text', input: 'Plain run.' })
+  await r3.await()
+  t.absent(binding.jobs[2].referenceAudio, 'no leftover fields on a plain run')
+  t.absent(binding.jobs[2].referenceText, 'no leftover transcript on a plain run')
+
+  await model.unload()
+})
+
+test('Audio8: a per-call recording without a transcript rejects before queueing', async (t) => {
+  const binding = new RecordingBinding()
+  const model = createMockedAudio8Model({
+    binding,
+    files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER }
+  })
+  await model.load()
+
+  await t.exception(
+    model.run({ type: 'text', input: 'x', referenceAudio: '/abs/voice.wav' }),
+    /referenceAudio needs a referenceText/,
+    'per-call half-specified voice rejects'
+  )
+  t.is(binding.jobs.length, 0, 'no job queued on conflict')
+  await model.unload()
+})
+
+test('Audio8: per-call voice fields on other engines throw', async (t) => {
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_SUPERTONIC,
+    files: { supertonicModel: './models/supertonic.gguf' },
+    voice: 'F1',
+    config: { language: 'en', useGPU: false }
+  })
+  model._createAddon = (configurationParams, outputCb) =>
+    new TTSInterface(new MockedBinding(), configurationParams, outputCb)
+  await model.load()
+  await t.exception(
+    model.run({ type: 'text', input: 'x', referenceText: 'Says this.' }),
+    /audio8-only/,
+    'per-call referenceText on supertonic rejects'
+  )
+  await model.unload()
+})
+
+test('Audio8: runStream pins the per-call voice on every chunk jobData', async (t) => {
+  const binding = new RecordingBinding()
+  const model = createMockedAudio8Model({
+    binding,
+    files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER }
+  })
+  await model.load()
+
+  const text = 'First chunk sentence. Second chunk sentence.'
+  const r = await model.runStream(text, {
+    maxChunkScalars: 20,
+    referenceAudio: '/abs/voice.wav',
+    referenceText: 'What the recording says.'
+  })
+  await r.onUpdate(() => {}).await()
+
+  t.ok(binding.jobs.length >= 2, `stream ran multiple jobs (got ${binding.jobs.length})`)
+  for (const job of binding.jobs) {
+    t.is(job.referenceAudio, '/abs/voice.wav', 'every chunk carries the pinned recording')
+    t.is(job.referenceText, 'What the recording says.', 'and its transcript')
+  }
+  await model.unload()
+})
+
+test('Audio8: reload merges the voice and the sampling knobs', async (t) => {
+  const model = createMockedAudio8Model({
+    files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER },
+    extra: { temperature: 0.7, maxFrames: 128 }
+  })
+  await model.load()
+
+  await model.reload({
+    temperature: 0.9,
+    maxFrames: 256,
+    greedy: false,
+    referenceAudio: '/abs/voice.wav',
+    referenceText: 'What the recording says.'
+  })
+  const params = model._buildTtsParams()
+  t.is(params.temperature, 0.9, 'reload updates temperature')
+  t.is(params.maxFrames, 256, 'reload updates maxFrames')
+  t.is(params.referenceAudio, '/abs/voice.wav', 'reload enrols a voice')
+  t.is(params.referenceText, 'What the recording says.')
+
+  await t.exception(
+    model.reload({ referenceText: '' }),
+    /referenceText/,
+    'reload cannot drop half of the voice'
+  )
+  await model.unload()
+})

--- a/packages/tts-ggml/test/unit/audio8.inference.test.js
+++ b/packages/tts-ggml/test/unit/audio8.inference.test.js
@@ -291,6 +291,31 @@ test('Audio8: a per-call recording without a transcript rejects before queueing'
   await model.unload()
 })
 
+test('Audio8: a per-call recording cannot inherit the configured transcript', async (t) => {
+  const binding = new RecordingBinding()
+  const model = createMockedAudio8Model({
+    binding,
+    files: { audio8Lm: LM, audio8CodecDecoder: DECODER, audio8CodecEncoder: ENCODER },
+    extra: {
+      referenceAudio: '/abs/configured.wav',
+      referenceText: 'The configured transcript.'
+    }
+  })
+  await model.load()
+
+  // The configured transcript describes the configured recording, so it cannot
+  // stand in for a different one. The native resolveVoice drops it for exactly
+  // this reason; rejecting here keeps the two layers agreeing.
+  await t.exception(
+    model.run({ type: 'text', input: 'x', referenceAudio: '/abs/other.wav' }),
+    /referenceAudio needs a referenceText/,
+    'a new recording without its own transcript rejects'
+  )
+  t.is(binding.jobs.length, 0, 'no job queued on conflict')
+
+  await model.unload()
+})
+
 test('Audio8: per-call voice fields on other engines throw', async (t) => {
   const model = new TTSGgml({
     engine: TTSGgml.ENGINE_SUPERTONIC,

--- a/packages/tts-ggml/test/unit/parler.inference.test.js
+++ b/packages/tts-ggml/test/unit/parler.inference.test.js
@@ -65,7 +65,7 @@ test('Parler: parlerModel file path alone routes to parler engine', (t) => {
 test('Parler: invalid engine error message lists parler', (t) => {
   t.exception(
     () => new TTSGgml({ engine: 'parakeet' }),
-    /'chatterbox', 'supertonic', 'cosyvoice3' or 'parler'/,
+    /'chatterbox', 'supertonic', 'cosyvoice3', 'parler' or 'audio8'/,
     'engine validation message includes parler'
   )
 })
@@ -288,8 +288,8 @@ test('Parler: parler-only options on other engines throw', (t) => {
         files: { t3Model: './models/t3.gguf', s3genModel: './models/s3gen.gguf' },
         temperature: 0.8
       }),
-    /parler-only/,
-    'temperature on chatterbox throws'
+    /parler\/audio8-only/,
+    'temperature on chatterbox throws (audio8 samples too, so it is shared)'
   )
 })
 

--- a/packages/tts-ggml/tts.d.ts
+++ b/packages/tts-ggml/tts.d.ts
@@ -14,6 +14,8 @@ export interface TTSJobData {
     noise?: string;
     reverb?: string;
     quality?: string;
+    referenceAudio?: string;
+    referenceText?: string;
 }
 export interface TTSWeightData {
     filename: string;

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-08-06"
+      "version>=": "2026-08-07#1"
     }
   ],
   "features": {


### PR DESCRIPTION
## What problem does this PR solve?

`@qvac/tts-ggml` wrapped four engine families; Audio8 was not one of them. Audio8
is a DualAR zero-shot model (24-layer semantic transformer + 4-layer acoustic
head over 8 codebooks, DAC-style codec, native 44.1 kHz) whose selling point is
voice cloning from a plain reference wav, with no enrolment step and no baked
profile.

The engine landed in `tts-cpp`
([qvac-ext-lib-whisper.cpp#128](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/128))
and was published as `2026-08-07#1`
([qvac-registry-vcpkg#291](https://github.com/tetherto/qvac-registry-vcpkg/pull/291)).
This PR exposes it through the JS surface.

## How does it solve it?

- **Engine wiring.** `EngineType::Audio8` + `Audio8Model` / `Audio8Config` in the
  addon, routed through `JSAdapter` like the other engines. Construction, `run`,
  and `reload` all take the Audio8 path.
- **Detection.** `engine: 'audio8'`, or `files.audio8Lm` /
  `files.audio8CodecDecoder`, or a `modelDir` holding `audio8-lm[-<quant>].gguf`
  (q8_0 > f16 > q4_0 > f32 within a role).
- **Three GGUFs, not one**, because their lifetimes differ: the language model
  and the codec's synthesis half are needed for every synthesis, the codec's
  analysis half only to enrol a voice, so a text-only deployment omits
  `files.audio8CodecEncoder` entirely.
- **Cloning in-process.** `referenceAudio` + `referenceText` at construction, on
  `reload()`, or per call. The transcript is required, not optional: the model
  conditions on it as the turn the recording answers, and a missing one degrades
  the clone silently. Codes for the most recent reference are cached, so
  repeating a reference across calls skips the encoder.
- **Sampling knobs.** `temperature` / `topK` / `topP` / `maxFrames` become
  Parler + Audio8 rather than Parler-only, plus `greedy`, `seed`, `threads` and
  `config.outputSampleRate`.
- **Dependency.** `tts-cpp` `2026-08-06` → `2026-08-07#1`. The registry baseline
  is unchanged: the `version>=` floor resolves the new port on its own, and I
  verified that against the published registry rather than assuming it.

Audio8 is CPU-only in this release, and native chunk streaming is rejected for
it (it synthesises a whole utterance at a time); sentence-level streaming via
`runStream` / `runStreaming` works as it does elsewhere.

## Breaking changes

None. No existing engine changes shape, and the only user-visible wording change
is the `engine` rejection message, which now lists `'audio8'` alongside the
others.

## Test plan

- C++ addon suite: 167 passing (the skips are other engines' real-GGUF tests,
  which need models this machine does not stage), including a real-GGUF Audio8
  text-only synthesis round trip and 21 Audio8 config tests.
- JS unit suite: 51 tests / 222 assertions passing, with a new
  `test/unit/audio8.inference.test.js` covering detection, per-call reference
  fields, and the option guards.
- `lint`, `typecheck`, and `check:generated` clean.
- End to end on linux-x64 against real GGUFs via `examples/audio8-tts.js`, both
  text-only (RTF ~1.4) and cloning from a reference wav (RTF ~3.5).