### PR TITLE
QVAC-22174 chore[skiplog]: fail-stop changelog gen on shallow git history

### DIFF
--- a/.cursor/skills/qv-sdk-changelog/SKILL.md
+++ b/.cursor/skills/qv-sdk-changelog/SKILL.md
@@ -42,19 +42,16 @@ three-part `release-<pkg>-x.y.z`. Full rules live in
 Tags live on the **upstream** remote (tetherto/qvac), not the contributor's fork.
 The script fetches from `upstream` first, falling back to `origin`.
 
-**Full-history requirement (fail-stop):** changelog discovery is
-`git log <base>..HEAD -- <packagePath>`. A shallow clone silently omits
-commits and produces incomplete release notes (this caused SDK 0.17.0 to
-miss `getSystemResources` and other path-scoped PRs). Before generating:
+**Full-history requirement (fail-stop):** discovery is
+`git log <base>..HEAD -- <packagePath>`. Before generating:
 
-1. Confirm `git rev-parse --is-shallow-repository` is `false`. If `true`,
-   run `git fetch --unshallow` (or re-clone without `--depth`) and stop —
-   do not generate from shallow history.
-2. Confirm the resolved base tag/commit is an ancestor of `HEAD`
-   (`git merge-base --is-ancestor <base> HEAD`). If not, check out the
+1. `git rev-parse --is-shallow-repository` must be `false` (else
+   `git fetch --unshallow` / re-clone without `--depth`, then stop).
+2. Base must be an ancestor of `HEAD`
+   (`git merge-base --is-ancestor <base> HEAD`); otherwise check out the
    release tip / package tag first.
 
-The generator script enforces both checks and exits non-zero on failure.
+The generator enforces both checks and exits non-zero on failure.
 
 Run `git tag --list "<package>-v*" --sort=-v:refname` to check for existing version tags.
 

--- a/.cursor/skills/qv-sdk-changelog/SKILL.md
+++ b/.cursor/skills/qv-sdk-changelog/SKILL.md
@@ -42,6 +42,20 @@ three-part `release-<pkg>-x.y.z`. Full rules live in
 Tags live on the **upstream** remote (tetherto/qvac), not the contributor's fork.
 The script fetches from `upstream` first, falling back to `origin`.
 
+**Full-history requirement (fail-stop):** changelog discovery is
+`git log <base>..HEAD -- <packagePath>`. A shallow clone silently omits
+commits and produces incomplete release notes (this caused SDK 0.17.0 to
+miss `getSystemResources` and other path-scoped PRs). Before generating:
+
+1. Confirm `git rev-parse --is-shallow-repository` is `false`. If `true`,
+   run `git fetch --unshallow` (or re-clone without `--depth`) and stop —
+   do not generate from shallow history.
+2. Confirm the resolved base tag/commit is an ancestor of `HEAD`
+   (`git merge-base --is-ancestor <base> HEAD`). If not, check out the
+   release tip / package tag first.
+
+The generator script enforces both checks and exits non-zero on failure.
+
 Run `git tag --list "<package>-v*" --sort=-v:refname` to check for existing version tags.
 
 - If tags exist: the script auto-detects the release type from `package.json` version:
@@ -336,7 +350,8 @@ Before completing:
 
 - [ ] Correct package identified
 - [ ] Working head (if branched for the release PR) is `chore/<pkg>-<x.y.z>-changelog`, not `release-*`
-- [ ] Base reference resolved (tag or `--base-commit`)
+- [ ] Clone is not shallow (`git rev-parse --is-shallow-repository` → `false`)
+- [ ] Base reference resolved (tag or `--base-commit`) and is an ancestor of `HEAD`
 - [ ] PRs scoped to package path only
 - [ ] Changelog files written to correct version directory
 - [ ] CHANGELOG_LLM.md generated (mandatory) and follows format guide

