### PR TITLE
QVAC-23222 chore[bc|notask]: release @qvac/cli 0.11.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## [0.11.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.11.0
+
+This release tightens the security posture of `qvac serve`. Browser access now requires an explicit list of trusted origins, a bind beyond loopback refuses to start without authentication, and the bearer key can be read from a file instead of the command line. Existing `--cors` and `--host` invocations will need updating.
+
+## Breaking Changes
+
+### Trusted browser origins must be named explicitly
+
+`--cors` no longer opens the server to every origin. It is now only a compatibility validation switch: it does not enable CORS by itself, and it fails startup unless at least one exact origin is supplied through `--cors-origin` or `serve.cors.origins`. Wildcards are rejected, as are origins ending in a trailing dot, which no browser sends.
+
+`--docs` no longer inherits wildcard access either. It adds same-port `localhost`, `127.0.0.1`, and `[::1]` origins for Swagger UI, and it rejects `--port 0`, because a same-port origin cannot be computed before the port is known.
+
+**Before:**
+
+```bash
+qvac serve openai --cors --docs
+```
+
+**After:**
+
+```bash
+qvac serve openai --cors --cors-origin https://app.example.com
+```
+
+### A non-loopback bind must authenticate
+
+Binding beyond `127.0.0.1` used to log a warning and start anyway, which quietly exposed an unauthenticated API to the network. It now fails startup unless a key is supplied, or unless the operator says outright that the exposure is intended.
+
+**Before:**
+
+```bash
+# Warned, then served the whole network with no authentication.
+qvac serve openai --host 0.0.0.0
+```
+
+**After:**
+
+```bash
+# Require a bearer token...
+qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
+
+# ...or accept the risk explicitly, which warns and starts as before.
+qvac serve openai --host 0.0.0.0 --allow-unauthenticated
+```
+
+## New Flags
+
+### `--api-key-file` keeps the credential out of the process list
+
+`--api-key <key>` places the token in the process's command line, which `/proc/<pid>/cmdline` exposes to every local account on Linux. `--api-key-file <path>` reads it from a file instead:
+
+```bash
+printf '%s' "$QVAC_API_KEY" > ~/.qvac/serve-key
+chmod 600 ~/.qvac/serve-key
+qvac serve openai --api-key-file ~/.qvac/serve-key
+```
+
+The path must be a regular file — symlinks and directories are refused — and the CLI warns when the file is readable beyond its owner. `--api-key` and `--api-key-file` are mutually exclusive.
+
+### `--allow-unauthenticated` opts back into an open bind
+
+For operators who genuinely want an unauthenticated listener beyond loopback, this restores the previous warn-and-start behaviour. Anyone who can reach the address can use the server.
+
 ## [0.10.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.10.0

--- a/packages/cli/NOTICE
+++ b/packages/cli/NOTICE
@@ -10,67 +10,40 @@ listed below.
 JavaScript Dependencies
 =========================================================================
 
---- (bsd-2-clause AND mit AND apache-2.0) ---
-
-  rc@1.2.8
-    https://github.com/dominictarr/rc
-
---- (bsd-3-clause AND gpl-2.0) ---
-
-  node-forge@1.4.0
-    https://github.com/digitalbazaar/forge
-
---- (mit AND apache-2.0) ---
-
-  fb-dotslash@0.5.8
-    https://github.com/facebook/dotslash
-
---- (mit AND cc0-1.0) ---
-
-  type-fest@0.13.1
-    https://github.com/sindresorhus/type-fest
-  type-fest@0.21.3
-    https://github.com/sindresorhus/type-fest
-  type-fest@0.7.1
-    https://github.com/sindresorhus/type-fest
-  type-fest@1.4.0
-    https://github.com/sindresorhus/type-fest
-
---- 0bsd (Zero-Clause BSD) ---
-
-  jsc-safe-url@0.2.4
-    https://github.com/robhogan/jsc-safe-url
-
 --- apache-2.0 (Apache License 2.0) ---
 
   @hyperswarm/secret-stream@6.9.1
     https://github.com/holepunchto/hyperswarm-secret-stream
-  @malept/cross-spawn-promise@2.0.0
-    https://github.com/malept/cross-spawn-promise
-  @qvac/bci-whispercpp@0.5.1
+  @qvac/asr-ggml@0.1.1
     https://github.com/tetherto/qvac
-  @qvac/classification-ggml@0.13.0
+  @qvac/audiogen-ggml@0.1.1
+    https://github.com/tetherto/qvac
+  @qvac/bci-whispercpp@0.6.0
+    https://github.com/tetherto/qvac
+  @qvac/classification-ggml@0.15.1
     https://github.com/tetherto/qvac
   @qvac/decoder-audio@0.5.0
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/diffusion-cpp@0.15.0
+  @qvac/diffusion-cpp@0.17.0
     https://github.com/tetherto/qvac
-  @qvac/embed-llamacpp@0.28.0
+  @qvac/embed-llamacpp@0.30.1
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
+  @qvac/fabric@0.3.1
+    https://github.com/tetherto/qvac
   @qvac/infer-base@0.4.2
     https://github.com/tetherto/qvac
-  @qvac/infer-base@0.6.1
+  @qvac/infer-base@0.6.2
     https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.38.2
+  @qvac/llm-llamacpp@0.39.4
     https://github.com/tetherto/qvac
   @qvac/logging@0.1.1
     https://github.com/tetherto/qvac
-  @qvac/ocr-ggml@0.12.1
+  @qvac/ocr-ggml@0.13.1
     https://github.com/tetherto/qvac
   @qvac/rag@0.6.4
     https://github.com/tetherto/qvac
@@ -78,17 +51,13 @@ JavaScript Dependencies
     https://github.com/tetherto/qvac
   @qvac/registry-schema@0.3.0
     https://github.com/tetherto/qvac
-  @qvac/sdk@0.16.0
+  @qvac/sdk@0.17.0
     https://github.com/tetherto/qvac
-  @qvac/transcription-parakeet@0.10.1
+  @qvac/translation-nmtcpp@8.3.1
     https://github.com/tetherto/qvac
-  @qvac/transcription-whispercpp@0.12.1
+  @qvac/tts-ggml@0.6.3
     https://github.com/tetherto/qvac
-  @qvac/translation-nmtcpp@8.1.0
-    https://github.com/tetherto/qvac
-  @qvac/tts-ggml@0.5.1
-    https://github.com/tetherto/qvac
-  @qvac/vla-ggml@0.14.0
+  @qvac/vla-ggml@0.16.2
     https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
@@ -110,6 +79,8 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-bundle
   bare-bundle-id@1.0.2
     https://github.com/holepunchto/bare-bundle-id
+  bare-cpu-info@0.1.1
+    https://github.com/holepunchto/bare-cpu-info
   bare-crypto@1.15.3
     https://github.com/holepunchto/bare-crypto
   bare-dns@2.1.4
@@ -124,8 +95,10 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-ffmpeg
   bare-form-data@1.2.2
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.7.4
+  bare-fs@4.8.0
     https://github.com/holepunchto/bare-fs
+  bare-gpu-info@0.1.1
+    https://github.com/holepunchto/bare-gpu-info
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
   bare-http-parser@1.1.5
@@ -136,10 +109,6 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-https
   bare-inspect@3.1.4
     https://github.com/holepunchto/bare-inspect
-  bare-lief@0.2.6
-    https://github.com/holepunchto/bare-lief
-  bare-link@3.3.0
-    https://github.com/holepunchto/bare-link
   bare-mime@1.0.0
     https://github.com/holepunchto/bare-mime
   bare-module-lexer@1.6.3
@@ -148,7 +117,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-module-resolve
   bare-module-traverse@2.4.4
     https://github.com/holepunchto/bare-module-traverse
-  bare-net@2.3.2
+  bare-net@2.3.3
     https://github.com/holepunchto/bare-net
   bare-os@3.9.3
     https://github.com/holepunchto/bare-os
@@ -166,9 +135,9 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-process
   bare-rpc@1.3.8
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.30.3
+  bare-runtime@1.31.0
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.30.3
+  bare-runtime-darwin-arm64@1.31.0
     https://github.com/holepunchto/bare-runtime
   bare-semver@1.1.0
     https://github.com/holepunchto/bare-semver
@@ -184,46 +153,30 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-structured-clone
   bare-subprocess@6.1.0
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.5.3
+  bare-tcp@2.5.4
     https://github.com/holepunchto/bare-tcp
-  bare-tls@3.1.7
+  bare-tls@3.1.8
     https://github.com/holepunchto/bare-tls
   bare-tty@5.1.2
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.6
+  bare-url@2.5.1
     https://github.com/holepunchto/bare-url
   bare-zlib@1.4.1
     https://github.com/holepunchto/bare-zlib
-  baseline-browser-mapping@2.11.4
-    https://github.com/web-platform-dx/baseline-browser-mapping
   blind-relay@1.6.1
     https://github.com/holepunchto/blind-relay
-  bser@2.1.1
-    https://github.com/facebook/watchman
-  chrome-launcher@0.15.2
-    https://github.com/GoogleChrome/chrome-launcher
-  chromium-edge-launcher@0.2.0
-    https://github.com/cezaraugusto/chromium-edge-launcher
-  chromium-edge-launcher@0.3.0
-    https://github.com/cezaraugusto/chromium-edge-launcher
   compact-encoding@3.3.0
     https://github.com/holepunchto/compact-encoding
   compact-encoding-bitfield@1.1.0
     https://github.com/compact-encoding/compact-encoding-bitfield
   compact-encoding-net@1.3.0
     https://github.com/compact-encoding/compact-encoding-net
-  detect-libc@2.1.2
-    https://github.com/lovell/detect-libc
   device-file@2.3.1
     https://github.com/holepunchto/device-file
   events-universal@1.0.1
     https://github.com/holepunchto/events-universal
-  exponential-backoff@3.1.3
-    https://github.com/coveooss/exponential-backoff
-  fb-watchman@2.0.2
-    https://github.com/facebook/watchman
   fd-lock@2.2.0
     https://github.com/holepunchto/fd-lock
   fs-native-extensions@1.5.0
@@ -234,11 +187,11 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-errors
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
-  hypercore-stats@2.4.0
+  hypercore-stats@2.5.1
     https://github.com/holepunchto/hypercore-stats
   hypercore-storage@3.2.0
     https://github.com/holepunchto/hypercore-storage
-  hyperdb@6.7.0
+  hyperdb@6.8.0
     https://github.com/holepunchto/hyperdb
   hyperdht-address@1.1.1
     https://github.com/holepunchto/hyperdht-address
@@ -248,26 +201,20 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdispatch
   hyperdrive@13.3.3
     https://github.com/holepunchto/hyperdrive
