### PR TITLE
chore[notask]: release @qvac/inference 0.17.0

### DIFF
--- a/packages/inference/CHANGELOG.md
+++ b/packages/inference/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.17.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/inference/v/0.17.0
+
+First public release of `@qvac/inference`, the Bare-only in-process engine aligned with `@qvac/sdk` 0.17.0. Same inference API surface as the SDK, without the RPC/worker layer — register the plugins you need and run directly on Bare.

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/inference",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Bare-only in-process core of the QVAC SDK. Runs inference directly on the Bare runtime with explicit plugin assembly and no RPC, worker, or subprocess layer.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/inference` has never had a real public npm release (npm still shows `0.0.0`; in-repo version was `0.16.0`).
- Ship the first public `0.17.0` cut, version-aligned with `@qvac/sdk` 0.17.0.

## 📝 How does it solve it?

- Bump `packages/inference/package.json` to `0.17.0`.
- Add a minimal `CHANGELOG.md` for the first public / SDK-0.17-aligned release.

## 🧪 How was it tested?

- Release merge-guard inputs checked: branch `release-inference-0.17.0`, version `0.17.0`, `CHANGELOG.md` present in the release commit.
- Confirm after merge/push: `General CI/CD (inference)` runs Release Merge Guard + Publish to NPM, then tag `inference-v0.17.0`.
- Optional local: `cd packages/inference && bun install && bun run build && bun run test:unit`
