### PR TITLE
QVAC-23254 chore: release @qvac/inference 0.17.1

### DIFF
--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/inference",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Bare-only in-process core of the QVAC SDK. Runs inference directly on the Bare runtime with explicit plugin assembly and no RPC, worker, or subprocess layer.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The NMT translation stats units fix (addon **seconds** → documented **milliseconds** for `totalTime`/`decodeTime`/`encodeTime`, merged in #3753) is on `main` but **unreleased**:

- `0.17.0` was cut (#3762, gitHead `3a56356`) *before* #3753 merged — verified against the published tarball: no `translate-stats.js`, no conversion in `dist/plugins/ops/translate.js`.
- The earlier `0.16.1` bump (#3770) merged after `0.17.0` and was never published.

Consumers on 0.17.0 still receive second-valued fields in the ms-documented `TranslationStats`.

## 📝 How does it solve it?

- `package.json` version `0.17.0` → `0.17.1` (bump only; the fix itself is already on main)

## 🧪 How was it tested?

The fix carries its own unit coverage (`test/translate-stats.test.ts`, in main since #3753); this PR is version-only.