### PR TITLE
infra[notask]: consolidate 13 on-pr-close-<pkg>.yml into on-pr-close.yml

### DIFF
--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -1,0 +1,54 @@
+# Consolidates the 13 on-pr-close-<pkg>.yml files (ephemeral GPR pr-<n> version cleanup).
+name: On PR Close (cleanup)
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - "packages/**"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Specific version to target for deletion"
+        required: false
+        type: string
+      pr-number:
+        description: "PR number to target for deletion"
+        required: false
+        type: string
+      pattern:
+        description: "Pattern to target for deletion"
+        required: false
+        type: string
+      packages:
+        description: "Packages to target for deletion, space separated"
+        required: false
+        type: string
+        default: "asr-ggml audiogen-ggml bci-whispercpp classification-ggml decoder-audio diffusion-cpp embed-llamacpp fabric llm-llamacpp ocr-ggml onnx tts-ggml vla"
+      dry-run:
+        description: "Is dry run? If true, lists versions without deleting."
+        type: boolean
+        default: true
+
+run-name: >-
+  Delete NPM Versions v=${{ inputs.version }} pr=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }} dry=${{ github.event_name == 'pull_request' && true || inputs.dry-run }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  delete-npm-versions-trigger:
+    permissions:
+      packages: write
+    uses: ./.github/workflows/public-delete-npm-versions.yml
+    with:
+      version: ${{ inputs.version }}
+      pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}
+      pattern: ${{ inputs.pattern }}
+      packages: ${{ inputs.packages || 'asr-ggml audiogen-ggml bci-whispercpp classification-ggml decoder-audio diffusion-cpp embed-llamacpp fabric llm-llamacpp ocr-ggml onnx tts-ggml vla' }}
+      dry-run: ${{ github.event_name == 'pull_request' && true || inputs.dry-run }}


### PR DESCRIPTION
## Summary
- Consolidates the 13 normal `on-pr-close-<pkg>.yml` files (ephemeral PR-version GPR cleanup on `pull_request: closed`) into one `on-pr-close.yml`.
- No nx, no matrix by design: the reusable `public-delete-npm-versions.yml` already loops a space-separated `packages` list and auto-scopes to `pr-<n>` from the event, and is a safe no-op for packages with no such version. Deletion is idempotent per package, so forcing nx-affected onto a `closed`-PR event would add cost with no functional benefit.
- Preserves legacy behavior exactly: `dry-run: true` forced on `pull_request` events (real deletes only via manual dispatch with `dry-run: false`), `paths: packages/**` scoping.
- 3 retired dispatch-only stubs (translation-nmtcpp, transcription-parakeet, transcription-whispercpp) are left as carve-outs — not part of the auto-close trigger.
- Additive only — legacy `on-pr-close-<pkg>.yml` files not deleted this pass.

## Test plan
- [x] `actionlint` clean (also validates the reusable-call input names against `public-delete-npm-versions.yml`)
- [x] `act -n` resolves and runs the reusable job graph on a `pull_request` event
- [ ] Live PR-close test to confirm the multi-package `packages` list behaves as expected end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)