### PR TITLE
QVAC-23416 feat[mod]: enable Audio8 desktop Vulkan in @qvac/tts-ggml

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audio8 engine.** Fifth engine family under the same
   `TTSGgml` surface: a DualAR model (24-layer semantic transformer +
   4-layer acoustic head over 8 codebooks) with a DAC-style codec, native
-  44.1 kHz, CPU-only in this release. Detection via `engine: 'audio8'`,
+  44.1 kHz, and CPU execution by default. Detection via `engine: 'audio8'`,
   `files.audio8Lm` / `files.audio8CodecDecoder`, or a `modelDir` containing
   `audio8-lm[-<quant>].gguf` (q8_0 > f16 > q4_0 > f32 within a role). It
   ships as three GGUFs rather than one because they have different
@@ -59,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `runStream`/`runStreaming` options), and the engine caches the codes for
   the most recent reference, so repeating one across calls skips the
   encoder.
+- **Audio8 desktop Vulkan support.** `config.useGPU: true` or
+  `nGpuLayers: 99` now offloads the Audio8 language model and codec graphs to
+  Vulkan on Linux and Windows. Text-only synthesis and voice cloning use the
+  same selected backend; unavailable or unsupported GPU backends fall back to
+  CPU and report that through `response.stats.gpuUnsupported`.
 - **Audio8 sampling/generation knobs.** `temperature`, `topK`, `topP`,
   `maxFrames`, `greedy`, `seed`, `threads`, `config.outputSampleRate`
   (engine-side resample from the native 44.1 kHz), all optional with the

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -6,7 +6,7 @@ GGML library.  Wraps multiple engines under one package: **Chatterbox**
 v1/v2 still loadable), **Parler** (mini/large English + indic 21-language,
 description-conditioned with voice/emotion templates), **CosyVoice3**
 (Fun-CosyVoice3-0.5B, instruct-conditioned, 24 kHz, CPU), and **Audio8**
