### PR TITLE
QVAC-23306 feat[audiogen-ggml]: align generation with official ACE-Step

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `useGPU: true` must resolve to Vulkan (`backendDevice=1`, `backendId=3`) and
   produce non-silent 48 kHz stereo audio. This covers ARM Mali devices such as
   Pixel 9a instead of silently accepting a CPU fallback.
+- Expose ACE-Step LM sampling controls, Haar DCW parameters, and optional frozen
+  semantic codes through the JavaScript API for reproducible quality comparisons.
+
+### Changed
+
+- Bump `audiogen-cpp` to `2026-08-10`, enabling official sampler-side Haar DCW
+  by default and using the validated LM decoding policy on Metal and Vulkan.
 
 ## [0.2.0] - 2026-08-06
 

--- a/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <any>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,6 +27,23 @@ namespace qvac::audiogenggml::addon_js {
 namespace js = qvac_lib_inference_addon_cpp::js;
 
 using acestep::AcestepModel;
+
+inline std::vector<int> copyAudioCodes(
+    js_env_t* env, js::TypedArray<int32_t> array) {
+  int32_t* data = nullptr;
+  size_t len = 0;
+  if (js_get_typedarray_info(
+          env,
+          array,
+          nullptr,
+          reinterpret_cast<void**>(&data),
+          &len,
+          nullptr,
+          nullptr) != 0) {
+    throw std::runtime_error("audioCodes must be an Int32Array");
+  }
+  return {data, data + len};
+}
 
 // Emits the generated track as interleaved stereo Int16 + sample rate, mirror
 // of ttsggml::JsAudioOutputHandler. The rate/channels are sourced from the model
@@ -126,8 +145,8 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
         "Unknown input type: " + type);
   }
 
-  // The caption is the primary text input; lyrics/seed/language/bpm/keyscale/
-  // timesignature/duration are read as optional per-call overrides from the
+  // The caption is the primary text input. Generation metadata, LM sampler
+  // controls and optional frozen semantic codes are per-call overrides on the
   // same job object the framework hands us at arg index 1.
   auto jobObj = args.getJsObject(1, "inputObj");
   auto optStr = [&](const char* key) -> std::optional<std::string> {
@@ -143,6 +162,16 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
     }
     return std::nullopt;
   };
+  auto optBool = [&](const char* key) -> std::optional<bool> {
+    js_value_t* raw = jobObj.getProperty(env, key);
+    if (js::is<js::Undefined>(env, raw) || js::is<js::Null>(env, raw)) {
+      return std::nullopt;
+    }
+    if (js::is<js::Boolean>(env, raw)) {
+      return js::Boolean{env, raw}.as<bool>(env);
+    }
+    return std::nullopt;
+  };
 
   AcestepModel::AnyInput modelInput;
   modelInput.caption = js::String(env, jsInput).as<std::string>(env);
@@ -153,6 +182,26 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
   if (auto v = optNum("seed")) modelInput.seed = static_cast<long long>(*v);
   if (auto v = optNum("bpm")) modelInput.bpm = static_cast<int>(*v);
   if (auto v = optNum("duration")) modelInput.duration = static_cast<float>(*v);
+  if (auto v = optNum("lmTemperature"))
+    modelInput.lmTemperature = static_cast<float>(*v);
+  if (auto v = optNum("lmTopP"))
+    modelInput.lmTopP = static_cast<float>(*v);
+  if (auto v = optNum("lmTopK"))
+    modelInput.lmTopK = static_cast<int>(*v);
+  if (auto v = optNum("lmCfgScale"))
+    modelInput.lmCfgScale = static_cast<float>(*v);
+  if (auto v = optBool("lmPhase1"))
+    modelInput.lmPhase1 = *v;
+  if (auto v = optBool("dcwEnabled"))
+    modelInput.dcwEnabled = *v;
+  if (auto v = optNum("dcwScaler"))
+    modelInput.dcwScaler = static_cast<float>(*v);
+  if (auto v = optNum("dcwHighScaler"))
+    modelInput.dcwHighScaler = static_cast<float>(*v);
+  if (auto codes = jobObj.getOptionalProperty<js::TypedArray<int32_t>>(
+          env, "audioCodes")) {
+    modelInput.audioCodes = copyAudioCodes(env, *codes);
+  }
   return instance.runJob(std::any(std::move(modelInput)));
 }
 JSCATCH

