### PR TITLE
fix[notask]: fail loudly when the CosyVoice3 LavaSR stub write fails

### DIFF
--- a/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_cosyvoice_config.cpp
@@ -105,6 +105,10 @@ public:
   explicit TempGguf(const char* name) : path_(lavasrStageDir() / name) {
     std::ofstream out(path_, std::ios::binary);
     out << STUB_CONTENTS;
+    out.close();
+    if (!out)
+      throw std::runtime_error(
+          "failed to stage the placeholder GGUF: " + path_.string());
   }
   ~TempGguf() {
     std::error_code ec;
@@ -172,6 +176,14 @@ TEST(CosyvoiceValidate, StreamingNonNativeOutputRateRejected) {
   cfg.streamChunkTokens = 25;
   cfg.outputSampleRate = 16000; // non-native while streaming
   EXPECT_THROW(CosyvoiceModel{cfg}, StatusError);
+}
+
+// The accept-path tests below are only meaningful if the placeholder really
+// reaches the disk; a silently failed write used to surface three tests later
+// as a "GGUF not found" rejection.
+TEST(CosyvoiceLavasrFixture, StagesAReadableFile) {
+  const TempGguf gguf("lavasr-fixture-probe.gguf");
+  EXPECT_TRUE(std::filesystem::exists(gguf.path()));
 }
 
 // The LavaSR enhancer resamples inside its overlap-reprocess window, so it


### PR DESCRIPTION
## What

Rebased onto `main`, and it shrank a lot — read this as a new PR.

The original version fixed two compounding causes of the `cpp-tests-coverage / linux-x64-cpp-tests`
failures (`lavasr enhancer GGUF not found: /tmp/qvac-tts-ggml-cosyvoice-tests-lavasr/...`): a fixed
stage-directory name under a `/tmp` that the persistent CI runner accounts share, and an unchecked
write into it.

**The first half landed independently in [#3723](https://github.com/tetherto/qvac/pull/3723)**, which
gave every scratch directory entropy in its name and put it behind a `ScratchDir` whose lifetime spans
the process — covering all three temp dirs (`emptyModelDir`, `lavasrStageDir`, the `CosyvoiceSetConfig`
scratch dir), not just the LavaSR one. That is a superset of what this PR did, so the conflict resolved
entirely in `main`'s favour and this PR is now the remainder: **the write itself**.

## Root cause of what's left

`main` still has:

```cpp
std::ofstream out(path_, std::ios::binary);
out << STUB_CONTENTS;
```

The stream state is discarded. A stage that never reaches the disk still reports success, and the
error surfaces three assertions later as a config rejection — pointing the reader at `validateConfig`
rather than at the staging that actually failed. That misdirection is exactly what made the original
CI failure hard to read.

## The fix

* Check the stream after `close()`, so a deferred flush error counts and not just a failed open, and
  throw naming the path.
* Add `CosyvoiceLavasrFixture.StagesAReadableFile` immediately before the first accept-path test that
  depends on the staging, pinning the contract that was silently broken.

## Test plan

Built and run against the rebased base (`3ec283633`):

- [x] The merge gate's own command, `./tts_ggml_tests --gtest_filter='-*RealGguf*'` — **183/183 pass**
      (183 rather than the 147 quoted before the rebase; `main` has since added the Audio8 tests)
- [x] Six concurrent instances of the LavaSR subset — **28/28 each**
- [x] The new check is not dead code: with staging temporarily redirected to an unwritable path, the
      constructor throws
      `failed to stage the placeholder GGUF: /System/unwritable-probe/lavasr-fixture-probe.gguf`
      instead of silently succeeding. Probe reverted; the committed tree is the 12-line diff above.
- [x] `clang-format` clean
- [ ] `linux-x64-cpp-tests` green on this PR's own run

No `CHANGELOG.md` entry: the change is test-only and does not reach the published NPM package.

The committed merge-conflict markers in `packages/tts-ggml/CHANGELOG.md` that the previous version of
this description flagged are **already gone from `main`** — that note no longer applies and has been
dropped.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217329053879204