-(DualAR + neural codec, in-process voice cloning, CPU-only), plus optional
+(DualAR + neural codec, in-process voice cloning, desktop Vulkan), plus optional
 LavaSR neural denoise + 48 kHz bandwidth-extension enhancement.  Unsure
 which checkpoint to stage? Start with [Choosing a model](#choosing-a-model).
 
@@ -20,7 +20,8 @@ Android `useGPU` flows through to `tts-cpp`, which picks the GPU
 backend per its own per-vendor allowlist (Adreno → OpenCL,
 Xclipse/Mali → Vulkan). Parler supports Apple/Metal and the validated
 Android paths, including Vulkan on ARM Mali (see
-[Backends & GPU acceleration](#backends--gpu-acceleration)).
+[Backends & GPU acceleration](#backends--gpu-acceleration)). Audio8 supports
+Vulkan offload on Linux and Windows.
 
 [qvac-tts-cpp]: https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/tts-cpp
 
@@ -61,7 +62,7 @@ obvious for each job.
 | Lowest RTF on phones / edge devices | `supertonic3-q4_0.gguf` (or `supertonic3-q8_0.gguf` for quality) | ~80 MB (`q4_0`) / ~126 MB (`q8_0`); 31 languages. Prefer v3 over v1/v2. |
 | English + voice cloning + low first-audio latency | `chatterbox-t3-turbo.gguf` + `chatterbox-s3gen.gguf` | Reference-wav / voice-profile cloning; native `streamChunkTokens` chunk streaming. Native 24 kHz. |
 | Multilingual + voice cloning (EU / CJK) | `chatterbox-t3-mtl.gguf` + `chatterbox-s3gen-mtl.gguf` | en/es/fr/de/pt/it/zh/ja/ko/…; same cloning + streaming surface as Turbo. |
-| Voice cloning at 44.1 kHz with nothing pre-baked | `audio8-lm-q8_0.gguf` + `audio8-codec-decoder-q8_0.gguf` (+ `audio8-codec-encoder-q8_0.gguf` to clone) | Clones from a reference wav **and its transcript**, encoded in-process — no enrolment step, no voice profile. Whole-utterance only (no native chunk streaming); CPU-only. |
+| Voice cloning at 44.1 kHz with nothing pre-baked | `audio8-lm-q8_0.gguf` + `audio8-codec-decoder-q8_0.gguf` (+ `audio8-codec-encoder-q8_0.gguf` to clone) | Clones from a reference wav **and its transcript**, encoded in-process — no enrolment step, no voice profile. Whole-utterance only (no native chunk streaming). |
 | Indic languages | `parler-indic-q8_0.gguf` | 21 Indic languages; voice / emotion templates. Emotion is officially tested on 10 languages — see [Parler descriptions & emotions](#parler-descriptions--emotions) (or the upstream model card). Native 44.1 kHz. |
 | Chinese dialects (Cantonese, Sichuan, Shanghai, …) | CosyVoice3 dir (`cosyvoice3-llm-*.gguf` + flow / hift / `voice.gguf`) | Instruct-conditioned; 17 dialects via `instruct: { dialect: '…' }`. CPU today; native 24 kHz. |
 | Description-conditioned English (caption / emotion) | `parler-mini-v1-q8_0.gguf` | Recommended English Parler checkpoint for caption / emotion control. |
@@ -486,6 +487,10 @@ host's policy:
 > Parler also opts into ARM Mali Vulkan on Android. Its GPU smoke test is
 > strict on Apple and Android; desktop Vulkan remains outside that test until
 > dedicated Linux and Windows validation is available.
+>
+> Audio8 uses Vulkan only and is validated on Linux and Windows. A GPU request
+> on another platform, or in a build without Vulkan, falls back to CPU and sets
+> `response.stats.gpuUnsupported`.
 
 ### Android: dynamic backend loading
 
@@ -598,12 +603,11 @@ falls into.  `greedy: true` takes the argmax instead and ignores
 `temperature` / `topK` / `topP`; it is reproducible but noticeably flatter.
 `maxFrames` caps generation in codec frames (~21.5/s of audio).
 
-Audio8 is **CPU-only** in this release.  `useGPU` / `nGpuLayers` are accepted
-and warn rather than failing, so callers do not have to special-case the
-engine; `response.stats.gpuUnsupported` reports when GPU was asked for and
-the CPU ran it.  Expect a real-time factor slightly above 1 on a desktop CPU
-for text-only synthesis, plus a one-off encode when a new reference voice is
-enrolled.
+Audio8 runs on CPU by default. Set `config.useGPU: true` or `nGpuLayers: 99`
+to offload the language model and codec graphs to Vulkan on Linux and Windows.
+If Vulkan is unavailable, the engine falls back to CPU and sets
+`response.stats.gpuUnsupported`. Voice cloning uses the same backend and adds
+a one-off encode when a new reference recording is supplied.
 
 ## API overview
 
@@ -655,7 +659,7 @@ enrolled.
 | `openclCacheDir`          | string     | unset      | Android-only: directory where the OpenCL backend persists its compiled program-binary cache.  Setting it across runs avoids re-JITing the kernels on every fresh process |
 | `vulkanCacheDir`          | string     | unset      | Supertonic + `useGPU: true` only: writable directory where the Vulkan backend persists its compiled pipeline cache (`GGML_VK_PIPELINE_CACHE_DIR`).  Moves the one-time first-dispatch pipeline-compile cost (seconds on Mali) off the first `run()` — paid once per install instead of once per process — and enables a load-time pre-warm.  Fully opt-in: unset -> no cross-process cache, no pre-warm, behaviour unchanged |
 | `config.language`         | string     | `"en"`     | Chatterbox MTL accepts `es/fr/de/pt/it/zh/ja/ko/...`; turbo & Supertonic are English |
-| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / Vulkan / CUDA / OpenCL if available. Honored for Chatterbox/Supertonic on GPU-capable hosts (including Android, per `tts-cpp`'s per-vendor allowlist); Parler is validated on Apple/Metal and Android/ARM Mali Vulkan; Audio8 is CPU-only. Unsupported backends fall back to CPU. See [Backends & GPU acceleration](#backends--gpu-acceleration) |
+| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / Vulkan / CUDA / OpenCL if available. Honored for Chatterbox/Supertonic on GPU-capable hosts (including Android, per `tts-cpp`'s per-vendor allowlist); Parler is validated on Apple/Metal and Android/ARM Mali Vulkan; Audio8 uses desktop Vulkan on Linux/Windows. Unsupported backends fall back to CPU. See [Backends & GPU acceleration](#backends--gpu-acceleration) |
 | `config.outputSampleRate` | number     | — (engine-native) | Resample the output to this rate (8000–192000 Hz). Omit to keep the engine-native rate (Chatterbox 24 kHz, Supertonic / Parler / Audio8 44.1 kHz, CosyVoice3 24 kHz, enhancer 48 kHz). Parler native chunk streaming accepts a non-native rate only with the enhancer active |
 | `opts.stats`              | boolean    | `false`    | Populate `response.stats` with RTF, `backendDevice` (0=CPU, 1=GPU), `backendId` (0=CPU, 1=Metal, 2=CUDA, 3=Vulkan, 4=OpenCL, 99=other), and — when an enhancer is active — `enhancerBackendDevice` / `enhancerBackendId` |
 | `exclusiveRun`            | boolean    | `false`    | **Top-level** option (not under `opts`): serialize overlapping streaming runs |
@@ -735,7 +739,7 @@ Runnable demos under `examples/`:
 | `parler-enhanced.js` | Parler + LavaSR 48 kHz enhancement. `bare examples/parler-enhanced.js "Hello" Laura happy` |
 | `cosyvoice-tts.js` | CosyVoice3 instruct-conditioned batch synth (24 kHz, CPU). `bare examples/cosyvoice-tts.js "Hello"` |
 | `cosyvoice-enhanced.js` | CosyVoice3 + LavaSR 48 kHz enhancement (add `--denoise` for the denoiser). `bare examples/cosyvoice-enhanced.js "Hello"` |
-| `audio8-tts.js` | Audio8 batch synth, optionally cloning a reference. `bare examples/audio8-tts.js "Hello" voice.wav "What it says."` |
+| `audio8-tts.js` | Audio8 batch synth, optionally cloning a reference. Set `QVAC_TTS_AUDIO8_GPU=1` for desktop Vulkan. `bare examples/audio8-tts.js "Hello" voice.wav "What it says."` |
 
 The two streaming examples feed PCM into a single long-running
 `sox play` / `ffplay` process so chunks play back-to-back without any

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Config.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Config.hpp
@@ -38,9 +38,7 @@ struct Audio8Config {
    * codec's native 44100. The engine resamples, so no addon-side pass.
    */
   std::optional<int> outputSampleRate;
-  // GPU offload. The engine is CPU-only today and warns on a positive value;
-  // the knobs are here so callers do not have to special-case this engine.
-  // nGpuLayers wins; else useGpu true->99 / false->0.
+  /** GPU offload: nGpuLayers wins; otherwise useGpu maps true to all layers. */
   std::optional<int> nGpuLayers;
   std::optional<bool> useGpu;
   std::string backendsDir;

--- a/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/audio8/Audio8Model.cpp
@@ -265,8 +265,6 @@ void Audio8Model::loadLocked() {
   backendName_ = engine_->backend_name();
   backendDevice_ = backendDeviceCode(engine_->backend_device());
   backendId_ = backendIdFromName(backendName_);
-  // The engine is CPU-only today, so GPU intent always resolves to the CPU
-  // device; report it the way ParlerModel derives the same signal.
   const bool wantsGpu = cfg_.nGpuLayers.has_value()
                             ? (*cfg_.nGpuLayers != 0)
                             : cfg_.useGpu.value_or(false);

--- a/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
@@ -46,7 +46,7 @@ tts_cpp::cosyvoice::EngineOptions toEngineOptions(const CosyvoiceConfig& cfg) {
   opts.reference_audio = cfg.referenceAudio;
   opts.prompt_text = cfg.promptText;
   opts.voice = cfg.voice;
-  opts.instruct_text = cfg.instruct;
+  opts.default_controls.instruct_text = cfg.instruct;
   if (!cfg.language.empty())
     opts.language = cfg.language;
   if (cfg.seed.has_value())

--- a/packages/tts-ggml/addon/tests/test_audio8_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_audio8_config.cpp
@@ -1,11 +1,5 @@
-// Constructor-validation tests for Audio8Model. Same shape as
-// test_parler_config.cpp: validateConfig is driven via the public
-// constructor, and the GGUF parse is deferred to load() so stub files are
-// enough to exercise every branch that does not touch weights.
-//
-// Real-GGUF round-trip is gated behind QVAC_TEST_AUDIO8_LM_GGUF.
-
 #include <atomic>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -17,14 +11,27 @@
 #include <gtest/gtest.h>
 
 #include "inference-addon-cpp/Errors.hpp"
+#include "model-interface/BackendUtils.hpp"
 #include "model-interface/audio8/Audio8Config.hpp"
 #include "model-interface/audio8/Audio8Model.hpp"
 
 using qvac::ttsggml::audio8::Audio8Config;
 using qvac::ttsggml::audio8::Audio8Model;
+using qvac::ttsggml::backendIdFromName;
+using qvac::ttsggml::kBackendDeviceGpu;
 using qvac_errors::StatusError;
 
 namespace {
+
+constexpr char AUDIO8_LM_ENV[] = "QVAC_TEST_AUDIO8_LM_GGUF";
+constexpr char AUDIO8_DECODER_ENV[] = "QVAC_TEST_AUDIO8_DECODER_GGUF";
+constexpr char AUDIO8_ENCODER_ENV[] = "QVAC_TEST_AUDIO8_ENCODER_GGUF";
+constexpr char AUDIO8_REFERENCE_WAV_ENV[] = "QVAC_TEST_AUDIO8_REFERENCE_WAV";
+constexpr char AUDIO8_REFERENCE_TEXT_ENV[] = "QVAC_TEST_AUDIO8_REFERENCE_TEXT";
+constexpr char AUDIO8_VULKAN_ENV[] = "QVAC_TEST_AUDIO8_VULKAN";
+constexpr char AUDIO8_BACKENDS_DIR_ENV[] = "QVAC_TEST_AUDIO8_BACKENDS_DIR";
+constexpr char VULKAN_BACKEND_NAME[] = "Vulkan";
+constexpr int REAL_GGUF_MAX_FRAMES = 16;
 
 std::filesystem::path tempPath(const std::string& suffix) {
   auto dir =
@@ -74,6 +81,22 @@ void swapConfigsUntilStopped(
 Audio8Model::Output
 synthesizeOnce(Audio8Model& model, const Audio8Model::AnyInput& input) {
   return std::any_cast<Audio8Model::Output>(model.process(std::any(input)));
+}
+
+int64_t runtimeInt(const Audio8Model& model, const std::string& key) {
+  for (const auto& entry : model.runtimeStats()) {
+    if (entry.first == key)
+      return std::get<int64_t>(entry.second);
+  }
+  ADD_FAILURE() << "missing runtimeStats key: " << key;
+  return 0;
+}
+
+void expectVulkanBackend(const Audio8Model& model) {
+  EXPECT_EQ(runtimeInt(model, "backendDevice"), kBackendDeviceGpu);
+  EXPECT_EQ(
+      runtimeInt(model, "backendId"), backendIdFromName(VULKAN_BACKEND_NAME));
+  EXPECT_EQ(runtimeInt(model, "gpuUnsupported"), 0);
 }
 
 void readVoiceRepeatedly(const Audio8Model& model, int iterations) {
@@ -219,8 +242,6 @@ TEST(Audio8Validate, UseGpuNGpuLayersConflictRejected) {
 }
 
 TEST(Audio8Validate, GpuIntentAcceptedAtConstruction) {
-  // The engine is CPU-only today and warns rather than failing, so GPU intent
-  // must not be rejected here.
   auto cfg = minimallyValidStubConfig();
   cfg.useGpu = true;
   EXPECT_NO_THROW(Audio8Model{cfg});
@@ -370,8 +391,8 @@ TEST(Audio8Reload, RefusedReloadKeepsTheConfiguration) {
 }
 
 TEST(Audio8RealGguf, TextOnlySynthesisRoundTrip) {
-  const std::string lm = envOrEmpty("QVAC_TEST_AUDIO8_LM_GGUF");
-  const std::string decoder = envOrEmpty("QVAC_TEST_AUDIO8_DECODER_GGUF");
+  const std::string lm = envOrEmpty(AUDIO8_LM_ENV);
+  const std::string decoder = envOrEmpty(AUDIO8_DECODER_ENV);
   if (lm.empty() || decoder.empty()) {
     GTEST_SKIP() << "set QVAC_TEST_AUDIO8_LM_GGUF and "
                     "QVAC_TEST_AUDIO8_DECODER_GGUF to run this";
@@ -381,7 +402,7 @@ TEST(Audio8RealGguf, TextOnlySynthesisRoundTrip) {
   cfg.lmModelPath = lm;
   cfg.codecDecoderPath = decoder;
   cfg.greedy = true;
-  cfg.maxFrames = 16;
+  cfg.maxFrames = REAL_GGUF_MAX_FRAMES;
 
   Audio8Model model{cfg};
   ASSERT_NO_THROW(model.load());
@@ -395,12 +416,40 @@ TEST(Audio8RealGguf, TextOnlySynthesisRoundTrip) {
       model.sampleRate(), qvac::ttsggml::audio8::AUDIO8_NATIVE_SAMPLE_RATE);
 }
 
+TEST(Audio8RealGguf, VulkanTextOnlySynthesisRoundTrip) {
+  if (envOrEmpty(AUDIO8_VULKAN_ENV).empty()) {
+    GTEST_SKIP() << "set QVAC_TEST_AUDIO8_VULKAN to run this";
+  }
+  const std::string lm = envOrEmpty(AUDIO8_LM_ENV);
+  const std::string decoder = envOrEmpty(AUDIO8_DECODER_ENV);
+  if (lm.empty() || decoder.empty()) {
+    GTEST_SKIP() << "set QVAC_TEST_AUDIO8_LM_GGUF and "
+                    "QVAC_TEST_AUDIO8_DECODER_GGUF to run this";
+  }
+
+  Audio8Config cfg;
+  cfg.lmModelPath = lm;
+  cfg.codecDecoderPath = decoder;
+  cfg.greedy = true;
+  cfg.maxFrames = REAL_GGUF_MAX_FRAMES;
+  cfg.useGpu = true;
+  cfg.backendsDir = envOrEmpty(AUDIO8_BACKENDS_DIR_ENV);
+
+  Audio8Model model{cfg};
+  ASSERT_NO_THROW(model.load());
+
+  Audio8Model::AnyInput input;
+  input.text = "Hello from Audio eight on Vulkan.";
+  EXPECT_FALSE(synthesizeOnce(model, input).empty());
+  expectVulkanBackend(model);
+}
+
 TEST(Audio8RealGguf, CloningSynthesisRoundTrip) {
-  const std::string lm = envOrEmpty("QVAC_TEST_AUDIO8_LM_GGUF");
-  const std::string decoder = envOrEmpty("QVAC_TEST_AUDIO8_DECODER_GGUF");
-  const std::string encoder = envOrEmpty("QVAC_TEST_AUDIO8_ENCODER_GGUF");
-  const std::string wav = envOrEmpty("QVAC_TEST_AUDIO8_REFERENCE_WAV");
-  const std::string transcript = envOrEmpty("QVAC_TEST_AUDIO8_REFERENCE_TEXT");
+  const std::string lm = envOrEmpty(AUDIO8_LM_ENV);
+  const std::string decoder = envOrEmpty(AUDIO8_DECODER_ENV);
+  const std::string encoder = envOrEmpty(AUDIO8_ENCODER_ENV);
+  const std::string wav = envOrEmpty(AUDIO8_REFERENCE_WAV_ENV);
+  const std::string transcript = envOrEmpty(AUDIO8_REFERENCE_TEXT_ENV);
   if (lm.empty() || decoder.empty() || encoder.empty() || wav.empty() ||
       transcript.empty()) {
     GTEST_SKIP() << "set QVAC_TEST_AUDIO8_LM_GGUF, "
@@ -417,7 +466,12 @@ TEST(Audio8RealGguf, CloningSynthesisRoundTrip) {
   cfg.referenceAudio = wav;
   cfg.referenceText = transcript;
   cfg.greedy = true;
-  cfg.maxFrames = 16;
+  cfg.maxFrames = REAL_GGUF_MAX_FRAMES;
+  const bool useVulkan = !envOrEmpty(AUDIO8_VULKAN_ENV).empty();
+  if (useVulkan) {
+    cfg.useGpu = true;
+    cfg.backendsDir = envOrEmpty(AUDIO8_BACKENDS_DIR_ENV);
+  }
 
   Audio8Model model{cfg};
   ASSERT_NO_THROW(model.load());
@@ -426,6 +480,8 @@ TEST(Audio8RealGguf, CloningSynthesisRoundTrip) {
   input.text = "The reference recording decides how this sounds.";
   const auto cloned = synthesizeOnce(model, input);
   EXPECT_FALSE(cloned.empty());
+  if (useVulkan)
+    expectVulkanBackend(model);
   EXPECT_EQ(
       model.sampleRate(), qvac::ttsggml::audio8::AUDIO8_NATIVE_SAMPLE_RATE);
 

--- a/packages/tts-ggml/examples/audio8-tts.js
+++ b/packages/tts-ggml/examples/audio8-tts.js
@@ -22,6 +22,7 @@
  * Examples:
  *   bare examples/audio8-tts.js "Hello from a fully on-device pipeline."
  *   bare examples/audio8-tts.js "Cloned speech." voice.wav "What the recording says."
+ *   QVAC_TTS_AUDIO8_GPU=1 bare examples/audio8-tts.js "Vulkan synthesis."
  *
  * Expects the Audio8 GGUFs (audio8-lm-q8_0.gguf,
  * audio8-codec-decoder-q8_0.gguf, and, to clone,
@@ -31,11 +32,11 @@
  * (engines/tts/scripts/convert-audio8-{lm,codec}-to-gguf.py) until they are
  * published to the model registry.
  *
- * NOTE: Audio8 is CPU-only in this release; useGPU / nGpuLayers are accepted
- * and warn rather than failing.
+ * GPU offload uses Vulkan on Linux and Windows. CPU remains the default.
  */
 
 const path = require('bare-path')
+const proc = require('bare-process')
 const TTSGgml = require('../')
 const { createWav } = require('./wav-helper')
 const { setLogger, releaseLogger } = require('../addonLogging')
@@ -72,6 +73,7 @@ function buildModel() {
     engine: TTSGgml.ENGINE_AUDIO8,
     files: { modelDir },
     ...voice,
+    config: { useGPU: proc.env.QVAC_TTS_AUDIO8_GPU === '1' },
     logger: console,
     opts: { stats: true }
   })
@@ -83,7 +85,8 @@ function reportStats(stats) {
     `Inference stats: totalTime=${stats.totalTime.toFixed(2)}s, ` +
       `framesPerSecond=${stats.tokensPerSecond.toFixed(2)}, ` +
       `realTimeFactor=${stats.realTimeFactor.toFixed(3)}, ` +
-      `audioDuration=${stats.audioDurationMs}ms, totalSamples=${stats.totalSamples}`
+      `audioDuration=${stats.audioDurationMs}ms, totalSamples=${stats.totalSamples}, ` +
+      `backendDevice=${stats.backendDevice}, backendId=${stats.backendId}`
   )
 }
 

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -163,9 +163,8 @@ interface TTSGgmlRuntimeConfig {
     language?: string;
     /**
      * Route inference through a GPU backend (Metal / Vulkan / OpenCL) if
-     * available. Defaults to `false` for both engines. Honored on Apple,
-     * desktop, and Android, where tts-cpp selects the backend using its
-     * per-vendor allowlist.
+     * available. Defaults to `false`. Audio8 uses Vulkan on Linux and Windows;
+     * the other GPU-capable engines select a backend for the host platform.
      */
     useGPU?: boolean;
     /**
@@ -255,6 +254,7 @@ interface TTSGgmlOptions extends ParlerDescriptionFields, Audio8VoiceFields {
     /**
      * Move N layers to the GPU backend. Chatterbox: pass 99 to move everything.
      * Supertonic: pass 99 to offload on GPU-capable hosts, including Android.
+     * Audio8: pass 99 to use Vulkan on Linux and Windows.
      */
     nGpuLayers?: number;
     /**

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -27,7 +27,7 @@
     "example:cosyvoice": "bare examples/cosyvoice-tts.js \"Hello from CosyVoice three.\"",
     "example:cosyvoice-enhanced": "bare examples/cosyvoice-enhanced.js \"Hello from CosyVoice three.\"",
     "example:parler": "bare examples/parler-tts.js \"Hey, how are you doing today?\"",
-    "example:audio8": "bare examples/audio8-tts.js \"Audio eight speaks on the CPU.\"",
+    "example:audio8": "bare examples/audio8-tts.js \"Audio eight speaks on-device.\"",
     "lint": "npm run lint:js && npm run lint:ts && npm run test:types",
     "lint:js": "prettier --check \"test/**/*.js\" \"binding.js\" && lunte \"test/**/*.js\" \"binding.js\"",
     "lint:ts": "eslint \"src/**/*.ts\" --max-warnings=0",

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -339,9 +339,8 @@ interface TTSGgmlRuntimeConfig {
   language?: string;
   /**
    * Route inference through a GPU backend (Metal / Vulkan / OpenCL) if
-   * available. Defaults to `false` for both engines. Honored on Apple,
-   * desktop, and Android, where tts-cpp selects the backend using its
-   * per-vendor allowlist.
+   * available. Defaults to `false`. Audio8 uses Vulkan on Linux and Windows;
+   * the other GPU-capable engines select a backend for the host platform.
    */
   useGPU?: boolean;
   /**
@@ -449,6 +448,7 @@ interface TTSGgmlOptions
   /**
    * Move N layers to the GPU backend. Chatterbox: pass 99 to move everything.
    * Supertonic: pass 99 to offload on GPU-capable hosts, including Android.
+   * Audio8: pass 99 to use Vulkan on Linux and Windows.
    */
   nGpuLayers?: number;
   /**

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-08-07#1"
+      "version>=": "2026-08-10#1"
     }
   ],
   "features": {


### PR DESCRIPTION
## Summary
- consume `tts-cpp@2026-08-10#1` and activate the existing Audio8 GPU options on Linux/Windows Vulkan
- report the resolved backend and add model-gated Vulkan coverage for text-only synthesis and voice cloning
- update the public types, example, changelog, and backend documentation
- migrate CosyVoice3 to `default_controls.instruct_text`, required by the base `tts-cpp@2026-08-10` API

This is stacked on #3723. The dependency is published by tetherto/qvac-registry-vcpkg#296, itself stacked on registry release #293.

## Test plan
- [x] `npm run test:unit`
- [x] `npm run lint`
- [x] Build `tts-cpp[core,vulkan]` from the registry overlay
- [x] `npm run test:cpp` against that port: 176 passed, 14 model-gated skips
- [ ] Run the Audio8 real-GGUF Vulkan tests with `QVAC_TEST_AUDIO8_VULKAN=1` on a staged model host