### PR TITLE
QVAC-22800 infra: support selectable inference sources in sdk e2e

### DIFF
--- a/.github/actions/sdk-e2e-prepare-inference/action.yml
+++ b/.github/actions/sdk-e2e-prepare-inference/action.yml
@@ -1,0 +1,48 @@
+name: Prepare SDK E2E inference
+description: Apply the centrally resolved inference package to an SDK E2E checkout.
+
+inputs:
+  source:
+    description: "Inference source: branch, gpr, npm, or manifest"
+    required: true
+  dependency-spec:
+    description: "Resolved package spec for gpr/npm; empty for branch/manifest"
+    required: false
+    default: ""
+  artifact-name:
+    description: "Branch tarball artifact name"
+    required: false
+    default: ""
+  project-directory:
+    description: "SDK package directory"
+    required: true
+  provenance:
+    description: "Human-readable immutable source identity"
+    required: true
+
+outputs:
+  dependency-spec:
+    description: "Dependency spec written to the SDK package manifest"
+    value: ${{ steps.apply.outputs.dependency-spec }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download branch inference package
+      if: inputs.source == 'branch'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/sdk-e2e-inference/${{ github.run_id }}-${{ github.run_attempt }}
+
+    - name: Apply resolved inference dependency
+      id: apply
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        INFERENCE_SOURCE: ${{ inputs.source }}
+        INFERENCE_DEPENDENCY_SPEC: ${{ inputs.dependency-spec }}
+        INFERENCE_ARTIFACT_DIRECTORY: ${{ runner.temp }}/sdk-e2e-inference/${{ github.run_id }}-${{ github.run_attempt }}
+        INFERENCE_PROVENANCE: ${{ inputs.provenance }}
+        PROJECT_DIRECTORY: ${{ inputs.project-directory }}
+      run: node "$ACTION_PATH/prepare.mjs" apply

--- a/.github/actions/sdk-e2e-prepare-inference/prepare.mjs
+++ b/.github/actions/sdk-e2e-prepare-inference/prepare.mjs
@@ -1,0 +1,274 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const INFERENCE_DEPENDENCY = "@qvac/inference";
+const GPR_PACKAGE = "@tetherto/inference-mono";
+const NPM_PACKAGE = "@qvac/inference";
+const SOURCES = new Set(["branch", "gpr", "npm", "manifest"]);
+
+function requireSource(source) {
+  const normalized = String(source || "manifest")
+    .trim()
+    .toLowerCase();
+  if (!SOURCES.has(normalized)) {
+    throw new Error(
+      `Unsupported inference source "${source}". Expected branch, gpr, npm, or manifest.`,
+    );
+  }
+  return normalized;
+}
+
+function readManifest(projectDirectory) {
+  const manifestPath = path.resolve(projectDirectory, "package.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const currentSpec = manifest.dependencies?.[INFERENCE_DEPENDENCY];
+  if (typeof currentSpec !== "string" || currentSpec.length === 0) {
+    throw new Error(
+      `${manifestPath} must declare an ${INFERENCE_DEPENDENCY} dependency.`,
+    );
+  }
+  return { manifest, manifestPath, currentSpec };
+}
+
+function writeOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+function appendSummary(lines) {
+  if (!process.env.GITHUB_STEP_SUMMARY) return;
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    stdio: options.capture ? ["ignore", "pipe", "inherit"] : "inherit",
+    ...options,
+  });
+}
+
+function exactVersion(value) {
+  const parsed = JSON.parse(value);
+  if (typeof parsed === "string" && parsed.length > 0) return parsed;
+  if (Array.isArray(parsed) && parsed.length > 0) return parsed.at(-1);
+  throw new Error(`Registry returned no resolved version: ${value}`);
+}
+
+export function resolvePublishedSource({
+  source,
+  requestedVersion = "",
+  resolvedVersion,
+}) {
+  const normalized = requireSource(source);
+  if (normalized !== "gpr" && normalized !== "npm") {
+    throw new Error(`"${normalized}" is not a published inference source.`);
+  }
+  if (typeof resolvedVersion !== "string" || resolvedVersion.length === 0) {
+    throw new Error(
+      `A resolved version is required for the ${normalized} inference source.`,
+    );
+  }
+
+  const request = requestedVersion || (normalized === "gpr" ? "dev" : "latest");
+  if (normalized === "gpr") {
+    return {
+      dependencySpec: `npm:${GPR_PACKAGE}@${resolvedVersion}`,
+      provenance: `gpr:${GPR_PACKAGE}@${resolvedVersion}`,
+      requestedVersion: request,
+    };
+  }
+  return {
+    dependencySpec: resolvedVersion,
+    provenance: `npm:${NPM_PACKAGE}@${resolvedVersion}`,
+    requestedVersion: request,
+  };
+}
+
+export function resolveManifestSource(dependencySpec) {
+  if (typeof dependencySpec !== "string" || dependencySpec.length === 0) {
+    throw new Error(
+      `Manifest source requires an ${INFERENCE_DEPENDENCY} dependency.`,
+    );
+  }
+  return {
+    dependencySpec,
+    provenance: `manifest:${dependencySpec}`,
+  };
+}
+
+function toLocalTarballSpec(tarballPath, platform = process.platform) {
+  if (platform === "win32") {
+    return path.win32.resolve(tarballPath).replaceAll("\\", "/");
+  }
+  return pathToFileURL(path.resolve(tarballPath)).href;
+}
+
+export function applyInferenceSource({
+  source,
+  projectDirectory,
+  dependencySpec = "",
+  artifactDirectory = "",
+}) {
+  const normalized = requireSource(source);
+  const { manifest, manifestPath, currentSpec } =
+    readManifest(projectDirectory);
+
+  if (normalized === "manifest") {
+    return { dependencySpec: currentSpec };
+  }
+
+  let appliedSpec = dependencySpec;
+  if (normalized === "branch") {
+    const tarballs = fs
+      .readdirSync(artifactDirectory, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".tgz"))
+      .map((entry) => path.resolve(artifactDirectory, entry.name));
+    if (tarballs.length !== 1) {
+      throw new Error(
+        `Branch inference artifact must contain exactly one .tgz file; found ${tarballs.length}.`,
+      );
+    }
+    appliedSpec = toLocalTarballSpec(tarballs[0]);
+  }
+
+  if (typeof appliedSpec !== "string" || appliedSpec.length === 0) {
+    throw new Error(
+      `Resolved dependency spec is required for the ${normalized} inference source.`,
+    );
+  }
+
+  manifest.dependencies[INFERENCE_DEPENDENCY] = appliedSpec;
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return { dependencySpec: appliedSpec };
+}
+
+function resolveRegistryVersion(source, requestedVersion) {
+  const isGpr = source === "gpr";
+  const packageName = isGpr ? GPR_PACKAGE : NPM_PACKAGE;
+  const request = requestedVersion || (isGpr ? "dev" : "latest");
+  const args = ["view", `${packageName}@${request}`, "version", "--json"];
+  if (isGpr) {
+    args.push("--registry=https://npm.pkg.github.com/");
+  }
+  const output = run("npm", args, { capture: true });
+  return { request, version: exactVersion(output) };
+}
+
+function packBranch(inferenceDirectory, artifactDirectory) {
+  fs.mkdirSync(artifactDirectory, { recursive: true });
+  run("bun", ["install", "--ignore-scripts"], { cwd: inferenceDirectory });
+  run("bun", ["run", "build"], { cwd: inferenceDirectory });
+  const output = run(
+    "npm",
+    [
+      "pack",
+      "--ignore-scripts",
+      "--json",
+      "--pack-destination",
+      artifactDirectory,
+    ],
+    { cwd: inferenceDirectory, capture: true },
+  );
+  const packed = JSON.parse(output);
+  if (!Array.isArray(packed) || packed.length !== 1 || !packed[0]?.filename) {
+    throw new Error(
+      `npm pack did not produce exactly one inference tarball: ${output}`,
+    );
+  }
+  return path.resolve(artifactDirectory, packed[0].filename);
+}
+
+function resolveCommand() {
+  const source = requireSource(process.env.INFERENCE_SOURCE);
+  const projectDirectory = process.env.PROJECT_DIRECTORY || "packages/sdk";
+  const { currentSpec } = readManifest(projectDirectory);
+  let result;
+  let artifactPath = "";
+
+  if (source === "manifest") {
+    result = resolveManifestSource(currentSpec);
+  } else if (source === "branch") {
+    const inferenceDirectory = path.resolve(
+      process.env.INFERENCE_DIRECTORY || "packages/inference",
+    );
+    const inferenceManifest = JSON.parse(
+      fs.readFileSync(path.join(inferenceDirectory, "package.json"), "utf8"),
+    );
+    artifactPath = packBranch(
+      inferenceDirectory,
+      path.resolve(process.env.ARTIFACT_DIRECTORY || ".sdk-e2e/inference"),
+    );
+    const sha = process.env.CHECKOUT_SHA || "unknown";
+    result = {
+      dependencySpec: "",
+      provenance: `branch:${sha}:${INFERENCE_DEPENDENCY}@${inferenceManifest.version}`,
+    };
+  } else {
+    const resolved = resolveRegistryVersion(
+      source,
+      process.env.INFERENCE_VERSION || "",
+    );
+    result = resolvePublishedSource({
+      source,
+      requestedVersion: resolved.request,
+      resolvedVersion: resolved.version,
+    });
+  }
+
+  writeOutput("source", source);
+  writeOutput("dependency-spec", result.dependencySpec);
+  writeOutput("provenance", result.provenance);
+  writeOutput("artifact-path", artifactPath);
+  appendSummary([
+    "### SDK E2E inference",
+    `- Source: \`${source}\``,
+    `- Provenance: \`${result.provenance}\``,
+  ]);
+}
+
+function applyCommand() {
+  const source = requireSource(process.env.INFERENCE_SOURCE);
+  const result = applyInferenceSource({
+    source,
+    projectDirectory: process.env.PROJECT_DIRECTORY || "packages/sdk",
+    dependencySpec: process.env.INFERENCE_DEPENDENCY_SPEC || "",
+    artifactDirectory: process.env.INFERENCE_ARTIFACT_DIRECTORY || "",
+  });
+  const provenance =
+    process.env.INFERENCE_PROVENANCE || `${source}:${result.dependencySpec}`;
+
+  writeOutput("dependency-spec", result.dependencySpec);
+  appendSummary([
+    "### SDK E2E inference dependency",
+    `- Source: \`${source}\``,
+    `- Applied: \`${result.dependencySpec}\``,
+    `- Provenance: \`${provenance}\``,
+  ]);
+}
+
+function main() {
+  const command = process.argv[2];
+  if (command === "resolve") {
+    resolveCommand();
+  } else if (command === "apply") {
+    applyCommand();
+  } else {
+    throw new Error("Usage: prepare.mjs <resolve|apply>");
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/.github/actions/sdk-e2e-report-finalize/action.yml
+++ b/.github/actions/sdk-e2e-report-finalize/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "Exclude-suite filter used for the run"
     required: false
     default: ""
+  inference-provenance:
+    description: "Immutable inference source identity"
+    required: false
+    default: ""
   update-summary:
     description: "Whether to append the rendered report to GITHUB_STEP_SUMMARY"
     required: false
@@ -88,6 +92,7 @@ runs:
         SUITE: ${{ inputs.suite }}
         FILTER: ${{ inputs.filter }}
         EXCLUDE_SUITE: ${{ inputs.exclude-suite }}
+        INFERENCE_PROVENANCE: ${{ inputs.inference-provenance }}
         UPDATE_SUMMARY: ${{ inputs.update-summary }}
         DEVICE_POOL_NAME: ${{ inputs.device-pool-name }}
         DEVICE_POOL_AVAILABILITY: ${{ inputs.device-pool-availability }}
@@ -102,6 +107,7 @@ runs:
           const suite = process.env.SUITE || '';
           const filter = process.env.FILTER || '';
           const excludeSuite = process.env.EXCLUDE_SUITE || '';
+          const inferenceProvenance = process.env.INFERENCE_PROVENANCE || '';
           const updateSummary = process.env.UPDATE_SUMMARY !== 'false';
 
           const pr = context.payload.pull_request?.number;
@@ -121,6 +127,7 @@ runs:
           const fmt = (v) => (v && v.length > 0 ? `\`${v}\`` : '`(none)`');
           const configLine =
             `**Config:** suite=${fmt(suite)} · filter=${fmt(filter)} · exclude=${fmt(excludeSuite)}`;
+          const inferenceLine = `**Inference:** ${fmt(inferenceProvenance)}`;
 
           // Device pool status line (mobile only). Weather emojis are used on
           // purpose so availability is not confused with pass/fail red/green.
@@ -234,6 +241,7 @@ runs:
                 mark,
                 `### QVAC E2E — \`${platform}\` — ✅ all tests passed (${passed}/${total}, ${duration}s)`,
                 configLine,
+                inferenceLine,
                 devicePoolLine,
                 linksLine,
               ].filter((line) => line !== null);
@@ -245,6 +253,7 @@ runs:
               `### QVAC E2E — \`${platform}\` — ❌ failed`,
               `**Totals:** ${passed}/${total} passed · ${failed} failed · ${rate}% · ${duration}s`,
               configLine,
+              inferenceLine,
               devicePoolLine,
               linksLine,
               '',
@@ -335,6 +344,7 @@ runs:
                 marker(platform),
                 `### QVAC E2E — \`${platform}\` — ⚠️ no results`,
                 configLine,
+                inferenceLine,
                 devicePoolLine,
                 linksLine,
                 '',

--- a/.github/actions/sdk-e2e-report-start/action.yml
+++ b/.github/actions/sdk-e2e-report-start/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Exclude-suite filter passed to the run"
     required: false
     default: ""
+  inference-provenance:
+    description: "Immutable inference source identity"
+    required: false
+    default: ""
 
 outputs:
   comment-ids:
@@ -46,6 +50,7 @@ runs:
         SUITE: ${{ inputs.suite }}
         FILTER: ${{ inputs.filter }}
         EXCLUDE_SUITE: ${{ inputs.exclude-suite }}
+        INFERENCE_PROVENANCE: ${{ inputs.inference-provenance }}
       with:
         script: |
           const family = process.env.FAMILY;
@@ -53,6 +58,7 @@ runs:
           const suite = process.env.SUITE || '';
           const filter = process.env.FILTER || '';
           const excludeSuite = process.env.EXCLUDE_SUITE || '';
+          const inferenceProvenance = process.env.INFERENCE_PROVENANCE || '';
 
           const pr = context.payload.pull_request?.number;
           if (!pr) {
@@ -68,6 +74,7 @@ runs:
           const fmt = (v) => (v && v.length > 0 ? `\`${v}\`` : '`(none)`');
           const configLine =
             `**Config:** suite=${fmt(suite)} · filter=${fmt(filter)} · exclude=${fmt(excludeSuite)}`;
+          const inferenceLine = `**Inference:** ${fmt(inferenceProvenance)}`;
 
           const marker = (p) => `<!-- sdk-e2e-report:pr=${pr}:family=${family}:platform=${p} -->`;
 
@@ -120,6 +127,7 @@ runs:
               `### QVAC E2E — \`${platform}\` — running`,
               `[View run](${runUrl})`,
               configLine,
+              inferenceLine,
             ].join('\n');
 
             const created = await github.rest.issues.createComment({

--- a/.github/workflows/on-pr-test-sdk.yml
+++ b/.github/workflows/on-pr-test-sdk.yml
@@ -3,7 +3,7 @@
 # Triggers SDK e2e tests via test-sdk.yml when:
 #   - "test-e2e-smoke" label applied: runs smoke suite on desktop + mobile
 #   - "test-e2e-full" label applied: runs full suite on desktop + mobile
-#   - PR opened/updated targeting release-* branch with packages/sdk/ changes: runs full suite
+#   - PR opened/updated targeting release-* branch with SDK/inference changes: runs full suite
 #
 # On success, applies "e2e-tested" label to the PR.
 #
@@ -17,6 +17,7 @@ on:
     types: [labeled, opened, synchronize]
     paths:
       - "packages/sdk/**"
+      - "packages/inference/**"
 
 permissions:
   actions: read
@@ -82,8 +83,8 @@ jobs:
               echo "should-run=false" >> "$GITHUB_OUTPUT"
             fi
           elif echo "$TARGET" | grep -q '^release-'; then
-            # Path filter on the trigger already ensures packages/sdk/ changes exist
-            echo "::notice::Release branch PR with SDK changes — running full suite"
+            # Path filter already ensures SDK or inference changes exist.
+            echo "::notice::Release branch PR with SDK/inference changes — running full suite"
             echo "should-run=true" >> "$GITHUB_OUTPUT"
             echo "suite=" >> "$GITHUB_OUTPUT"
           else
@@ -99,6 +100,8 @@ jobs:
     with:
       targets: desktop + mobile
       suite: ${{ needs.resolve-config.outputs.suite }}
+      test-version: ${{ github.event.pull_request.head.sha }}
+      inference-source: branch
     secrets: inherit
 
   apply-label:

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -58,6 +58,26 @@ on:
         description: "Git ref to checkout (branch, tag, or SHA). Defaults to trigger ref."
         required: false
         type: string
+      inference-source:
+        description: "Resolved inference source"
+        required: false
+        type: string
+        default: manifest
+      inference-dependency-spec:
+        description: "Resolved inference package spec for gpr/npm"
+        required: false
+        type: string
+        default: ""
+      inference-artifact-name:
+        description: "Branch inference tarball artifact"
+        required: false
+        type: string
+        default: ""
+      inference-provenance:
+        description: "Immutable inference source identity"
+        required: false
+        type: string
+        default: ""
       plugins:
         description: >-
           Optional comma-separated SDK plugin specifiers (e.g.
@@ -134,6 +154,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
 
   build:
     name: "[android] build"
@@ -159,7 +180,9 @@ jobs:
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          sparse-checkout: ${{ inputs.project-directory }}
+          sparse-checkout: |
+            ${{ inputs.project-directory }}
+            .github/actions/sdk-e2e-prepare-inference
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -265,6 +288,15 @@ jobs:
           const target = path.join('${{ inputs.project-directory }}', '.npmrc');
           fs.writeFileSync(target, npmrc, 'utf8');
           console.log(`.npmrc configured at ${target}`);
+
+      - name: Apply resolved inference
+        uses: ./.github/actions/sdk-e2e-prepare-inference
+        with:
+          source: ${{ inputs.inference-source }}
+          dependency-spec: ${{ inputs.inference-dependency-spec }}
+          artifact-name: ${{ inputs.inference-artifact-name }}
+          project-directory: ${{ inputs.project-directory }}
+          provenance: ${{ inputs.inference-provenance }}
 
       - name: Setup MQTT CA certificate
         shell: node {0}
@@ -684,6 +716,7 @@ jobs:
           sparse-checkout: |
             ${{ inputs.project-directory }}
             .github/actions/sdk-e2e-fail-on-failures
+            .github/actions/sdk-e2e-prepare-inference
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -709,6 +742,15 @@ jobs:
           const npmrc = lines.join('\n');
           const target = path.join('${{ inputs.project-directory }}', '.npmrc');
           fs.writeFileSync(target, npmrc, 'utf8');
+
+      - name: Apply resolved inference
+        uses: ./.github/actions/sdk-e2e-prepare-inference
+        with:
+          source: ${{ inputs.inference-source }}
+          dependency-spec: ${{ inputs.inference-dependency-spec }}
+          artifact-name: ${{ inputs.inference-artifact-name }}
+          project-directory: ${{ inputs.project-directory }}
+          provenance: ${{ inputs.inference-provenance }}
 
       - name: Setup MQTT CA certificate
         shell: node {0}
@@ -1037,6 +1079,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
           device-pool-name: ${{ needs.select-pool.outputs.name }}
           device-pool-availability: ${{ needs.select-pool.outputs.availability }}
 
@@ -1063,6 +1106,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
           device-pool-name: ${{ needs.select-pool.outputs.name }}
           device-pool-availability: ${{ needs.select-pool.outputs.availability }}
           update-summary: "false"

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -57,6 +57,26 @@ on:
         description: "Git ref to checkout (branch, tag, or SHA). Defaults to trigger ref."
         required: false
         type: string
+      inference-source:
+        description: "Resolved inference source"
+        required: false
+        type: string
+        default: manifest
+      inference-dependency-spec:
+        description: "Resolved inference package spec for gpr/npm"
+        required: false
+        type: string
+        default: ""
+      inference-artifact-name:
+        description: "Branch inference tarball artifact"
+        required: false
+        type: string
+        default: ""
+      inference-provenance:
+        description: "Immutable inference source identity"
+        required: false
+        type: string
+        default: ""
     secrets:
       # MQTT_*, NPM_TOKEN, and Apple signing secrets (TEST_APP_APPLE_*,
       # APPLE_P12_PASSWORD, APPLE_KEYCHAIN_PASSWORD) are typically provided
@@ -125,6 +145,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
 
   build:
     name: "[ios] build"
@@ -146,7 +167,9 @@ jobs:
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          sparse-checkout: ${{ inputs.project-directory }}
+          sparse-checkout: |
+            ${{ inputs.project-directory }}
+            .github/actions/sdk-e2e-prepare-inference
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -346,6 +369,15 @@ jobs:
           const target = path.join('${{ inputs.project-directory }}', '.npmrc');
           fs.writeFileSync(target, npmrc, 'utf8');
           console.log(`.npmrc configured at ${target}`);
+
+      - name: Apply resolved inference
+        uses: ./.github/actions/sdk-e2e-prepare-inference
+        with:
+          source: ${{ inputs.inference-source }}
+          dependency-spec: ${{ inputs.inference-dependency-spec }}
+          artifact-name: ${{ inputs.inference-artifact-name }}
+          project-directory: ${{ inputs.project-directory }}
+          provenance: ${{ inputs.inference-provenance }}
 
       - name: Setup MQTT CA certificate
         shell: node {0}
@@ -718,6 +750,7 @@ jobs:
           sparse-checkout: |
             ${{ inputs.project-directory }}
             .github/actions/sdk-e2e-fail-on-failures
+            .github/actions/sdk-e2e-prepare-inference
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -743,6 +776,15 @@ jobs:
           const npmrc = lines.join('\n');
           const target = path.join('${{ inputs.project-directory }}', '.npmrc');
           fs.writeFileSync(target, npmrc, 'utf8');
+
+      - name: Apply resolved inference
+        uses: ./.github/actions/sdk-e2e-prepare-inference
+        with:
+          source: ${{ inputs.inference-source }}
+          dependency-spec: ${{ inputs.inference-dependency-spec }}
+          artifact-name: ${{ inputs.inference-artifact-name }}
+          project-directory: ${{ inputs.project-directory }}
+          provenance: ${{ inputs.inference-provenance }}
 
       - name: Setup MQTT CA certificate
         shell: node {0}
@@ -1071,6 +1113,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
           device-pool-name: ${{ needs.select-pool.outputs.name }}
           device-pool-availability: ${{ needs.select-pool.outputs.availability }}
 
@@ -1097,6 +1140,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
           device-pool-name: ${{ needs.select-pool.outputs.name }}
           device-pool-availability: ${{ needs.select-pool.outputs.availability }}
           update-summary: "false"

--- a/.github/workflows/test-node-sdk.yml
+++ b/.github/workflows/test-node-sdk.yml
@@ -44,6 +44,26 @@ on:
         description: "Git ref to checkout (branch, tag, or SHA). Defaults to trigger ref."
         required: false
         type: string
+      inference-source:
+        description: "Resolved inference source"
+        required: false
+        type: string
+        default: manifest
+      inference-dependency-spec:
+        description: "Resolved inference package spec for gpr/npm"
+        required: false
+        type: string
+        default: ""
+      inference-artifact-name:
+        description: "Branch inference tarball artifact"
+        required: false
+        type: string
+        default: ""
+      inference-provenance:
+        description: "Immutable inference source identity"
+        required: false
+        type: string
+        default: ""
       cache-models:
         description: "Cache downloaded models between runs"
         required: false
@@ -122,6 +142,7 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}
 
   test-node:
     name: "[${{ inputs.consumer }}] test (${{ matrix.os }})"
@@ -153,6 +174,7 @@ jobs:
           sparse-checkout: |
             ${{ inputs.project-directory }}
             .github/actions/sdk-e2e-fail-on-failures
+            .github/actions/sdk-e2e-prepare-inference
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -182,6 +204,15 @@ jobs:
           const target = path.join('${{ inputs.project-directory }}', '.npmrc');
           fs.writeFileSync(target, npmrc, 'utf8');
           console.log(`.npmrc configured at ${target}`);
+
+      - name: Apply resolved inference
+        uses: ./.github/actions/sdk-e2e-prepare-inference
+        with:
+          source: ${{ inputs.inference-source }}
+          dependency-spec: ${{ inputs.inference-dependency-spec }}
+          artifact-name: ${{ inputs.inference-artifact-name }}
+          project-directory: ${{ inputs.project-directory }}
+          provenance: ${{ inputs.inference-provenance }}
 
       - name: Setup MQTT certificates
         shell: node {0}
@@ -803,3 +834,4 @@ jobs:
           suite: ${{ inputs.suite }}
           filter: ${{ inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
+          inference-provenance: ${{ inputs.inference-provenance }}

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -56,6 +56,18 @@ on:
       test-version:
         description: "Code ref to test (branch, tag, or SHA; blank = selected workflow branch)"
         type: string
+      inference-source:
+        description: "Inference source (branch builds packages/inference; gpr/npm resolve a version; manifest keeps SDK package.json)"
+        type: choice
+        options:
+          - manifest
+          - branch
+          - gpr
+          - npm
+        default: manifest
+      inference-version:
+        description: "Inference version or dist-tag (gpr defaults to dev; npm defaults to latest)"
+        type: string
       cache-models:
         description: "Reuse downloaded models for Desktop, Electron, and Snap"
         type: boolean
@@ -138,6 +150,14 @@ on:
         default: '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]'
       test-version:
         type: string
+      inference-source:
+        description: "Inference source: branch, gpr, npm, or manifest"
+        type: string
+        default: "manifest"
+      inference-version:
+        description: "Inference version or dist-tag for gpr/npm"
+        type: string
+        default: ""
       cache-models:
         type: boolean
         default: true
@@ -254,8 +274,93 @@ jobs:
             echo "run-ios=$RESOLVED_IOS"
           } >> "$GITHUB_OUTPUT"
 
-  desktop-tests:
+  prepare-inference:
+    name: Resolve inference source
     needs: resolve
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      checkout-sha: ${{ steps.checkout.outputs.commit }}
+      source: ${{ steps.inference.outputs.source }}
+      dependency-spec: ${{ steps.inference.outputs.dependency-spec }}
+      provenance: ${{ steps.inference.outputs.provenance }}
+      artifact-name: ${{ steps.artifact.outputs.name }}
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
+    steps:
+      - id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}
+          token: ${{ secrets.PAT_TOKEN }}
+          persist-credentials: false
+          sparse-checkout: |
+            packages/sdk/package.json
+            packages/inference
+            .github/actions/sdk-e2e-prepare-inference
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 22
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
+        with:
+          bun-version: latest
+
+      - name: Configure package registries
+        shell: node {0}
+        run: |
+          const fs = require('fs');
+          const lines = [
+            'registry=https://registry.npmjs.org/',
+            '@qvac:registry=https://registry.npmjs.org/',
+            '@tetherto:registry=https://npm.pkg.github.com/',
+          ];
+          if (process.env.NPM_TOKEN) {
+            lines.push(`//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`);
+          }
+          if (process.env.PAT_TOKEN) {
+            lines.push(`//npm.pkg.github.com/:_authToken=${process.env.PAT_TOKEN}`);
+          }
+          fs.writeFileSync(process.env.NPM_CONFIG_USERCONFIG, `${lines.join('\n')}\n`);
+
+      - name: Resolve and prepare inference
+        id: inference
+        shell: bash
+        env:
+          INFERENCE_SOURCE: ${{ inputs.inference-source || 'manifest' }}
+          INFERENCE_VERSION: ${{ inputs.inference-version || '' }}
+          PROJECT_DIRECTORY: packages/sdk
+          INFERENCE_DIRECTORY: packages/inference
+          ARTIFACT_DIRECTORY: ${{ runner.temp }}/sdk-e2e-inference-package
+          CHECKOUT_SHA: ${{ steps.checkout.outputs.commit }}
+        run: node .github/actions/sdk-e2e-prepare-inference/prepare.mjs resolve
+
+      - name: Derive branch artifact name
+        id: artifact
+        shell: node {0}
+        run: |
+          const fs = require('fs');
+          const name = `sdk-e2e-inference-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\n`);
+
+      - name: Upload branch inference package
+        if: steps.inference.outputs.source == 'branch'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: ${{ steps.inference.outputs.artifact-path }}
+          if-no-files-found: error
+          retention-days: 7
+
+  desktop-tests:
+    needs: [resolve, prepare-inference]
     if: needs.resolve.outputs.run-desktop == 'true'
     uses: ./.github/workflows/test-node-sdk.yml
     with:
@@ -267,12 +372,16 @@ jobs:
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
-      test-version: ${{ inputs.test-version || '' }}
+      test-version: ${{ needs.prepare-inference.outputs.checkout-sha }}
+      inference-source: ${{ needs.prepare-inference.outputs.source }}
+      inference-dependency-spec: ${{ needs.prepare-inference.outputs.dependency-spec }}
+      inference-artifact-name: ${{ needs.prepare-inference.outputs.artifact-name }}
+      inference-provenance: ${{ needs.prepare-inference.outputs.provenance }}
       cache-models: ${{ inputs.cache-models }}
     secrets: inherit
 
   electron-tests:
-    needs: resolve
+    needs: [resolve, prepare-inference]
     if: needs.resolve.outputs.run-electron == 'true'
     uses: ./.github/workflows/test-node-sdk.yml
     with:
@@ -284,12 +393,16 @@ jobs:
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
-      test-version: ${{ inputs.test-version || '' }}
+      test-version: ${{ needs.prepare-inference.outputs.checkout-sha }}
+      inference-source: ${{ needs.prepare-inference.outputs.source }}
+      inference-dependency-spec: ${{ needs.prepare-inference.outputs.dependency-spec }}
+      inference-artifact-name: ${{ needs.prepare-inference.outputs.artifact-name }}
+      inference-provenance: ${{ needs.prepare-inference.outputs.provenance }}
       cache-models: ${{ inputs.cache-models }}
     secrets: inherit
 
   snap-tests:
-    needs: resolve
+    needs: [resolve, prepare-inference]
     if: needs.resolve.outputs.run-snap == 'true'
     uses: ./.github/workflows/test-node-sdk.yml
     with:
@@ -301,12 +414,16 @@ jobs:
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
-      test-version: ${{ inputs.test-version || '' }}
+      test-version: ${{ needs.prepare-inference.outputs.checkout-sha }}
+      inference-source: ${{ needs.prepare-inference.outputs.source }}
+      inference-dependency-spec: ${{ needs.prepare-inference.outputs.dependency-spec }}
+      inference-artifact-name: ${{ needs.prepare-inference.outputs.artifact-name }}
+      inference-provenance: ${{ needs.prepare-inference.outputs.provenance }}
       cache-models: ${{ inputs.cache-models }}
     secrets: inherit
 
   android-tests:
-    needs: resolve
+    needs: [resolve, prepare-inference]
     permissions:
       actions: read
       id-token: write
@@ -327,11 +444,15 @@ jobs:
       device-farm-project-arn: ${{ vars.SDK_DEVICE_FARM_PROJECT_ARN }}
       device-pools: ${{ vars.SDK_ANDROID_DEVICE_FARM_POOLS }}
       device-pool-name: ${{ inputs.android-device-pool }}
-      test-version: ${{ inputs.test-version || '' }}
+      test-version: ${{ needs.prepare-inference.outputs.checkout-sha }}
+      inference-source: ${{ needs.prepare-inference.outputs.source }}
+      inference-dependency-spec: ${{ needs.prepare-inference.outputs.dependency-spec }}
+      inference-artifact-name: ${{ needs.prepare-inference.outputs.artifact-name }}
+      inference-provenance: ${{ needs.prepare-inference.outputs.provenance }}
     secrets: inherit
 
   ios-tests:
-    needs: resolve
+    needs: [resolve, prepare-inference]
     permissions:
       actions: read
       id-token: write
@@ -352,5 +473,9 @@ jobs:
       device-farm-project-arn: ${{ vars.SDK_DEVICE_FARM_PROJECT_ARN }}
       ios-device-pools: ${{ vars.SDK_IOS_DEVICE_FARM_POOLS }}
       device-pool-name: ${{ inputs.ios-device-pool }}
-      test-version: ${{ inputs.test-version || '' }}
+      test-version: ${{ needs.prepare-inference.outputs.checkout-sha }}
+      inference-source: ${{ needs.prepare-inference.outputs.source }}
+      inference-dependency-spec: ${{ needs.prepare-inference.outputs.dependency-spec }}
+      inference-artifact-name: ${{ needs.prepare-inference.outputs.artifact-name }}
+      inference-provenance: ${{ needs.prepare-inference.outputs.provenance }}
     secrets: inherit

--- a/packages/sdk/e2e/README.md
+++ b/packages/sdk/e2e/README.md
@@ -161,7 +161,8 @@ See [`.github/workflows/on-pr-test-sdk.yml`](../../../.github/workflows/on-pr-te
 
 - `test-e2e-smoke` — runs the `smoke` suite on desktop and mobile consumers.
 - `test-e2e-full` — runs the full catalog on desktop and mobile consumers.
-- Release-branch PRs with SDK changes auto-run the same desktop and mobile suite.
+- Both labels build `packages/inference` and test it together with `packages/sdk` from the authorized PR HEAD.
+- Release-branch PRs with SDK or inference changes auto-run the same desktop and mobile suite.
 - Success applies the `e2e-tested` label.
 
 ### Manual runs
@@ -178,6 +179,17 @@ Non-obvious inputs:
   picks the branch that supplies the _workflow YAML_; `test-version` is the git ref that gets checked out for
   the _code under test_ (and the e2e package). Leave `test-version` blank to test the same branch the
   workflow was loaded from. Set it to test workflow edits from one branch against SDK code on another.
+- `inference-source` controls the `@qvac/inference` package used by every selected platform:
+  - `branch` builds and packs `packages/inference` from `test-version`. The resulting tarball is produced once
+    and reused by desktop, Electron, Snap, Android, and iOS jobs, so SDK and inference changes from that ref are
+    tested together.
+  - `gpr` resolves `@tetherto/inference-mono` from GitHub Packages. Set `inference-version` to an exact
+    prerelease or dist-tag; blank means `dev`.
+  - `npm` resolves the public `@qvac/inference` package. Set `inference-version` to a version/range or dist-tag;
+    blank means `latest`.
+  - `manifest` preserves the dependency already declared in `packages/sdk/package.json`.
+- GPR/npm selectors are resolved to one immutable version before platform fan-out. The exact branch SHA/package
+  version is shown in the workflow summary and PR test comments.
 - `suite` + `suite-custom` — pick `custom` to pass arbitrary comma-separated suite tags via `suite-custom`.
 - `desktop-platforms`, `electron-platforms`, and `snap-platforms` — advanced JSON runner overrides,
   pre-filled with the workflow defaults. Narrow them to specific runners only when debugging.


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK e2e could not validate thin SDK and in-repo inference changes together, so PR runs could silently use a published inference baseline.
- Manual runs had no supported way to select a branch-built inference package or an immutable GPR/npm version.

## 📝 How does it solve it?

- Resolve `branch`, `gpr`, `npm`, or `manifest` inference once before platform fan-out and pin every consumer to the same commit or package version.
- Build branch inference once as a tarball and reuse it across desktop, Electron, Snap, Android, and iOS.
- Run label-triggered SDK e2e against the authorized PR HEAD and report exact inference provenance in summaries and PR comments.
- Keep the existing fork approval and SHA-bound authorization gates intact.
- Stack this change on [PR #3595](https://github.com/tetherto/qvac/pull/3595), which introduces the thin SDK dependency on `@qvac/inference`.

## 🧪 How was it tested?

- Ran 95 inference-helper, workflow-policy, trust-policy, and prebuild-status tests.
- Validated modified workflow syntax with `actionlint`.
- Built and packed `packages/inference` locally and verified the tarball contains its runtime and type entrypoints.
- Verified the final diff with `git diff --check`.