-  hyperschema@1.21.0
+  hyperschema@1.22.0
     https://github.com/holepunchto/hyperschema
   hyperswarm-stats@1.3.1
     https://github.com/holepunchto/hyperswarm-stats
   index-encoder@3.5.0
     https://github.com/holepunchto/index-encoder
-  lighthouse-logger@1.4.2
-  marky@1.3.0
-    https://github.com/nolanlawson/marky
   mirror-drive@1.14.2
     https://github.com/holepunchto/mirror-drive
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
-  paparam@1.10.1
+  paparam@1.12.0
     https://github.com/holepunchto/paparam
   passive-core-watcher@1.0.1
     https://github.com/holepunchto/passive-core-watcher
-  pear-pipe@1.0.6
-  qrcode-terminal@0.11.0
-    https://github.com/gtanner/qrcode-terminal
   quickbit-native@2.4.8
     https://github.com/holepunchto/quickbit-native
   rabin-native@2.0.0
@@ -276,8 +223,6 @@ JavaScript Dependencies
     https://github.com/holepunchto/rabin-stream
   rache@1.0.0
     https://github.com/holepunchto/rache
-  react-native-bare-kit@0.14.5
-    https://github.com/holepunchto/react-native-bare-kit
   refcounter@1.0.0
     https://github.com/holepunchto/refcounter
   require-addon@1.2.0
@@ -286,511 +231,79 @@ JavaScript Dependencies
     https://github.com/holepunchto/require-asset
   resource-on-exit@1.0.0
     https://github.com/holepunchto/bare-teardown
-  rocksdb-native@3.17.2
+  rocksdb-native@3.17.3
     https://github.com/holepunchto/rocksdb-native
   scope-lock@1.2.4
     https://github.com/holepunchto/scope-lock
   simdle-native@1.3.9
     https://github.com/holepunchto/simdle-native
-  spdx-correct@3.2.0
-    https://github.com/jslicense/spdx-correct.js
   sub-encoder@2.1.3
     https://github.com/holepunchto/sub-encoder
-  sumchecker@3.0.1
-    https://github.com/malept/sumchecker
   text-decoder@1.2.7
     https://github.com/holepunchto/text-decoder
-  ts-interface-checker@0.1.13
-    https://github.com/gristlabs/ts-interface-checker
-  typescript@5.9.3
-    https://github.com/microsoft/TypeScript
-  udx-native@1.20.7
+  udx-native@1.21.0
     https://github.com/holepunchto/udx-native
   unslab@1.3.0
     https://github.com/holepunchto/unslab
-  validate-npm-package-license@3.0.4
-    https://github.com/kemitchell/validate-npm-package-license.js
-  walker@1.0.8
-    https://github.com/daaku/nodejs-walker
   which-runtime@1.4.0
     https://github.com/holepunchto/which-runtime
-  xcode@3.0.1
-    https://github.com/apache/cordova-node-xcode
 
 --- blueoak-1.0.0 ---
 
-  chownr@3.0.0
-    https://github.com/isaacs/chownr
   glob@13.0.6
     https://github.com/isaacs/node-glob
   lru-cache@11.5.2
     https://github.com/isaacs/node-lru-cache
-  minimatch@10.2.5
+  minimatch@10.2.6
     https://github.com/isaacs/minimatch
   minipass@7.1.3
     https://github.com/isaacs/minipass
-  minipass-flush@1.0.7
-    https://github.com/isaacs/minipass-flush
   path-scurry@2.0.2
     https://github.com/isaacs/path-scurry
-  sax@1.6.1
-    https://github.com/isaacs/sax-js
-  tar@7.5.22
-    https://github.com/isaacs/node-tar
-  yallist@5.0.0
-    https://github.com/isaacs/yallist
-
---- bsd-2-clause (BSD 2-Clause License) ---
-
-  @electron/osx-sign@1.3.3
-    https://github.com/electron/osx-sign
-  @electron/packager@18.4.4
-    https://github.com/electron/packager
-  @electron/windows-sign@1.2.2
-    https://github.com/electron/windows-sign
-  dotenv@16.4.7
-    https://github.com/motdotla/dotenv
-  dotenv-expand@11.0.7
-    https://github.com/motdotla/dotenv-expand
-  extract-zip@2.0.1
-    https://github.com/maxogden/extract-zip
-  fontfaceobserver@2.3.0
-    https://github.com/bramstein/fontfaceobserver
-  http-cache-semantics@4.2.0
-    https://github.com/kornelski/http-cache-semantics
-  normalize-package-data@2.5.0
-    https://github.com/npm/normalize-package-data
-  regjsparser@0.13.2
-    https://github.com/jviereck/regjsparser
-  terser@5.49.0
-    https://github.com/terser/terser
-  webidl-conversions@5.0.0
-    https://github.com/jsdom/webidl-conversions
 
 --- bsd-3-clause (BSD 3-Clause License) ---
 
-  @expo/xcpretty@4.4.4
-    https://github.com/expo/expo-cli
-  @react-native/debugger-frontend@0.81.5
-    https://github.com/facebook/react-native
-  @react-native/debugger-frontend@0.86.0
-    https://github.com/facebook/react-native
-  fast-uri@3.1.4
+  fast-uri@3.1.5
     https://github.com/fastify/fast-uri
-  fast-uri@4.1.1
+  fast-uri@4.1.2
     https://github.com/fastify/fast-uri
-  global-agent@3.0.0
-    https://github.com/gajus/global-agent
-  ieee754@1.2.1
-    https://github.com/feross/ieee754
   light-my-request@6.6.0
     https://github.com/fastify/light-my-request
-  makeerror@1.0.12
-    https://github.com/daaku/nodejs-makeerror
-  roarr@2.15.4
-    https://github.com/gajus/roarr
   secure-json-parse@4.1.0
     https://github.com/fastify/secure-json-parse
-  source-map@0.5.7
-    https://github.com/mozilla/source-map
-  source-map@0.6.1
-    https://github.com/mozilla/source-map
-  source-map-js@1.2.1
-    https://github.com/7rulnik/source-map-js
-  sprintf-js@1.1.3
-    https://github.com/alexei/sprintf.js
-  tmpl@1.0.5
-    https://github.com/daaku/nodejs-tmpl
-
---- cc-by-3.0 ---
-
-  spdx-exceptions@2.5.0
-    https://github.com/kemitchell/spdx-exceptions.json
-
---- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
-
-  caniuse-lite@1.0.30001806
-    https://github.com/browserslist/caniuse-lite
-
---- cc0-1.0 (Creative Commons Zero 1.0) ---
-
-  spdx-license-ids@3.0.23
-    https://github.com/jslicense/spdx-license-ids
 
 --- isc (ISC License) ---
 
-  @isaacs/fs-minipass@4.0.1
-    https://github.com/npm/fs-minipass
-  @isaacs/ttlcache@1.4.1
-    https://github.com/isaacs/ttlcache
-  @npmcli/fs@2.1.2
-    https://github.com/npm/fs
-  @ungap/structured-clone@1.3.3
-    https://github.com/ungap/structured-clone
-  abbrev@1.1.1
-    https://github.com/isaacs/abbrev-js
-  at-least-node@1.0.0
-    https://github.com/RyanZim/at-least-node
   bits-to-bytes@1.3.0
     https://github.com/holepunchto/bits-to-bytes
-  cacache@16.1.3
-    https://github.com/npm/cacache
-  chownr@2.0.0
-    https://github.com/isaacs/chownr
-  cliui@8.0.1
-    https://github.com/yargs/cliui
-  electron-to-chromium@1.5.396
-    https://github.com/Kilian/electron-to-chromium
   fastq@1.20.1
     https://github.com/mcollina/fastq
-  fs-minipass@2.1.0
-    https://github.com/npm/fs-minipass
-  fs.realpath@1.0.0
-    https://github.com/isaacs/fs.realpath
-  get-caller-file@2.0.5
-    https://github.com/stefanpenner/get-caller-file
-  glob@7.2.3
-    https://github.com/isaacs/node-glob
-  glob@8.1.0
-    https://github.com/isaacs/node-glob
-  graceful-fs@4.2.11
-    https://github.com/isaacs/node-graceful-fs
-  hosted-git-info@2.8.9
-    https://github.com/npm/hosted-git-info
-  hosted-git-info@7.0.2
-    https://github.com/npm/hosted-git-info
-  infer-owner@1.0.4
-    https://github.com/npm/infer-owner
-  inflight@1.0.6
-    https://github.com/npm/inflight
   inherits@2.0.4
     https://github.com/isaacs/inherits
-  ini@1.3.8
-    https://github.com/isaacs/ini
-  isexe@2.0.0
-    https://github.com/isaacs/isexe
-  json-stringify-safe@5.0.1
-    https://github.com/isaacs/json-stringify-safe
-  lru-cache@10.4.3
-    https://github.com/isaacs/node-lru-cache
-  lru-cache@5.1.1
-    https://github.com/isaacs/node-lru-cache
-  lru-cache@7.18.3
-    https://github.com/isaacs/node-lru-cache
-  make-fetch-happen@10.2.1
-    https://github.com/npm/make-fetch-happen
-  minimatch@3.1.5
-    https://github.com/isaacs/minimatch
-  minimatch@5.1.9
-    https://github.com/isaacs/minimatch
-  minimatch@9.0.9
-    https://github.com/isaacs/minimatch
-  minipass@3.3.6
-    https://github.com/isaacs/minipass
-  minipass@5.0.0
-    https://github.com/isaacs/minipass
-  minipass-collect@1.0.2
-    https://izs.me
-  minipass-pipeline@1.2.4
-    https://izs.me
-  minipass-sized@1.0.3
-    https://github.com/isaacs/minipass-sized
   nanoassert@2.0.0
     https://github.com/emilbayes/nanoassert
   noise-curve-ed@2.1.0
     https://github.com/chm-diederichs/noise-curve-ed
-  nopt@6.0.0
-    https://github.com/npm/nopt
-  npm-package-arg@11.0.3
-    https://github.com/npm/npm-package-arg
-  once@1.4.0
-    https://github.com/isaacs/once
-  picocolors@1.1.1
-    https://github.com/alexeyraspopov/picocolors
-  proc-log@2.0.1
-    https://github.com/npm/proc-log
-  proc-log@4.2.0
-    https://github.com/npm/proc-log
-  promise-inflight@1.0.1
-    https://github.com/iarna/promise-inflight
   quickbit-universal@2.2.0
     https://github.com/holepunchto/quickbit-universal
-  rimraf@3.0.2
-    https://github.com/isaacs/rimraf
-  semver@5.7.2
-    https://github.com/npm/node-semver
-  semver@6.3.1
-    https://github.com/npm/node-semver
   semver@7.8.5
     https://github.com/npm/node-semver
   setprototypeof@1.2.0
     https://github.com/wesleytodd/setprototypeof
