### PR TITLE
QVAC-22886 fix[audiogen-ggml]: require registry port revision

### DIFF
--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "audiogen-cpp",
-      "version>=": "2026-08-11"
+      "version>=": "2026-08-11#1"
     }
   ],
   "features": {


### PR DESCRIPTION
## Summary
- require `audiogen-cpp@2026-08-11#1`, published by [qvac-registry-vcpkg#307](https://github.com/tetherto/qvac-registry-vcpkg/pull/307)
- consume the ext-lib `3497ca01` source pin from the registry default branch
- leave `vcpkg-configuration.json` and its existing baseline unchanged

## Test plan
- [x] Run a clean `bare-make generate --build build-registry-revision-1 --no-cache`; confirmed the unchanged baseline resolves `audiogen-cpp[core,metal]:arm64-osx@2026-08-11#1`
- [x] Run `npm run test:types`
- [x] Run `npm run test:unit` sequentially (31 tests / 128 assertions)