### PR TITLE
QVAC-23272 chore: bump classification-ggml to 0.18.0 for @qvac/fabric 0.4.0

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-08-10
+
+### Changed
+
+- `@qvac/fabric` dependency bumped `^0.3.1` -> `^0.4.0`, which carries `qvac-fabric`
+  `9840.1.1` -> `10069.0.0` (b10069 rebase). This package consumes the shared runtime
+  via npm rather than building the vcpkg port, so the range bump is what picks up the
+  new fabric. A caret on a `0.x` version locks the minor, so `^0.3.1` would not have
+  resolved `0.4.0` on its own. No API change for this package.
+
 ## [0.17.0] - 2026-08-06
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {
@@ -85,7 +85,7 @@
     "typescript-eslint": "^8.63.0"
   },
   "dependencies": {
-    "@qvac/fabric": "^0.3.1",
+    "@qvac/fabric": "^0.4.0",
     "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",
     "bare-env": "^3.0.0",


### PR DESCRIPTION
## 🎯 Problem

`@qvac/fabric` was published as **0.4.0** in the qvac-fabric 10069.0.0 consumer release
(follow-up to #3742), carrying `qvac-fabric` `9840.1.1` -> `10069.0.0` (b10069 rebase).

`classification-ggml` pinned `"@qvac/fabric": "^0.3.1"`. On a `0.x` version a caret **locks
the minor**, so `^0.3.1` absorbs `0.3.x` but will **not** resolve `0.4.0`. Left alone, this
package would keep installing the old fabric runtime indefinitely while every other consumer
moved to 10069.0.0.

`classification-ggml` is not part of the fabric rollout PR itself — it dropped the
`qvac-fabric` vcpkg dependency in #3301 and now consumes the shared runtime as an npm
package, so it needs this separate range bump rather than a vcpkg `version>=` change.

## 📝 How

- `packages/classification-ggml/package.json` — `@qvac/fabric` `^0.3.1` -> `^0.4.0`
- `packages/classification-ggml/package.json` — package version `0.17.0` -> `0.18.0`
- `packages/classification-ggml/CHANGELOG.md` — dated `## [0.18.0]` entry under `### Changed`

Minor bump, matching the precedent this package already set for the same kind of change
(`0.15.0` for `^0.2.0` -> `^0.3.0`, `0.15.1` for `^0.3.0` -> `^0.3.1`).

No vcpkg change: `packages/classification-ggml/vcpkg.json` contains no `qvac-fabric`
reference, and the only version pin anywhere in the package is the one `package.json` line.

## 🧪 Tested

- Verified `@qvac/fabric@0.4.0` is published and publicly installable (token-less install
  with an isolated `HOME` and a bare registry `.npmrc`).
- Verified the dependency pin is the package's only `@qvac/fabric` version reference — the
  remaining mentions are code comments and runtime `require`/`require.resolve` calls with no
  version.
- Confirmed the changelog heading matches the release extractor's regex
  (`^## \[0\.18\.0\]`).
- Confirmed the diff touches exactly two files.
- CI on this PR is what validates the addon actually builds and tests against `fabric@0.4.0`.

## ⚠️ Breaking changes

None. No public API or config surface change for this package — only the resolved fabric
runtime moves.
