### PR TITLE
QVAC-23272 chore: bump consumer package versions for qvac-fabric 10069.0.0

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.32.0] - 2026-08-10
 
 ### Changed
 

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/fabric/CHANGELOG.md
+++ b/packages/fabric/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.4.0] - 2026-08-10
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9840.1.1` -> `10069.0.0` (b10069 rebase; no
+  API change for this package).
+
+### Pull Requests
+
+- [#3621](https://github.com/tetherto/qvac/pull/3621) - Sync all addons with
+  fabric v10069.0.0
+
 ## [0.3.1] - 2026-07-30
 
 ### Changed

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/fabric",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Shared bare addon hosting the qvac-fabric (forked llama.cpp + ggml) runtime for QVAC inference addons",
   "addon": true,
   "engines": {

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.42.0] - 2026-08-10
 
 ### Changed
 

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.0] - 2026-08-10
+
+### Added
+
+- Initial release of `@qvac/model-fit`, a memory-fit **preflight** addon that
+  wraps llama.cpp's `llama_params_fit` C API to project — without loading any
+  weights — whether a GGUF model fits available device memory, and if so with
+  what offload plan (layers / context / tensor split). Intended to run in a
+  short-lived isolated worklet before handing a model to `@qvac/llm-llamacpp`.
+  (The wrapped entry point became `common_fit_params` before this first
+  publish — see *Changed* below.)
+- `reason` on the result — `fits`, `does-not-fit`, `model-unreadable` or
+  `no-backend-device`. `status` alone could not separate "this hardware cannot
+  run it" from "the model could not be read", which left the documented
+  proceed-on-unknown path impossible to diagnose.
+- `buftOverrides` on the result: the tensor placement the fitter selected. These
+  were previously discarded, so a `SUCCESS` could depend on placement the real
+  load would not reproduce.
+- `FitResult` is now a discriminated union on `status`, with the plan valid only
+  on `SUCCESS`, plus a consumer type test (`test/types/`) that checks branch
+  narrowing and exhaustiveness — the dts check previously only compiled the
+  declaration itself.
+- `NOTICE` and `LICENSE`, which `package.json` already listed in `files`.
+
+- Coverage for what the fitter does under memory pressure. `llama_params_fit`
+  assumes host memory is unlimited, so an unsatisfiable device margin is met by
+  moving every layer to the host rather than by reporting `FAILURE` — `fits`
+  stays true, and the plan rather than the flag is the admission signal. Driven
+  by the margin rather than by model size, which keeps it deterministic across
+  runners with different VRAM.
+- Coverage for the `FAILURE` verdict, which turns out to require a pinned
+  constraint. Unpinned, the fitter always has the host to fall back on, so it
+  answers even an unsatisfiable margin with `SUCCESS` and zero offload; pinning
+  `nGpuLayers` makes offload a hard requirement and produces a real "won't fit".
+  Documented, because it means `fits` alone is not an admission signal.
+- Documented two crash paths inside `llama_params_fit` that this addon cannot
+  contain: a `ggml_abort()` in `graph_reserve` on a large `nCtx`, and the
+  Windows divide-by-zero. Both terminate the process.
+- `nDevices` and `nGpuDevices` on the result — the device inventory the
+  projection was actually made against. Zero registered devices now returns
+  `ERROR` instead of a verdict. `maxDevices` is a build-time bound and must not
+  be read as a detection result.
 
 ### Changed
 
@@ -141,47 +182,3 @@
   place, win32 CI returns a real projection and the SEH filter never fires.
   Removing it also resolves the objection that resuming after a structured
   exception leaves llama's global logger pointing at a dead stack frame.
-
-### Added
-
-- `reason` on the result — `fits`, `does-not-fit`, `model-unreadable` or
-  `no-backend-device`. `status` alone could not separate "this hardware cannot
-  run it" from "the model could not be read", which left the documented
-  proceed-on-unknown path impossible to diagnose.
-- `buftOverrides` on the result: the tensor placement the fitter selected. These
-  were previously discarded, so a `SUCCESS` could depend on placement the real
-  load would not reproduce.
-- `FitResult` is now a discriminated union on `status`, with the plan valid only
-  on `SUCCESS`, plus a consumer type test (`test/types/`) that checks branch
-  narrowing and exhaustiveness — the dts check previously only compiled the
-  declaration itself.
-- `NOTICE` and `LICENSE`, which `package.json` already listed in `files`.
-
-- Coverage for what the fitter does under memory pressure. `llama_params_fit`
-  assumes host memory is unlimited, so an unsatisfiable device margin is met by
-  moving every layer to the host rather than by reporting `FAILURE` — `fits`
-  stays true, and the plan rather than the flag is the admission signal. Driven
-  by the margin rather than by model size, which keeps it deterministic across
-  runners with different VRAM.
-- Coverage for the `FAILURE` verdict, which turns out to require a pinned
-  constraint. Unpinned, the fitter always has the host to fall back on, so it
-  answers even an unsatisfiable margin with `SUCCESS` and zero offload; pinning
-  `nGpuLayers` makes offload a hard requirement and produces a real "won't fit".
-  Documented, because it means `fits` alone is not an admission signal.
-- Documented two crash paths inside `llama_params_fit` that this addon cannot
-  contain: a `ggml_abort()` in `graph_reserve` on a large `nCtx`, and the
-  Windows divide-by-zero. Both terminate the process.
-- `nDevices` and `nGpuDevices` on the result — the device inventory the
-  projection was actually made against. Zero registered devices now returns
-  `ERROR` instead of a verdict. `maxDevices` is a build-time bound and must not
-  be read as a detection result.
-
-## [0.1.0] - 2026-07-27
-
-### Added
-
-- Initial release of `@qvac/model-fit`, a memory-fit **preflight** addon that
-  wraps llama.cpp's `llama_params_fit` C API to project — without loading any
-  weights — whether a GGUF model fits available device memory, and if so with
-  what offload plan (layers / context / tensor split). Intended to run in a
-  short-lived isolated worklet before handing a model to `@qvac/llm-llamacpp`.

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-08-10
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9840.1.1` -> `10069.0.0` (b10069 rebase; no
+  API change for this package).
+
+### Pull Requests
+
+- [#3621](https://github.com/tetherto/qvac/pull/3621) - Sync all addons with
+  fabric v10069.0.0
+
 ## [0.14.0] - 2026-08-06
 
 ### Changed

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR pipeline on GGUF weights)",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.0] - 2026-08-10
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9840.1.1` -> `10069.0.0` (b10069 rebase; no
+  API change for this package).
+
+### Pull Requests
+
+- [#3621](https://github.com/tetherto/qvac/pull/3621) - Sync all addons with
+  fabric v10069.0.0
+
 ## [9.0.0] - 2026-08-06
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.19.0] - 2026-08-10
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9840.1.1` -> `10069.0.0` (b10069 rebase; no
+  API change for this package).
+
+### Pull Requests
+
+- [#3621](https://github.com/tetherto/qvac/pull/3621) - Sync all addons with
+  fabric v10069.0.0
+
 ## [0.18.0] - 2026-08-06
 
 ### Fixed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 Problem

#3621 moved every consumer's `vcpkg.json` floor to `qvac-fabric 10069.0.0` but touched no `package.json`. All seven fabric consumers are therefore sitting on `main` with the new fabric compiled in and their previous published version number — unreleasable, because `release-merge-guard` requires the version to have moved.

Three of them (`embed-llamacpp`, `llm-llamacpp`, `model-fit`) also had their changelog copy written under `## [Unreleased]`, which the release-notes extractor does not accept as a version section.

## 📝 How

Version bumps only — no `vcpkg.json`, no `vcpkg-configuration.json`, no source changes.

| Package | Version | Level |
|---|---|---|
| `embed-llamacpp` | 0.31.0 → **0.32.0** | minor |
| `fabric` | 0.3.1 → **0.4.0** | minor |
| `llm-llamacpp` | 0.41.0 → **0.42.0** | minor |
| `model-fit` | **0.1.0** (unchanged) | — |
| `ocr-ggml` | 0.14.0 → **0.15.0** | minor |
| `translation-nmtcpp` | 9.0.0 → **10.0.0** | major |
| `vla-ggml` | 0.18.0 → **0.19.0** | minor |

`translation-nmtcpp` takes a major because it is past 1.0; the rest are `0.x` and take a minor, which is the breaking-change signal at `0.x`.

**`model-fit` stays at `0.1.0`.** It has never been published — npm carries only a `0.0.0` name placeholder (1 file, 44 bytes) and no release tag exists — so `0.1.0` is still free. Its changelog previously had a `## [0.1.0] - 2026-07-27` entry describing only the initial commit, with everything since parked under `## [Unreleased]`. Those are folded into one dated `## [0.1.0]` entry so the first publish is not understated. All 26 bullets are preserved.

The other three new entries (`fabric`, `ocr-ggml`, `translation-nmtcpp`, `vla-ggml`) record the `9840.1.1 → 10069.0.0` bump and reference #3621.

## 🧪 Tested

- Every changelog heading matches the release extractor's own regex `^## \[<version>\] - <date>` exactly once, and equals the package's `package.json` version.
- No `## [Unreleased]` heading remains in any of the seven.
- `git diff origin/main` touches **only** `package.json` and `CHANGELOG.md` across the seven packages — 13 files, nothing else.
- `model-fit` bullet count is 26 before and after the fold, so no content was dropped.
- Preflight against `origin/main` confirmed the upstream state this PR depends on: fabric tag `v10069.0.0` exists (`63bfbdea0`), `qvac-fabric 10069.0.0` is published to the registry versions DB, all seven `vcpkg.json` floors already read `10069.0.0`, no overlay port or `overlay-ports` key is present, and no `default-registry.baseline` drift.

CI is the real check for the build itself; this PR changes no code.

## ⚠️ Breaking changes

**`embed-llamacpp` and `llm-llamacpp` — `split-mode: 'row'` is no longer effective on any shipped backend.** This arrived with the b10069 rebase in #3621 and is documented here because these are the releases that ship it.

Row split needs a backend exposing `ggml_backend_split_buffer_type`; at qvac-fabric v10069 only SYCL still does. CUDA dropped it and moved tensor parallelism to a separate `LLAMA_SPLIT_MODE_TENSOR` these packages do not expose, and Vulkan, Metal and OpenCL never provided it. qvac-fabric also stopped silently treating `row` as `layer` and now fails the model load with `device <name> does not support split buffers`.

The addons therefore degrade `row` → `layer` themselves before loading and log a `WARNING`. **Models keep loading and `row` keeps behaving like `layer` as it did on Vulkan/Metal before** — but callers who set `split-mode: 'row'` for real tensor parallelism no longer get it. The config surface is unchanged; `'row'` is still accepted.

No breaking changes in `fabric`, `model-fit`, `ocr-ggml`, `translation-nmtcpp` or `vla-ggml` — `translation-nmtcpp`'s major is the post-1.0 rollout convention, not a break.

## Follow-up (not in this PR)

`fabric` `0.3.1 → 0.4.0` crosses a minor. `classification-ggml` depends on `"@qvac/fabric": "^0.3.1"`, and on a `0.x` version a caret locks the minor — so it will **not** pick up `0.4.0` automatically and needs a separate dependency bump after `@qvac/fabric` publishes.

Related: #3621 (fabric floors + changelog copy).
