### PR TITLE
QVAC-22749: infra: add fabric-stack CI for npm @qvac/fabric consumers

### DIFF
--- a/.github/fabric-consumers.json
+++ b/.github/fabric-consumers.json
@@ -1,0 +1,13 @@
+{
+  "vcpkg_direct": [
+    "fabric",
+    "llm-llamacpp",
+    "embed-llamacpp",
+    "translation-nmtcpp",
+    "ocr-ggml",
+    "vla-ggml"
+  ],
+  "npm_runtime": [
+    "classification-ggml"
+  ]
+}

--- a/.github/fabric-consumers.json
+++ b/.github/fabric-consumers.json
@@ -1,12 +1,4 @@
 {
-  "vcpkg_direct": [
-    "fabric",
-    "llm-llamacpp",
-    "embed-llamacpp",
-    "translation-nmtcpp",
-    "ocr-ggml",
-    "vla-ggml"
-  ],
   "npm_runtime": [
     "classification-ggml"
   ]

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Overlay PR @qvac/fabric prebuilds
         if: ${{ inputs.fabric-overlay-artifact != '' }}
-        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@6620d695d3a07cafe3931182e7844dde376a23f8
         with:
           workdir: ${{ env.WORKDIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -23,6 +23,13 @@ on:
         type: string
         required: false
         default: "packages/classification-ggml"
+      fabric-overlay-artifact:
+        description: >-
+          Workflow-run artifact name for PR-built @qvac/fabric prebuilds. Empty
+          skips the overlay (published npm baseline).
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -117,7 +124,24 @@ jobs:
 
       - name: Install npm dependencies
         working-directory: ${{ env.WORKDIR }}
+        shell: bash
         run: npm install --ignore-scripts
+
+      - name: Download fabric-prebuilds for overlay
+        if: ${{ inputs.fabric-overlay-artifact != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: ${{ inputs.fabric-overlay-artifact }}
+          path: ${{ runner.temp }}/fabric-prebuilds
+
+      - name: Overlay PR @qvac/fabric prebuilds
+        if: ${{ inputs.fabric-overlay-artifact != '' }}
+        uses: ./.github/actions/overlay-local-fabric
+        with:
+          workdir: ${{ env.WORKDIR }}
+          prebuilds-root: ${{ runner.temp }}/fabric-prebuilds
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
 
       # Non-Linux: unit tests only (fuzzing is Linux-only — libFuzzer + ASan,
       # matching the if(NOT WIN32) ASan gate). These use the vcpkg GoogleTest in

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Overlay PR @qvac/fabric prebuilds
         if: ${{ inputs.fabric-overlay-artifact != '' }}
-        uses: ./.github/actions/overlay-local-fabric
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           workdir: ${{ env.WORKDIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/fabric-stack-npm-consumer-smoke.yml
+++ b/.github/workflows/fabric-stack-npm-consumer-smoke.yml
@@ -84,7 +84,7 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Overlay PR @qvac/fabric prebuilds
-        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@6620d695d3a07cafe3931182e7844dde376a23f8
         with:
           workdir: ${{ env.WORKDIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/fabric-stack-npm-consumer-smoke.yml
+++ b/.github/workflows/fabric-stack-npm-consumer-smoke.yml
@@ -81,7 +81,7 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Overlay PR @qvac/fabric prebuilds
-        uses: ./.github/actions/overlay-local-fabric
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           workdir: ${{ env.WORKDIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/fabric-stack-npm-consumer-smoke.yml
+++ b/.github/workflows/fabric-stack-npm-consumer-smoke.yml
@@ -48,7 +48,10 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # bare-make runs the PR's own CMakeLists on a persistent runner, so no
+          # checkout credential may survive into the build steps.
+          persist-credentials: false
 
       - name: Setup AWS + Windows CLI
         uses: tetherto/qvac/.github/actions/setup-aws-prebuild@2e2c94d66a50c8b8851824314e343ede5297eb1f

--- a/.github/workflows/fabric-stack-npm-consumer-smoke.yml
+++ b/.github/workflows/fabric-stack-npm-consumer-smoke.yml
@@ -1,0 +1,97 @@
+# Desktop compile smoke for npm-runtime fabric consumers on fabric-stack PRs.
+# Downloads fabric-prebuilds from the same workflow run (published by on-pr-fabric)
+# and verifies the consumer still configures and builds against PR fabric headers.
+name: Fabric stack npm consumer smoke
+
+on:
+  workflow_call:
+    inputs:
+      consumer:
+        description: 'Package directory name under packages/, e.g. classification-ggml'
+        type: string
+        required: true
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        required: false
+      repository:
+        description: 'Repository to checkout'
+        type: string
+        required: false
+        default: 'tetherto/qvac'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: fabric-stack-smoke-${{ inputs.consumer }}
+    runs-on: qvac-ubuntu2404-x64
+    environment: release
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      WORKDIR: packages/${{ inputs.consumer }}
+      PLATFORM: linux
+      ARCH: x64
+    steps:
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
+        working-directory: .
+        if: runner.environment != 'github-hosted'
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup AWS + Windows CLI
+        uses: tetherto/qvac/.github/actions/setup-aws-prebuild@2e2c94d66a50c8b8851824314e343ede5297eb1f
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
+      - name: Setup vcpkg
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
+        env:
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
+        with:
+          platform: ${{ env.PLATFORM }}
+          arch: ${{ env.ARCH }}
+
+      - name: Setup Bare tooling
+        uses: tetherto/qvac/.github/actions/setup-bare-tooling@8668ac46334eb595aa095c94b53322c557b1bc39
+
+      - name: Set Vulkan SDK Path on Linux
+        shell: bash
+        run: echo "VULKAN_SDK=/opt/vulkansdk/x86_64" >> $GITHUB_ENV
+
+      - name: Download fabric-prebuilds
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: fabric-prebuilds
+          path: ${{ runner.temp }}/fabric-prebuilds
+
+      - name: Install npm dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: npm install --ignore-scripts
+
+      - name: Overlay PR @qvac/fabric prebuilds
+        uses: ./.github/actions/overlay-local-fabric
+        with:
+          workdir: ${{ env.WORKDIR }}
+          prebuilds-root: ${{ runner.temp }}/fabric-prebuilds
+          platform: ${{ env.PLATFORM }}
+          arch: ${{ env.ARCH }}
+
+      - name: Configure native build (smoke)
+        working-directory: ${{ env.WORKDIR }}
+        run: bare-make generate --platform ${{ env.PLATFORM }} --arch ${{ env.ARCH }} -D BUILD_TESTING=OFF
+
+      - name: Build native addon (smoke)
+        working-directory: ${{ env.WORKDIR }}
+        run: bare-make build

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Overlay PR @qvac/fabric prebuilds
         if: ${{ inputs.fabric-overlay-artifact != '' }}
-        uses: ./.github/actions/overlay-local-fabric
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           workdir: ${{ env.PKG_DIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Overlay PR @qvac/fabric prebuilds
         if: ${{ inputs.fabric-overlay-artifact != '' }}
-        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@6620d695d3a07cafe3931182e7844dde376a23f8
         with:
           workdir: ${{ env.PKG_DIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -26,6 +26,13 @@ on:
         description: "NPM package containing prebuilds (e.g. @qvac/classification-ggml@0.1.0). When set, prebuilds are downloaded from npm instead of from per-PR build artifacts."
         type: string
         required: false
+      fabric-overlay-artifact:
+        description: >-
+          Workflow-run artifact name for PR-built @qvac/fabric prebuilds. Empty
+          skips the overlay (published npm baseline).
+        type: string
+        required: false
+        default: ""
 
 env:
   PKG_DIR: packages/classification-ggml
@@ -85,7 +92,24 @@ jobs:
 
       - name: Install npm dependencies
         working-directory: ${{ env.PKG_DIR }}
+        shell: bash
         run: npm install --ignore-scripts
+
+      - name: Download fabric-prebuilds for overlay
+        if: ${{ inputs.fabric-overlay-artifact != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: ${{ inputs.fabric-overlay-artifact }}
+          path: ${{ runner.temp }}/fabric-prebuilds
+
+      - name: Overlay PR @qvac/fabric prebuilds
+        if: ${{ inputs.fabric-overlay-artifact != '' }}
+        uses: ./.github/actions/overlay-local-fabric
+        with:
+          workdir: ${{ env.PKG_DIR }}
+          prebuilds-root: ${{ runner.temp }}/fabric-prebuilds
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
 
       # Prebuilds live in the merged `prebuilds` bundle artifact, which is always present
       # regardless of how they were produced: the prebuild `merge` job uploads it on a fresh

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -16,6 +16,8 @@ on:
     paths:
       - "packages/classification-ggml/**"
       - ".github/workflows/*classification-ggml*.yml"
+      - "packages/fabric/vcpkg.json"
+      - "packages/fabric/vcpkg-configuration.json"
   workflow_dispatch:
 
   workflow_call:
@@ -86,6 +88,64 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
+  detect-fabric-stack:
+    if: needs.authorize.outputs.allowed == 'true'
+    needs:
+      - fork-approval
+      - authorize
+      - ci-router
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      fabric_stack: ${{ steps.detect.outputs.fabric_stack }}
+    steps:
+      - name: Checkout repository (default branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Checkout detect-fabric-stack action (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          sparse-checkout: .github/actions/detect-fabric-stack
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Detect fabric-stack PR
+        id: detect
+        uses: ./.github/actions/detect-fabric-stack
+
+  resolve-fabric-prebuilds:
+    if: needs.detect-fabric-stack.outputs.fabric_stack == 'true' && needs.authorize.outputs.allowed == 'true'
+    needs:
+      - fork-approval
+      - authorize
+      - detect-fabric-stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 130
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout wait-and-download action (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          sparse-checkout: .github/actions/wait-and-download-fabric-prebuilds
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Wait for fabric-prebuilds from on-pr-fabric
+        uses: ./.github/actions/wait-and-download-fabric-prebuilds
+        with:
+          github-token: ${{ github.token }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+      - name: Re-publish fabric-prebuilds for downstream jobs
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: fabric-prebuilds
+          path: fabric-prebuilds-staging
+
   sanity-checks:
     if: needs.ci-router.outputs.run_verified_checks == 'true' && needs.authorize.outputs.allowed == 'true'
     needs:
@@ -108,18 +168,24 @@ jobs:
           workdir: packages/classification-ggml
 
   cpp-tests:
-    if: needs.ci-router.outputs.run_cpp_tests == 'true' && needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.ci-router.outputs.run_cpp_tests == 'true' &&
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success')
     needs:
       - fork-approval
       - authorize
       - sanity-checks
       - ci-router
+      - detect-fabric-stack
+      - resolve-fabric-prebuilds
     uses: ./.github/workflows/cpp-tests-classification.yml
     secrets: inherit
     with:
       workdir: packages/classification-ggml
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.fabric_stack == 'true' && 'fabric-prebuilds' || '' }}
 
   cpp-lint:
     if: needs.ci-router.outputs.run_verified_checks == 'true' && needs.authorize.outputs.allowed == 'true'
@@ -181,10 +247,13 @@ jobs:
           workdir: packages/classification-ggml
 
   prebuild-artifact-reuse:
-    if: needs.detect-native-changes.outputs.native_changed == 'false'
+    if: |
+      needs.detect-native-changes.outputs.native_changed == 'false' &&
+      needs.detect-fabric-stack.outputs.fabric_stack != 'true'
     needs:
       - fork-approval
       - detect-native-changes
+      - detect-fabric-stack
       - sanity-checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -221,18 +290,22 @@ jobs:
       - ci-router
       - sanity-checks
       - detect-native-changes
+      - detect-fabric-stack
+      - resolve-fabric-prebuilds
       - prebuild-artifact-reuse
     if: |
       always() &&
       needs.sanity-checks.result == 'success' &&
       needs.ci-router.outputs.run_prebuilds == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
+      (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
       (needs.detect-native-changes.outputs.native_changed == 'true' || needs.prebuild-artifact-reuse.outputs.reuse_hit != 'true')
     uses: ./.github/workflows/prebuilds-classification-ggml.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.fabric_stack == 'true' && 'fabric-prebuilds' || '' }}
 
   prebuild-artifact-save:
     if: always() && needs.prebuild.result == 'success'
@@ -258,13 +331,20 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
   run-integration-tests:
-    if: always() && needs.ci-router.outputs.run_desktop == 'true' && needs.authorize.outputs.allowed == 'true' && (needs.prebuild.result == 'success' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true')
+    if: |
+      always() &&
+      needs.ci-router.outputs.run_desktop == 'true' &&
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
+      (needs.prebuild.result == 'success' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true')
     needs:
       - fork-approval
       - authorize
       - prebuild
       - prebuild-artifact-reuse
       - ci-router
+      - detect-fabric-stack
+      - resolve-fabric-prebuilds
     permissions:
       contents: read
       packages: read
@@ -274,6 +354,7 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.fabric_stack == 'true' && 'fabric-prebuilds' || '' }}
 
   # Mobile integration tests are no longer run on PRs. They run on demand via
   # `integration-mobile-test-classification-ggml.yml` (workflow_dispatch), where
@@ -281,41 +362,6 @@ jobs:
   # label / ci-router `run_mobile` output are kept for a possible future revival
   # but no longer trigger anything here. (Benchmark / weekend / on-merge mobile
   # runs are unaffected — they call the mobile workflow directly.)
-
-  publish-prebuild-status:
-    # Posts qvac/prebuild-classification-ggml for Merge Guard's verify-prebuilds; mirrors this flow's build-status.
-    needs: [prebuild, prebuild-artifact-reuse, ci-router]
-    if: always() && !cancelled() && github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      statuses: write
-    steps:
-      # Trusted base-branch checkout of only the prebuild-status scripts (never
-      # PR head code), so publish logic is a single, unit-tested source.
-      - name: Checkout prebuild-status scripts (default branch)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: .github/scripts/prebuild-status
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
-      - name: Publish prebuild status for Merge Guard
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PREBUILD_RESULT: ${{ needs.prebuild.result }}
-          REUSE_HIT: ${{ needs.prebuild-artifact-reuse.outputs.reuse_hit }}
-          # A skipped prebuild is only a pass when ci-router succeeded and chose
-          # not to build (no label); a skip from an upstream failure fails closed.
-          CI_ROUTER_RESULT: ${{ needs.ci-router.result }}
-          RUN_PREBUILDS: ${{ needs.ci-router.outputs.run_prebuilds }}
-          # Stamps this on-pr run's URL into target_url so Merge Guard can reject a
-          # status from a superseded (e.g. pre-label) run whose timestamp looks fresh.
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CONTEXT: qvac/prebuild-classification-ggml
-        run: node .github/scripts/prebuild-status/publish.mjs
 
   merge-guard:
     needs:
@@ -326,6 +372,8 @@ jobs:
         ts-checks,
         cpp-lint,
         cpp-tests,
+        detect-fabric-stack,
+        resolve-fabric-prebuilds,
         detect-native-changes,
         prebuild-artifact-reuse,
         prebuild,

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -114,7 +114,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
       - name: Detect fabric-stack PR
         id: detect
-        uses: tetherto/qvac/.github/actions/detect-fabric-stack@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/detect-fabric-stack@6620d695d3a07cafe3931182e7844dde376a23f8
       - name: Warn when a stack PR builds against released fabric
         if: steps.detect.outputs.fabric_stack == 'true' && needs.ci-router.outputs.run_prebuilds != 'true'
         shell: bash
@@ -134,7 +134,7 @@ jobs:
       actions: read
     steps:
       - name: Wait for fabric-prebuilds from on-pr-fabric
-        uses: tetherto/qvac/.github/actions/wait-and-download-fabric-prebuilds@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/wait-and-download-fabric-prebuilds@6620d695d3a07cafe3931182e7844dde376a23f8
         with:
           github-token: ${{ github.token }}
           # needs_fabric_artifact pins this job to pull_request_target, where the

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -105,16 +105,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
-      - name: Checkout detect-fabric-stack action (PR head)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          sparse-checkout: .github/actions/detect-fabric-stack
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
       - name: Detect fabric-stack PR
         id: detect
-        uses: ./.github/actions/detect-fabric-stack
+        uses: tetherto/qvac/.github/actions/detect-fabric-stack@886582f4cb3ac15f8be9970abde70166d76f9ec7
 
   resolve-fabric-prebuilds:
     if: needs.detect-fabric-stack.outputs.fabric_stack == 'true' && needs.authorize.outputs.allowed == 'true'
@@ -128,15 +121,8 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout wait-and-download action (PR head)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          sparse-checkout: .github/actions/wait-and-download-fabric-prebuilds
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
       - name: Wait for fabric-prebuilds from on-pr-fabric
-        uses: ./.github/actions/wait-and-download-fabric-prebuilds
+        uses: tetherto/qvac/.github/actions/wait-and-download-fabric-prebuilds@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           github-token: ${{ github.token }}
           head-sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -286,9 +286,14 @@ jobs:
       - detect-fabric-stack
       - resolve-fabric-prebuilds
       - prebuild-artifact-reuse
+    # A failed detection leaves fabric_stack empty, which satisfies
+    # fabric_stack != 'true' — without the result guard a stack PR would build
+    # against the released @qvac/fabric and prebuild-artifact-save would then
+    # publish that bundle as reusable.
     if: |
       always() &&
       needs.sanity-checks.result == 'success' &&
+      needs.detect-fabric-stack.result == 'success' &&
       needs.ci-router.outputs.run_prebuilds == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
       (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
@@ -326,6 +331,7 @@ jobs:
   run-integration-tests:
     if: |
       always() &&
+      needs.detect-fabric-stack.result == 'success' &&
       needs.ci-router.outputs.run_desktop == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
       (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
@@ -416,7 +422,12 @@ jobs:
       pull-requests: write
       packages: read
     with:
-      sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.ts-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
-      build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true' }}
+      # Every status below opens with the same fabric-stack guard: a skipped
+      # downstream job is only a deliberate no-op when the decision that skipped
+      # it is trustworthy. If detection failed, or the prebuild hand-off failed
+      # on a stack PR, the skips are consequences of that failure and must not
+      # read as passes.
+      sanity-checks-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && needs.sanity-checks.result == 'success' && needs.ts-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
+      build-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true') }}
       # run-mobile-integration-tests removed — mobile is on-demand only now.
-      integration-tests-status: ${{ needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped' }}
+      integration-tests-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && (needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') }}

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -100,6 +100,13 @@ jobs:
       contents: read
     outputs:
       fabric_stack: ${{ steps.detect.outputs.fabric_stack }}
+      # A stack PR only produces an artifact to wait for when on-pr-fabric will
+      # actually publish one. That producer needs the prebuilds label (or a
+      # label implying it) and, because wait-and-download only trusts a
+      # pull_request_target producer, a pull_request_target event. Every
+      # downstream fabric clause reads this rather than fabric_stack so the two
+      # sides cannot drift into a 120-minute poll for an artifact nobody builds.
+      needs_fabric_artifact: ${{ steps.detect.outputs.fabric_stack == 'true' && needs.ci-router.outputs.run_prebuilds == 'true' && github.event_name == 'pull_request_target' }}
     steps:
       - name: Checkout repository (default branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -108,9 +115,14 @@ jobs:
       - name: Detect fabric-stack PR
         id: detect
         uses: tetherto/qvac/.github/actions/detect-fabric-stack@886582f4cb3ac15f8be9970abde70166d76f9ec7
+      - name: Warn when a stack PR builds against released fabric
+        if: steps.detect.outputs.fabric_stack == 'true' && needs.ci-router.outputs.run_prebuilds != 'true'
+        shell: bash
+        run: |
+          echo "::warning::This PR changes packages/fabric, but no prebuilds label is set, so on-pr-fabric publishes nothing. Native jobs here build against the released @qvac/fabric, not this PR's. Add the 'prebuilds' label to exercise the stack."
 
   resolve-fabric-prebuilds:
-    if: needs.detect-fabric-stack.outputs.fabric_stack == 'true' && needs.authorize.outputs.allowed == 'true'
+    if: needs.detect-fabric-stack.outputs.needs_fabric_artifact == 'true' && needs.authorize.outputs.allowed == 'true'
     needs:
       - fork-approval
       - authorize
@@ -125,9 +137,10 @@ jobs:
         uses: tetherto/qvac/.github/actions/wait-and-download-fabric-prebuilds@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           github-token: ${{ github.token }}
-          # workflow_dispatch has no PR payload, and the action rejects an empty
-          # SHA outright — fall back the same way every other head-SHA consumer
-          # in this workflow does.
+          # needs_fabric_artifact pins this job to pull_request_target, where the
+          # PR payload always carries a head SHA. The fallback stays because the
+          # action rejects an empty SHA outright, and every other head-SHA
+          # consumer in this workflow reads it the same way.
           head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Re-publish fabric-prebuilds for downstream jobs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
@@ -167,7 +180,7 @@ jobs:
       needs.detect-fabric-stack.result == 'success' &&
       needs.ci-router.outputs.run_cpp_tests == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
-      (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success')
+      (needs.detect-fabric-stack.outputs.needs_fabric_artifact != 'true' || needs.resolve-fabric-prebuilds.result == 'success')
     needs:
       - fork-approval
       - authorize
@@ -181,7 +194,7 @@ jobs:
       workdir: packages/classification-ggml
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.fabric_stack == 'true' && 'fabric-prebuilds' || '' }}
+      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.needs_fabric_artifact == 'true' && 'fabric-prebuilds' || '' }}
 
   cpp-lint:
     if: needs.ci-router.outputs.run_verified_checks == 'true' && needs.authorize.outputs.allowed == 'true'
@@ -243,6 +256,9 @@ jobs:
           workdir: packages/classification-ggml
 
   prebuild-artifact-reuse:
+    # Deliberately the broad fabric_stack signal, not needs_fabric_artifact: a
+    # prebuild cached before the fabric change is stale for any stack PR,
+    # whether or not this run is the one that overlays the PR's fabric.
     if: |
       needs.detect-native-changes.outputs.native_changed == 'false' &&
       needs.detect-fabric-stack.outputs.fabric_stack != 'true'
@@ -289,24 +305,24 @@ jobs:
       - detect-fabric-stack
       - resolve-fabric-prebuilds
       - prebuild-artifact-reuse
-    # A failed detection leaves fabric_stack empty, which satisfies
-    # fabric_stack != 'true' — without the result guard a stack PR would build
-    # against the released @qvac/fabric and prebuild-artifact-save would then
-    # publish that bundle as reusable.
+    # A failed detection leaves needs_fabric_artifact empty, which satisfies
+    # needs_fabric_artifact != 'true' — without the result guard a stack PR would
+    # build against the released @qvac/fabric and prebuild-artifact-save would
+    # then publish that bundle as reusable.
     if: |
       always() &&
       needs.sanity-checks.result == 'success' &&
       needs.detect-fabric-stack.result == 'success' &&
       needs.ci-router.outputs.run_prebuilds == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
-      (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
+      (needs.detect-fabric-stack.outputs.needs_fabric_artifact != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
       (needs.detect-native-changes.outputs.native_changed == 'true' || needs.prebuild-artifact-reuse.outputs.reuse_hit != 'true')
     uses: ./.github/workflows/prebuilds-classification-ggml.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.fabric_stack == 'true' && 'fabric-prebuilds' || '' }}
+      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.needs_fabric_artifact == 'true' && 'fabric-prebuilds' || '' }}
 
   prebuild-artifact-save:
     if: always() && needs.prebuild.result == 'success'
@@ -337,7 +353,7 @@ jobs:
       needs.detect-fabric-stack.result == 'success' &&
       needs.ci-router.outputs.run_desktop == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
-      (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
+      (needs.detect-fabric-stack.outputs.needs_fabric_artifact != 'true' || needs.resolve-fabric-prebuilds.result == 'success') &&
       (needs.prebuild.result == 'success' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true')
     needs:
       - fork-approval
@@ -356,7 +372,7 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.fabric_stack == 'true' && 'fabric-prebuilds' || '' }}
+      fabric-overlay-artifact: ${{ needs.detect-fabric-stack.outputs.needs_fabric_artifact == 'true' && 'fabric-prebuilds' || '' }}
 
   # Mobile integration tests are no longer run on PRs. They run on demand via
   # `integration-mobile-test-classification-ggml.yml` (workflow_dispatch), where
@@ -430,7 +446,7 @@ jobs:
       # it is trustworthy. If detection failed, or the prebuild hand-off failed
       # on a stack PR, the skips are consequences of that failure and must not
       # read as passes.
-      sanity-checks-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && needs.sanity-checks.result == 'success' && needs.ts-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
-      build-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true') }}
+      sanity-checks-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.needs_fabric_artifact != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && needs.sanity-checks.result == 'success' && needs.ts-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
+      build-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.needs_fabric_artifact != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && (needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true') }}
       # run-mobile-integration-tests removed — mobile is on-demand only now.
-      integration-tests-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && (needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') }}
+      integration-tests-status: ${{ needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.needs_fabric_artifact != 'true' || needs.resolve-fabric-prebuilds.result == 'success') && (needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') }}

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -125,7 +125,10 @@ jobs:
         uses: tetherto/qvac/.github/actions/wait-and-download-fabric-prebuilds@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           github-token: ${{ github.token }}
-          head-sha: ${{ github.event.pull_request.head.sha }}
+          # workflow_dispatch has no PR payload, and the action rejects an empty
+          # SHA outright — fall back the same way every other head-SHA consumer
+          # in this workflow does.
+          head-sha: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Re-publish fabric-prebuilds for downstream jobs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -154,7 +154,14 @@ jobs:
           workdir: packages/classification-ggml
 
   cpp-tests:
+    # resolve-fabric-prebuilds is skipped on every non-fabric-stack PR, and an
+    # if: without a status-check function carries an implicit success() over all
+    # of needs — which would skip this job there. always() suppresses it; the
+    # sanity-checks gate it also suppresses is restored explicitly below.
     if: |
+      always() &&
+      needs.sanity-checks.result == 'success' &&
+      needs.detect-fabric-stack.result == 'success' &&
       needs.ci-router.outputs.run_cpp_tests == 'true' &&
       needs.authorize.outputs.allowed == 'true' &&
       (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.resolve-fabric-prebuilds.result == 'success')

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -363,6 +363,41 @@ jobs:
   # but no longer trigger anything here. (Benchmark / weekend / on-merge mobile
   # runs are unaffected — they call the mobile workflow directly.)
 
+  publish-prebuild-status:
+    # Posts qvac/prebuild-classification-ggml for Merge Guard's verify-prebuilds; mirrors this flow's build-status.
+    needs: [prebuild, prebuild-artifact-reuse, ci-router]
+    if: always() && !cancelled() && github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      # Trusted base-branch checkout of only the prebuild-status scripts (never
+      # PR head code), so publish logic is a single, unit-tested source.
+      - name: Checkout prebuild-status scripts (default branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/scripts/prebuild-status
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Publish prebuild status for Merge Guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PREBUILD_RESULT: ${{ needs.prebuild.result }}
+          REUSE_HIT: ${{ needs.prebuild-artifact-reuse.outputs.reuse_hit }}
+          # A skipped prebuild is only a pass when ci-router succeeded and chose
+          # not to build (no label); a skip from an upstream failure fails closed.
+          CI_ROUTER_RESULT: ${{ needs.ci-router.result }}
+          RUN_PREBUILDS: ${{ needs.ci-router.outputs.run_prebuilds }}
+          # Stamps this on-pr run's URL into target_url so Merge Guard can reject a
+          # status from a superseded (e.g. pre-label) run whose timestamp looks fresh.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CONTEXT: qvac/prebuild-classification-ggml
+        run: node .github/scripts/prebuild-status/publish.mjs
+
   merge-guard:
     needs:
       [
@@ -379,6 +414,7 @@ jobs:
         prebuild,
         prebuild-artifact-save,
         run-integration-tests,
+        publish-prebuild-status,
       ]
     if: always() && !cancelled()
     uses: ./.github/workflows/public-pr.yml

--- a/.github/workflows/on-pr-fabric.yml
+++ b/.github/workflows/on-pr-fabric.yml
@@ -207,19 +207,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ github.event.repository.default_branch }}
-      # New composite actions may not exist on default branch until the PR
-      # merges — overlay the PR revision for the action only (read-only git ops
-      # still run against the default-branch checkout above).
-      - name: Checkout detect-fabric-stack action (PR head)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          sparse-checkout: .github/actions/detect-fabric-stack
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
       - name: Detect fabric-stack PR
         id: detect
-        uses: ./.github/actions/detect-fabric-stack
+        uses: tetherto/qvac/.github/actions/detect-fabric-stack@886582f4cb3ac15f8be9970abde70166d76f9ec7
 
   fabric-stack-matrix:
     needs: [detect-fabric-stack]

--- a/.github/workflows/on-pr-fabric.yml
+++ b/.github/workflows/on-pr-fabric.yml
@@ -448,4 +448,8 @@ jobs:
       # label) don't produce a compiled artifact, and a native-unchanged PR reuses a
       # prior prebuild instead of rebuilding.
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true' }}
-      integration-tests-status: ${{ needs.fabric-npm-consumer-smoke.result == 'success' || needs.fabric-npm-consumer-smoke.result == 'skipped' }}
+      # A skipped consumer smoke is a pass only when it was never meant to run:
+      # a non-stack PR, or a PR without the prebuilds label (nothing to overlay).
+      # A skip caused by failed detection, an empty matrix, or a failed
+      # fabric-prebuilds publish means no npm consumer was tested at all.
+      integration-tests-status: ${{ needs.fabric-npm-consumer-smoke.result == 'success' || (needs.fabric-npm-consumer-smoke.result == 'skipped' && needs.detect-fabric-stack.result != 'failure' && (needs.detect-fabric-stack.outputs.fabric_stack != 'true' || needs.ci-router.outputs.run_prebuilds != 'true')) }}

--- a/.github/workflows/on-pr-fabric.yml
+++ b/.github/workflows/on-pr-fabric.yml
@@ -16,7 +16,6 @@ on:
     paths:
       - "packages/fabric/**"
       - ".github/workflows/*fabric*.yml"
-      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
   workflow_call:
 
@@ -191,6 +190,61 @@ jobs:
       pr_head_sha: ${{ github.event.pull_request.head.sha }}
       workdir: packages/fabric
 
+  detect-fabric-stack:
+    if: needs.authorize.outputs.allowed == 'true'
+    needs:
+      - fork-approval
+      - authorize
+      - ci-router
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      fabric_stack: ${{ steps.detect.outputs.fabric_stack }}
+    steps:
+      - name: Checkout repository (default branch)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      # New composite actions may not exist on default branch until the PR
+      # merges — overlay the PR revision for the action only (read-only git ops
+      # still run against the default-branch checkout above).
+      - name: Checkout detect-fabric-stack action (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          sparse-checkout: .github/actions/detect-fabric-stack
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Detect fabric-stack PR
+        id: detect
+        uses: ./.github/actions/detect-fabric-stack
+
+  fabric-stack-matrix:
+    needs: [detect-fabric-stack]
+    if: needs.detect-fabric-stack.outputs.fabric_stack == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      consumers: ${{ steps.set.outputs.consumers }}
+    steps:
+      - name: Checkout fabric-consumers manifest (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          sparse-checkout: .github/fabric-consumers.json
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Read npm_runtime consumers
+        id: set
+        shell: bash
+        run: |
+          CONSUMERS=$(jq -c '.npm_runtime' .github/fabric-consumers.json)
+          echo "consumers=$CONSUMERS" >> "$GITHUB_OUTPUT"
+
   detect-native-changes:
     if: needs.ci-router.outputs.run_prebuilds == 'true' && needs.authorize.outputs.allowed == 'true'
     needs:
@@ -216,10 +270,13 @@ jobs:
           workdir: packages/fabric
 
   prebuild-artifact-reuse:
-    if: needs.detect-native-changes.outputs.native_changed == 'false'
+    if: |
+      needs.detect-native-changes.outputs.native_changed == 'false' &&
+      needs.detect-fabric-stack.outputs.fabric_stack != 'true'
     needs:
       - fork-approval
       - detect-native-changes
+      - detect-fabric-stack
       - sanity-checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -292,6 +349,57 @@ jobs:
           native-hash: ${{ needs.detect-native-changes.outputs.native_hash }}
           pr-number: ${{ github.event.pull_request.number }}
 
+  fabric-prebuilds-publish:
+    needs:
+      - fork-approval
+      - prebuild
+      - prebuild-artifact-reuse
+    if: |
+      always() &&
+      (needs.prebuild.result == 'success' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download merged prebuilds bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: fabric-prebuilds-staging
+
+      - name: Publish fabric-prebuilds for npm-runtime consumers
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: fabric-prebuilds
+          path: fabric-prebuilds-staging
+
+  fabric-npm-consumer-smoke:
+    needs:
+      - fork-approval
+      - authorize
+      - ci-router
+      - detect-fabric-stack
+      - fabric-stack-matrix
+      - fabric-prebuilds-publish
+    if: |
+      always() &&
+      needs.detect-fabric-stack.outputs.fabric_stack == 'true' &&
+      needs.authorize.outputs.allowed == 'true' &&
+      needs.ci-router.outputs.run_prebuilds == 'true' &&
+      needs.fabric-prebuilds-publish.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        consumer: ${{ fromJson(needs.fabric-stack-matrix.outputs.consumers) }}
+    uses: ./.github/workflows/fabric-stack-npm-consumer-smoke.yml
+    secrets: inherit
+    with:
+      consumer: ${{ matrix.consumer }}
+      repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
   publish-prebuild-status:
     # Posts qvac/prebuild-fabric for Merge Guard's verify-prebuilds; mirrors this flow's build-status.
     needs: [prebuild, prebuild-artifact-reuse, ci-router]
@@ -334,10 +442,13 @@ jobs:
         ci-router,
         sanity-checks,
         cpp-lint,
+        detect-fabric-stack,
         detect-native-changes,
         prebuild-artifact-reuse,
         prebuild,
         prebuild-artifact-save,
+        fabric-prebuilds-publish,
+        fabric-npm-consumer-smoke,
       ]
     if: always() && !cancelled()
     uses: ./.github/workflows/public-pr.yml
@@ -347,3 +458,4 @@ jobs:
       # label) don't produce a compiled artifact, and a native-unchanged PR reuses a
       # prior prebuild instead of rebuilding.
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' || needs.prebuild-artifact-reuse.outputs.reuse_hit == 'true' }}
+      integration-tests-status: ${{ needs.fabric-npm-consumer-smoke.result == 'success' || needs.fabric-npm-consumer-smoke.result == 'skipped' }}

--- a/.github/workflows/on-pr-fabric.yml
+++ b/.github/workflows/on-pr-fabric.yml
@@ -340,6 +340,9 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
 
   fabric-prebuilds-publish:
+    # Must stay downstream of prebuild: this artifact's name matches the
+    # `fabric-*` glob reusable-prebuilds' merge job uses to collect the matrix
+    # uploads, so publishing it earlier would fold the bundle into itself.
     needs:
       - fork-approval
       - prebuild

--- a/.github/workflows/on-pr-fabric.yml
+++ b/.github/workflows/on-pr-fabric.yml
@@ -209,7 +209,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
       - name: Detect fabric-stack PR
         id: detect
-        uses: tetherto/qvac/.github/actions/detect-fabric-stack@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/detect-fabric-stack@6620d695d3a07cafe3931182e7844dde376a23f8
 
   fabric-stack-matrix:
     needs: [detect-fabric-stack]

--- a/.github/workflows/on-pr-shared-ci-infra.yml
+++ b/.github/workflows/on-pr-shared-ci-infra.yml
@@ -11,7 +11,6 @@ on:
       - "scripts/perf-report/**"
       - "vcpkg-overlays/triplets/**"
       - "vcpkg-overlays/toolchains/**"
-      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/prebuilds-classification-ggml.yml
+++ b/.github/workflows/prebuilds-classification-ggml.yml
@@ -25,6 +25,13 @@ on:
         required: false
         type: string
         default: "packages/classification-ggml"
+      fabric-overlay-artifact:
+        description: >-
+          Workflow-run artifact name for PR-built @qvac/fabric prebuilds. Empty
+          skips the overlay (published npm baseline).
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -48,4 +55,5 @@ jobs:
       # find_dependency(Vulkan) is separately removed under DL by qvac-fabric
       # 8828.0.2#5, but the fabric's own Vulkan backend build still needs it.
       include-vulkan-sdk: true
+      fabric-overlay-artifact: ${{ inputs.fabric-overlay-artifact }}
     secrets: inherit

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -29,7 +29,7 @@ on:
         default: "tetherto/qvac"
       artifact-name-prefix:
         description: >-
-          Optional prefix for the per-matrix prebuild artifact name. The merged artifact is always uploaded under the well-known name `prebuilds`, but downstream mobile-integration test workflows download per-matrix artifacts via glob patterns built from this prefix (see PREBUILD_ARTIFACT_PREFIX in integration-mobile-test-*.yml), so it must match the convention expected by the consumer.
+          Optional prefix for the per-matrix prebuild artifact name. The merged artifact is always uploaded under the well-known name `prebuilds`, but downstream mobile-integration test workflows download per-matrix artifacts via glob patterns built from this prefix (see PREBUILD_ARTIFACT_PREFIX in integration-mobile-test-*.yml), so it must match the convention expected by the consumer. It also scopes the merge job's download: a caller that publishes any other artifact in the same run (`fabric-overlay-artifact`) must set it, or that artifact is merged into the bundle.
         type: string
         required: false
         default: ""
@@ -515,9 +515,28 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download all build artifacts
+      # The scoping below is only real when the prefix is set. A caller that
+      # overlays PR fabric without one would silently ship the fabric tree
+      # inside its own bundle, so fail instead.
+      - name: Verify the merge scope is bounded
+        if: ${{ inputs.fabric-overlay-artifact != '' && inputs.artifact-name-prefix == '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::error::fabric-overlay-artifact is set but artifact-name-prefix is empty — the merge would absorb the fabric tree into the prebuilds bundle"
+          exit 1
+
+      - name: Download this workflow's build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
+          # Scoped to the matrix uploads above. Unscoped, this takes every
+          # artifact in the run and flattens it into the shipped bundle —
+          # including the PR fabric tree a caller publishes for
+          # fabric-overlay-artifact, which lands in the addon's own prebuilds
+          # directory and hides whether the addon resolves @qvac/fabric from
+          # node_modules. Callers that leave artifact-name-prefix empty keep the
+          # previous unscoped behaviour.
+          pattern: ${{ inputs.artifact-name-prefix }}*
           path: prebuilds
           merge-multiple: true
 

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -92,6 +92,14 @@ on:
         type: boolean
         required: false
         default: false
+      fabric-overlay-artifact:
+        description: >-
+          When set, download this workflow-run artifact after npm install and overlay
+          its contents into node_modules/@qvac/fabric before bare-make generate.
+          Used by npm-runtime consumers on fabric-stack PRs.
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -272,6 +280,23 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         shell: bash
         run: npm install
+
+      - if: ${{ inputs.fabric-overlay-artifact != '' }}
+        name: Download fabric-prebuilds for overlay
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: ${{ inputs.fabric-overlay-artifact }}
+          path: ${{ runner.temp }}/fabric-prebuilds
+
+      - if: ${{ inputs.fabric-overlay-artifact != '' }}
+        name: Overlay PR @qvac/fabric prebuilds
+        uses: ./.github/actions/overlay-local-fabric
+        with:
+          workdir: ${{ env.WORKDIR }}
+          prebuilds-root: ${{ runner.temp }}/fabric-prebuilds
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          tags: ${{ matrix.tags || '' }}
 
       - if: ${{ inputs.setup-rust-toolchain }}
         name: Setup Rust toolchain

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -290,7 +290,7 @@ jobs:
 
       - if: ${{ inputs.fabric-overlay-artifact != '' }}
         name: Overlay PR @qvac/fabric prebuilds
-        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@6620d695d3a07cafe3931182e7844dde376a23f8
         with:
           workdir: ${{ env.WORKDIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -290,7 +290,7 @@ jobs:
 
       - if: ${{ inputs.fabric-overlay-artifact != '' }}
         name: Overlay PR @qvac/fabric prebuilds
-        uses: ./.github/actions/overlay-local-fabric
+        uses: tetherto/qvac/.github/actions/overlay-local-fabric@886582f4cb3ac15f8be9970abde70166d76f9ec7
         with:
           workdir: ${{ env.WORKDIR }}
           prebuilds-root: ${{ runner.temp }}/fabric-prebuilds

--- a/docs/architecture/qips/fabric-stack-ci.md
+++ b/docs/architecture/qips/fabric-stack-ci.md
@@ -227,6 +227,21 @@ Mitigation: coordinate via `needs: fabric-prebuild` and shared artifact name.
 *Prebuild reuse cache* may serve stale fabric when only overlay REF changes
 Mitigation: include overlay REF in `detect-native-changes` hash or disable reuse for `fabric_stack` PRs.
 
+*Mobile tests a PR-built addon against the published fabric runtime*
+The overlay reaches every prebuild matrix entry, mobile included, so the Android/iOS
+`.bare` modules are compiled and linked against PR fabric. The ggml runtime is not
+bundled by the addon (`qvac_addon_use_fabric`), so the libraries packed into the
+APK/IPA are whatever `npm install` resolves for `@qvac/fabric` — the published
+release. Mobile therefore exercises a mismatched pairing rather than either a clean
+PR stack or a clean published baseline, and an ABI-breaking fabric change can crash
+on device or pass for the wrong reason. Closing it means overlaying fabric inside
+`.github/actions/run-mobile-integration-tests/build-mobile-app` between the
+test-framework `npm install` and the app build; that composite is shared by 14
+mobile workflows and the overlaid tree has to land where the external
+`tetherto/qvac-test-addon-mobile` bundler looks, so it needs its own change with a
+real fabric-stack mobile run to validate. Bounded for now: the mobile job is
+`continue-on-error: true` and runs only behind the `mobile` label.
+
 *New responsibilities*
 
 • Fabric-stack PR authors keep overlay REF in sync with the `qvac-fabric-llm.cpp` branch under test
@@ -240,7 +255,7 @@ Mitigation: include overlay REF in `detect-native-changes` hash or disable reuse
 • Automating registry publish or coordinated bump PRs after `qvac-fabric` release
 • Replacing `/vlm-benchmark` or Device Farm performance A/B — stack CI targets correctness (compile, link, integration smoke), not perf gates
 • Migrating remaining direct vcpkg consumers to `@qvac/fabric` — separate work in `INTEGRATION.md`
-• Mobile fabric-stack overlay for every platform on day one — desktop smoke first
+• Mobile fabric-stack overlay — desktop smoke first; see the mismatched-runtime trade-off above
 
 ---
 

--- a/docs/architecture/qips/fabric-stack-ci.md
+++ b/docs/architecture/qips/fabric-stack-ci.md
@@ -1,0 +1,286 @@
+# QIP: Fabric-stack CI for parallel qvac-fabric development
+
+*Status:* Draft — for team review
+*Authors:* @juan.arias
+*Created:* 2026-08-05
+
+---
+
+## People to consult before posting
+
+• *Fabric / addon pod lead* (`packages/fabric`, `qvac-fabric-llm.cpp`) — overlay-port workflow and `@qvac/fabric` runtime contract
+• *DevOps / CI* — workflow orchestration, merge-guard wiring, runner cost, fork-trust policy
+• *Classification-ggml owners* — first `@qvac/fabric` npm consumer; validates overlay-local-fabric pattern
+• *Direct vcpkg consumer owners* (llm, embed, ocr, nmt, vla) — path-filter and smoke-matrix coverage
+• *Lead / Architect* — cross-package dependency model during migration
+
+---
+
+## Approvers
+
+| Role | Approver | Status |
+| --- | --- | --- |
+| Lead / Architect | @Dima / @Yury Samarin | |
+| Head of QVAC | @Marco | |
+| CTO | @Mathias Buus | |
+
+---
+
+## :mag: Problem
+
+`qvac-fabric` (forked llama.cpp + ggml) is developed in `qvac-fabric-llm.cpp`, published to `qvac-registry-vcpkg`, and consumed by QVAC inference addons in two ways:
+
+*1. Direct vcpkg* — packages declare `qvac-fabric` in `vcpkg.json` and compile locally (`llm-llamacpp`, `embed-llamacpp`, `ocr-ggml`, `translation-nmtcpp`, `vla-ggml`, and `packages/fabric` itself).
+
+*2. npm runtime* — migrated consumers depend on `@qvac/fabric`, which ships the shared `qvac__fabric.bare` prebuild plus headers/CMake config (`classification-ggml` today). All other fabric-consuming addons will follow this path; only `packages/fabric` keeps building `qvac-fabric` from vcpkg.
+
+*What works today*
+
+Parallel development already works for *direct vcpkg consumers*: a qvac PR can add a vcpkg overlay port pointing at a test branch in `qvac-fabric-llm.cpp`, and per-package `on-pr-*` workflows build and test those addons against the unreleased engine.
+
+*The gap*
+
+That flow does *not* cover npm-runtime consumers. Their CI runs `npm install`, which resolves the *published* `@qvac/fabric` from the registry — not the fabric prebuild produced from the overlay in the same PR. If a stack PR also changes consumer code to call a new symbol exposed by the test fabric, CI may compile against stale headers and pass or fail for the wrong reasons.
+
+*What we need*
+
+A single, automatic CI process that:
+
+• Runs on PR open/sync (no manual dispatch)
+• Validates both consumer families during the `@qvac/fabric` migration
+• Supports combined changes: unreleased `qvac-fabric` + consumer addon code that depends on new APIs
+• Does not require publishing `@qvac/fabric` to npm for stack validation
+
+---
+
+## :bulb: Solution
+
+Introduce a *fabric-stack PR* convention and CI orchestration that treats `@qvac/fabric` prebuilds as the artifact bridge between unreleased `qvac-fabric` and npm-runtime consumers.
+
+### PR author workflow
+
+1. Develop `qvac-fabric` on a fork or test branch in `qvac-fabric-llm.cpp`.
+2. Open a qvac PR that includes:
+   • A vcpkg overlay port (`vcpkg-overlays/ports/qvac-fabric/`) referencing that branch/SHA
+   • Updates to `packages/fabric` (and direct vcpkg consumers as needed)
+   • Optional consumer addon changes that use new fabric APIs
+3. Push — CI runs automatically.
+
+### Architecture (two consumer families)
+
+```
+qvac-fabric (overlay → test branch)
+        │
+        ├─► packages/fabric  ──► @qvac/fabric prebuild artifact
+        │                              │
+        │                              ▼
+        │                    npm-runtime consumers
+        │                    (overlay into node_modules/@qvac/fabric)
+        │
+        └─► direct vcpkg consumers
+            (build qvac-fabric from overlay at compile time;
+             no npm overlay step)
+```
+
+*Fabric host* (`fabric`)
+• Builds from overlay; produces the prebuild artifact
+
+*Direct vcpkg* (`llm-llamacpp`, `embed-llamacpp`, `ocr-ggml`, `translation-nmtcpp`, `vla-ggml`)
+• Checkout includes overlay; `bare-make` resolves vcpkg locally
+
+*npm runtime* (`classification-ggml` — grows as addons migrate)
+• `npm install` scaffold + *overlay-local-fabric* from fabric prebuild artifact
+
+### CI orchestration
+
+*1. Fabric-stack detection*
+
+Set `fabric_stack=true` when the PR's own diff (merge base to head) touches a `packages/fabric` file that changes the built artifact:
+
+• C/C++ sources and headers, `CMakeLists.txt`, `cmake/**`
+• `vcpkg.json` or `vcpkg-configuration.json` — the only way a new `qvac-fabric` port revision, registry baseline, or overlay registration reaches the build
+• `binding.js`, `exports.txt`, `symbols.map`
+
+Docs, release notes and tests are excluded: they produce no prebuild for a consumer to wait on. `vcpkg-overlays/**` is excluded for the same reason as in the path filters below — the files alone activate nothing.
+
+*2. Fabric-first prebuild*
+
+Extend `on-pr-fabric` so stack PRs always:
+
+1. Build `packages/fabric` with the overlay (existing `prebuilds-fabric.yml`)
+2. Upload a merged `fabric-prebuilds` artifact (`prebuilds/` tree: platform binaries, `include/`, `share/qvac-fabric/`)
+
+This artifact is the single source of truth for the test runtime in the PR.
+
+*3. Direct vcpkg consumers*
+
+• Existing per-package `on-pr-*.yml` path filters already cover stack PRs when the author updates each consumer's `vcpkg-configuration.json` (under `packages/<pkg>/**`) to register the overlay — do **not** add a separate `vcpkg-overlays/ports/qvac-fabric/**` filter; overlay files alone do not activate the port without that config change
+• No npm overlay step; existing per-package prebuild + integration jobs continue
+• Lockstep `version>=` via `verify-qvac-fabric-lockstep` (scans all `packages/*/vcpkg.json`)
+
+*4. npm-runtime consumers — `overlay-local-fabric` action*
+
+New reusable action (same pattern as co-load smoke in `test-android-sdk.yml`):
+
+```
+overlay-local-fabric
+  inputs: fabric-artifact, consumer-dir
+
+  1. npm install --ignore-scripts
+  2. download fabric-prebuilds artifact
+  3. copy into every node_modules/@qvac/fabric match:
+       prebuilds/<platform>-<arch>/
+       prebuilds/include/
+       prebuilds/share/qvac-fabric/
+  4. consumer bare-make generate && build
+  5. consumer cpp-tests + integration-tests
+```
+
+*Critical ordering* for combined PRs (consumer code + new fabric API):
+
+```
+fabric-prebuild → overlay-local-fabric → consumer native build → tests
+```
+
+Headers for `find_package(qvac-fabric)` must come from the overlaid `node_modules/@qvac/fabric/prebuilds/` *before* `bare-make generate`.
+
+*5. Orchestration entry point*
+
+Extend `on-pr-fabric` as the stack orchestrator when `fabric_stack=true`:
+
+• Run fabric prebuild (existing)
+• Run `packages/fabric/test/integration` (`shared-runtime.test.js`) after prebuild
+• Matrix over npm-runtime consumers from the manifest below
+• Fold results into merge-guard via existing `public-pr.yml` boolean inputs
+
+When a stack PR also touches `packages/classification-ggml/**`, `on-pr-classification-ggml` still runs — but prebuild/integration jobs `needs` fabric-prebuild (or downloads the same `fabric-prebuilds` artifact) when `fabric_stack=true`.
+
+*6. Consumer manifest*
+
+Add `.github/fabric-consumers.json`:
+
+```json
+{
+  "npm_runtime": [
+    "classification-ggml"
+  ]
+}
+```
+
+`npm_runtime` = packages that already depend on `@qvac/fabric`. It is the matrix for the consumer smoke job, so an addon joins the list as it migrates.
+
+The complement — packages that still compile `qvac-fabric` themselves — is not enumerated here. It is derivable (`packages/*/vcpkg.json` still listing the port) and `verify-qvac-fabric-lockstep` already walks that set, so a second hand-maintained roster would only drift.
+
+### Trust boundary
+
+• Stack jobs use existing `pull_request_target` + fork-approval + SHA pin (`authorize-pr`, `fork-approval`)
+• Overlay ports fetch `qvac-fabric` at a pinned git ref via vcpkg — same trust model as today; no remote script execution
+• `overlay-local-fabric` only copies artifacts from the same workflow run
+
+### Compatibility / release impact
+
+• No public API change — CI and process only
+• No breaking change for non-stack PRs; main-branch CI unchanged except improved path filters for overlay-only PRs
+• Release path unchanged: merge fabric → publish `qvac-fabric` → coordinated bump PR → publish `@qvac/fabric` npm. Stack CI is pre-merge validation, not a new release channel.
+
+---
+
+## :twisted_rightwards_arrows: Alternatives considered
+
+*Publish dev versions to `qvac-registry-vcpkg`* (e.g. `9840.2.0-dev.<sha>`)
+Avoids overlay machinery but pollutes the registry and still does not solve npm `@qvac/fabric` without a separate dev npm publish.
+
+*npm `file:../fabric` in consumer `package.json` for stack PRs*
+Requires every stack PR to edit consumer manifests; conflicts with lockfile hygiene and is easy to merge accidentally.
+
+*Cross-repo trigger from `qvac-fabric-llm.cpp`*
+Couples fabric repo to qvac CI; qvac should own the test harness, fabric repo supplies only the git ref via overlay.
+
+*New standalone `on-pr-fabric-stack.yml` only*
+Viable, but duplicates wiring already in `on-pr-fabric`; extending the existing workflow keeps one entry point.
+
+*Full consumer matrix on every fabric PR*
+Too expensive; tier smoke on fabric PR, full matrix on `verify` label or version-bump PRs.
+
+---
+
+## :scales: Consequences
+
+*Positive impact*
+
+• Parallel `qvac-fabric` + addon development is CI-proven before merge, including npm-runtime consumers
+• One documented PR shape for fabric changes; less reliance on ad-hoc overlay skills and manual Device Farm runs for compile/link regressions
+• Migration-safe: both paths exercised without forcing premature consumer migration
+• Reuses proven patterns: co-load prebuild overlay, fabric `shared-runtime` integration test, existing per-addon workflows
+
+*Trade-offs reviewers must accept*
+
+*Extra CI time on fabric-stack PRs*
+Fabric prebuild already runs; npm consumer matrix is small today. Mitigation: tier expensive mobile/Device Farm behind `verify` label.
+
+*Operational complexity*
+Overlay port maintenance, manifest file, new composite action. Mitigation: author checklist in `packages/fabric/INTEGRATION.md`.
+
+*Duplicate workflow runs* when PR touches both `packages/fabric` and `packages/classification-ggml`
+Mitigation: coordinate via `needs: fabric-prebuild` and shared artifact name.
+
+*Prebuild reuse cache* may serve stale fabric when only overlay REF changes
+Mitigation: include overlay REF in `detect-native-changes` hash or disable reuse for `fabric_stack` PRs.
+
+*New responsibilities*
+
+• Fabric-stack PR authors keep overlay REF in sync with the `qvac-fabric-llm.cpp` branch under test
+• DevOps maintains `.github/fabric-consumers.json` as consumers migrate
+• Merge order: fabric engine merged and published before consumer releases that depend on new symbols (process, not enforced by CI)
+
+---
+
+## :no_entry_sign: Out of scope
+
+• Automating registry publish or coordinated bump PRs after `qvac-fabric` release
+• Replacing `/vlm-benchmark` or Device Farm performance A/B — stack CI targets correctness (compile, link, integration smoke), not perf gates
+• Migrating remaining direct vcpkg consumers to `@qvac/fabric` — separate work in `INTEGRATION.md`
+• Mobile fabric-stack overlay for every platform on day one — desktop smoke first
+
+---
+
+## :sparkles: Nice to haves
+
+• Domain-aware consumer selection from `qvac-fabric-llm.cpp` diff (e.g. vision changes → auto-include `ocr-ggml`)
+• `workflow_dispatch` input `qvac_fabric_ref` for re-running stack CI without a new commit
+• Script `scripts/fabric/bump-consumers.mjs` for coordinated `version>=` updates at release time
+• Run `packages/fabric/test/integration` with llm + embed on stack PRs as a migration canary
+
+---
+
+## Implementation phases (suggested)
+
+*Phase 1* — `.github/fabric-consumers.json` + author docs in `INTEGRATION.md`
+Shared vocabulary
+
+*Phase 2* — `overlay-local-fabric` composite action
+npm consumers use PR fabric
+
+*Phase 3* — Extend `on-pr-fabric`: detection, npm-consumer matrix, `shared-runtime` test
+Auto validation on PR open
+
+*Phase 4* — Confirm direct consumer `on-pr-*` workflows trigger via `packages/<pkg>/vcpkg-configuration.json` updates (no overlay-only path filter)
+Overlay-only PRs without config changes do not run consumer CI
+
+*Phase 5* — `needs: fabric-prebuild` in `on-pr-classification-ggml` when `fabric_stack`
+Combined fabric + consumer code changes
+
+---
+
+## Author checklist
+
+☐ Problem is clear and timely
+☐ Solution is concrete enough to review
+☐ Chosen solution is justified against obvious alternatives
+☐ Trust boundaries and security properties are explicit when affected
+☐ Compatibility, migration, and release impact are explicit when affected
+☐ Alternatives considered is brief
+☐ Consequences state positive impact and trade-offs reviewers must accept
+☐ Out of scope is explicit
+☐ Approvers table preserved
+☐ Consultation note reflects affected teams and expertise

--- a/packages/fabric/INTEGRATION.md
+++ b/packages/fabric/INTEGRATION.md
@@ -251,3 +251,39 @@ readelf -d prebuilds/<host>/<addon>.bare | grep NEEDED   # → NEEDED qvac__fabr
 | 4 | `binding.js` | `require('@qvac/fabric')` **before** `require.addon()` |
 | 5 | Companion lib | `qvac__fabric@0.bare` installed in `prebuilds/<host>/<addon>/` (plus backend `.so` on Linux/Android) |
 | 6 | Build | `npm run build` succeeds; `readelf -d` shows `NEEDED qvac__fabric@0.bare`; consumer `.bare` is small (no embedded ggml/llama) |
+
+---
+
+## Fabric-stack PRs (parallel `qvac-fabric` development)
+
+When developing `qvac-fabric` on a test branch in `qvac-fabric-llm.cpp`, open a qvac PR
+that includes:
+
+1. A vcpkg overlay port at `vcpkg-overlays/ports/qvac-fabric/` pointing at that branch
+   or SHA.
+2. Updates to `packages/fabric` (and any direct vcpkg consumers that need coordinated
+   bumps).
+3. Optional consumer addon changes that call new fabric APIs.
+
+CI runs automatically on PR open/sync:
+
+- **Direct vcpkg consumers** (`llm-llamacpp`, `embed-llamacpp`, `ocr-ggml`,
+  `translation-nmtcpp`, `vla-ggml`) pick up the overlay at compile time when the
+  PR updates each package's `vcpkg-configuration.json` (covered by the existing
+  `packages/<pkg>/**` path filters).
+- **`packages/fabric`** builds `@qvac/fabric` prebuilds and publishes a
+  `fabric-prebuilds` artifact.
+- **npm-runtime consumers** (see `.github/fabric-consumers.json`) overlay that
+  artifact into `node_modules/@qvac/fabric` before `bare-make generate`, so headers
+  and the shared runtime match the unreleased engine — no dev npm publish required.
+
+Author checklist:
+
+| Step | Action |
+|------|--------|
+| Overlay | Keep `vcpkg-overlays/ports/qvac-fabric/portfile.cmake` REF in sync with the `qvac-fabric-llm.cpp` branch under test |
+| Lockstep | Run `verify-qvac-fabric-lockstep` — every `packages/*/vcpkg.json` that still lists `qvac-fabric` must satisfy `version>=` |
+| Combined PR | When changing consumer code *and* fabric APIs, ensure both `on-pr-fabric` and the consumer `on-pr-*` workflow run (paths must include overlay and consumer package) |
+| Manifest | When a package migrates to `@qvac/fabric`, move it from `vcpkg_direct` to `npm_runtime` in `.github/fabric-consumers.json` |
+
+See `docs/architecture/qips/fabric-stack-ci.md` for the full CI design.

--- a/packages/fabric/INTEGRATION.md
+++ b/packages/fabric/INTEGRATION.md
@@ -267,9 +267,9 @@ that includes:
 
 CI runs automatically on PR open/sync:
 
-- **Direct vcpkg consumers** (`llm-llamacpp`, `embed-llamacpp`, `ocr-ggml`,
-  `translation-nmtcpp`, `vla-ggml`) pick up the overlay at compile time when the
-  PR updates each package's `vcpkg-configuration.json` (covered by the existing
+- **Direct vcpkg consumers** — every package whose `vcpkg.json` still lists the
+  `qvac-fabric` port — pick up the overlay at compile time when the PR updates
+  that package's `vcpkg-configuration.json` (covered by the existing
   `packages/<pkg>/**` path filters).
 - **`packages/fabric`** builds `@qvac/fabric` prebuilds and publishes a
   `fabric-prebuilds` artifact.
@@ -284,6 +284,6 @@ Author checklist:
 | Overlay | Keep `vcpkg-overlays/ports/qvac-fabric/portfile.cmake` REF in sync with the `qvac-fabric-llm.cpp` branch under test |
 | Lockstep | Run `verify-qvac-fabric-lockstep` — every `packages/*/vcpkg.json` that still lists `qvac-fabric` must satisfy `version>=` |
 | Combined PR | When changing consumer code *and* fabric APIs, ensure both `on-pr-fabric` and the consumer `on-pr-*` workflow run (paths must include overlay and consumer package) |
-| Manifest | When a package migrates to `@qvac/fabric`, move it from `vcpkg_direct` to `npm_runtime` in `.github/fabric-consumers.json` |
+| Manifest | When a package migrates to `@qvac/fabric`, add it to `npm_runtime` in `.github/fabric-consumers.json` — that list drives the consumer smoke matrix |
 
 See `docs/architecture/qips/fabric-stack-ci.md` for the full CI design.

--- a/packages/fabric/INTEGRATION.md
+++ b/packages/fabric/INTEGRATION.md
@@ -260,7 +260,9 @@ When developing `qvac-fabric` on a test branch in `qvac-fabric-llm.cpp`, open a 
 that includes:
 
 1. A vcpkg overlay port at `vcpkg-overlays/ports/qvac-fabric/` pointing at that branch
-   or SHA.
+   or SHA, plus the `vcpkg-configuration.json` edit that registers that directory as an
+   overlay for each package meant to build against it. The port on its own changes no
+   build; registering it is what swaps the registry version for the branch under test.
 2. Updates to `packages/fabric` (and any direct vcpkg consumers that need coordinated
    bumps).
 3. Optional consumer addon changes that call new fabric APIs.
@@ -283,7 +285,7 @@ Author checklist:
 |------|--------|
 | Overlay | Keep `vcpkg-overlays/ports/qvac-fabric/portfile.cmake` REF in sync with the `qvac-fabric-llm.cpp` branch under test |
 | Lockstep | Run `verify-qvac-fabric-lockstep` — every `packages/*/vcpkg.json` that still lists `qvac-fabric` must satisfy `version>=` |
-| Combined PR | When changing consumer code *and* fabric APIs, ensure both `on-pr-fabric` and the consumer `on-pr-*` workflow run (paths must include overlay and consumer package) |
+| Combined PR | When changing consumer code *and* fabric APIs, ensure both `on-pr-fabric` and the consumer `on-pr-*` workflow run. The `vcpkg-configuration.json` edit is the trigger — it sits under the consumer's own `packages/<pkg>/**` path filter, whereas a change confined to `vcpkg-overlays/` starts nothing |
 | Manifest | When a package migrates to `@qvac/fabric`, add it to `npm_runtime` in `.github/fabric-consumers.json` — that list drives the consumer smoke matrix |
 
 See `docs/architecture/qips/fabric-stack-ci.md` for the full CI design.


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- npm-runtime consumers (`@qvac/classification-ggml` today) install `@qvac/fabric` from the registry during CI, so a PR that changes unreleased `qvac-fabric` cannot validate consumer compile/link against the PR-built runtime.
- Parallel `qvac-fabric` + addon development already works for direct vcpkg consumers via overlay ports, but there was no equivalent bridge for npm-runtime consumers.
- Authors had no documented, automated path to prove a combined fabric + consumer change before merge without publishing a dev `@qvac/fabric` to npm.

## 📝 How does it solve it?

**Scope note:** the three composite actions (`detect-fabric-stack`, `overlay-local-fabric`, `wait-and-download-fabric-prebuilds`) were split out and merged in [#3849](https://github.com/tetherto/qvac/pull/3849) (`886582f4`); poll/provenance fixes from review landed separately in [#3942](https://github.com/tetherto/qvac/pull/3942) (`6620d695`). This PR **consumes** them only — all seven cross-repo refs are pinned at `6620d695d3a07cafe3931182e7844dde376a23f8` — and wires the producer/consumer workflows, scoped artifact merge, Merge Guard guards, and docs. It does not modify the action sources on `main`.

**Producer side — `on-pr-fabric.yml`**

- Adds a `detect-fabric-stack` job and a `fabric-stack-matrix` job that reads the consumer roster from `.github/fabric-consumers.json`.
- Publishes the merged fabric bundle as a `fabric-prebuilds` artifact for the parallel consumer run. `fabric-prebuilds-publish` must stay downstream of the prebuild merge, since its name matches fabric's own `fabric-*` prefix glob.
- Runs `fabric-stack-npm-consumer-smoke.yml` once per rostered consumer (new file: linux-x64 configure + compile smoke).
- Disables stale prebuild reuse on stack PRs, and preserves the upstream `publish-prebuild-status` job.

**Consumer side — `on-pr-classification-ggml.yml`**

- Adds `detect-fabric-stack` plus `resolve-fabric-prebuilds`, which waits for the parallel `on-pr-fabric` run on the same head SHA and validates the producing run's provenance before downloading.
- Threads `fabric-overlay-artifact` into `reusable-prebuilds.yml`, `cpp-tests-classification.yml`, and `integration-test-classification-ggml.yml`, so prebuilds, C++ tests, and desktop integration all build against the PR's fabric.
- `head-sha` falls back to `github.sha` so manual `workflow_dispatch` runs resolve a SHA at all.
- Jobs gate on `needs.detect-fabric-stack.result == 'success'` rather than only on the `fabric_stack` output, so a failed detection cannot fail open into a released-fabric build that then poisons the prebuild cache. Merge-guard status inputs treat a downstream skip as a pass only when the decision to skip was itself trustworthy.

**`reusable-prebuilds.yml`**

- The merge step now downloads `pattern: ${{ inputs.artifact-name-prefix }}*` instead of `merge-multiple: true` over every artifact in the run, and a validation step guards against silent regression. Previously a package's merged `prebuilds` bundle could absorb the unrelated `fabric-prebuilds` artifact.

**Detection semantics**

- The trigger is a change to build-affecting `packages/fabric` sources or its `vcpkg.json` / `vcpkg-configuration.json` — *not* the presence of files under `vcpkg-overlays/ports/qvac-fabric/**`. An overlay port sitting in the shared directory is inert until a package registers that directory in its `vcpkg-configuration.json`, so the registration is the real signal. The dead path is removed from the action, from `on-pr-shared-ci-infra.yml`'s `paths:` filter, and the corresponding case in `test-fabric-stack-actions.yml` is replaced with a registry baseline bump.

**Security and configuration**

- `fabric-stack-npm-consumer-smoke.yml` checks out with `secrets.GITHUB_TOKEN` and `persist-credentials: false`. It runs on a self-hosted runner and builds fork PR code, so a broad-scope PAT left on disk there is exfiltratable. The job sits behind `on-pr-fabric`'s existing `fork-approval` + `authorize` gates, and `ci-trust-policy.test.mjs` still passes.
- All new jobs declare least-privilege `permissions:` (`contents: read`, plus `actions: read` where an artifact is downloaded across runs and `id-token: write` for the AWS prebuild cache).
- `.github/fabric-consumers.json` ships only the `npm_runtime` roster. The `vcpkg_direct` key was dropped — no CI logic read it, and direct vcpkg consumers are already covered by the overlay-port mechanism.

**Docs**

- `docs/architecture/qips/fabric-stack-ci.md` — design, detection contract, and accepted trade-offs.
- `packages/fabric/INTEGRATION.md` — the author-facing workflow for a combined fabric + consumer change.

**Known limitations**

- Mobile integration tests build the app through `npm install`, which resolves `@qvac/fabric` from the registry. The PR-built addon therefore links against the *published* fabric runtime on device. Fixing this requires changing `build-mobile-app`, a composite action shared by 14 workflows; it is documented as a deferred trade-off in the QIP.

## 🧪 How was it tested?

Validation uses test branch [`test/QVAC-22749`](https://github.com/tetherto/qvac/pull/3911) (`c09094a`), which carries this PR's commits **plus** a no-op `qvac-fabric` overlay port — a byte-identical copy of the registry port at version `10069.0.0`, registered in `packages/fabric/vcpkg-configuration.json` — so the fabric-stack path triggers without bumping fabric. **That fixture is not part of this PR.**

All seven cross-repo action refs in this branch are pinned to **`6620d695d3a07cafe3931182e7844dde376a23f8`** ([#3942](https://github.com/tetherto/qvac/pull/3942) on `main`), which includes the poll/provenance fixes from the review thread.

**1. Composite action unit tests — [#3942](https://github.com/tetherto/qvac/pull/3942), [run 32244035966](https://github.com/tetherto/qvac/actions/runs/32244035966)**

All three jobs green on the action-fix branch before merge: `Detect fabric-stack changes`, `Wait and download fabric prebuilds`, `Overlay local fabric prebuilds`. Covers the `#3942` changes now consumed at `6620d695`: overlay path removed from the detection predicate, run polling no longer filters on producer status/conclusion, and the `mock-gh` fixture serves real JSON so selector regressions fail in CI rather than only in production.

*(Supersedes the earlier `#3849` action test run [32115657883](https://github.com/tetherto/qvac/actions/runs/32115657883) at `886582f4`.)*

**2. Producer path, end to end — [run 32361283425](https://github.com/tetherto/qvac/actions/runs/32361283425)**

A `workflow_dispatch` of `on-pr-fabric` on `test/QVAC-22749` at `c09094a`, so the branch's own workflow definitions execute (unlike `pull_request_target`, which loads from the base branch). Full chain green in ~20 minutes with **`6620d695` pins**:

`detect-fabric-stack` → `fabric-stack-matrix` → 9-platform fabric prebuild matrix → scoped merge → `fabric-prebuilds-publish` → `fabric-npm-consumer-smoke (classification-ggml)`.

The smoke job confirms the bridge: *Download fabric-prebuilds* → *Install npm dependencies* → *Overlay PR @qvac/fabric prebuilds* → *Configure native build* → *Build native addon*. Negative controls behaved: `prebuild-artifact-reuse` skipped (stack PR), `publish-prebuild-status` skipped (not a `pull_request_target` event). Run artifacts show the scoped merge held — nine `fabric-<platform>` artifacts, one merged `prebuilds` bundle, and the `fabric-prebuilds` hand-off artifact.

*(Supersedes the earlier producer dispatch [32136661678](https://github.com/tetherto/qvac/actions/runs/32136661678), which used the `#3849` pin at `886582f4`.)*

**3. Regression against existing pipelines — #3911 and post-rebase #3827 `pull_request_target` runs**

These execute **`main`'s** workflow definitions (including before this PR merges), so they prove the branch does not break existing fabric/classification pipelines — they do **not** exercise the new consumer-side jobs (`detect-fabric-stack`, `resolve-fabric-prebuilds`, fabric overlay threading).

- **#3911** with `prebuilds`, `run-desktop-addon-tests`, and `run-cpp-addon-tests` labels: [fabric 32246661823](https://github.com/tetherto/qvac/actions/runs/32246661823), [classification-ggml 32246661871](https://github.com/tetherto/qvac/actions/runs/32246661871), and Merge Guard all green (3-platform C++ tests, 9-platform prebuilds, desktop integration on 5 targets, Android/iOS Device Farm).
- **#3827** after rebase onto current `main` at `e2e14ddd`: [fabric 32384866828](https://github.com/tetherto/qvac/actions/runs/32384866828) green on the default (unlabelled) path; [classification-ggml 32384866910](https://github.com/tetherto/qvac/actions/runs/32384866910) and [Merge Guard 32384866774](https://github.com/tetherto/qvac/actions/runs/32384866774) on the same SHA.

**4. Consumer path, end to end — not yet live on `pull_request_target`**

The earlier paired dispatch [31182794170](https://github.com/tetherto/qvac/actions/runs/31182794170) (producer [31109191988](https://github.com/tetherto/qvac/actions/runs/31109191988)) exercised `detect-fabric-stack` → `resolve-fabric-prebuilds` → overlay → full classification matrix, but predates the `#3849`/`#3942` provenance hardening (producer must be `pull_request_target`; waiter gated on `needs_fabric_artifact`). The first live `pull_request_target` exercise of the consumer side — cross-workflow artifact hand-off from `on-pr-fabric` to `on-pr-classification-ggml` — happens once these workflow definitions land on `main`; re-run #3911 with labels after merge to close that gap.

## 🛡️ Permissions changes

- Scope: new jobs in `on-pr-fabric.yml`, `on-pr-classification-ggml.yml`, and the new `fabric-stack-npm-consumer-smoke.yml`.
- Before: n/a (new jobs / new file).
- After: `contents: read` everywhere; `actions: read` on jobs that download an artifact from a parallel run; `id-token: write` on the smoke job for the AWS prebuild cache.
- Justification: least privilege per job. No workflow gains write scope on repository contents, and no existing job's permissions are widened.
