### PR TITLE
QVAC-23254 chore: release @qvac/translation-nmtcpp 0.8.0

### DIFF
--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-08-13
+
+### Changed
+
+- Content-identical republish of 0.7.0 under a collision-free version line.
+  The package's 2025-era lineage still owns `0.7.1` on npm, so semver ranges
+  around 0.7.0 (`^`/`~`) resolve to that obsolete pre-TypeScript artifact
+  instead of the current release. `0.8.x` has no historic versions, restoring
+  normal range semantics (`^0.8.0`) for consumers. No code changes.
+
 ## [0.7.0] - 2026-08-11
 
 ### Added

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/translation-nmtcpp` 0.7.0 was published to npm on 2026-08-12 (dist-tag `release-0.7`), but the package's pre-renumbering 2025 lineage still owns `0.7.1` on npm (published 2025-10-14, old pre-TypeScript API). Because `0.7.1 > 0.7.0`, normal semver ranges around the current release (`^0.7.0` / `~0.7.0`) resolve to the obsolete 2025 artifact instead of the current one. npm never allows republishing a version, so `0.7.1` can never be reclaimed — the 0.7.x line is permanently poisoned for range resolution.

## 📝 How does it solve it?

- Bumps `packages/translation-nmtcpp/package.json` version `0.7.0` → `0.8.0`.
- Adds a `0.8.0` CHANGELOG entry documenting that this is a content-identical republish of 0.7.0 under a collision-free version line (no code changes).
- `0.8.x` has no historic versions on npm (verified), so consumers can depend on `^0.8.0` and get normal range semantics.

After merge, the npm publish requires pushing a `release-translation-nmtcpp-0.8.0` branch per the release pipeline. Once 0.8.0 is live, the stray 0.7.0 on npm should be deprecated so nobody pins to the collided line.
