### PR TITLE
QVAC-22886 feat[audiogen-ggml]: wire reference/source audio and cover tasks

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose ACE-Step reference/source audio and cover task controls through the
+  JavaScript API (`referenceAudio`, `sourceAudio`, `taskType`,
+  `audioCoverStrength`, `coverNoiseStrength`) and forward them to audiogen-cpp.
 - Validate ACE-Step GPU generation on Android with a strict mobile smoke test:
   `useGPU: true` must resolve to Vulkan (`backendDevice=1`, `backendId=3`) and
   produce non-silent 48 kHz stereo audio. This covers ARM Mali devices such as
@@ -18,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump `audiogen-cpp` to `2026-08-11` (registry branch
+  `QVAC-22886/reference-audio-input`) so native builds pick up cover-nofsq and
+  reference-audio support.
 - Bump `audiogen-cpp` to `2026-08-10`, enabling official sampler-side Haar DCW
   by default and using the validated LM decoding policy on Metal and Vulkan.
 

--- a/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
@@ -45,6 +45,23 @@ copyAudioCodes(js_env_t* env, js::TypedArray<int32_t> array) {
   return {data, data + len};
 }
 
+inline std::vector<float>
+copyFloat32Pcm(js_env_t* env, js::TypedArray<float> array, const char* name) {
+  float* data = nullptr;
+  size_t len = 0;
+  if (js_get_typedarray_info(
+          env,
+          array,
+          nullptr,
+          reinterpret_cast<void**>(&data),
+          &len,
+          nullptr,
+          nullptr) != 0) {
+    throw std::runtime_error(std::string(name) + " must be a Float32Array");
+  }
+  return {data, data + len};
+}
+
 // Emits the generated track as interleaved stereo Int16 + sample rate, mirror
 // of ttsggml::JsAudioOutputHandler. The rate/channels are sourced from the model
 // (which reads them from the engine's decode result) rather than hardcoded, so
@@ -202,6 +219,19 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
           env, "audioCodes")) {
     modelInput.audioCodes = copyAudioCodes(env, *codes);
   }
+  if (auto ref = jobObj.getOptionalProperty<js::TypedArray<float>>(
+          env, "referenceAudio")) {
+    modelInput.referenceAudio = copyFloat32Pcm(env, *ref, "referenceAudio");
+  }
+  if (auto src = jobObj.getOptionalProperty<js::TypedArray<float>>(
+          env, "sourceAudio")) {
+    modelInput.sourceAudio = copyFloat32Pcm(env, *src, "sourceAudio");
+  }
+  if (auto v = optStr("taskType")) modelInput.taskType = *v;
+  if (auto v = optNum("audioCoverStrength"))
+    modelInput.audioCoverStrength = static_cast<float>(*v);
+  if (auto v = optNum("coverNoiseStrength"))
+    modelInput.coverNoiseStrength = static_cast<float>(*v);
   return instance.runJob(std::any(std::move(modelInput)));
 }
 JSCATCH

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
@@ -171,6 +171,11 @@ AcestepModel::Output AcestepModel::generate(const AnyInput& in) {
   params.dcw_scaler = in.dcwScaler;
   params.dcw_high_scaler = in.dcwHighScaler;
   params.audio_codes = in.audioCodes;
+  params.reference_audio = in.referenceAudio;
+  params.source_audio = in.sourceAudio;
+  params.task_type = in.taskType;
+  params.audio_cover_strength = in.audioCoverStrength;
+  params.cover_noise_strength = in.coverNoiseStrength;
   // 0 = auto: the engine resolves steps/shift from the DiT model type
   // (turbo -> 8 / shift 3.0, base/sft -> 50 / shift 1.0). Forcing 8/3.0 here
   // would make a base/sft model render with turbo settings and sound wrong.

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
@@ -61,6 +61,12 @@ public:
     float dcwHighScaler = 0.02F;
     std::vector<int>
         audioCodes; // non-empty => skip LM and synthesize these codes
+    // Optional timbre / cover PCM (interleaved stereo float @ 48 kHz).
+    std::vector<float> referenceAudio;
+    std::vector<float> sourceAudio;
+    std::string taskType = "text2music";
+    float audioCoverStrength = 1.0F;
+    float coverNoiseStrength = 0.0F;
   };
 
   explicit AcestepModel(AcestepConfig config);