-  signal-exit@3.0.7
-    https://github.com/tapjs/signal-exit
   simdle-universal@1.1.2
     https://github.com/holepunchto/simdle-universal
   split2@4.2.0
     https://github.com/mcollina/split2
-  ssri@9.0.1
-    https://github.com/npm/ssri
-  tar@6.2.1
-    https://github.com/isaacs/node-tar
-  unique-filename@2.0.1
-    https://github.com/npm/unique-filename
-  unique-slug@3.0.0
-    https://github.com/npm/unique-slug
-  validate-npm-package-name@5.0.1
-    https://github.com/npm/validate-npm-package-name
-  which@2.0.2
-    https://github.com/isaacs/node-which
-  wrappy@1.0.2
-    https://github.com/npm/wrappy
-  y18n@5.0.8
-    https://github.com/yargs/y18n
-  yallist@3.1.1
-    https://github.com/isaacs/yallist
-  yallist@4.0.0
-    https://github.com/isaacs/yallist
   yaml@2.9.0
     https://github.com/eemeli/yaml
-  yargs-parser@21.1.1
-    https://github.com/yargs/yargs-parser
 
 --- mit (MIT License) ---
 
-  @0no-co/graphql.web@1.3.2
-    https://github.com/0no-co/graphql.web
-  @babel/code-frame@7.10.4
-    https://github.com/babel/babel
-  @babel/code-frame@7.29.7
-    https://github.com/babel/babel
-  @babel/compat-data@7.29.7
-    https://github.com/babel/babel
-  @babel/core@7.29.7
-    https://github.com/babel/babel
-  @babel/generator@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-annotate-as-pure@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-compilation-targets@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-create-class-features-plugin@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-create-regexp-features-plugin@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-define-polyfill-provider@0.6.8
-    https://github.com/babel/babel-polyfills
-  @babel/helper-globals@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-member-expression-to-functions@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-module-imports@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-module-transforms@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-optimise-call-expression@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-plugin-utils@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-remap-async-to-generator@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-replace-supers@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-skip-transparent-expression-wrappers@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-string-parser@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-validator-identifier@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-validator-option@7.29.7
-    https://github.com/babel/babel
-  @babel/helper-wrap-function@7.29.7
-    https://github.com/babel/babel
-  @babel/helpers@7.29.7
-    https://github.com/babel/babel
-  @babel/highlight@7.25.9
-    https://github.com/babel/babel
-  @babel/parser@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-proposal-decorators@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-proposal-export-default-from@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-syntax-decorators@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-syntax-dynamic-import@7.8.3
-    https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
-  @babel/plugin-syntax-export-default-from@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-syntax-flow@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-syntax-jsx@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
-    https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator
-  @babel/plugin-syntax-optional-chaining@7.8.3
-    https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining
-  @babel/plugin-syntax-typescript@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-arrow-functions@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-async-generator-functions@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-async-to-generator@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-block-scoping@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-class-properties@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-class-static-block@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-classes@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-computed-properties@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-destructuring@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-export-namespace-from@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-flow-strip-types@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-for-of@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-function-name@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-literals@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-logical-assignment-operators@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-modules-commonjs@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-named-capturing-groups-regex@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-nullish-coalescing-operator@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-numeric-separator@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-object-rest-spread@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-optional-catch-binding@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-optional-chaining@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-parameters@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-private-methods@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-private-property-in-object@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-react-display-name@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-react-jsx@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-react-jsx-development@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-react-jsx-self@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-react-jsx-source@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-react-pure-annotations@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-regenerator@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-runtime@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-shorthand-properties@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-spread@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-sticky-regex@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-typescript@7.29.7
-    https://github.com/babel/babel
-  @babel/plugin-transform-unicode-regex@7.29.7
-    https://github.com/babel/babel
-  @babel/preset-react@7.29.7
-    https://github.com/babel/babel
-  @babel/preset-typescript@7.29.7
-    https://github.com/babel/babel
-  @babel/runtime@7.29.7
-    https://github.com/babel/babel
-  @babel/template@7.29.7
-    https://github.com/babel/babel
-  @babel/traverse@7.29.7
-    https://github.com/babel/babel
-  @babel/types@7.29.7
-    https://github.com/babel/babel
-  @electron-forge/plugin-base@7.11.2
-    https://github.com/electron/forge
-  @electron-forge/shared-types@7.11.2
-    https://github.com/electron/forge
-  @electron-forge/tracer@7.11.2
-    https://github.com/electron/forge
-  @electron/asar@3.4.1
-    https://github.com/electron/asar
-  @electron/get@3.1.0
-    https://github.com/electron/get
-  @electron/node-gyp@10.2.0-electron.1
-    https://github.com/nodejs/node-gyp
-  @electron/notarize@2.5.0
-    https://github.com/electron/notarize
-  @electron/rebuild@3.7.2
-    https://github.com/electron/rebuild
-  @electron/universal@2.0.3
-    https://github.com/electron/universal
-  @esbuild/darwin-arm64@0.28.1
+  @esbuild/darwin-arm64@0.28.2
     https://github.com/evanw/esbuild
-  @expo/cli@54.0.26
-    https://github.com/expo/expo
-  @expo/code-signing-certificates@0.0.6
-    https://github.com/expo/code-signing-certificates
-  @expo/config@12.0.14
-    https://github.com/expo/expo
-  @expo/config-plugins@54.0.5
-    https://github.com/expo/expo
-  @expo/config-types@54.0.10
-    https://github.com/expo/expo
-  @expo/devcert@1.2.1
-    https://github.com/expo/devcert
-  @expo/devtools@0.1.8
-    https://github.com/expo/expo
-  @expo/env@2.0.12
-    https://github.com/expo/expo
-  @expo/fingerprint@0.15.5
-    https://github.com/expo/expo
-  @expo/image-utils@0.8.15
-    https://github.com/expo/expo
-  @expo/json-file@10.0.16
-    https://github.com/expo/expo
-  @expo/json-file@11.0.1
-    https://github.com/expo/expo
-  @expo/metro@54.2.0
-    https://github.com/expo/expo-metro
-  @expo/metro-config@54.0.17
-    https://github.com/expo/expo
-  @expo/osascript@2.7.1
-    https://github.com/expo/expo
-  @expo/package-manager@1.13.1
-    https://github.com/expo/expo
-  @expo/plist@0.4.9
-    https://github.com/expo/expo
-  @expo/prebuild-config@54.0.9
-    https://github.com/expo/expo
-  @expo/require-utils@55.0.6
-    https://github.com/expo/expo
-  @expo/schema-utils@0.1.9
-    https://github.com/expo/expo
-  @expo/sdk-runtime-versions@1.0.0
-  @expo/spawn-async@1.8.0
-    https://github.com/expo/spawn-async
-  @expo/sudo-prompt@9.3.2
-    https://github.com/expo/sudo-prompt
-  @expo/vector-icons@15.1.1
-    https://github.com/expo/vector-icons
-  @expo/ws-tunnel@1.0.6
-  @fastify/accept-negotiator@2.0.1
+  @fastify/accept-negotiator@2.1.0
     https://github.com/fastify/accept-negotiator
-  @fastify/ajv-compiler@4.0.5
+  @fastify/ajv-compiler@4.0.6
     https://github.com/fastify/ajv-compiler
   @fastify/autoload@6.5.0
     https://github.com/fastify/fastify-autoload
@@ -804,7 +317,7 @@ JavaScript Dependencies
     https://github.com/fastify/fastify-error
   @fastify/fast-json-stringify-compiler@5.1.0
     https://github.com/fastify/fast-json-stringify-compiler
-  @fastify/forwarded@3.0.1
+  @fastify/forwarded@3.0.2
     https://github.com/fastify/forwarded
   @fastify/merge-json-schemas@0.2.1
     https://github.com/fastify/merge-json-schemas
@@ -812,7 +325,7 @@ JavaScript Dependencies
     https://github.com/fastify/fastify-multipart
   @fastify/proxy-addr@5.1.0
     https://github.com/fastify/proxy-addr
-  @fastify/send@4.1.0
+  @fastify/send@4.1.1
     https://github.com/fastify/send
   @fastify/static@9.3.0
     https://github.com/fastify/fastify-static
@@ -820,402 +333,56 @@ JavaScript Dependencies
     https://github.com/fastify/fastify-swagger
   @fastify/swagger-ui@5.2.6
     https://github.com/fastify/fastify-swagger-ui
-  @gar/promisify@1.1.3
-    https://github.com/wraithgar/gar-promisify
-  @jest/schemas@29.6.3
-    https://github.com/jestjs/jest
-  @jest/types@29.6.3
-    https://github.com/jestjs/jest
-  @jridgewell/gen-mapping@0.3.13
-    https://github.com/jridgewell/sourcemaps
-  @jridgewell/remapping@2.3.5
-    https://github.com/jridgewell/sourcemaps
-  @jridgewell/resolve-uri@3.1.2
-    https://github.com/jridgewell/resolve-uri
-  @jridgewell/source-map@0.3.11
-    https://github.com/jridgewell/sourcemaps
-  @jridgewell/sourcemap-codec@1.5.5
-    https://github.com/jridgewell/sourcemaps
-  @jridgewell/trace-mapping@0.3.31
-    https://github.com/jridgewell/sourcemaps
   @lukeed/ms@2.0.2
     https://github.com/lukeed/ms
-  @npmcli/move-file@2.0.1
-    https://github.com/npm/move-file
   @pinojs/redact@0.4.0
     https://github.com/pinojs/redact
-  @react-native/assets-registry@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/babel-plugin-codegen@0.81.5
-    https://github.com/facebook/react-native
-  @react-native/babel-preset@0.81.5
-    https://github.com/facebook/react-native
-  @react-native/codegen@0.81.5
-    https://github.com/facebook/react-native
-  @react-native/codegen@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/community-cli-plugin@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/debugger-shell@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/dev-middleware@0.81.5
-    https://github.com/facebook/react-native
-  @react-native/dev-middleware@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/gradle-plugin@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/js-polyfills@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/normalize-colors@0.81.5
-    https://github.com/facebook/react-native
-  @react-native/normalize-colors@0.86.0
-    https://github.com/facebook/react-native
-  @react-native/virtualized-lists@0.86.0
-    https://github.com/facebook/react-native
-  @sinclair/typebox@0.27.12
-    https://github.com/sinclairzx81/sinclair-typebox
-  @sindresorhus/is@4.6.0
-    https://github.com/sindresorhus/is
-  @szmarczak/http-timer@4.0.6
-    https://github.com/szmarczak/http-timer
-  @tootallnate/once@2.0.1
-    https://github.com/TooTallNate/once
-  @types/cacheable-request@6.0.3
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/http-cache-semantics@4.2.0
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/istanbul-lib-coverage@2.0.6
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/istanbul-lib-report@3.0.3
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/istanbul-reports@3.0.4
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/keyv@3.1.4
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/node@24.13.3
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/responselike@1.0.3
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/yargs@17.0.35
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/yargs-parser@21.0.3
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/yauzl@2.10.3
-    https://github.com/DefinitelyTyped/DefinitelyTyped
-  @urql/core@5.2.0
-    https://github.com/urql-graphql/urql
-  @urql/exchange-retry@1.3.2
-    https://github.com/urql-graphql/urql
-  @xmldom/xmldom@0.8.13
-    https://github.com/xmldom/xmldom
-  @xmldom/xmldom@0.9.10
-    https://github.com/xmldom/xmldom
-  abort-controller@3.0.0
-    https://github.com/mysticatea/abort-controller
   abstract-logging@2.0.1
     https://github.com/jsumners/abstract-logging
