### PR TITLE
chore[notask]: release @qvac/model-fit 0.1.0

### DIFF
--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.0] - 2026-08-10
+## [0.1.0] - 2026-08-12
 
 ### Added
 
@@ -42,6 +42,30 @@
   projection was actually made against. Zero registered devices now returns
   `ERROR` instead of a verdict. `maxDevices` is a build-time bound and must not
   be read as a detection result.
+- `@qvac/model-fit/process`, a boundary for running a projection in a child that
+  can be thrown away. The subpath exports a versioned NDJSON codec
+  (`encodeFitProcessRequest`, `parseFitProcessResponse`) and resolves a private
+  one-shot runner to spawn with a Bare executable. It exists because the crash
+  paths above terminate whoever calls the fitter, so the only way to survive
+  them is to ask the question from a process that is expendable. Spawning and
+  supervision are deliberately left to the caller.
+- The runner answers with one line on stdout, and that line rather than the exit
+  code is the result: `completed` for a projection, `invocation-error` for a
+  request that threw or never reached the fitter, and no line at all when native
+  code aborted. A missing or unparseable line is a failure whatever the status —
+  exit 0 does not prove delivery, and exit 2 arrives both with and without a
+  response. The outcome table in the README is the full contract.
+- The addon is loaded only once a request has parsed, so a malformed or oversized
+  request costs a spawn and never backend registration. The runner imposes no
+  timeout of its own; bounding and cancelling the child is the supervisor's job.
+- Two platform constraints a supervisor has to honour. On Windows the child's
+  stdio must be created as overlapped pipes (`stdio: ['overlapped', ...]`), or
+  the runner — itself a libuv program handed synchronous handles — never
+  observes the request and hangs with no output and no diagnostic; the flag is a
+  no-op elsewhere, so set it unconditionally. On darwin a cold child recompiles
+  the embedded Metal library during backend discovery, which costs roughly ten
+  seconds against a quarter of a second on linux and Windows, so a deadline must
+  be sized for discovery rather than for the projection.
 
 ### Changed
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/model-fit` has never had a real public npm release: npm shows only a `0.0.0` placeholder as `latest`, and there is no `model-fit-v*` tag. The in-repo version has been `0.1.0` since #3697 without ever shipping.
- The `## [0.1.0]` changelog entry was written on 2026-08-10, before the process boundary landed in #3736. It documents none of `@qvac/model-fit/process`, so publishing as written would ship that public API — and the two platform constraints a caller has to honour — undocumented.

## 📝 How does it solve it?

- Document `@qvac/model-fit/process` in the `0.1.0` entry: the versioned NDJSON codec and the private one-shot runner, the stdout-line-over-exit-code response contract, the addon being loaded only after a request parses, and the absence of an internal timeout.
- Record the two constraints found while getting #3736 green on every desktop platform, because a supervisor gets them wrong silently:
  - Windows requires the child's stdio to be created as overlapped pipes, otherwise the runner (itself a libuv program handed synchronous handles) never observes the request and hangs with no output and no diagnostic.
  - A cold child on darwin recompiles the embedded Metal library during backend discovery — roughly ten seconds against a quarter of a second on linux and Windows — so deadlines must be sized for discovery rather than for the projection.
- Move the release date to 2026-08-12, the day it actually ships.
- No version bump: `packages/model-fit/package.json` is already `0.1.0` and that version is unspent, so `0.1.0` is the first public cut. Same situation as #3762 for `@qvac/inference`.

## 🧪 How was it tested?

- Release merge guard inputs checked against `.github/actions/release-merge-guard`: branch `release-model-fit-0.1.0` matches `release-<slug>-x.y.z`, `package.json` version is `0.1.0` and equals the branch version, and `packages/model-fit/CHANGELOG.md` is modified in this push. The `0.1.0` block is non-empty.
- `pr-release-guard` no-ops here by design — model-fit is not an SDK pod package, so it is guarded by `on-merge-model-fit.yml` on push instead.
- Prebuilds are not built by this PR: `on-merge-model-fit.yml` builds all nine targets before publishing. The same reusable build ran on `main` for the #3736 merge (`012ae5c3d`) as a dry run for this release.
- Docs-only change; no code, tests or dependencies touched.

## Post-merge

Merging into `release-model-fit-0.1.0` triggers Release Merge Guard → prebuilds → npm publish → tag `model-fit-v0.1.0`. A backmerge PR then brings the changelog entry back to `main`.