### PR TITLE
QVAC-23254 fix[api]: correct NMT translation stats units in @qvac/sdk

### DIFF
--- a/packages/sdk/server/bare/ops/translate-stats.ts
+++ b/packages/sdk/server/bare/ops/translate-stats.ts
@@ -1,0 +1,15 @@
+import type { TranslationStats } from '@/schemas'
+import type { NmtStats } from '@/server/bare/types/addon-responses'
+
+export const NMT_SECONDS_TO_MS = 1000
+
+export function buildNmtTranslationStats(stats: NmtStats | undefined): TranslationStats {
+  return {
+    ...(stats?.totalTime !== undefined && { totalTime: stats.totalTime * NMT_SECONDS_TO_MS }),
+    ...(stats?.totalTokens !== undefined && { totalTokens: stats.totalTokens }),
+    ...(stats?.decodeTime !== undefined && { decodeTime: stats.decodeTime * NMT_SECONDS_TO_MS }),
+    ...(stats?.encodeTime !== undefined && { encodeTime: stats.encodeTime * NMT_SECONDS_TO_MS }),
+    ...(stats?.TPS !== undefined && { tokensPerSecond: stats.TPS }),
+    ...(stats?.TTFT !== undefined && { timeToFirstToken: stats.TTFT })
+  }
+}

--- a/packages/sdk/server/bare/ops/translate.ts
+++ b/packages/sdk/server/bare/ops/translate.ts
@@ -13,6 +13,7 @@ import { getLangName, detectOne } from '@qvac/langdetect-text'
 import { nowMs } from '@/profiling'
 import { buildStreamResult } from '@/profiling/model-execution'
 import type { NmtResponse, LlmResponse } from '@/server/bare/types/addon-responses'
+import { buildNmtTranslationStats } from '@/server/bare/ops/translate-stats'
 import {
   ModelIsDelegatedError,
   ModelNotFoundError,
@@ -234,20 +235,7 @@ export async function* translate(
   }
   const modelExecutionMs = nowMs() - modelStart
 
-  const stats: TranslationStats = {
-    ...(nmtResponse.stats?.totalTime !== undefined && { totalTime: nmtResponse.stats.totalTime }),
-    ...(nmtResponse.stats?.totalTokens !== undefined && {
-      totalTokens: nmtResponse.stats.totalTokens
-    }),
-    ...(nmtResponse.stats?.decodeTime !== undefined && {
-      decodeTime: nmtResponse.stats.decodeTime
-    }),
-    ...(nmtResponse.stats?.encodeTime !== undefined && {
-      encodeTime: nmtResponse.stats.encodeTime
-    }),
-    ...(nmtResponse.stats?.TPS !== undefined && { tokensPerSecond: nmtResponse.stats.TPS }),
-    ...(nmtResponse.stats?.TTFT !== undefined && { timeToFirstToken: nmtResponse.stats.TTFT })
-  }
+  const stats = buildNmtTranslationStats(nmtResponse.stats)
 
   return buildStreamResult(modelExecutionMs, stats)
 }

--- a/packages/sdk/test/unit/translate-stats.test.ts
+++ b/packages/sdk/test/unit/translate-stats.test.ts
@@ -1,0 +1,35 @@
+import test from 'brittle'
+import { buildNmtTranslationStats, NMT_SECONDS_TO_MS } from '@/server/bare/ops/translate-stats'
+
+test('NMT stats: second-valued fields are converted to milliseconds', (t) => {
+  const stats = buildNmtTranslationStats({
+    totalTime: 1.5,
+    decodeTime: 0.75,
+    encodeTime: 0.25,
+    totalTokens: 42,
+    TPS: 28,
+    TTFT: 250
+  })
+
+  t.is(stats.totalTime, 1.5 * NMT_SECONDS_TO_MS, 'totalTime is scaled to ms')
+  t.is(stats.decodeTime, 0.75 * NMT_SECONDS_TO_MS, 'decodeTime is scaled to ms')
+  t.is(stats.encodeTime, 0.25 * NMT_SECONDS_TO_MS, 'encodeTime is scaled to ms')
+  t.is(stats.tokensPerSecond, 28, 'TPS is not scaled')
+  t.is(stats.timeToFirstToken, 250, 'TTFT is already ms and not scaled')
+  t.is(stats.totalTokens, 42, 'totalTokens is not scaled')
+})
+
+test('NMT stats: absent fields stay absent', (t) => {
+  const stats = buildNmtTranslationStats({ totalTime: 2, TPS: 10 })
+
+  t.is(stats.totalTime, 2 * NMT_SECONDS_TO_MS)
+  t.is(stats.tokensPerSecond, 10)
+  t.absent(stats.decodeTime, 'decodeTime is omitted when the addon did not report it')
+  t.absent(stats.encodeTime, 'encodeTime is omitted when the addon did not report it')
+  t.absent(stats.timeToFirstToken, 'timeToFirstToken is omitted when the addon did not report it')
+  t.absent(stats.totalTokens, 'totalTokens is omitted when the addon did not report it')
+})
+
+test('NMT stats: undefined stats produce an empty object', (t) => {
+  t.alike(buildNmtTranslationStats(undefined), {})
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`packages/sdk`'s bare translate op forwards the nmtcpp addon's **seconds**-based `totalTime`/`decodeTime`/`encodeTime` unchanged into `TranslationStats` fields documented as **milliseconds** — the same defect fixed for `packages/inference` in #3753 (which shipped only on the inference side of the WIP engine split).

Directed at `packages/sdk` per the SDK team's guidance that engine changes follow the SDK package + normal release cadence until the `qvac/inference` migration is finalized.

## 📝 How does it solve it?

- New `server/bare/ops/translate-stats.ts`: `buildNmtTranslationStats()` owns the mapping with a named `NMT_SECONDS_TO_MS = 1000` constant (`TTFT`/`TPS`/`totalTokens` intentionally unscaled — TTFT is already ms).
- `server/bare/ops/translate.ts` uses it instead of the inline field-by-field copy.
- Mirrors `packages/inference`'s `src/plugins/ops/translate-stats.ts` exactly, so the two sides of the split stay identical until the migration completes.

## 🧪 How was it tested?

- New `test/unit/translate-stats.test.ts` locks the contract: seconds fields scaled to ms; `TPS`/`TTFT`/`totalTokens` unscaled; absent fields stay absent; `undefined` → `{}`.
- `bun run build` (eslint + typecheck + compile) and `bun run test:unit` (full suite incl. the new test) pass locally.

Related: #3819 (inference 0.17.1 bump) is deferred to the SDK team's release cadence.