-  accepts@1.3.8
-    https://github.com/jshttp/accepts
-  accepts@2.0.0
-    https://github.com/jshttp/accepts
-  acorn@8.17.0
-    https://github.com/acornjs/acorn
-  agent-base@6.0.2
-    https://github.com/TooTallNate/node-agent-base
-  agent-base@7.1.4
-    https://github.com/TooTallNate/proxy-agents
-  agentkeepalive@4.6.0
-    https://github.com/node-modules/agentkeepalive
-  aggregate-error@3.1.0
-    https://github.com/sindresorhus/aggregate-error
   ajv@8.20.0
     https://github.com/ajv-validator/ajv
   ajv-formats@3.0.1
     https://github.com/ajv-validator/ajv-formats
-  anser@1.4.10
-    https://github.com/IonicaBizau/anser
-  ansi-escapes@4.3.2
-    https://github.com/sindresorhus/ansi-escapes
-  ansi-escapes@5.0.0
-    https://github.com/sindresorhus/ansi-escapes
-  ansi-regex@4.1.1
-    https://github.com/chalk/ansi-regex
-  ansi-regex@5.0.1
-    https://github.com/chalk/ansi-regex
-  ansi-regex@6.2.2
-    https://github.com/chalk/ansi-regex
-  ansi-styles@3.2.1
-    https://github.com/chalk/ansi-styles
-  ansi-styles@4.3.0
-    https://github.com/chalk/ansi-styles
-  ansi-styles@5.2.0
-    https://github.com/chalk/ansi-styles
-  ansi-styles@6.2.3
-    https://github.com/chalk/ansi-styles
-  any-promise@1.3.0
-    https://github.com/kevinbeaty/any-promise
-  arg@5.0.2
-    https://github.com/vercel/arg
-  asap@2.0.6
-    https://github.com/kriskowal/asap
-  async-limiter@1.0.1
-    https://github.com/strml/async-limiter
   atomic-sleep@1.0.0
     https://github.com/davidmarkclements/atomic-sleep
-  author-regex@1.0.0
-    https://github.com/jonschlinkert/author-regex
   avvio@9.3.0
     https://github.com/fastify/avvio
-  babel-plugin-polyfill-corejs2@0.4.17
-    https://github.com/babel/babel-polyfills
-  babel-plugin-polyfill-corejs3@0.13.0
-    https://github.com/babel/babel-polyfills
-  babel-plugin-polyfill-regenerator@0.6.8
-    https://github.com/babel/babel-polyfills
-  babel-plugin-react-compiler@1.0.0
-    https://github.com/facebook/react
-  babel-plugin-react-native-web@0.21.2
-    https://github.com/necolas/react-native-web
-  babel-plugin-syntax-hermes-parser@0.29.1
-    https://github.com/facebook/hermes
-  babel-plugin-syntax-hermes-parser@0.36.0
-    https://github.com/facebook/hermes
-  babel-plugin-transform-flow-enums@0.0.2
-    https://github.com/facebook/flow
-  babel-preset-expo@54.0.12
-    https://github.com/expo/expo
-  balanced-match@1.0.2
-    https://github.com/juliangruber/balanced-match
   balanced-match@4.0.4
     https://github.com/juliangruber/balanced-match
-  base64-js@1.5.1
-    https://github.com/beatgammit/base64-js
-  better-opn@3.0.2
-    https://github.com/ExiaSR/better-opn
   big-sparse-array@1.0.3
     https://github.com/mafintosh/big-sparse-array
   binary-stream-equals@1.0.0
     https://github.com/mafintosh/binary-stream-equals
-  bl@4.1.0
-    https://github.com/rvagg/bl
-  bluebird@3.7.2
-    https://github.com/petkaantonov/bluebird
   bogon@1.3.0
     https://github.com/mafintosh/bogon
-  boolean@3.2.0
-    https://github.com/thenativeweb/boolean
-  bplist-creator@0.1.0
-    https://github.com/nearinfinity/node-bplist-creator
-  bplist-parser@0.3.1
-    https://github.com/nearinfinity/node-bplist-parser
-  bplist-parser@0.3.2
-    https://github.com/nearinfinity/node-bplist-parser
-  brace-expansion@1.1.16
+  brace-expansion@5.0.9
     https://github.com/juliangruber/brace-expansion
-  brace-expansion@2.1.2
-    https://github.com/juliangruber/brace-expansion
-  brace-expansion@5.0.8
-    https://github.com/juliangruber/brace-expansion
-  braces@3.0.3
-    https://github.com/micromatch/braces
-  browserslist@4.28.7
-    https://github.com/browserslist/browserslist
-  buffer@5.7.1
-    https://github.com/feross/buffer
-  buffer-crc32@0.2.13
-    https://github.com/brianloveswords/buffer-crc32
-  buffer-from@1.1.2
-    https://github.com/LinusU/buffer-from
-  bytes@3.1.2
-    https://github.com/visionmedia/bytes.js
-  cacheable-lookup@5.0.4
-    https://github.com/szmarczak/cacheable-lookup
-  cacheable-request@7.0.4
-    https://github.com/lukechilds/cacheable-request
-  camelcase@6.3.0
-    https://github.com/sindresorhus/camelcase
-  chalk@2.4.2
-    https://github.com/chalk/chalk
-  chalk@4.1.2
-    https://github.com/chalk/chalk
-  chrome-trace-event@1.0.4
-    https://github.com/samccone/chrome-trace-event
-  ci-info@2.0.0
-    https://github.com/watson/ci-info
-  ci-info@3.9.0
-    https://github.com/watson/ci-info
-  clean-stack@2.2.0
-    https://github.com/sindresorhus/clean-stack
-  cli-cursor@2.1.0
-    https://github.com/sindresorhus/cli-cursor
-  cli-cursor@3.1.0
-    https://github.com/sindresorhus/cli-cursor
-  cli-cursor@4.0.0
-    https://github.com/sindresorhus/cli-cursor
-  cli-spinners@2.9.2
-    https://github.com/sindresorhus/cli-spinners
-  cli-truncate@3.1.0
-    https://github.com/sindresorhus/cli-truncate
-  clone@1.0.4
-    https://github.com/pvorb/node-clone
-  clone-response@1.0.3
-    https://github.com/sindresorhus/clone-response
   close-with-grace@2.5.0
     https://github.com/mcollina/close-with-grace
   codecs@3.1.0
     https://github.com/mafintosh/codecs
-  color-convert@1.9.3
-    https://github.com/Qix-/color-convert
-  color-convert@2.0.1
-    https://github.com/Qix-/color-convert
-  color-name@1.1.3
-    https://github.com/dfcreative/color-name
-  color-name@1.1.4
-    https://github.com/colorjs/color-name
-  colorette@2.0.20
-    https://github.com/jorgebucaran/colorette
-  commander@12.1.0
-    https://github.com/tj/commander.js
   commander@14.0.3
     https://github.com/tj/commander.js
-  commander@2.20.3
-    https://github.com/tj/commander.js
-  commander@4.1.1
-    https://github.com/tj/commander.js
-  commander@5.1.0
-    https://github.com/tj/commander.js
-  commander@7.2.0
-    https://github.com/tj/commander.js
-  commander@9.5.0
-    https://github.com/tj/commander.js
-  compare-version@0.1.2
-    https://github.com/kevva/compare-version
-  compressible@2.0.18
-    https://github.com/jshttp/compressible
-  compression@1.8.1
-    https://github.com/expressjs/compression
-  concat-map@0.0.1
-    https://github.com/substack/node-concat-map
-  connect@3.7.0
-    https://github.com/senchalabs/connect
   content-disposition@1.1.0
     https://github.com/jshttp/content-disposition
-  convert-source-map@2.0.0
-    https://github.com/thlorenz/convert-source-map
   cookie@1.1.1
     https://github.com/jshttp/cookie
-  core-js-compat@3.49.0
-    https://github.com/zloirock/core-js
-  corestore@7.11.1
+  corestore@7.12.0
     https://github.com/holepunchto/corestore
-  cross-dirname@0.1.0
-    https://github.com/JumpLink/cross-dirname
-  cross-spawn@7.0.6
-    https://github.com/moxystudio/node-cross-spawn
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
-  debug@2.6.9
-    https://github.com/visionmedia/debug
-  debug@3.2.7
-    https://github.com/visionmedia/debug
   debug@4.4.3
     https://github.com/debug-js/debug
-  decompress-response@6.0.0
-    https://github.com/sindresorhus/decompress-response
-  deep-extend@0.6.0
-    https://github.com/unclechu/node-deep-extend
-  deepmerge@4.3.1
-    https://github.com/TehShrike/deepmerge
-  defaults@1.0.4
-    https://github.com/sindresorhus/node-defaults
-  defer-to-connect@2.0.1
-    https://github.com/szmarczak/defer-to-connect
-  define-data-property@1.1.4
-    https://github.com/ljharb/define-data-property
-  define-lazy-prop@2.0.0
-    https://github.com/sindresorhus/define-lazy-prop
-  define-properties@1.2.1
-    https://github.com/ljharb/define-properties
   depd@2.0.0
     https://github.com/dougwilson/nodejs-depd
   dequal@2.0.3
     https://github.com/lukeed/dequal
-  destroy@1.2.0
-    https://github.com/stream-utils/destroy
-  detect-node@2.1.0
-    https://github.com/iliakan/detect-node
   dht-rpc@6.27.0
     https://github.com/holepunchto/dht-rpc