--- a/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include <js.h>
 #include <inference-addon-cpp/JsInterface.hpp>
 #include <inference-addon-cpp/JsUtils.hpp>
 #include <inference-addon-cpp/ModelInterfaces.hpp>
@@ -18,6 +17,7 @@
 #include <inference-addon-cpp/handlers/JsOutputHandlerImplementations.hpp>
 #include <inference-addon-cpp/handlers/OutputHandler.hpp>
 #include <inference-addon-cpp/queue/OutputCallbackJs.hpp>
+#include <js.h>
 
 #include "js-interface/JSAdapter.hpp"
 #include "model-interface/acestep/AcestepModel.hpp"
@@ -28,8 +28,8 @@ namespace js = qvac_lib_inference_addon_cpp::js;
 
 using acestep::AcestepModel;
 
-inline std::vector<int> copyAudioCodes(
-    js_env_t* env, js::TypedArray<int32_t> array) {
+inline std::vector<int>
+copyAudioCodes(js_env_t* env, js::TypedArray<int32_t> array) {
   int32_t* data = nullptr;
   size_t len = 0;
   if (js_get_typedarray_info(

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
@@ -18,7 +18,7 @@ int16_t f32ToI16(float x) {
   float v = x * 32767.0F;
   if (v > 32767.0F) v = 32767.0F;
   if (v < -32768.0F) v = -32768.0F;
-  return static_cast<int16_t>(v);
+  return static_cast<int16_t>(std::lrint(v));
 }
 
 constexpr int64_t BACKEND_DEVICE_CPU = 0;
@@ -162,6 +162,15 @@ AcestepModel::Output AcestepModel::generate(const AnyInput& in) {
   // Pass duration straight through: >0 caps the track to that many seconds,
   // 0 (the default) lets LM Phase-1 decide the full song length.
   params.duration = in.duration;
+  params.lm_temperature = in.lmTemperature;
+  params.lm_top_p = in.lmTopP;
+  params.lm_top_k = in.lmTopK;
+  params.lm_cfg_scale = in.lmCfgScale;
+  params.lm_phase1 = in.lmPhase1;
+  params.dcw_enabled = in.dcwEnabled;
+  params.dcw_scaler = in.dcwScaler;
+  params.dcw_high_scaler = in.dcwHighScaler;
+  params.audio_codes = in.audioCodes;
   // 0 = auto: the engine resolves steps/shift from the DiT model type
   // (turbo -> 8 / shift 3.0, base/sft -> 50 / shift 1.0). Forcing 8/3.0 here
   // would make a base/sft model render with turbo settings and sound wrong.

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
@@ -51,15 +51,16 @@ public:
     std::string keyscale;       // optional, e.g. "C minor"
     std::string timesignature;  // optional, e.g. "4/4"
     float       duration = 0.0F;  // 0 => keep engine default / let LM decide
-    float       lmTemperature = 0.85F;
-    float       lmTopP = 0.9F;
-    int         lmTopK = 0;
-    float       lmCfgScale = 2.0F;
-    bool        lmPhase1 = true;
-    bool        dcwEnabled = true;
-    float       dcwScaler = 0.05F;
-    float       dcwHighScaler = 0.02F;
-    std::vector<int> audioCodes;  // non-empty => skip LM and synthesize these codes
+    float lmTemperature = 0.85F;
+    float lmTopP = 0.9F;
+    int lmTopK = 0;
+    float lmCfgScale = 2.0F;
+    bool lmPhase1 = true;
+    bool dcwEnabled = true;
+    float dcwScaler = 0.05F;
+    float dcwHighScaler = 0.02F;
+    std::vector<int>
+        audioCodes; // non-empty => skip LM and synthesize these codes
   };
 
   explicit AcestepModel(AcestepConfig config);

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
@@ -51,6 +51,15 @@ public:
     std::string keyscale;       // optional, e.g. "C minor"
     std::string timesignature;  // optional, e.g. "4/4"
     float       duration = 0.0F;  // 0 => keep engine default / let LM decide
+    float       lmTemperature = 0.85F;
+    float       lmTopP = 0.9F;
+    int         lmTopK = 0;
+    float       lmCfgScale = 2.0F;
+    bool        lmPhase1 = true;
+    bool        dcwEnabled = true;
+    float       dcwScaler = 0.05F;
+    float       dcwHighScaler = 0.02F;
+    std::vector<int> audioCodes;  // non-empty => skip LM and synthesize these codes
   };
 
   explicit AcestepModel(AcestepConfig config);

--- a/packages/audiogen-ggml/audiogen.d.ts
+++ b/packages/audiogen-ggml/audiogen.d.ts
@@ -34,6 +34,15 @@ export interface AudioGenJobData {
     keyscale?: string;
     timesignature?: string;
     duration?: number;
+    lmTemperature?: number;
+    lmTopP?: number;
+    lmTopK?: number;
+    lmCfgScale?: number;
+    lmPhase1?: boolean;
+    dcwEnabled?: boolean;
+    dcwScaler?: number;
+    dcwHighScaler?: number;
+    audioCodes?: Int32Array;
 }
 /** Native output event: (handle, event, data, error). */
 export type AudioGenOutputCallback = (handle: unknown, event: unknown, data: unknown, error: unknown) => void;

--- a/packages/audiogen-ggml/examples/generate-music.js
+++ b/packages/audiogen-ggml/examples/generate-music.js
@@ -14,6 +14,11 @@
 //   AUDIOGEN_TSIG        time signature, e.g. "4/4"
 //   AUDIOGEN_DUR         target seconds (omit => LM decides length)
 //   AUDIOGEN_SEED        RNG seed
+//   AUDIOGEN_CODES       JSON file containing `audio_codes` as CSV or an array;
+//                        skips the LM for deterministic synthesis comparisons
+//   AUDIOGEN_DCW         "0" to disable Haar DCW (enabled by default)
+//   AUDIOGEN_DCW_LOW     low-band DCW strength (default 0.05)
+//   AUDIOGEN_DCW_HIGH    high-band DCW strength (default 0.02)
 //   AUDIOGEN_FORMAT      output format: "wav" (default) or "pcm"
 //   AUDIOGEN_GPU         "1" to run the whole pipeline (LM/DiT/encoders AND the
 //                        VAE) on GPU (Metal/Vulkan). Falls back to CPU if
@@ -27,6 +32,20 @@ const { AudioGen } = require('..')
 function numEnv (name) {
   const v = process.env[name]
   return v === undefined || v === '' ? undefined : Number(v)
+}
+
+function audioCodesEnv () {
+  const file = process.env.AUDIOGEN_CODES
+  if (!file) return undefined
+  const value = JSON.parse(fs.readFileSync(file, 'utf8')).audio_codes
+  const codes = Array.isArray(value) ? value : String(value).split(',').filter(Boolean).map(Number)
+  return Int32Array.from(codes)
+}
+
+function boolEnv (name) {
+  const v = process.env[name]
+  if (v === undefined || v === '') return undefined
+  return /^(1|true|yes|on)$/i.test(v)
 }
 
 async function main () {
@@ -49,7 +68,11 @@ async function main () {
     keyscale: process.env.AUDIOGEN_KEY || undefined,
     timesignature: process.env.AUDIOGEN_TSIG || undefined,
     duration: numEnv('AUDIOGEN_DUR'),
-    seed: numEnv('AUDIOGEN_SEED')
+    seed: numEnv('AUDIOGEN_SEED'),
+    dcwEnabled: boolEnv('AUDIOGEN_DCW'),
+    dcwScaler: numEnv('AUDIOGEN_DCW_LOW'),
+    dcwHighScaler: numEnv('AUDIOGEN_DCW_HIGH'),
+    audioCodes: audioCodesEnv()
   }
 
   console.log('[audiogen] prompt: ' + caption)

--- a/packages/audiogen-ggml/index.d.ts
+++ b/packages/audiogen-ggml/index.d.ts
@@ -58,6 +58,24 @@ export interface GenerateOptions {
     timesignature?: string;
     /** Target length in seconds; undefined lets the LM decide the full length. */
     duration?: number;
+    /** LM sampling temperature (ACE-Step default: 0.85). */
+    lmTemperature?: number;
+    /** LM nucleus-sampling probability (ACE-Step default: 0.9). */
+    lmTopP?: number;
+    /** LM top-k cutoff; 0 disables top-k filtering. */
+    lmTopK?: number;
+    /** Classifier-free guidance scale used by the LM. */
+    lmCfgScale?: number;
+    /** Allow the LM to infer missing metadata before semantic-code generation. */
+    lmPhase1?: boolean;
+    /** Apply official ACE-Step Haar DCW correction during DiT sampling (default: true). */
+    dcwEnabled?: boolean;
+    /** DCW low-frequency correction strength (official default: 0.05). */
+    dcwScaler?: number;
+    /** DCW high-frequency correction strength (official default: 0.02). */
+    dcwHighScaler?: number;
+    /** Frozen ACE-Step semantic codes; when present, skips the LM stage. */
+    audioCodes?: Int32Array;
 }
 /** A per-step progress tick from the engine (stage = "lm" | "dit" | "vae"). */
 export interface AudiogenProgress {

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -132,6 +132,15 @@ class AudioGen {
         // start() is typed QvacResponse<any>; run()'s explicit return type narrows
         // the public surface to QvacResponse<AudiogenOutputChunk>.
         this._logger.debug(`audiogen-ggml: run (caption ${caption.length} chars, lyrics=${opts.lyrics ? 'yes' : 'no'})`);
+        if (opts.lmPhase1 !== undefined && typeof opts.lmPhase1 !== 'boolean') {
+            throw new Error('audiogen-ggml: lmPhase1 must be a boolean');
+        }
+        if (opts.dcwEnabled !== undefined && typeof opts.dcwEnabled !== 'boolean') {
+            throw new Error('audiogen-ggml: dcwEnabled must be a boolean');
+        }
+        if (opts.audioCodes !== undefined && !(opts.audioCodes instanceof Int32Array)) {
+            throw new Error('audiogen-ggml: audioCodes must be an Int32Array');
+        }
         const response = this._job.start();
         try {
             await this._requireAddon().runJob({
@@ -143,7 +152,16 @@ class AudioGen {
                 bpm: optionalFiniteNumber(opts.bpm, 'bpm', true),
                 keyscale: opts.keyscale,
                 timesignature: opts.timesignature,
-                duration: optionalFiniteNumber(opts.duration, 'duration')
+                duration: optionalFiniteNumber(opts.duration, 'duration'),
+                lmTemperature: optionalFiniteNumber(opts.lmTemperature, 'lmTemperature'),
+                lmTopP: optionalFiniteNumber(opts.lmTopP, 'lmTopP'),
+                lmTopK: optionalFiniteNumber(opts.lmTopK, 'lmTopK', true),
+                lmCfgScale: optionalFiniteNumber(opts.lmCfgScale, 'lmCfgScale'),
+                lmPhase1: opts.lmPhase1,
+                dcwEnabled: opts.dcwEnabled,
+                dcwScaler: optionalFiniteNumber(opts.dcwScaler, 'dcwScaler'),
+                dcwHighScaler: optionalFiniteNumber(opts.dcwHighScaler, 'dcwHighScaler'),
+                audioCodes: opts.audioCodes
             });
         }
         catch (error) {

--- a/packages/audiogen-ggml/src/audiogen.ts
+++ b/packages/audiogen-ggml/src/audiogen.ts
@@ -39,6 +39,15 @@ export interface AudioGenJobData {
   keyscale?: string
   timesignature?: string
   duration?: number
+  lmTemperature?: number
+  lmTopP?: number
+  lmTopK?: number
+  lmCfgScale?: number
+  lmPhase1?: boolean
+  dcwEnabled?: boolean
+  dcwScaler?: number
+  dcwHighScaler?: number
+  audioCodes?: Int32Array
 }
 
 /** Native output event: (handle, event, data, error). */

--- a/packages/audiogen-ggml/src/index.ts
+++ b/packages/audiogen-ggml/src/index.ts
@@ -84,6 +84,24 @@ export interface GenerateOptions {
   timesignature?: string
   /** Target length in seconds; undefined lets the LM decide the full length. */
   duration?: number
+  /** LM sampling temperature (ACE-Step default: 0.85). */
+  lmTemperature?: number
+  /** LM nucleus-sampling probability (ACE-Step default: 0.9). */
+  lmTopP?: number
+  /** LM top-k cutoff; 0 disables top-k filtering. */
+  lmTopK?: number
+  /** Classifier-free guidance scale used by the LM. */
+  lmCfgScale?: number
+  /** Allow the LM to infer missing metadata before semantic-code generation. */
+  lmPhase1?: boolean
+  /** Apply official ACE-Step Haar DCW correction during DiT sampling (default: true). */
+  dcwEnabled?: boolean
+  /** DCW low-frequency correction strength (official default: 0.05). */
+  dcwScaler?: number
+  /** DCW high-frequency correction strength (official default: 0.02). */
+  dcwHighScaler?: number
+  /** Frozen ACE-Step semantic codes; when present, skips the LM stage. */
+  audioCodes?: Int32Array
 }
 
 /** A per-step progress tick from the engine (stage = "lm" | "dit" | "vae"). */
@@ -271,6 +289,15 @@ export class AudioGen {
     this._logger.debug(
       `audiogen-ggml: run (caption ${caption.length} chars, lyrics=${opts.lyrics ? 'yes' : 'no'})`
     )
+    if (opts.lmPhase1 !== undefined && typeof opts.lmPhase1 !== 'boolean') {
+      throw new Error('audiogen-ggml: lmPhase1 must be a boolean')
+    }
+    if (opts.dcwEnabled !== undefined && typeof opts.dcwEnabled !== 'boolean') {
+      throw new Error('audiogen-ggml: dcwEnabled must be a boolean')
+    }
+    if (opts.audioCodes !== undefined && !(opts.audioCodes instanceof Int32Array)) {
+      throw new Error('audiogen-ggml: audioCodes must be an Int32Array')
+    }
     const response = this._job.start()
     try {
       await this._requireAddon().runJob({
@@ -282,7 +309,16 @@ export class AudioGen {
         bpm: optionalFiniteNumber(opts.bpm, 'bpm', true),
         keyscale: opts.keyscale,
         timesignature: opts.timesignature,
-        duration: optionalFiniteNumber(opts.duration, 'duration')
+        duration: optionalFiniteNumber(opts.duration, 'duration'),
+        lmTemperature: optionalFiniteNumber(opts.lmTemperature, 'lmTemperature'),
+        lmTopP: optionalFiniteNumber(opts.lmTopP, 'lmTopP'),
+        lmTopK: optionalFiniteNumber(opts.lmTopK, 'lmTopK', true),
+        lmCfgScale: optionalFiniteNumber(opts.lmCfgScale, 'lmCfgScale'),
+        lmPhase1: opts.lmPhase1,
+        dcwEnabled: opts.dcwEnabled,
+        dcwScaler: optionalFiniteNumber(opts.dcwScaler, 'dcwScaler'),
+        dcwHighScaler: optionalFiniteNumber(opts.dcwHighScaler, 'dcwHighScaler'),
+        audioCodes: opts.audioCodes
       })
     } catch (error) {
       this._logger.error(

--- a/packages/audiogen-ggml/test/integration/addon.test.js
+++ b/packages/audiogen-ggml/test/integration/addon.test.js
@@ -18,6 +18,11 @@ const {
 const { AudioGen } = require('@qvac/audiogen-ggml')
 
 const VARIANT = 'turbo-q4'
+const FROZEN_AUDIO_CODES = new Int32Array([
+  12095, 63487, 12741, 54319, 52716, 20464, 2469, 515, 22717, 2326, 62840, 61416, 18896, 55746,
+  54256, 12095, 63935, 12741, 54319, 52716, 20464, 2469, 515, 22718, 2455, 10103, 12567, 27863,
+  30367, 30367, 30367, 30367, 30367, 30367, 30367, 30367, 30367, 15206
+])
 
 function modelsDir() {
   return path.join(getBaseDir(), 'models')
@@ -45,7 +50,18 @@ test(
 
     const { data } = await runAudioGen(gen, {
       caption: 'lo-fi hip hop, mellow piano, rainy night',
-      opts: { lyrics: '[Instrumental]', duration: 8, seed: 42 }
+      opts: {
+        lyrics: '[Instrumental]',
+        duration: 8,
+        seed: 42,
+        lmTemperature: 0.8,
+        lmTopP: 0.9,
+        lmTopK: 64,
+        lmCfgScale: 2,
+        dcwEnabled: true,
+        dcwScaler: 0.05,
+        dcwHighScaler: 0.02
+      }
     })
 
     t.ok(data.sampleCount > 0, `produced ${data.sampleCount} interleaved samples`)
@@ -114,5 +130,51 @@ test(
     const wav = AudioGen.encode(bytes, 'wav', { sampleRate, channels })
     t.is(wav.extension, 'wav', 'encoded a WAV file')
     t.ok(wav.data && wav.data.length > 44, 'WAV has a header + payload')
+  }
+)
+
+test(
+  'AudioGen (ggml): frozen semantic codes bypass LM length generation',
+  { timeout: INTEGRATION_TIMEOUT_MS },
+  async (t) => {
+    const download = await ensureAudiogenModels({ targetDir: modelsDir(), variant: VARIANT })
+    if (!download.success) {
+      t.fail('ACE-Step models unavailable — run `npm run download-models:registry`.')
+      return
+    }
+
+    const gen = await loadAudioGen({
+      modelDir: download.modelDir,
+      ditVariant: VARIANT,
+      useGPU: !NO_GPU
+    })
+    t.teardown(() => gen.destroy())
+
+    const { data } = await runAudioGen(gen, {
+      caption: 'upbeat pop rock with driving electric guitars and a catchy hook',
+      opts: {
+        lyrics: '[Instrumental]',
+        duration: 30,
+        seed: 42,
+        bpm: 158,
+        keyscale: 'C# major',
+        timesignature: '4/4',
+        lmPhase1: false,
+        dcwEnabled: true,
+        dcwScaler: 0.05,
+        dcwHighScaler: 0.02,
+        audioCodes: FROZEN_AUDIO_CODES
+      }
+    })
+
+    t.ok(data.sampleCount > 0, 'frozen codes produced audio')
+    t.is(data.channels, 2, 'stereo output')
+    t.is(data.sampleRate, 48000, '48 kHz output')
+    t.ok(
+      data.durationMs >= 6000 && data.durationMs <= 10000,
+      `38 frozen 5 Hz codes determine a short render (${Math.round(data.durationMs)} ms), not the requested 30 s`
+    )
+    t.ok(data.peak > 0.0001, `non-silent peak (${data.peak.toFixed(6)})`)
+    t.ok(data.rms > 0.00001, `non-silent RMS (${data.rms.toFixed(6)})`)
   }
 )

--- a/packages/audiogen-ggml/test/unit/generate-options.test.js
+++ b/packages/audiogen-ggml/test/unit/generate-options.test.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const test = require('brittle')
+const { AudioGen } = require('../../index.js')
+
+function createHarness() {
+  let received
+  const gen = new AudioGen()
+  gen.addon = {
+    runJob(data) {
+      received = data
+      gen._addonOutputCallback(null, null, { totalTimeMs: 0 }, null)
+      return Promise.resolve()
+    },
+    cancel: () => Promise.resolve(),
+    destroyInstance: () => Promise.resolve()
+  }
+  return { gen, received: () => received }
+}
+
+test('AudioGen.run forwards sampler, DCW and frozen-code controls', async (t) => {
+  const { gen, received } = createHarness()
+  const audioCodes = new Int32Array([12095, 63487, 12741])
+
+  const response = await gen.run('upbeat pop rock', {
+    duration: 8,
+    lmTemperature: 0.7,
+    lmTopP: 0.8,
+    lmTopK: 0,
+    lmCfgScale: 1.5,
+    lmPhase1: false,
+    dcwEnabled: false,
+    dcwScaler: 0,
+    dcwHighScaler: 0,
+    audioCodes
+  })
+  await response.await()
+
+  const job = received()
+  t.is(job.input, 'upbeat pop rock')
+  t.is(job.duration, 8)
+  t.is(job.lmTemperature, 0.7)
+  t.is(job.lmTopP, 0.8)
+  t.is(job.lmTopK, 0, 'zero top-k is preserved')
+  t.is(job.lmCfgScale, 1.5)
+  t.is(job.lmPhase1, false, 'false Phase 1 flag is preserved')
+  t.is(job.dcwEnabled, false, 'false DCW flag is preserved')
+  t.is(job.dcwScaler, 0, 'zero low-frequency scaler is preserved')
+  t.is(job.dcwHighScaler, 0, 'zero high-frequency scaler is preserved')
+  t.is(job.audioCodes, audioCodes, 'the Int32Array reaches the native job unchanged')
+})
+
+test('AudioGen.run rejects invalid sampler and DCW controls before native dispatch', async (t) => {
+  const numericControls = ['lmTemperature', 'lmTopP', 'lmCfgScale', 'dcwScaler', 'dcwHighScaler']
+
+  for (const name of numericControls) {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { [name]: Number.POSITIVE_INFINITY }),
+      new RegExp(`${name} must be a finite number`)
+    )
+  }
+
+  {
+    const { gen } = createHarness()
+    await t.exception(() => gen.run('test', { lmTopK: 1.5 }), /lmTopK must be an integer/)
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(() => gen.run('test', { lmPhase1: 1 }), /lmPhase1 must be a boolean/)
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(() => gen.run('test', { dcwEnabled: 'yes' }), /dcwEnabled must be a boolean/)
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { audioCodes: new Uint32Array([1, 2, 3]) }),
+      /audioCodes must be an Int32Array/
+    )
+  }
+})

--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "65b1d890edc1da43617f599e92bea19f1b9bc30e",
+    "baseline": "cbcfef8dc9e860fe7851f96711fb85050f91b86a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "cbcfef8dc9e860fe7851f96711fb85050f91b86a",
+    "baseline": "65b1d890edc1da43617f599e92bea19f1b9bc30e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "audiogen-cpp",
-      "version>=": "2026-08-04#1"
+      "version>=": "2026-08-10"
     }
   ],
   "features": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/audiogen-ggml` still consumes the older AudioGen quality path and cannot reproduce the generation controls validated against official ACE-Step.
- Consumers cannot configure LM sampling and Haar DCW or provide frozen semantic codes to skip the LM stage.

## 📝 How does it solve it?

- Requires `audiogen-cpp >= 2026-08-10` from the merged [registry PR #292](https://github.com/tetherto/qvac-registry-vcpkg/pull/292) while preserving the monorepo registry baseline.
- Exposes LM sampling, Phase 1, DCW, and frozen semantic-code controls through the TypeScript API, generated declarations, JavaScript wrapper, and native addon bridge.
- Updates the example and changelog, and adds unit and model-backed integration coverage for the new controls.

## 🧪 How was it tested?

- `npm run lint:js`
- `npm run test:types`
- `npm run test:unit` — 19 tests, 110 assertions
- vcpkg dry-run resolves `audiogen-cpp[core,metal]:arm64-osx@2026-08-10` with the existing baseline
- Added integration coverage for explicit LM/DCW settings and frozen semantic codes; the model-backed lane runs this in CI

## 🔌 API Changes

```typescript
await audioGen.run(caption, {
  lmTemperature: 0.8,
  lmTopP: 0.9,
  lmTopK: 64,
  lmCfgScale: 2,
  lmPhase1: true,
  dcwEnabled: true,
  dcwScaler: 0.05,
  dcwHighScaler: 0.02
})

await audioGen.run(caption, {
  audioCodes: new Int32Array(cachedCodes)
})
```