### PR TITLE
QVAC-22886 fix[audiogen-ggml]: pin registry revision 1

### DIFF
--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "65b1d890edc1da43617f599e92bea19f1b9bc30e",
+    "baseline": "837c9db120fbbbc2a771770e725029e6dea43737",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [


### PR DESCRIPTION
## Summary
- pin the audiogen package registry baseline to the merge commit from [qvac-registry-vcpkg#307](https://github.com/tetherto/qvac-registry-vcpkg/pull/307)
- ensure clean builds resolve `audiogen-cpp@2026-08-11#1`, backed by ext-lib `3497ca01`

## Test plan
- [x] Run a clean `bare-make generate --build build-registry-307 --no-cache`; confirmed `audiogen-cpp[core,metal]:arm64-osx@2026-08-11#1` builds from ext-lib `3497ca01`
- [x] Run `npm run test:types`
- [x] Run `npm run test:unit` (31 tests / 128 assertions)