### PR TITLE
QVAC-22886 fix[audiogen-ggml]: pin published registry baseline

### DIFF
--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "65b1d890edc1da43617f599e92bea19f1b9bc30e",
+    "baseline": "dffb96c0a594e45737eeefc1babb5b740a8dcc96",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [


### PR DESCRIPTION
## Summary
- pin the audiogen package registry baseline to the commit merged by [qvac-registry-vcpkg#305](https://github.com/tetherto/qvac-registry-vcpkg/pull/305)
- ensure clean builds resolve `audiogen-cpp@2026-08-11` from the official registry `main` history

## Test plan
- [x] Run a clean `bare-make generate` against the new baseline; confirmed `audiogen-cpp[core,metal]:arm64-osx@2026-08-11` resolves
- [x] Run `npm run test:types`
- [x] Run `npm run test:unit` (31 tests / 128 assertions)