-  dir-compare@4.2.0
-    https://github.com/gliviu/dir-compare
-  eastasianwidth@0.2.0
-    https://github.com/komagata/eastasianwidth
-  ee-first@1.1.1
-    https://github.com/jonathanong/ee-first
-  emoji-regex@8.0.0
-    https://github.com/mathiasbynens/emoji-regex
-  emoji-regex@9.2.2
-    https://github.com/mathiasbynens/emoji-regex
-  encodeurl@1.0.2
-    https://github.com/pillarjs/encodeurl
-  encodeurl@2.0.0
-    https://github.com/pillarjs/encodeurl
-  encoding@0.1.13
-    https://github.com/andris9/encoding
-  end-of-stream@1.4.5
-    https://github.com/mafintosh/end-of-stream
-  env-editor@0.4.2
-    https://github.com/sindresorhus/env-editor
-  env-paths@2.2.1
-    https://github.com/sindresorhus/env-paths
-  err-code@2.0.3
-    https://github.com/IndigoUnited/js-err-code
-  error-ex@1.3.4
-    https://github.com/qix-/node-error-ex
-  error-stack-parser@2.1.4
-    https://github.com/stacktracejs/error-stack-parser
-  es-define-property@1.0.1
-    https://github.com/ljharb/es-define-property
-  es-errors@1.3.0
-    https://github.com/ljharb/es-errors
-  es6-error@4.1.1
-    https://github.com/bjyoungblood/es6-error
-  esbuild@0.28.1
+  esbuild@0.28.2
     https://github.com/evanw/esbuild
-  escalade@3.2.0
-    https://github.com/lukeed/escalade
   escape-html@1.0.3
     https://github.com/component/escape-html
-  escape-string-regexp@1.0.5
-    https://github.com/sindresorhus/escape-string-regexp
-  escape-string-regexp@4.0.0
-    https://github.com/sindresorhus/escape-string-regexp
-  etag@1.8.1
-    https://github.com/jshttp/etag
-  event-target-shim@5.0.1
-    https://github.com/mysticatea/event-target-shim
-  eventemitter3@5.0.4
-    https://github.com/primus/eventemitter3
-  expo@54.0.36
-    https://github.com/expo/expo
-  expo-asset@12.0.13
-    https://github.com/expo/expo
-  expo-constants@18.0.13
-    https://github.com/expo/expo
-  expo-device@8.0.10
-    https://github.com/expo/expo
-  expo-file-system@19.0.23
-    https://github.com/expo/expo
-  expo-font@14.0.12
-    https://github.com/expo/expo
-  expo-keep-awake@15.0.8
-    https://github.com/expo/expo
-  expo-modules-autolinking@3.0.26
-    https://github.com/expo/expo
-  expo-modules-core@3.0.30
-    https://github.com/expo/expo
-  expo-server@1.0.7
-    https://github.com/expo/expo
   fast-decode-uri-component@1.0.1
     https://github.com/delvedor/fast-decode-uri-component
   fast-deep-equal@3.1.3
@@ -1228,7 +395,7 @@ JavaScript Dependencies
     https://github.com/anonrig/fast-querystring
   fast-safe-stringify@2.1.1
     https://github.com/davidmarkclements/fast-safe-stringify
-  fastify@5.10.0
+  fastify@5.11.3
     https://github.com/fastify/fastify
   fastify-plugin@5.1.0
     https://github.com/fastify/fastify-plugin
@@ -1236,105 +403,21 @@ JavaScript Dependencies
     https://github.com/fastify/fastify-plugin
   fastify-type-provider-zod@5.1.0
     https://github.com/turkerdev/fastify-type-provider-zod
-  fd-slicer@1.1.0
-    https://github.com/andrewrk/node-fd-slicer
-  fdir@6.5.0
-    https://github.com/thecodrr/fdir
-  filename-reserved-regex@2.0.0
-    https://github.com/sindresorhus/filename-reserved-regex
-  filenamify@4.3.0
-    https://github.com/sindresorhus/filenamify
-  fill-range@7.1.1
-    https://github.com/jonschlinkert/fill-range
-  finalhandler@1.1.2
-    https://github.com/pillarjs/finalhandler
   find-my-way@9.7.0
     https://github.com/delvedor/find-my-way
-  find-up@2.1.0
-    https://github.com/sindresorhus/find-up
   flat-tree@1.13.0
     https://github.com/mafintosh/flat-tree
-  flora-colossus@2.0.0
-    https://github.com/MarshallOfSound/flora-colossus
-  flow-enums-runtime@0.0.6
-    https://github.com/facebook/flow
-  freeport-async@2.0.0
-    https://github.com/expo/freeport-async
-  fresh@0.5.2
-    https://github.com/jshttp/fresh
-  fs-extra@10.1.0
-    https://github.com/jprichardson/node-fs-extra
-  fs-extra@11.4.0
-    https://github.com/jprichardson/node-fs-extra
-  fs-extra@8.1.0
-    https://github.com/jprichardson/node-fs-extra
-  fs-extra@9.1.0
-    https://github.com/jprichardson/node-fs-extra
   fsevents@2.3.3
     https://github.com/fsevents/fsevents
-  function-bind@1.1.2
-    https://github.com/Raynos/function-bind
-  galactus@1.0.0
-    https://github.com/marshallOfSound/galactus
   generate-object-property@2.0.0
     https://github.com/mafintosh/generate-object-property
   generate-string@1.0.1
     https://github.com/mafintosh/generate-string
-  gensync@1.0.0-beta.2
-    https://github.com/loganfsmyth/gensync
-  get-package-info@1.0.0
-    https://github.com/rahatarmanahmed/get-package-info
-  get-stream@5.2.0
-    https://github.com/sindresorhus/get-stream
-  getenv@2.0.0
-    https://github.com/ctavan/node-getenv
-  globalthis@1.0.4
-    https://github.com/ljharb/System.global
-  gopd@1.2.0
-    https://github.com/ljharb/gopd
-  got@11.8.6
-    https://github.com/sindresorhus/got
-  has-flag@3.0.0
-    https://github.com/sindresorhus/has-flag
-  has-flag@4.0.0
-    https://github.com/sindresorhus/has-flag
-  has-property-descriptors@1.0.2
-    https://github.com/inspect-js/has-property-descriptors
-  hasown@2.0.4
-    https://github.com/inspect-js/hasOwn
-  hermes-compiler@250829098.0.14
-    https://github.com/facebook/hermes
-  hermes-estree@0.29.1
-    https://github.com/facebook/hermes
-  hermes-estree@0.32.0
-    https://github.com/facebook/hermes
-  hermes-estree@0.35.0
-    https://github.com/facebook/hermes
-  hermes-estree@0.36.0
-    https://github.com/facebook/hermes
-  hermes-parser@0.29.1
-    https://github.com/facebook/hermes
-  hermes-parser@0.32.0
-    https://github.com/facebook/hermes
-  hermes-parser@0.35.0
-    https://github.com/facebook/hermes
-  hermes-parser@0.36.0
-    https://github.com/facebook/hermes
   http-errors@2.0.1
     https://github.com/jshttp/http-errors
-  http-proxy-agent@5.0.0
-    https://github.com/TooTallNate/node-http-proxy-agent
-  http2-wrapper@1.0.3
-    https://github.com/szmarczak/http2-wrapper
-  https-proxy-agent@5.0.1
-    https://github.com/TooTallNate/node-https-proxy-agent
-  https-proxy-agent@7.0.6
-    https://github.com/TooTallNate/proxy-agents
-  humanize-ms@1.2.1
-    https://github.com/node-modules/humanize-ms
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.35.0
+  hypercore@11.35.1
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
@@ -1342,386 +425,58 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
-  iconv-lite@0.6.3
-    https://github.com/ashtuchkin/iconv-lite
-  ignore@5.3.2
-    https://github.com/kaelzhang/node-ignore
-  image-size@1.2.1
-    https://github.com/image-size/image-size
-  imurmurhash@0.1.4
-    https://github.com/jensyt/imurmurhash-js
-  indent-string@4.0.0
-    https://github.com/sindresorhus/indent-string
-  invariant@2.2.4
-    https://github.com/zertosh/invariant
-  ip-address@10.3.1
-    https://github.com/beaugunderson/ip-address
-  ipaddr.js@2.4.0
+  ipaddr.js@2.5.0
     https://github.com/whitequark/ipaddr.js
-  is-arrayish@0.2.1
-    https://github.com/qix-/node-is-arrayish
-  is-core-module@2.16.2
-    https://github.com/inspect-js/is-core-module
-  is-docker@2.2.1
-    https://github.com/sindresorhus/is-docker
-  is-fullwidth-code-point@3.0.0
-    https://github.com/sindresorhus/is-fullwidth-code-point
-  is-fullwidth-code-point@4.0.0
-    https://github.com/sindresorhus/is-fullwidth-code-point
-  is-interactive@1.0.0
-    https://github.com/sindresorhus/is-interactive
-  is-lambda@1.0.1
-    https://github.com/watson/is-lambda
-  is-number@7.0.0
-    https://github.com/jonschlinkert/is-number
   is-options@1.0.2
     https://github.com/mafintosh/is-options
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
-  is-unicode-supported@0.1.0
-    https://github.com/sindresorhus/is-unicode-supported
-  is-wsl@2.2.0
-    https://github.com/sindresorhus/is-wsl
-  isbinaryfile@4.0.10
-    https://github.com/gjtorikian/isBinaryFile
-  jest-get-type@29.6.3
-    https://github.com/jestjs/jest
-  jest-util@29.7.0
-    https://github.com/jestjs/jest
-  jest-validate@29.7.0
-    https://github.com/jestjs/jest
-  jest-worker@29.7.0
-    https://github.com/jestjs/jest
-  jimp-compact@0.16.1
-    https://github.com/nuxt-community/jimp-compact
-  js-tokens@4.0.0
-    https://github.com/lydell/js-tokens
-  js-yaml@4.3.0
+  js-yaml@4.3.1
     https://github.com/nodeca/js-yaml
-  jsesc@3.1.0
-    https://github.com/mathiasbynens/jsesc
-  json-buffer@3.0.1
-    https://github.com/dominictarr/json-buffer
   json-schema-ref-resolver@3.0.0
     https://github.com/fastify/json-schema-ref-resolver
   json-schema-resolver@3.0.0
     https://github.com/Eomm/json-schema-resolver
   json-schema-traverse@1.0.0
     https://github.com/epoberezkin/json-schema-traverse
-  json5@2.2.3
-    https://github.com/json5/json5
-  jsonfile@4.0.0
-    https://github.com/jprichardson/node-jsonfile
-  jsonfile@6.2.1
-    https://github.com/jprichardson/node-jsonfile
-  junk@3.1.0
-    https://github.com/sindresorhus/junk
   kademlia-routing-table@1.0.6
     https://github.com/mafintosh/kademlia-routing-table
