### PR TITLE
infra[notask]: consolidate 14 on-pr-<pkg>.yml orchestrators into on-pr-nx.yml

### DIFF
--- a/.github/actions/run-mobile-integration-tests/combine-perf-reports/action.yml
+++ b/.github/actions/run-mobile-integration-tests/combine-perf-reports/action.yml
@@ -23,6 +23,10 @@ inputs:
       generated without it, so they keep every row.
     required: false
     default: ''
+  extra-args:
+    description: 'Extra args appended to the combined aggregate.js call (e.g. "--addon-type vision --device-details").'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -61,6 +65,7 @@ runs:
       shell: bash
       env:
         EXCLUDE: ${{ inputs.exclude }}
+        EXTRA_ARGS: ${{ inputs.extra-args }}
       run: |
         if ! find combined-reports -name "performance-report.json" -type f 2>/dev/null | grep -q .; then
           echo "No performance reports found."
@@ -75,12 +80,16 @@ runs:
         if [ -n "$EXCLUDE" ]; then
           EXCLUDE_ARG=(--exclude "$EXCLUDE")
         fi
+        EXTRA_ARGS_ARR=()
+        if [ -n "$EXTRA_ARGS" ]; then
+          read -ra EXTRA_ARGS_ARR <<< "$EXTRA_ARGS"
+        fi
         node scripts/perf-report/aggregate.js \
           --dir combined-reports \
           --output-html combined-output/performance-report-combined.html \
           --output-json combined-output/performance-summary-combined.json \
           --output combined-output/performance-report-combined.md \
-          "${EXCLUDE_ARG[@]}"
+          "${EXCLUDE_ARG[@]}" "${EXTRA_ARGS_ARR[@]}"
 
     - name: Generate per-device HTML reports
       if: always()

--- a/.github/workflows/cpp-tests-nx.yml
+++ b/.github/workflows/cpp-tests-nx.yml
@@ -343,6 +343,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
     secrets: inherit
     with:

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -328,6 +328,20 @@ jobs:
           QVAC_PERF_RUNS: ${{ inputs.qvac_perf_runs }}
           QVAC_PERF_WARMUP_RUNS: ${{ inputs.qvac_perf_warmup_runs }}
 
+      # Stamp the physical-device grouping label from the matrix so the two
+      # ubuntu 22/24 GPU legs collapse into one <platform>-<arch> column in the
+      # combined report. device.gpu (real hardware) is untouched. Set at source
+      # so the shared combine-perf-reports action needs no llm-specific folding.
+      - name: Stamp device grouping label
+        if: ${{ always() && !cancelled() }}
+        working-directory: ${{ env.WORKDIR }}
+        shell: bash
+        run: |
+          f=test/results/performance-report.json
+          if [ -f "$f" ]; then
+            jq --arg name "${{ matrix.platform }}-${{ matrix.arch }}" '.device.name = $name' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+          fi
+
       - name: Generate HTML performance report
         if: ${{ always() && !cancelled() }}
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -186,6 +186,7 @@ jobs:
   # Flag-gated per-package jobs, driven by the on-pr fold map. sanity runs for
   # every affected package; the rest run over their pre-filtered sublist.
   sanity-checks:
+    name: sanity-checks (${{ matrix.package }})
     needs: [authorize, ci-router, matrix]
     if: needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_verified_checks == 'true' && needs.matrix.outputs.any == 'true'
     strategy:
@@ -207,6 +208,7 @@ jobs:
           workdir: ${{ matrix.workdir }}
 
   cpp-lint:
+    name: cpp-lint (${{ matrix.package }})
     needs: [authorize, ci-router, matrix]
     if: needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_verified_checks == 'true' && needs.matrix.outputs.cpplint != '[]'
     strategy:
@@ -222,6 +224,7 @@ jobs:
       include-rocm-sdk: ${{ matrix.includeRocmSdk == true }}
 
   ts-checks:
+    name: ts-checks (${{ matrix.package }})
     needs: [authorize, matrix]
     if: needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.tschecks != '[]'
     strategy:
@@ -253,6 +256,7 @@ jobs:
           workdir: ${{ matrix.workdir }}
 
   fabric-lockstep:
+    name: fabric-lockstep (${{ matrix.package }})
     needs: [authorize, matrix]
     if: needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.fabric != '[]'
     strategy:
@@ -267,6 +271,7 @@ jobs:
         uses: ./.github/actions/verify-qvac-fabric-lockstep
 
   coload-smoke:
+    name: coload-smoke (${{ matrix.package }})
     needs: [authorize, ci-router, matrix, prebuild]
     if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.coload != '[]' && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped')
     permissions:
@@ -285,6 +290,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
 
   coload-smoke-mobile:
+    name: coload-smoke-mobile (${{ matrix.package }})
     needs: [authorize, ci-router, matrix, prebuild]
     if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.coload != '[]' && needs.ci-router.outputs.run_mobile == 'true' && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped')
     permissions:
@@ -309,6 +315,7 @@ jobs:
   # (asr) via its own aggregator. llm perf-report is pending (needs the
   # composite extra-args extension for --addon-type vision).
   perf-report:
+    name: perf-report (${{ matrix.package }})
     needs: [authorize, matrix, run-integration-tests, run-mobile-integration-tests]
     if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.perfcomposite != '[]'
     permissions:
@@ -341,6 +348,7 @@ jobs:
           extra-args: ${{ matrix.perfReportExtraArgs }}
 
   perf-report-rtf:
+    name: perf-report-rtf (${{ matrix.package }})
     needs: [authorize, matrix, run-integration-tests, run-mobile-integration-tests]
     if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.perfrtf != '[]'
     permissions:

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -1,8 +1,4 @@
-# Consolidates the 14 on-pr-<pkg>.yml orchestrators. INTERIM: triggers on
-# pull_request (unprivileged) — the leaves self-affect via nx-set-shas, so no
-# context/sha job and no fork-security overlay yet. Flip to pull_request_target
-# + fork-security once nx lands on main (see plan Part 2). Spine (4a): gates +
-# the 4 self-affecting -nx leaves + merge-guard; flag-gated per-package jobs (4b).
+# Consolidates the 14 on-pr-<pkg>.yml orchestrators.
 name: On PR Trigger (nx)
 
 on:

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -329,6 +329,7 @@ jobs:
           sparse-checkout: |
             .github/actions/run-mobile-integration-tests
             scripts/perf-report
+            ${{ matrix.perfReportMediaDir }}
           sparse-checkout-cone-mode: false
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
@@ -340,6 +341,7 @@ jobs:
           artifact-pattern: ${{ matrix.perfReportPattern }}-${{ github.run_number }}
           report-title: ${{ matrix.perfReportTitle }}
           exclude: ${{ matrix.perfReportExclude }}
+          extra-args: ${{ matrix.perfReportExtraArgs }}
 
   perf-report-rtf:
     needs: [authorize, matrix, run-integration-tests, run-mobile-integration-tests]

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -105,6 +105,8 @@ jobs:
       tschecks: ${{ steps.filter.outputs.tschecks }}
       fabric: ${{ steps.filter.outputs.fabric }}
       coload: ${{ steps.filter.outputs.coload }}
+      perfcomposite: ${{ steps.filter.outputs.perfcomposite }}
+      perfrtf: ${{ steps.filter.outputs.perfrtf }}
     steps:
       - id: compute
         uses: ./.github/actions/nx-project-matrix
@@ -120,6 +122,8 @@ jobs:
             echo "tschecks=$(echo "$M" | jq -c '[.[] | select(.hasTsChecks == true)]')"
             echo "fabric=$(echo "$M" | jq -c '[.[] | select(.hasFabricLockstep == true)]')"
             echo "coload=$(echo "$M" | jq -c '[.[] | select(.hasCoload == true and .coloadActive == true)]')"