--- a/packages/audiogen-ggml/audiogen.d.ts
+++ b/packages/audiogen-ggml/audiogen.d.ts
@@ -43,6 +43,11 @@ export interface AudioGenJobData {
     dcwScaler?: number;
     dcwHighScaler?: number;
     audioCodes?: Int32Array;
+    referenceAudio?: Float32Array;
+    sourceAudio?: Float32Array;
+    taskType?: string;
+    audioCoverStrength?: number;
+    coverNoiseStrength?: number;
 }
 /** Native output event: (handle, event, data, error). */
 export type AudioGenOutputCallback = (handle: unknown, event: unknown, data: unknown, error: unknown) => void;

--- a/packages/audiogen-ggml/index.d.ts
+++ b/packages/audiogen-ggml/index.d.ts
@@ -76,6 +76,32 @@ export interface GenerateOptions {
     dcwHighScaler?: number;
     /** Frozen ACE-Step semantic codes; when present, skips the LM stage. */
     audioCodes?: Int32Array;
+    /**
+     * Optional timbre reference: interleaved stereo float PCM at 48 kHz.
+     * Empty / omitted keeps the engine's canonical silence reference.
+     */
+    referenceAudio?: Float32Array;
+    /**
+     * Source / cover audio (same layout as `referenceAudio`). Required when
+     * `taskType` is `"cover"` or `"cover-nofsq"`.
+     */
+    sourceAudio?: Float32Array;
+    /**
+     * Task discriminator. Supported today: `"text2music"` (default) |
+     * `"cover-nofsq"`. `"cover"` (FSQ roundtrip) is accepted but not implemented
+     * in the engine yet.
+     */
+    taskType?: 'text2music' | 'cover' | 'cover-nofsq' | string;
+    /**
+     * Fraction of DiT steps that keep the source context (0..1). Default 1.0.
+     * Values < 1 are rejected by the engine until context switching lands.
+     */
+    audioCoverStrength?: number;
+    /**
+     * Blend initial DiT noise toward clean source latents (0..1). 0 = pure noise;
+     * 1 ≈ source latent. Default 0.
+     */
+    coverNoiseStrength?: number;
 }
 /** A per-step progress tick from the engine (stage = "lm" | "dit" | "vae"). */
 export interface AudiogenProgress {

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -44,6 +44,29 @@ function requireFiniteNumber(value, name, integer = false) {
 function optionalFiniteNumber(value, name, integer = false) {
     return value === undefined ? undefined : requireFiniteNumber(value, name, integer);
 }
+const GENERATE_TASK_TYPES = new Set(['text2music', 'cover', 'cover-nofsq']);
+function optionalTaskType(value) {
+    if (value === undefined)
+        return undefined;
+    if (typeof value !== 'string' || !GENERATE_TASK_TYPES.has(value)) {
+        throw new Error('audiogen-ggml: taskType must be one of text2music|cover|cover-nofsq');
+    }
+    return value;
+}
+function optionalStereoPcm(value, name) {
+    if (value === undefined)
+        return undefined;
+    if (!(value instanceof Float32Array)) {
+        throw new Error(`audiogen-ggml: ${name} must be a Float32Array`);
+    }
+    if ((value.length & 1) !== 0) {
+        throw new Error(`audiogen-ggml: ${name} must be interleaved stereo`);
+    }
+    return value;
+}
+function isCoverTask(taskType) {
+    return taskType === 'cover' || taskType === 'cover-nofsq';
+}
 /**
  * GGML-backed music generation via the ACE-Step engine. Owns a persistent
  * native engine: the four model stages are loaded once by `load()` and reused
@@ -141,6 +164,12 @@ class AudioGen {
         if (opts.audioCodes !== undefined && !(opts.audioCodes instanceof Int32Array)) {
             throw new Error('audiogen-ggml: audioCodes must be an Int32Array');
         }
+        const taskType = optionalTaskType(opts.taskType);
+        const referenceAudio = optionalStereoPcm(opts.referenceAudio, 'referenceAudio');
+        const sourceAudio = optionalStereoPcm(opts.sourceAudio, 'sourceAudio');
+        if (isCoverTask(taskType) && (sourceAudio === undefined || sourceAudio.length === 0)) {
+            throw new Error(`audiogen-ggml: taskType '${taskType}' requires sourceAudio`);
+        }
         const response = this._job.start();
         try {
             await this._requireAddon().runJob({
@@ -161,7 +190,12 @@ class AudioGen {
                 dcwEnabled: opts.dcwEnabled,
                 dcwScaler: optionalFiniteNumber(opts.dcwScaler, 'dcwScaler'),
                 dcwHighScaler: optionalFiniteNumber(opts.dcwHighScaler, 'dcwHighScaler'),
-                audioCodes: opts.audioCodes
+                audioCodes: opts.audioCodes,
+                referenceAudio,
+                sourceAudio,
+                taskType,
+                audioCoverStrength: optionalFiniteNumber(opts.audioCoverStrength, 'audioCoverStrength'),
+                coverNoiseStrength: optionalFiniteNumber(opts.coverNoiseStrength, 'coverNoiseStrength')
             });
         }
         catch (error) {

--- a/packages/audiogen-ggml/src/audiogen.ts
+++ b/packages/audiogen-ggml/src/audiogen.ts
@@ -48,6 +48,11 @@ export interface AudioGenJobData {
   dcwScaler?: number
   dcwHighScaler?: number
   audioCodes?: Int32Array
+  referenceAudio?: Float32Array
+  sourceAudio?: Float32Array
+  taskType?: string
+  audioCoverStrength?: number
+  coverNoiseStrength?: number
 }
 
 /** Native output event: (handle, event, data, error). */

--- a/packages/audiogen-ggml/src/index.ts
+++ b/packages/audiogen-ggml/src/index.ts
@@ -102,6 +102,32 @@ export interface GenerateOptions {
   dcwHighScaler?: number
   /** Frozen ACE-Step semantic codes; when present, skips the LM stage. */
   audioCodes?: Int32Array
+  /**
+   * Optional timbre reference: interleaved stereo float PCM at 48 kHz.
+   * Empty / omitted keeps the engine's canonical silence reference.
+   */
+  referenceAudio?: Float32Array
+  /**
+   * Source / cover audio (same layout as `referenceAudio`). Required when
+   * `taskType` is `"cover"` or `"cover-nofsq"`.
+   */
+  sourceAudio?: Float32Array
+  /**
+   * Task discriminator. Supported today: `"text2music"` (default) |
+   * `"cover-nofsq"`. `"cover"` (FSQ roundtrip) is accepted but not implemented
+   * in the engine yet.
+   */
+  taskType?: 'text2music' | 'cover' | 'cover-nofsq' | string
+  /**
+   * Fraction of DiT steps that keep the source context (0..1). Default 1.0.
+   * Values < 1 are rejected by the engine until context switching lands.
+   */
+  audioCoverStrength?: number
+  /**
+   * Blend initial DiT noise toward clean source latents (0..1). 0 = pure noise;
+   * 1 ≈ source latent. Default 0.
+   */
+  coverNoiseStrength?: number
 }
 
 /** A per-step progress tick from the engine (stage = "lm" | "dit" | "vae"). */
@@ -190,6 +216,36 @@ function optionalFiniteNumber (
   integer = false
 ): number | undefined {
   return value === undefined ? undefined : requireFiniteNumber(value, name, integer)
+}
+
+const GENERATE_TASK_TYPES = new Set(['text2music', 'cover', 'cover-nofsq'])
+
+function optionalTaskType (value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !GENERATE_TASK_TYPES.has(value)) {
+    throw new Error(
+      'audiogen-ggml: taskType must be one of text2music|cover|cover-nofsq'
+    )
+  }
+  return value
+}
+
+function optionalStereoPcm (
+  value: Float32Array | undefined,
+  name: string
+): Float32Array | undefined {
+  if (value === undefined) return undefined
+  if (!(value instanceof Float32Array)) {
+    throw new Error(`audiogen-ggml: ${name} must be a Float32Array`)
+  }
+  if ((value.length & 1) !== 0) {
+    throw new Error(`audiogen-ggml: ${name} must be interleaved stereo`)
+  }
+  return value
+}
+
+function isCoverTask (taskType: string | undefined): boolean {
+  return taskType === 'cover' || taskType === 'cover-nofsq'
 }
 
 /**
@@ -298,6 +354,12 @@ export class AudioGen {
     if (opts.audioCodes !== undefined && !(opts.audioCodes instanceof Int32Array)) {
       throw new Error('audiogen-ggml: audioCodes must be an Int32Array')
     }
+    const taskType = optionalTaskType(opts.taskType)
+    const referenceAudio = optionalStereoPcm(opts.referenceAudio, 'referenceAudio')
+    const sourceAudio = optionalStereoPcm(opts.sourceAudio, 'sourceAudio')
+    if (isCoverTask(taskType) && (sourceAudio === undefined || sourceAudio.length === 0)) {
+      throw new Error(`audiogen-ggml: taskType '${taskType}' requires sourceAudio`)
+    }
     const response = this._job.start()
     try {
       await this._requireAddon().runJob({
@@ -318,7 +380,18 @@ export class AudioGen {
         dcwEnabled: opts.dcwEnabled,
         dcwScaler: optionalFiniteNumber(opts.dcwScaler, 'dcwScaler'),
         dcwHighScaler: optionalFiniteNumber(opts.dcwHighScaler, 'dcwHighScaler'),
-        audioCodes: opts.audioCodes
+        audioCodes: opts.audioCodes,
+        referenceAudio,
+        sourceAudio,
+        taskType,
+        audioCoverStrength: optionalFiniteNumber(
+          opts.audioCoverStrength,
+          'audioCoverStrength'
+        ),
+        coverNoiseStrength: optionalFiniteNumber(
+          opts.coverNoiseStrength,
+          'coverNoiseStrength'
+        )
       })
     } catch (error) {
       this._logger.error(

--- a/packages/audiogen-ggml/test/unit/generate-options.test.js
+++ b/packages/audiogen-ggml/test/unit/generate-options.test.js
@@ -81,3 +81,100 @@ test('AudioGen.run rejects invalid sampler and DCW controls before native dispat
     )
   }
 })
+
+test('AudioGen.run forwards reference/source audio, taskType and cover strengths', async (t) => {
+  const { gen, received } = createHarness()
+  const referenceAudio = new Float32Array([0.1, -0.1, 0.2, -0.2])
+  const sourceAudio = new Float32Array([0.3, -0.3, 0.4, -0.4, 0.5, -0.5])
+
+  const response = await gen.run('salsa cover', {
+    taskType: 'cover-nofsq',
+    referenceAudio,
+    sourceAudio,
+    audioCoverStrength: 1,
+    coverNoiseStrength: 0.25
+  })
+  await response.await()
+
+  const job = received()
+  t.is(job.taskType, 'cover-nofsq')
+  t.is(job.referenceAudio, referenceAudio)
+  t.is(job.sourceAudio, sourceAudio)
+  t.is(job.audioCoverStrength, 1)
+  t.is(job.coverNoiseStrength, 0.25)
+})
+
+test('AudioGen.run forwards text2music with optional referenceAudio only', async (t) => {
+  const { gen, received } = createHarness()
+  const referenceAudio = new Float32Array([0, 0, 0.5, -0.5])
+
+  const response = await gen.run('timbre conditioned', {
+    taskType: 'text2music',
+    referenceAudio
+  })
+  await response.await()
+
+  const job = received()
+  t.is(job.taskType, 'text2music')
+  t.is(job.referenceAudio, referenceAudio)
+  t.is(job.sourceAudio, undefined)
+})
+
+test('AudioGen.run rejects invalid cover/reference options before native dispatch', async (t) => {
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { taskType: 'repaint' }),
+      /taskType must be one of text2music\|cover\|cover-nofsq/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { taskType: 'cover-nofsq' }),
+      /taskType 'cover-nofsq' requires sourceAudio/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { taskType: 'cover', sourceAudio: new Float32Array(0) }),
+      /taskType 'cover' requires sourceAudio/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { referenceAudio: new Int16Array([1, 2]) }),
+      /referenceAudio must be a Float32Array/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { sourceAudio: new Float32Array([1, 2, 3]) }),
+      /sourceAudio must be interleaved stereo/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { referenceAudio: new Float32Array([1, 2, 3]) }),
+      /referenceAudio must be interleaved stereo/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { audioCoverStrength: Number.NaN }),
+      /audioCoverStrength must be a finite number/
+    )
+  }
+  {
+    const { gen } = createHarness()
+    await t.exception(
+      () => gen.run('test', { coverNoiseStrength: Number.POSITIVE_INFINITY }),
+      /coverNoiseStrength must be a finite number/
+    )
+  }
+})

--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "65b1d890edc1da43617f599e92bea19f1b9bc30e",
+    "baseline": "7297cf476489e5086db43594d35d087fe4772271",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "audiogen-cpp",
-      "version>=": "2026-08-10"
+      "version>=": "2026-08-11"
     }
   ],
   "features": {


### PR DESCRIPTION
## Summary
- Expose `referenceAudio`, `sourceAudio`, `taskType`, `audioCoverStrength`, and `coverNoiseStrength` through `@qvac/audiogen-ggml` and forward them to audiogen-cpp.
- Point the package vcpkg baseline at registry branch `QVAC-22886/reference-audio-input` (`7297cf4`) and require `audiogen-cpp >= 2026-08-11`.
- Add unit tests for forwarding and validation of the new options.

Depends on registry branch/PR: tetherto/qvac-registry-vcpkg `QVAC-22886/reference-audio-input`.

## Test plan
- [x] `brittle-bare test/unit/generate-options.test.js` (5/5)
- [ ] PR CI prebuilds against pinned `audiogen-cpp`
- [ ] PR CI unit + integration for audiogen-ggml