-  keyv@4.5.4
-    https://github.com/jaredwray/keyv
-  kleur@3.0.3
-    https://github.com/lukeed/kleur
-  lan-network@0.2.1
-    https://github.com/kitten/lan-network
-  leven@3.1.0
-    https://github.com/sindresorhus/leven
-  lines-and-columns@1.2.4
-    https://github.com/eventualbuddha/lines-and-columns
-  listr2@7.0.2
-    https://github.com/listr2/listr2
   llm-splitter@0.2.0
     https://github.com/nearform/llm-splitter
-  load-json-file@2.0.0
-    https://github.com/sindresorhus/load-json-file
-  locate-path@2.0.0
-    https://github.com/sindresorhus/locate-path
-  lodash.debounce@4.0.8
-    https://github.com/lodash/lodash
-  lodash.get@4.4.2
-    https://github.com/lodash/lodash
-  lodash.throttle@4.1.1
-    https://github.com/lodash/lodash
-  log-symbols@2.2.0
-    https://github.com/sindresorhus/log-symbols
-  log-symbols@4.1.0
-    https://github.com/sindresorhus/log-symbols
-  log-update@5.0.1
-    https://github.com/sindresorhus/log-update
-  loose-envify@1.4.0
-    https://github.com/zertosh/loose-envify
-  lowercase-keys@2.0.0
-    https://github.com/sindresorhus/lowercase-keys
-  matcher@3.0.0
-    https://github.com/sindresorhus/matcher
-  memoize-one@5.2.1
-    https://github.com/alexreardon/memoize-one
-  merge-stream@2.0.0
-    https://github.com/grncdr/merge-stream
-  metro@0.83.3
-    https://github.com/facebook/metro
-  metro@0.84.4
-    https://github.com/facebook/metro
-  metro-babel-transformer@0.83.3
-    https://github.com/facebook/metro
-  metro-babel-transformer@0.84.4
-    https://github.com/facebook/metro
-  metro-cache@0.83.3
-    https://github.com/facebook/metro
-  metro-cache@0.84.4
-    https://github.com/facebook/metro
-  metro-cache-key@0.83.3
-    https://github.com/facebook/metro
-  metro-cache-key@0.84.4
-    https://github.com/facebook/metro
-  metro-config@0.83.3
-    https://github.com/facebook/metro
-  metro-config@0.84.4
-    https://github.com/facebook/metro
-  metro-core@0.83.3
-    https://github.com/facebook/metro
-  metro-core@0.84.4
-    https://github.com/facebook/metro
-  metro-file-map@0.83.3
-    https://github.com/facebook/metro
-  metro-file-map@0.84.4
-    https://github.com/facebook/metro
-  metro-minify-terser@0.83.3
-    https://github.com/facebook/metro
-  metro-minify-terser@0.84.4
-    https://github.com/facebook/metro
-  metro-resolver@0.83.3
-    https://github.com/facebook/metro
-  metro-resolver@0.84.4
-    https://github.com/facebook/metro
-  metro-runtime@0.83.3
-    https://github.com/facebook/metro
-  metro-runtime@0.84.4
-    https://github.com/facebook/metro
-  metro-source-map@0.83.3
-    https://github.com/facebook/metro
-  metro-source-map@0.84.4
-    https://github.com/facebook/metro
-  metro-symbolicate@0.83.3
-    https://github.com/facebook/metro
-  metro-symbolicate@0.84.4
-    https://github.com/facebook/metro
-  metro-transform-plugins@0.83.3
-    https://github.com/facebook/metro
-  metro-transform-plugins@0.84.4
-    https://github.com/facebook/metro
-  metro-transform-worker@0.83.3
-    https://github.com/facebook/metro
-  metro-transform-worker@0.84.4
-    https://github.com/facebook/metro
-  micromatch@4.0.8
-    https://github.com/micromatch/micromatch
-  mime@1.6.0
-    https://github.com/broofa/node-mime
   mime@3.0.0
     https://github.com/broofa/mime
-  mime-db@1.52.0
-    https://github.com/jshttp/mime-db
-  mime-db@1.54.0
-    https://github.com/jshttp/mime-db
-  mime-types@2.1.35
-    https://github.com/jshttp/mime-types
-  mime-types@3.0.2
-    https://github.com/jshttp/mime-types
-  mimic-fn@1.2.0
-    https://github.com/sindresorhus/mimic-fn
-  mimic-fn@2.1.0
-    https://github.com/sindresorhus/mimic-fn
-  mimic-response@1.0.1
-    https://github.com/sindresorhus/mimic-response
-  mimic-response@3.1.0
-    https://github.com/sindresorhus/mimic-response
-  minimist@1.2.8
-    https://github.com/minimistjs/minimist
-  minipass-fetch@2.1.2
-    https://github.com/npm/minipass-fetch
-  minizlib@2.1.2
-    https://github.com/isaacs/minizlib
-  minizlib@3.1.0
-    https://github.com/isaacs/minizlib
-  mkdirp@1.0.4
-    https://github.com/isaacs/node-mkdirp
-  ms@2.0.0
-    https://github.com/zeit/ms
   ms@2.1.3
     https://github.com/vercel/ms
   mutexify@1.4.0
     https://github.com/mafintosh/mutexify
-  mz@2.7.0
-    https://github.com/normalize/mz
-  nanoid@3.3.16
-    https://github.com/ai/nanoid
   nat-sampler@1.0.1
     https://github.com/mafintosh/nat-sampler
-  negotiator@0.6.3
-    https://github.com/jshttp/negotiator
-  negotiator@0.6.4
-    https://github.com/jshttp/negotiator
-  negotiator@1.0.0
-    https://github.com/jshttp/negotiator
-  nested-error-stacks@2.0.1
-    https://github.com/mdlavin/nested-error-stacks
-  node-abi@3.94.0
-    https://github.com/electron/node-abi
-  node-api-version@0.2.1
-    https://github.com/timfish/node-api-version
-  node-int64@0.4.0
-    https://github.com/broofa/node-int64
-  node-releases@2.0.51
-    https://github.com/chicoxyzzy/node-releases
-  normalize-url@6.1.0
-    https://github.com/sindresorhus/normalize-url
-  nullthrows@1.1.1
-    https://github.com/zertosh/nullthrows
-  ob1@0.83.3
-    https://github.com/facebook/metro
-  ob1@0.84.4
-    https://github.com/facebook/metro
-  object-assign@4.1.1
-    https://github.com/sindresorhus/object-assign
-  object-keys@1.1.1
-    https://github.com/ljharb/object-keys
   on-exit-leak-free@2.1.2
     https://github.com/mcollina/on-exit-or-gc
-  on-finished@2.3.0
-    https://github.com/jshttp/on-finished
-  on-finished@2.4.1
-    https://github.com/jshttp/on-finished
-  on-headers@1.1.0
-    https://github.com/jshttp/on-headers
-  onetime@2.0.1
-    https://github.com/sindresorhus/onetime
-  onetime@5.1.2
-    https://github.com/sindresorhus/onetime
-  open@7.4.2
-    https://github.com/sindresorhus/open
-  open@8.4.2
-    https://github.com/sindresorhus/open
   openapi-types@12.1.3
     https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-types
-  ora@3.4.0
-    https://github.com/sindresorhus/ora
-  ora@5.4.1
-    https://github.com/sindresorhus/ora
-  p-cancelable@2.1.1
-    https://github.com/sindresorhus/p-cancelable
-  p-limit@1.3.0
-    https://github.com/sindresorhus/p-limit
-  p-limit@3.1.0
-    https://github.com/sindresorhus/p-limit
-  p-locate@2.0.0
-    https://github.com/sindresorhus/p-locate
-  p-map@4.0.0
-    https://github.com/sindresorhus/p-map
-  p-try@1.0.0
-    https://github.com/sindresorhus/p-try
-  parse-author@2.0.0
-    https://github.com/jonschlinkert/parse-author
-  parse-json@2.2.0
-    https://github.com/sindresorhus/parse-json
-  parse-png@2.1.0
-    https://github.com/kevva/parse-png
-  parseurl@1.3.3
-    https://github.com/pillarjs/parseurl
-  path-exists@3.0.0
-    https://github.com/sindresorhus/path-exists
-  path-is-absolute@1.0.1
-    https://github.com/sindresorhus/path-is-absolute
-  path-key@3.1.1
-    https://github.com/sindresorhus/path-key
-  path-parse@1.0.7
-    https://github.com/jbgutierrez/path-parse
-  path-type@2.0.0
-    https://github.com/sindresorhus/path-type
-  pe-library@1.0.1
-    https://github.com/jet2jet/pe-library-js
-  pend@1.2.0
-    https://github.com/andrewrk/node-pend
-  picomatch@2.3.2
-    https://github.com/micromatch/picomatch
-  picomatch@4.0.5
-    https://github.com/micromatch/picomatch
-  pify@2.3.0
-    https://github.com/sindresorhus/pify
   pino@10.3.1
     https://github.com/pinojs/pino
   pino-abstract-transport@3.0.0
     https://github.com/pinojs/pino-abstract-transport
   pino-std-serializers@7.1.0
     https://github.com/pinojs/pino-std-serializers
-  pirates@4.0.7
-    https://github.com/danez/pirates
-  plist@3.1.1
-    https://github.com/TooTallNate/node-plist
-  pngjs@3.4.0
-    https://github.com/lukeapage/pngjs2
-  postcss@8.4.49
-    https://github.com/postcss/postcss
-  postject@1.0.0-alpha.6
-    https://github.com/nodejs/postject
-  prettier@3.9.6
-    https://github.com/prettier/prettier
-  pretty-bytes@5.6.0
-    https://github.com/sindresorhus/pretty-bytes
-  pretty-format@29.7.0
-    https://github.com/jestjs/jest
   process-warning@4.0.1
     https://github.com/fastify/process-warning
-  process-warning@5.0.0
+  process-warning@5.1.0
     https://github.com/fastify/process-warning
-  progress@2.0.3
-    https://github.com/visionmedia/node-progress
   promaphore@1.0.0
     https://github.com/mafintosh/promaphore
-  promise@8.3.0
-    https://github.com/then/promise
-  promise-retry@2.0.1
-    https://github.com/IndigoUnited/node-promise-retry
-  prompts@2.4.2
-    https://github.com/terkelg/prompts
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
   protomux@3.11.0
     https://github.com/holepunchto/protomux
-  pump@3.0.4
-    https://github.com/mafintosh/pump
-  punycode@2.3.1
-    https://github.com/mathiasbynens/punycode.js
-  queue@6.0.2
-    https://github.com/jessetane/queue
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
   quick-format-unescaped@4.0.4
     https://github.com/davidmarkclements/quick-format
-  quick-lru@5.1.1
-    https://github.com/sindresorhus/quick-lru
   random-array-iterator@1.0.0
     https://github.com/mafintosh/random-array-iterator