+            echo "perfcomposite=$(echo "$M" | jq -c '[.[] | select(.perfReportVariant == "composite" and .perfReportPattern != null)]')"
+            echo "perfrtf=$(echo "$M" | jq -c '[.[] | select(.perfReportVariant == "rtf")]')"
           } >> "$GITHUB_OUTPUT"
 
   # The 4 leaves self-affect from their own project.json targets (and absorb
@@ -302,6 +306,90 @@ jobs:
       addon: ${{ matrix.package }}
       repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+  # Perf reports (informational, not a merge gate). Composite variant
+  # (ocr/diffusion) via the shared combine-perf-reports action; rtf variant
+  # (asr) via its own aggregator. llm perf-report is pending (needs the
+  # composite extra-args extension for --addon-type vision).
+  perf-report:
+    needs: [authorize, matrix, run-integration-tests, run-mobile-integration-tests]
+    if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.perfcomposite != '[]'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.perfcomposite || '[]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo (composites + perf scripts)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions/run-mobile-integration-tests
+            scripts/perf-report
+          sparse-checkout-cone-mode: false
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+      - name: Combine performance reports
+        uses: ./.github/actions/run-mobile-integration-tests/combine-perf-reports
+        with:
+          artifact-pattern: ${{ matrix.perfReportPattern }}-${{ github.run_number }}
+          report-title: ${{ matrix.perfReportTitle }}
+          exclude: ${{ matrix.perfReportExclude }}
+
+  perf-report-rtf:
+    needs: [authorize, matrix, run-integration-tests, run-mobile-integration-tests]
+    if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.perfrtf != '[]'
+    permissions:
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.perfrtf || '[]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+      - name: Download desktop RTF artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          pattern: ${{ matrix.perfReportDesktopPattern }}
+          path: benchmark-artifacts/desktop
+          merge-multiple: false
+      - name: Download mobile performance artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          pattern: ${{ matrix.perfReportMobilePattern }}
+          path: benchmark-artifacts/mobile
+          merge-multiple: false
+      - name: Generate unified performance report
+        run: |
+          node "${{ matrix.perfReportScript }}" \
+            --dir benchmark-artifacts \
+            --manual-dir "${{ matrix.perfReportManualDir }}" \
+            --output "benchmark-artifacts/${{ matrix.perfReportOutputStem }}.md" \
+            --output-json "benchmark-artifacts/${{ matrix.perfReportOutputStem }}.json" \
+            --output-html "benchmark-artifacts/${{ matrix.perfReportOutputStem }}.html"
+      - name: Add unified performance summary
+        run: node -e "process.stdout.write(require('fs').readFileSync('benchmark-artifacts/${{ matrix.perfReportOutputStem }}.md', 'utf8'))" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload unified performance report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: ${{ matrix.perfReportOutputStem }}
+          path: |
+            benchmark-artifacts/${{ matrix.perfReportOutputStem }}.md
+            benchmark-artifacts/${{ matrix.perfReportOutputStem }}.json
+            benchmark-artifacts/${{ matrix.perfReportOutputStem }}.html
+          retention-days: 30
 
   merge-guard:
     needs: [authorize, ci-router, matrix, sanity-checks, cpp-lint, ts-checks, fabric-lockstep, prebuild, cpp-tests, run-integration-tests, run-mobile-integration-tests, coload-smoke, coload-smoke-mobile]

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -1,0 +1,161 @@
+# Consolidates the 14 on-pr-<pkg>.yml orchestrators. INTERIM: triggers on
+# pull_request (unprivileged) — the leaves self-affect via nx-set-shas, so no
+# context/sha job and no fork-security overlay yet. Flip to pull_request_target
+# + fork-security once nx lands on main (see plan Part 2). Spine (4a): gates +
+# the 4 self-affecting -nx leaves + merge-guard; flag-gated per-package jobs (4b).
+name: On PR Trigger (nx)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    branches: [main, release-*, feature-*, tmp-*]
+    paths:
+      - "packages/**"
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Repo to build (owner/name). Defaults to this repo."
+        required: false
+        type: string
+      ref:
+        description: "Git ref (branch/tag/SHA). Defaults to current ref."
+        required: false
+        type: string
+      run_verify:
+        description: "Run all CI stages (prebuild + integration)."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  packages: read
+  checks: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fork-approval:
+    permissions:
+      statuses: write
+    uses: ./.github/workflows/reusable-fork-approval.yml
+
+  ci-router:
+    name: CI Router (label detection)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_verified_checks: ${{ steps.route.outputs.run_verified_checks }}
+      run_prebuilds: ${{ steps.route.outputs.run_prebuilds }}
+      run_cpp_tests: ${{ steps.route.outputs.run_cpp_tests }}
+      run_desktop: ${{ steps.route.outputs.run_desktop }}
+      run_mobile: ${{ steps.route.outputs.run_mobile }}
+    steps:
+      - name: Checkout ci-router composite (default branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/actions/ci-router
+          sparse-checkout-cone-mode: false
+      - name: Route CI stages
+        id: route
+        uses: ./.github/actions/ci-router
+
+  authorize:
+    needs: [fork-approval]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: read
+    outputs:
+      allowed: ${{ steps.auth.outputs.allowed }}
+    steps:
+      - name: Checkout authorize-pr (default branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/actions/authorize-pr
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Authorize
+        id: auth
+        uses: ./.github/actions/authorize-pr
+        with:
+          github-token: ${{ github.token }}
+
+  # The 4 leaves self-affect from their own project.json targets (and absorb
+  # their carve-out packages internally), so on-pr calls them uniformly. On
+  # pull_request the leaves' nx-set-shas computes affected from the PR diff.
+  prebuild:
+    needs: [authorize, ci-router]
+    if: needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_prebuilds == 'true'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/prebuilds-nx.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+  cpp-tests:
+    needs: [authorize, ci-router]
+    if: needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_cpp_tests == 'true'
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
+      actions: read
+      id-token: write
+    uses: ./.github/workflows/cpp-tests-nx.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+  run-integration-tests:
+    needs: [authorize, ci-router, prebuild]
+    if: always() && needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_desktop == 'true' && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    uses: ./.github/workflows/integration-test-nx.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+  run-mobile-integration-tests:
+    needs: [authorize, ci-router, prebuild]
+    if: always() && needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_mobile == 'true' && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/integration-mobile-test-nx.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+  merge-guard:
+    needs: [authorize, ci-router, prebuild, cpp-tests, run-integration-tests, run-mobile-integration-tests]
+    if: always() && !cancelled()
+    uses: ./.github/workflows/public-pr.yml
+    with:
+      sanity-checks-status: ${{ needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped' }}
+      build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}
+      integration-tests-status: ${{ (needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') && (needs.run-mobile-integration-tests.result == 'success' || needs.run-mobile-integration-tests.result == 'skipped') }}

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -104,6 +104,7 @@ jobs:
       perfcomposite: ${{ steps.filter.outputs.perfcomposite }}
       perfrtf: ${{ steps.filter.outputs.perfrtf }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - id: compute
         uses: ./.github/actions/nx-project-matrix
         with:

--- a/.github/workflows/on-pr-nx.yml
+++ b/.github/workflows/on-pr-nx.yml
@@ -91,6 +91,37 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
+  # Affected packages + their on-pr flags (fold map), plus pre-filtered sublists
+  # for the flag-gated jobs (a uses: job can't gate per matrix row, so it runs
+  # over a filtered list). On pull_request nx-set-shas computes affected.
+  matrix:
+    needs: [authorize]
+    if: needs.authorize.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+      any: ${{ steps.compute.outputs.any }}
+      cpplint: ${{ steps.filter.outputs.cpplint }}
+      tschecks: ${{ steps.filter.outputs.tschecks }}
+      fabric: ${{ steps.filter.outputs.fabric }}
+      coload: ${{ steps.filter.outputs.coload }}
+    steps:
+      - id: compute
+        uses: ./.github/actions/nx-project-matrix
+        with:
+          target: on-pr
+      - id: filter
+        shell: bash
+        env:
+          M: ${{ steps.compute.outputs.matrix }}
+        run: |
+          {
+            echo "cpplint=$(echo "$M" | jq -c '[.[] | select(.hasCppLint == true)]')"
+            echo "tschecks=$(echo "$M" | jq -c '[.[] | select(.hasTsChecks == true)]')"
+            echo "fabric=$(echo "$M" | jq -c '[.[] | select(.hasFabricLockstep == true)]')"
+            echo "coload=$(echo "$M" | jq -c '[.[] | select(.hasCoload == true and .coloadActive == true)]')"
+          } >> "$GITHUB_OUTPUT"
+
   # The 4 leaves self-affect from their own project.json targets (and absorb
   # their carve-out packages internally), so on-pr calls them uniformly. On
   # pull_request the leaves' nx-set-shas computes affected from the PR diff.
@@ -151,11 +182,132 @@ jobs:
       repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
 
+  # Flag-gated per-package jobs, driven by the on-pr fold map. sanity runs for
+  # every affected package; the rest run over their pre-filtered sublist.
+  sanity-checks:
+    needs: [authorize, ci-router, matrix]
+    if: needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_verified_checks == 'true' && needs.matrix.outputs.any == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.matrix || '[]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+      - name: Run Sanity checks
+        uses: ./.github/actions/sanity-checks
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          pat-token: ${{ secrets.PAT_TOKEN }}
+          run-integration: ${{ needs.authorize.outputs.allowed == 'true' }}
+          workdir: ${{ matrix.workdir }}
+
+  cpp-lint:
+    needs: [authorize, ci-router, matrix]
+    if: needs.authorize.outputs.allowed == 'true' && needs.ci-router.outputs.run_verified_checks == 'true' && needs.matrix.outputs.cpplint != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.cpplint || '[]') }}
+    uses: ./.github/workflows/cpp-lint.yaml
+    secrets: inherit
+    with:
+      sha: ${{ github.event.pull_request.base.sha }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      workdir: ${{ matrix.workdir }}
+      include-rocm-sdk: ${{ matrix.includeRocmSdk == true }}
+
+  ts-checks:
+    needs: [authorize, matrix]
+    if: needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.tschecks != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.tschecks || '[]') }}
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 20
+      - name: Install dependencies
+        working-directory: ${{ matrix.workdir }}
+        run: npm install
+      - name: Type declaration check
+        working-directory: ${{ matrix.workdir }}
+        run: npm run test:dts
+      - name: Run lint and unit tests
+        if: matrix.tsChecksMode == 'dts+lint'
+        uses: ./.github/actions/run-lint-and-unit-tests
+        with:
+          gpr-token: ${{ secrets.GITHUB_TOKEN }}
+          pat-token: ${{ secrets.GITHUB_TOKEN }}
+          registry-type: gpr
+          workdir: ${{ matrix.workdir }}
+
+  fabric-lockstep:
+    needs: [authorize, matrix]
+    if: needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.fabric != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.fabric || '[]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+      - name: Verify qvac-fabric versions are lockstep
+        uses: ./.github/actions/verify-qvac-fabric-lockstep
+
+  coload-smoke:
+    needs: [authorize, ci-router, matrix, prebuild]
+    if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.coload != '[]' && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.coload || '[]') }}
+    uses: ./.github/workflows/coload-smoke.yml
+    secrets: inherit
+    with:
+      addon: ${{ matrix.package }}
+      repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
+  coload-smoke-mobile:
+    needs: [authorize, ci-router, matrix, prebuild]
+    if: always() && needs.authorize.outputs.allowed == 'true' && needs.matrix.outputs.coload != '[]' && needs.ci-router.outputs.run_mobile == 'true' && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped')
+    permissions:
+      actions: read
+      id-token: write
+      contents: read
+      pull-requests: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.coload || '[]') }}
+    uses: ./.github/workflows/coload-smoke-mobile.yml
+    secrets: inherit
+    with:
+      addon: ${{ matrix.package }}
+      repository: ${{ github.event.pull_request.head.repo.full_name || inputs.repository || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}
+
   merge-guard:
-    needs: [authorize, ci-router, prebuild, cpp-tests, run-integration-tests, run-mobile-integration-tests]
+    needs: [authorize, ci-router, matrix, sanity-checks, cpp-lint, ts-checks, fabric-lockstep, prebuild, cpp-tests, run-integration-tests, run-mobile-integration-tests, coload-smoke, coload-smoke-mobile]
     if: always() && !cancelled()
     uses: ./.github/workflows/public-pr.yml
     with:
-      sanity-checks-status: ${{ needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped' }}
+      sanity-checks-status: ${{ (needs.sanity-checks.result == 'success' || needs.sanity-checks.result == 'skipped') && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.ts-checks.result == 'success' || needs.ts-checks.result == 'skipped') && (needs.fabric-lockstep.result == 'success' || needs.fabric-lockstep.result == 'skipped') && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}
       integration-tests-status: ${{ (needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') && (needs.run-mobile-integration-tests.result == 'success' || needs.run-mobile-integration-tests.result == 'skipped') }}


### PR DESCRIPTION
## Summary
- Consolidates all 14 addon `on-pr-<pkg>.yml` PR pipelines into one config-driven `on-pr-nx.yml`, following the same `project.json` options.ci pattern as the 5 already-merged `-nx.yml` leaves.
- Gates (fork-approval/ci-router/authorize) + `nx-project-matrix` (`on-pr` target, fold-map flags) + the 4 uniform leaf calls (prebuild/cpp-tests/integration/mobile) + flag-gated per-package jobs (sanity-checks, cpp-lint incl. ROCm, ts-checks, fabric-lockstep, coload-smoke, perf-report) + merge-guard.
- Carve-out packages (llm-llamacpp, audiogen-ggml, translation-nmtcpp, asr-ggml) are routed to their bespoke reusables from *inside* each leaf via a new `carveouts` output on `nx-project-matrix` — the parent stays uniform, no per-package special-casing.
- Perf-report folded for all 4 packages that have it: ocr-ggml + diffusion-cpp + llm-llamacpp via the shared `combine-perf-reports` composite (extended with an optional `extra-args` input for llm's `--addon-type vision`), asr-ggml via its own RTF aggregator.
- Interim trigger is `pull_request` (not `pull_request_target`) + `workflow_dispatch` — fork-security overlay and the `pull_request_target` flip are deferred until `nx.json`/`project.json`/the `-nx` leaves land on `main` (the default branch currently has none of this, so base-branch sparse-checkout/`git show base:` reads would resolve to nothing).
- Additive only — no legacy `on-pr-<pkg>.yml` deleted this pass.

## Test plan
- [x] JSON-validated all edited `project.json` files
- [x] `nx-project-matrix` `on-pr` target parity-simmed against the real 14-package fold map (flags match)
- [x] Carve-out partition sim: generic matrices unchanged for cpp-tests (7 pkgs/17 rows), integration-test (10 pkgs/65 rows), mobile (11 pkgs) — carve-outs cleanly separated
- [x] `actionlint` clean on `on-pr-nx.yml` and all touched leaf/action files (only pre-existing `[shellcheck]` findings tolerated)
- [x] `act -n` dry-run resolves the gate chain, `matrix`, `ci-router`, and `perf-report`/`perf-report-rtf` jobs
- [ ] Live dispatch/PR test on a feature branch (pending — see interim-trigger note above)
- [ ] Fork-PR verification of the eventual `pull_request_target` fork-security path (Part 2, deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)