--- a/scripts/generate-changelog-qvac.cjs
+++ b/scripts/generate-changelog-qvac.cjs
@@ -333,7 +333,7 @@ function parseArgs(argv) {
  * @param {string} baseRef
  */
 function assertChangelogHistoryReady(baseRef) {
-  let isShallow = "false";
+  let isShallow;
   try {
     isShallow = git("rev-parse --is-shallow-repository");
   } catch (error) {

--- a/scripts/generate-changelog-qvac.cjs
+++ b/scripts/generate-changelog-qvac.cjs
@@ -138,6 +138,36 @@ function resolveBaseRef(packageName, baseCommit, releaseType = "minor") {
 }
 
 /**
+ * Extract the PR number from a commit subject line.
+ *
+ * Prefer the trailing squash-merge `(#123)` / `Merge pull request #123`
+ * form. Falling back to the first `#N` is unsafe: subjects like
+ * `chore: … - #3522 (#3534)` would otherwise attribute the wrong PR.
+ *
+ * @param {string} line
+ * @returns {number|null}
+ */
+function extractPRNumberFromSubject(line) {
+  const trailingSquash = line.match(/\(#(\d+)\)\s*$/);
+  if (trailingSquash) {
+    return parseInt(trailingSquash[1], 10);
+  }
+
+  const mergeRequest = line.match(/Merge pull request #(\d+)/i);
+  if (mergeRequest) {
+    return parseInt(mergeRequest[1], 10);
+  }
+
+  const matches = [...line.matchAll(/#(\d+)/g)];
+  if (matches.length === 0) {
+    return null;
+  }
+
+  // Last resort: last #N on the line (closer to GitHub's squash trailer).
+  return parseInt(matches[matches.length - 1][1], 10);
+}
+
+/**
  * Get PR numbers from path-scoped commits.
  * Searches all commits (not just merges) because squash-merged PRs
  * have only one parent but still contain "#123" in the commit message.
@@ -161,10 +191,9 @@ function getPRNumbers(baseRef, packagePath) {
     const lines = commits.split("\n");
 
     for (const line of lines) {
-      // Match "Merge pull request #123" or "(#123)" squash-merge patterns
-      const match = line.match(/#(\d+)/);
-      if (match) {
-        prNumbers.push(parseInt(match[1], 10));
+      const prNumber = extractPRNumberFromSubject(line);
+      if (prNumber !== null) {
+        prNumbers.push(prNumber);
       }
     }
 
@@ -301,6 +330,56 @@ function parseArgs(argv) {
  * @param {boolean} [options.dryRun] - If true, don't write files
  * @returns {Promise<{packageName: string, baseRef: string|null, baseVersion: string|null, version: string, prs: Array}>}
  */
+/**
+ * Fail-stop when the working clone cannot produce a complete changelog.
+ * Shallow clones silently omit commits from `git log base..HEAD`, which
+ * drops real package PRs from the release notes (seen on SDK 0.17.0).
+ *
+ * @param {string} baseRef
+ */
+function assertChangelogHistoryReady(baseRef) {
+  let isShallow = "false";
+  try {
+    isShallow = git("rev-parse --is-shallow-repository");
+  } catch (error) {
+    throw new Error(
+      "Unable to determine whether the repository is shallow. " +
+        "Refusing to generate a changelog without a full history check.",
+    );
+  }
+
+  if (isShallow === "true") {
+    throw new Error(
+      "Repository is a shallow clone. Changelog generation requires full " +
+        "history so path-scoped `git log` does not miss merged PRs.\n" +
+        "Fix: `git fetch --unshallow` (or re-clone without --depth), then re-run.",
+    );
+  }
+
+  try {
+    git(`rev-parse --verify ${baseRef}^{commit}`);
+  } catch (error) {
+    throw new Error(
+      `Base reference '${baseRef}' does not resolve to a commit in this clone.`,
+    );
+  }
+
+  try {
+    // merge-base --is-ancestor exits 0 when baseRef is an ancestor of HEAD.
+    execSync(`git merge-base --is-ancestor ${baseRef} HEAD`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    throw new Error(
+      `Base reference '${baseRef}' is not an ancestor of HEAD. ` +
+        "Changelog ranges are empty or misleading when the tip does not " +
+        "contain the release base. Check out the release tip (or the " +
+        "package tag) before generating.",
+    );
+  }
+}
+
 async function generateChangelog(options) {
   const { packageName, baseCommit, baseVersion, dryRun } = options;
   const packagePath = getPackageDir(packageName);
@@ -343,6 +422,8 @@ async function generateChangelog(options) {
         `For initial release, use: --base-commit=<sha> --base-version=<version>`,
     );
   }
+
+  assertChangelogHistoryReady(baseRef);
 
   const resolvedBaseVersion =
     baseVersion || extractVersionFromTag(baseRef) || null;
@@ -528,6 +609,8 @@ module.exports = {
   detectReleaseType,
   resolveBaseRef,
   getPRNumbers,
+  extractPRNumberFromSubject,
+  assertChangelogHistoryReady,
   fetchPRMetadata,
   getGitHubToken,
   getRepoRoot,

--- a/scripts/generate-changelog-qvac.cjs
+++ b/scripts/generate-changelog-qvac.cjs
@@ -138,11 +138,8 @@ function resolveBaseRef(packageName, baseCommit, releaseType = "minor") {
 }
 
 /**
- * Extract the PR number from a commit subject line.
- *
- * Prefer the trailing squash-merge `(#123)` / `Merge pull request #123`
- * form. Falling back to the first `#N` is unsafe: subjects like
- * `chore: … - #3522 (#3534)` would otherwise attribute the wrong PR.
+ * Extract PR number from a commit subject.
+ * Prefer trailing `(#123)` / `Merge pull request #123`; last `#N` otherwise.
  *
  * @param {string} line
  * @returns {number|null}
@@ -331,9 +328,7 @@ function parseArgs(argv) {
  * @returns {Promise<{packageName: string, baseRef: string|null, baseVersion: string|null, version: string, prs: Array}>}
  */
 /**
- * Fail-stop when the working clone cannot produce a complete changelog.
- * Shallow clones silently omit commits from `git log base..HEAD`, which
- * drops real package PRs from the release notes (seen on SDK 0.17.0).
+ * Fail-stop if the clone is shallow or baseRef is not an ancestor of HEAD.
  *
  * @param {string} baseRef
  */
@@ -343,16 +338,14 @@ function assertChangelogHistoryReady(baseRef) {
     isShallow = git("rev-parse --is-shallow-repository");
   } catch (error) {
     throw new Error(
-      "Unable to determine whether the repository is shallow. " +
-        "Refusing to generate a changelog without a full history check.",
+      "Unable to determine whether the repository is shallow.",
     );
   }
 
   if (isShallow === "true") {
     throw new Error(
-      "Repository is a shallow clone. Changelog generation requires full " +
-        "history so path-scoped `git log` does not miss merged PRs.\n" +
-        "Fix: `git fetch --unshallow` (or re-clone without --depth), then re-run.",
+      "Shallow clone: run `git fetch --unshallow` (or re-clone without " +
+        "--depth), then re-run.",
     );
   }
 
@@ -360,12 +353,11 @@ function assertChangelogHistoryReady(baseRef) {
     git(`rev-parse --verify ${baseRef}^{commit}`);
   } catch (error) {
     throw new Error(
-      `Base reference '${baseRef}' does not resolve to a commit in this clone.`,
+      `Base reference '${baseRef}' does not resolve to a commit.`,
     );
   }
 
   try {
-    // merge-base --is-ancestor exits 0 when baseRef is an ancestor of HEAD.
     execSync(`git merge-base --is-ancestor ${baseRef} HEAD`, {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -373,9 +365,7 @@ function assertChangelogHistoryReady(baseRef) {
   } catch (error) {
     throw new Error(
       `Base reference '${baseRef}' is not an ancestor of HEAD. ` +
-        "Changelog ranges are empty or misleading when the tip does not " +
-        "contain the release base. Check out the release tip (or the " +
-        "package tag) before generating.",
+        "Check out the release tip (or package tag) before generating.",
     );
   }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Changelog generation can miss path-scoped PRs on shallow clones / wrong HEAD.
- Subjects like `… - #3522 (#3534)` can bind the wrong PR if the first `#N` wins.

## 📝 How does it solve it?

- Fail-stop when the clone is shallow or base is not an ancestor of `HEAD`.
- Prefer trailing squash `(#N)` / merge-request forms for PR extraction.
- Document the same checks in `qv-sdk-changelog`.

## 🧪 How was it tested?

- `extractPRNumberFromSubject` smoke cases.
- `assertChangelogHistoryReady('sdk-v0.16.0')` on a full clone.