-  range-parser@1.2.1
-    https://github.com/jshttp/range-parser
-  react@19.2.8
-    https://github.com/react/react
-  react-devtools-core@6.1.5
-    https://github.com/facebook/react
-  react-is@18.3.1
-    https://github.com/facebook/react
-  react-native@0.86.0
-    https://github.com/facebook/react-native
-  react-refresh@0.14.2
-    https://github.com/facebook/react
-  read-binary-file-arch@1.0.6
-    https://github.com/samuelmaddock/read-binary-file-arch
-  read-pkg@2.0.0
-    https://github.com/sindresorhus/read-pkg
-  read-pkg-up@2.0.0
-    https://github.com/sindresorhus/read-pkg-up
-  readable-stream@3.6.2
-    https://github.com/nodejs/readable-stream
   ready-resource@1.2.0
     https://github.com/holepunchto/ready-resource
   real-require@0.2.0
@@ -1730,108 +485,32 @@ JavaScript Dependencies
     https://github.com/pinojs/real-require
   record-cache@1.2.0
     https://github.com/mafintosh/record-cache
-  regenerate@1.4.2
-    https://github.com/mathiasbynens/regenerate
-  regenerate-unicode-properties@10.2.2
-    https://github.com/mathiasbynens/regenerate-unicode-properties
-  regenerator-runtime@0.13.11
-    https://github.com/facebook/regenerator/tree/main/packages/runtime
-  regexpu-core@6.4.0
-    https://github.com/mathiasbynens/regexpu-core
-  regjsgen@0.8.0
-    https://github.com/bnjmnt4n/regjsgen
-  require-directory@2.1.1
-    https://github.com/troygoode/node-require-directory
   require-from-string@2.0.2
     https://github.com/floatdrop/require-from-string
-  requireg@0.2.2
-    https://github.com/h2non/requireg
-  resedit@2.0.3
-    https://github.com/jet2jet/resedit-js
-  resolve@1.22.12
-    https://github.com/browserify/resolve
-  resolve@1.7.1
-    https://github.com/browserify/resolve
-  resolve-alpn@1.2.1
-    https://github.com/szmarczak/resolve-alpn
-  resolve-from@5.0.0
-    https://github.com/sindresorhus/resolve-from
   resolve-reject-promise@1.1.0
     https://github.com/mafintosh/resolve-reject-promise
-  resolve-workspace-root@2.0.1
-    https://github.com/byCedric/resolve-workspace-root
-  resolve.exports@2.0.3
-    https://github.com/lukeed/resolve.exports
-  responselike@2.0.1
-    https://github.com/sindresorhus/responselike
-  restore-cursor@2.0.0
-    https://github.com/sindresorhus/restore-cursor
-  restore-cursor@3.1.0
-    https://github.com/sindresorhus/restore-cursor
-  restore-cursor@4.0.0
-    https://github.com/sindresorhus/restore-cursor
   ret@0.5.0
     https://github.com/fent/ret.js
-  retry@0.12.0
-    https://github.com/tim-kos/node-retry
   reusify@1.1.0
     https://github.com/mcollina/reusify
   rfdc@1.4.1
     https://github.com/davidmarkclements/rfdc
-  safe-buffer@5.2.1
-    https://github.com/feross/safe-buffer
   safe-regex2@5.1.1
     https://github.com/fastify/safe-regex2
   safe-stable-stringify@2.5.0
     https://github.com/BridgeAR/safe-stable-stringify
-  safer-buffer@2.1.2
-    https://github.com/ChALkeR/safer-buffer
   safety-catch@1.0.3
     https://github.com/mafintosh/safety-catch
   same-data@1.0.0
     https://github.com/mafintosh/same-data
-  scheduler@0.27.0
-    https://github.com/facebook/react
-  semver-compare@1.0.0
-    https://github.com/substack/semver-compare
-  send@0.19.2
-    https://github.com/pillarjs/send
-  serialize-error@2.1.0
-    https://github.com/sindresorhus/serialize-error
-  serialize-error@7.0.1
-    https://github.com/sindresorhus/serialize-error
-  serve-static@1.16.3
-    https://github.com/expressjs/serve-static
   set-cookie-parser@2.7.2
     https://github.com/nfriedly/set-cookie-parser
-  shebang-command@2.0.0
-    https://github.com/kevva/shebang-command
-  shebang-regex@3.0.0
-    https://github.com/sindresorhus/shebang-regex
-  shell-quote@1.10.0
-    https://github.com/ljharb/shell-quote
   shuffled-priority-queue@2.1.0
     https://github.com/mafintosh/shuffled-priority-queue
   signal-promise@1.0.3
     https://github.com/mafintosh/signal-promise
   signed-varint@2.0.1
     https://github.com/dominictarr/signed-varint
-  simple-plist@1.3.1
-    https://github.com/wollardj/simple-plist
-  sisteransi@1.0.5
-    https://github.com/terkelg/sisteransi
-  slash@3.0.0
-    https://github.com/sindresorhus/slash
-  slice-ansi@5.0.0
-    https://github.com/chalk/slice-ansi
-  slugify@1.6.9
-    https://github.com/simov/slugify
-  smart-buffer@4.2.0
-    https://github.com/JoshGlazebrook/smart-buffer
-  socks@2.8.9
-    https://github.com/JoshGlazebrook/socks
-  socks-proxy-agent@7.0.0
-    https://github.com/TooTallNate/node-socks-proxy-agent
   sodium-native@5.1.0
     https://github.com/holepunchto/sodium-native
   sodium-secretstream@1.2.0
@@ -1840,179 +519,47 @@ JavaScript Dependencies
     https://github.com/holepunchto/sodium-universal
   sonic-boom@4.2.1
     https://github.com/pinojs/sonic-boom
-  source-map-support@0.5.21
-    https://github.com/evanw/node-source-map-support
-  spdx-expression-parse@3.0.1
-    https://github.com/jslicense/spdx-expression-parse.js
   speedometer@1.1.0
     https://github.com/mafintosh/speedometer
-  stackframe@1.3.4
-    https://github.com/stacktracejs/stackframe
-  stacktrace-parser@0.1.11
-    https://github.com/errwischt/stacktrace-parser
-  statuses@1.5.0
-    https://github.com/jshttp/statuses
   statuses@2.0.2
     https://github.com/jshttp/statuses
   streamx@2.28.0
     https://github.com/mafintosh/streamx
-  string_decoder@1.3.0
-    https://github.com/nodejs/string_decoder
-  string-width@4.2.3
-    https://github.com/sindresorhus/string-width
-  string-width@5.1.2
-    https://github.com/sindresorhus/string-width
-  strip-ansi@5.2.0
-    https://github.com/chalk/strip-ansi
-  strip-ansi@6.0.1
-    https://github.com/chalk/strip-ansi
-  strip-ansi@7.2.0
-    https://github.com/chalk/strip-ansi
-  strip-bom@3.0.0
-    https://github.com/sindresorhus/strip-bom
-  strip-json-comments@2.0.1
-    https://github.com/sindresorhus/strip-json-comments
-  strip-outer@1.0.1
-    https://github.com/sindresorhus/strip-outer
-  structured-headers@0.4.1
-    https://github.com/evert/structured-header
-  sucrase@3.35.1
-    https://github.com/alangpierce/sucrase
-  supports-color@5.5.0
-    https://github.com/chalk/supports-color
-  supports-color@7.2.0
-    https://github.com/chalk/supports-color
-  supports-color@8.1.1
-    https://github.com/chalk/supports-color
-  supports-hyperlinks@2.3.0
-    https://github.com/jamestalmage/supports-hyperlinks
-  supports-preserve-symlinks-flag@1.0.0
-    https://github.com/inspect-js/node-supports-preserve-symlinks-flag
   tar-stream@3.2.0
     https://github.com/mafintosh/tar-stream
   teex@1.0.1
     https://github.com/mafintosh/teex
-  terminal-link@2.1.1
-    https://github.com/sindresorhus/terminal-link
-  thenify@3.3.1
-    https://github.com/thenables/thenify
-  thenify-all@1.6.0
-    https://github.com/thenables/thenify-all
   thread-stream@4.2.0
     https://github.com/mcollina/thread-stream
-  throat@5.0.0
-    https://github.com/ForbesLindesay/throat
   time-ordered-set@2.0.1
     https://github.com/mafintosh/time-ordered-set
   timeout-refresh@2.0.1
     https://github.com/mafintosh/timeout-refresh
   tiny-byte-size@1.1.0
     https://github.com/mafintosh/tiny-byte-size
-  tinyglobby@0.2.17
-    https://github.com/SuperchupuDev/tinyglobby
   tinyld@1.3.4
     https://github.com/komodojp/tinyld
-  to-regex-range@5.0.1
-    https://github.com/micromatch/to-regex-range
   toad-cache@3.7.4
     https://github.com/kibertoad/toad-cache
   toidentifier@1.0.1
     https://github.com/component/toidentifier
-  trim-repeated@1.0.0
-    https://github.com/sindresorhus/trim-repeated
-  tsx@4.23.1
+  tsx@4.23.12
     https://github.com/privatenumber/tsx
-  ua-parser-js@0.7.41
-    https://github.com/faisalman/ua-parser-js
-  undici@6.28.0
-    https://github.com/nodejs/undici
-  undici-types@7.18.2
-    https://github.com/nodejs/undici
-  unicode-canonical-property-names-ecmascript@2.0.1
-    https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
-  unicode-match-property-ecmascript@2.0.0
-    https://github.com/mathiasbynens/unicode-match-property-ecmascript
-  unicode-match-property-value-ecmascript@2.2.1
-    https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
-  unicode-property-aliases-ecmascript@2.2.0
-    https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
-  universalify@0.1.2
-    https://github.com/RyanZim/universalify
-  universalify@2.0.1
-    https://github.com/RyanZim/universalify
   unix-path-resolve@1.0.2
     https://github.com/mafintosh/unix-path-resolve
   unordered-set@2.0.1
     https://github.com/mafintosh/unordered-set
-  unpipe@1.0.0
-    https://github.com/stream-utils/unpipe
-  update-browserslist-db@1.2.3
-    https://github.com/browserslist/update-db
-  util-deprecate@1.0.2
-    https://github.com/TooTallNate/util-deprecate
-  utils-merge@1.0.1
-    https://github.com/jaredhanson/utils-merge
-  uuid@7.0.3
-    https://github.com/uuidjs/uuid
   varint@5.0.0
     https://github.com/chrisdickinson/varint
