### PR TITLE
QVAC-23256 fix[api]: integrate @qvac/ocr-ggml 0.16.0 in @qvac/sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -219,7 +219,7 @@
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/llm-llamacpp": "^0.39.3",
     "@qvac/logging": "^0.1.0",
-    "@qvac/ocr-ggml": "^0.13.1",
+    "@qvac/ocr-ggml": "^0.16.0",
     "@qvac/rag": "^0.6.4",
     "@qvac/registry-client": "^0.6.1",
     "@qvac/translation-nmtcpp": "^8.3.0",

--- a/packages/sdk/server/bare/plugins/ggml-ocr/plugin.ts
+++ b/packages/sdk/server/bare/plugins/ggml-ocr/plugin.ts
@@ -32,7 +32,9 @@ function createOCRModel(
   const params = {
     pathDetector: detectorPath,
     pathRecognizer: recognizerPath,
-    langList: ocrConfig.langList || ['en'],
+    ...(ocrConfig.langList !== undefined
+      ? { langList: ocrConfig.langList }
+      : ocrConfig.pipelineType !== 'doctr' && { langList: ['en'] }),
     ...(ocrConfig.pipelineType !== undefined && {
       pipelineType: ocrConfig.pipelineType
     }),


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

SDK integration of the `@qvac/ocr-ggml` **0.16.0** package-review release (#3740 / #3766). `packages/sdk` pinned `^0.13.1` (cannot resolve 0.16.0) and the ggml-ocr plugin had not been adapted to what 0.16.0 changed. Scope is **`packages/sdk` only** — no `packages/inference` changes (the engine split is WIP and inference follows its own process).

## 📝 How does it solve it?

- **Dependency**: `@qvac/ocr-ggml` floor raised to `^0.16.0` in `packages/sdk`.
- **DocTR `langList`**: 0.16.0 makes `langList` optional (and ignored) for the language-agnostic DocTR pipeline — the plugin stops force-defaulting `['en']` for `pipelineType: 'doctr'` and lets the addon handle it; the `['en']` default is kept for easyocr when the caller omits it.
- Remaining 0.16.0 changes are transparent to the SDK: structured load errors (`UNSUPPORTED_LANGUAGE`/`FAILED_TO_LOAD_WEIGHTS` with native messages preserved), activation-failure cleanup, lazy native-binding resolution, and `bare-fs`/`bare-path` as proper runtime dependencies of the addon.

## 🧪 How was it tested?

- `bun install` resolves `@qvac/ocr-ggml@0.16.0`; `bun run build` (eslint + typecheck + compile against the published 0.16.0 types, including the now-optional `langList`) passes locally.
- Full `bun run test:unit` suite passes locally.

Companion PR: #3817 (`@qvac/translation-nmtcpp` 0.7.0 integration).

## 🔌 API Changes

DocTR models can now be loaded without a `langList` — the plugin no longer injects a default for the language-agnostic pipeline (optional in `@qvac/ocr-ggml` 0.16.0):

```typescript
// Auto-inferred pipelineType: 'doctr' — no langList required
const modelId = await loadModel({ modelSrc: OCR_DOCTR })

// EasyOCR keeps the ['en'] default when langList is omitted,
// and explicit lists are forwarded unchanged:
await loadModel({
  modelSrc: OCR_LATIN,
  modelConfig: { langList: ['en', 'fr'], detectorModelSrc: OCR_CRAFT }
})
```
