### PR TITLE
test[notask]: try macos-26-xlarge for diffusion darwin-arm64 GPU capability

### DIFF
--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -136,7 +136,7 @@ jobs:
           - os: mac-mini-m4
             platform: darwin
             arch: arm64
-            runner: mac-mini-m4-gpu
+            runner: macos-26-xlarge
             ltx: 'true'
           - os: macos-15-large
             platform: darwin


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Explores whether the GitHub-hosted `macos-26-xlarge` runner can host the diffusion darwin-arm64 GPU integration tests, as an alternative to the self-hosted `mac-mini-m4-gpu` fleet used since #3775.

## 📝 How does it solve it?

- Routes the diffusion `darwin-arm64` matrix entry to `macos-26-xlarge`:

  ```yaml
  - os: mac-mini-m4
    platform: darwin
    arch: arm64
    runner: macos-26-xlarge   # was: mac-mini-m4-gpu
    ltx: 'true'
  ```

  No `actionlint.yaml` change needed — `macos-26-xlarge` is a GitHub-hosted label, not self-hosted.

## ⚠️ This is unproven, not a fix

- #3775 moved this job off GitHub-hosted `macos-26` because its Metal device is virtualised and reports `MTLGPUFamilyApple5`, which lacks bf16 (`has bfloat = false`) and aborts on FLUX2's bf16 weights (`ggml_abort`, exit 134). The self-hosted `mac-mini-m4-gpu` (real M4, `MTLGPUFamilyApple9`) fixed it and has been passing since.

- `macos-26-xlarge` is a larger *tier* of the same GitHub-hosted macOS fleet, not different hardware in the relevant sense. Per GitHub's [larger runners reference](https://docs.github.com/en/actions/reference/runners/larger-runners), it runs on an M2 host and states: *"Nested-virtualization is not supported due to the limitation of Apple's Virtualization Framework."* That confirms it is still a macOS VM. Per a detailed writeup on Apple's own paravirtualized Metal GPU passthrough ([trycua/cua](https://github.com/trycua/cua/blob/main/blog/gpu-passthrough-macos-vms.md)): *"The paravirtualized device reports roughly an Apple 5-era family... and SIMD-group matrix support as unavailable"* — independent of the host chip generation. So `macos-26-xlarge` is expected to hit the same `MTLGPUFamilyApple5` / `has bfloat = false` ceiling that `macos-26` did, and this PR may simply reproduce #3775's original failure.

- I attempted to verify this empirically before opening this PR (see below) but was blocked by an unrelated `PAT_TOKEN` permission issue, so the capability question is still open. This PR exists to get a real CI run and settle it either way, not because the fix is confirmed.

## 🧪 How was it tested?

- `actionlint` clean on the changed workflow.
- Attempted a `workflow_dispatch` probe on a throwaway branch before opening this PR. It failed at the prebuild-download step with:
  ```
  npm error code E403
  npm error 403 403 Forbidden - GET https://npm.pkg.github.com/@tetherto%2fdiffusion-cpp-mono - Permission permission_denied: read_package
  ```
  This is `PAT_TOKEN` lacking `read:packages` for the org, unrelated to the runner change, but it means the GPU-family question was never actually tested. Once this PR's CI runs (via the normal PR path, which uses artifact-based prebuilds rather than the package-based path that hit the 403), we'll get a real answer.
- [ ] Check `ggml_metal_device_init` in the job log: `GPU family`, `has bfloat`
- [ ] Confirm the darwin-arm64 job schedules onto a GitHub-hosted runner (`Runner name` should read `GitHub Actions <id>`, not `mac-mini-m4-gpu`)
- [ ] If `has bfloat = false` and FLUX2 aborts again (exit 134) — confirms the prediction, close this PR without merging
- [ ] If `has bfloat = true` and FLUX2 passes — worth pursuing as a lower-maintenance alternative to the self-hosted fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