-  vary@1.1.2
-    https://github.com/jshttp/vary
-  vlq@1.0.1
-    https://github.com/Rich-Harris/vlq
-  wcwidth@1.0.1
-    https://github.com/timoxley/wcwidth
-  whatwg-fetch@3.6.20
-    https://github.com/github/fetch
-  whatwg-url-without-unicode@8.0.0-3
-    https://github.com/charpeni/whatwg-url
-  wonka@6.3.6
-    https://github.com/0no-co/wonka
-  wrap-ansi@7.0.0
-    https://github.com/chalk/wrap-ansi
-  wrap-ansi@8.1.0
-    https://github.com/chalk/wrap-ansi
-  ws@6.2.6
-    https://github.com/websockets/ws
-  ws@7.5.13
-    https://github.com/websockets/ws
-  ws@8.21.1
-    https://github.com/websockets/ws
   xache@1.3.0
     https://github.com/mafintosh/xache
-  xml2js@0.6.0
-    https://github.com/Leonidas-from-XIV/node-xml2js
-  xmlbuilder@11.0.1
-    https://github.com/oozcitak/xmlbuilder-js
-  xmlbuilder@15.1.1
-    https://github.com/oozcitak/xmlbuilder-js
-  yargs@17.7.3
-    https://github.com/yargs/yargs
-  yauzl@2.10.0
-    https://github.com/thejoshwolfe/yauzl
-  yocto-queue@0.1.0
-    https://github.com/sindresorhus/yocto-queue
   z32@1.1.0
     https://github.com/mafintosh/z32
   zod@4.4.3
     https://github.com/colinhacks/zod
 
---- mpl-2.0 (Mozilla Public License 2.0) ---
-
-  lightningcss@1.33.0
-    https://github.com/parcel-bundler/lightningcss
-  lightningcss-darwin-arm64@1.33.0
-    https://github.com/parcel-bundler/lightningcss
-
 --- python-2.0 (Python Software Foundation License) ---
 
   argparse@2.0.1
     https://github.com/nodeca/argparse
-
---- unlicense (The Unlicense) ---
-
-  big-integer@1.6.52
-    https://github.com/peterolson/BigInteger.js
-  stream-buffers@2.2.0
-    https://github.com/samcday/node-stream-buffer
 

--- a/packages/cli/changelog/0.11.0/CHANGELOG.md
+++ b/packages/cli/changelog/0.11.0/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog v0.11.0
+
+Release Date: 2026-08-13
+
+## 🐞 Fixes
+
+- Harden serve CORS and managed authentication. (see PR [#3744](https://github.com/tetherto/qvac/pull/3744)) - See [breaking changes](./breaking.md)
+
+## ⚙️ Infrastructure
+
+- Switch mac CI jobs to GitHub-hosted macos-26 runners. (see PR [#3765](https://github.com/tetherto/qvac/pull/3765))

--- a/packages/cli/changelog/0.11.0/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.11.0/CHANGELOG_LLM.md
@@ -1,0 +1,64 @@
+# QVAC CLI v0.11.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.11.0
+
+This release tightens the security posture of `qvac serve`. Browser access now requires an explicit list of trusted origins, a bind beyond loopback refuses to start without authentication, and the bearer key can be read from a file instead of the command line. Existing `--cors` and `--host` invocations will need updating.
+
+## Breaking Changes
+
+### Trusted browser origins must be named explicitly
+
+`--cors` no longer opens the server to every origin. It is now only a compatibility validation switch: it does not enable CORS by itself, and it fails startup unless at least one exact origin is supplied through `--cors-origin` or `serve.cors.origins`. Wildcards are rejected, as are origins ending in a trailing dot, which no browser sends.
+
+`--docs` no longer inherits wildcard access either. It adds same-port `localhost`, `127.0.0.1`, and `[::1]` origins for Swagger UI, and it rejects `--port 0`, because a same-port origin cannot be computed before the port is known.
+
+**Before:**
+
+```bash
+qvac serve openai --cors --docs
+```
+
+**After:**
+
+```bash
+qvac serve openai --cors --cors-origin https://app.example.com
+```
+
+### A non-loopback bind must authenticate
+
+Binding beyond `127.0.0.1` used to log a warning and start anyway, which quietly exposed an unauthenticated API to the network. It now fails startup unless a key is supplied, or unless the operator says outright that the exposure is intended.
+
+**Before:**
+
+```bash
+# Warned, then served the whole network with no authentication.
+qvac serve openai --host 0.0.0.0
+```
+
+**After:**
+
+```bash
+# Require a bearer token...
+qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
+
+# ...or accept the risk explicitly, which warns and starts as before.
+qvac serve openai --host 0.0.0.0 --allow-unauthenticated
+```
+
+## New Flags
+
+### `--api-key-file` keeps the credential out of the process list
+
+`--api-key <key>` places the token in the process's command line, which `/proc/<pid>/cmdline` exposes to every local account on Linux. `--api-key-file <path>` reads it from a file instead:
+
+```bash
+printf '%s' "$QVAC_API_KEY" > ~/.qvac/serve-key
+chmod 600 ~/.qvac/serve-key
+qvac serve openai --api-key-file ~/.qvac/serve-key
+```
+
+The path must be a regular file — symlinks and directories are refused — and the CLI warns when the file is readable beyond its owner. `--api-key` and `--api-key-file` are mutually exclusive.
+
+### `--allow-unauthenticated` opts back into an open bind
+
+For operators who genuinely want an unauthenticated listener beyond loopback, this restores the previous warn-and-start behaviour. Anyone who can reach the address can use the server.

--- a/packages/cli/changelog/0.11.0/breaking.md
+++ b/packages/cli/changelog/0.11.0/breaking.md
@@ -1,0 +1,43 @@
+# 💥 Breaking Changes v0.11.0
+
+## Harden serve CORS and managed authentication
+
+PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
+
+**BEFORE:**
+
+```typescript
+// --cors enabled wildcard browser access; --docs inherited it.
+qvac serve openai --cors --docs
+
+// A non-loopback bind logged a warning and started anyway.
+qvac serve openai --host 0.0.0.0
+
+// Managed callers could pass an apiKey option that was not enforced by serve.
+await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
+```
+
+**AFTER:**
+
+```typescript
+// Name every trusted browser origin. --docs adds same-port loopback origins only.
+qvac serve openai --cors --cors-origin https://app.example.com
+
+// A non-loopback bind must authenticate, or say out loud that it will not.
+qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
+qvac serve openai --host 0.0.0.0 --allow-unauthenticated
+
+// Managed mode generates the enforced key; consumers may read the live value.
+const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
+provider.apiKey
+```
+
+- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
+- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
+- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
+- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
+- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
+- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
+- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+
+---

--- a/packages/cli/changelog/0.11.0/breaking.md
+++ b/packages/cli/changelog/0.11.0/breaking.md
@@ -6,38 +6,28 @@ PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
 
 **BEFORE:**
 
-```typescript
-// --cors enabled wildcard browser access; --docs inherited it.
+```bash
+# --cors enabled wildcard browser access; --docs inherited it.
 qvac serve openai --cors --docs
 
-// A non-loopback bind logged a warning and started anyway.
+# A non-loopback bind logged a warning and started anyway.
 qvac serve openai --host 0.0.0.0
-
-// Managed callers could pass an apiKey option that was not enforced by serve.
-await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
 ```
 
 **AFTER:**
 
-```typescript
-// Name every trusted browser origin. --docs adds same-port loopback origins only.
+```bash
+# Name every trusted browser origin. --docs adds same-port loopback origins only.
 qvac serve openai --cors --cors-origin https://app.example.com
 
-// A non-loopback bind must authenticate, or say out loud that it will not.
+# A non-loopback bind must authenticate, or say out loud that it will not.
 qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
 qvac serve openai --host 0.0.0.0 --allow-unauthenticated
-
-// Managed mode generates the enforced key; consumers may read the live value.
-const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
-provider.apiKey
 ```
 
 - `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
 - `--docs` no longer enables wildcard CORS and rejects `--port 0`.
 - A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
 - `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
-- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
-- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
-- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
 
 ---

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Cuts `@qvac/cli` 0.11.0, which publishes the `qvac serve` security hardening from #3744. Until this is on npm, every managed launcher — `@qvac/ai-sdk-provider`, the OpenCode plugin, and the OpenClaw plugin — still starts `qvac serve` with `--api-key <key>`, because they all gate the file-based credential on a resolved CLI of at least 0.11.0. This release is what flips them onto `--api-key-file` and takes the bearer token out of the process command line.

It is the first step of the agent-stack cascade; `@qvac/ai-sdk-provider` 0.6.0 and both plugins at 0.2.0 follow once this is live on npm.

## 📝 How does it solve it?

- `packages/cli/package.json` — version `0.10.0` → `0.11.0`. No dependency changes: `@qvac/sdk` stays at `^0.17.0`, since no SDK release is part of this cascade.
- `packages/cli/changelog/0.11.0/` — new changelog folder (`CHANGELOG.md`, `CHANGELOG_LLM.md`, `breaking.md`).
- `packages/cli/CHANGELOG.md` — aggregated entry prepended.
- `packages/cli/NOTICE` — regenerated (see the note below before reviewing the diff).

Merging this publishes to GPR. The npm publish happens when the release branch reaches `main` via the companion backmerge PR.

### Note on the NOTICE diff

The NOTICE diff is large (-1504 / +51) and that is expected. `qv-notice-generate` scans **production dependencies only** (`npm install --production`, `license-checker --production`), but the committed file predates that behaviour and still lists devDependencies such as `typescript` and `prettier`. It was last regenerated for 0.9.0 — the 0.10.0 release skipped the step — so this release absorbs two releases' worth of drift. Every entry removed is a build-time dependency that is not distributed with the package.

## 🧪 How was it tested?

From `packages/cli`, all green:

- `npm run lint` (lunte) — no issues
- `npm run format` (prettier) — clean
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run test:unit` — 465 tests, 464 pass, 0 fail
- `node scripts/check-publish-ready.cjs` — exit 0
- `prettier --check` over `changelog/**/*.md` and `CHANGELOG.md` — clean

## 💥 Breaking Changes

Carried from #3744; see `packages/cli/changelog/0.11.0/breaking.md` for the full list.

**BEFORE:**

```bash
# --cors opened the server to every origin; --docs inherited that.
qvac serve openai --cors --docs

# A non-loopback bind warned and started anyway, unauthenticated.
qvac serve openai --host 0.0.0.0
```

**AFTER:**

```bash
# Every trusted browser origin must be named. --docs adds same-port loopback only.
qvac serve openai --cors --cors-origin https://app.example.com

# A non-loopback bind must authenticate, or say outright that it will not.
qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
qvac serve openai --host 0.0.0.0 --allow-unauthenticated
```

- `--cors` fails startup without `--cors-origin` or `serve.cors.origins`; `*` and trailing-dot origins are rejected.
- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
- A non-loopback `--host` fails startup without `--api-key` / `--api-key-file`, unless `--allow-unauthenticated` is passed.
- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.