### PR TITLE
QVAC-23222 chore[bc|notask]: release @qvac/ai-sdk-provider 0.6.0

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## [0.6.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.0
+
+Managed mode now authenticates. The provider generates a random API key for every serve it starts, enforces it on outgoing requests, and keeps it out of the process command line. Callers no longer supply a managed key — they read the live one from the provider when they need it.
+
+## Breaking Changes
+
+### Managed mode owns the API key
+
+`QvacManagedOptions.apiKey` is gone. Passing a key was misleading: the previous `qvac serve` did not validate it, so the option gave the appearance of authentication without any. Managed mode now generates a cryptographically random key per serve fleet, stores it in the private managed registry record, and reuses that record's key when attaching to an existing fleet.
+
+Because the provider owns the credential, a caller-supplied `authorization` header on a managed provider is replaced with the resolved managed key. Custom `fetch` wrappers still run, but they receive requests that are already authorized — treat the `Authorization` header they see as secret material and keep it out of logs.
+
+**Before:**
+
+```ts
+const qvac = await createQvac({
+  mode: 'managed',
+  models: ['QWEN3_8B_INST_Q4_K_M'],
+  apiKey: 'local-key'
+})
+```
+
+**After:**
+
+```ts
+const qvac = await createQvac({
+  mode: 'managed',
+  models: ['QWEN3_8B_INST_Q4_K_M']
+})
+```
+
+### External mode keys are now enforced by serve
+
+In external mode the provider's default `apiKey` is still the literal string `'qvac'`, but `qvac serve` no longer ignores it. If the server was started with `--api-key` or `--api-key-file`, the value passed to `createQvac` must match it, or requests are rejected with a 401.
+
+## New APIs
+
+### `provider.apiKey` exposes the live managed credential
+
+Trusted in-process adapters that need to reach the managed serve outside the provider's own `fetch` can read the key it is currently using:
+
+```ts
+await using qvac = await createQvac({ mode: 'managed', models: ['QWEN3_8B_INST_Q4_K_M'] })
+
+// Read it fresh per request: crash recovery respawns the serve with a new key.
+const res = await fetch(`${qvac.baseURL}/models`, {
+  headers: { authorization: `Bearer ${qvac.apiKey}` }
+})
+```
+
+The property is deliberately non-enumerable, so `{ ...provider }`, `Object.keys(provider)`, and casual object dumps never carry it. Never log it or hand it to an untrusted process.
+
+## Security
+
+### The key never appears in a process argument list
+
+Neither the detached runner nor the `qvac serve` process it starts receives the key through argv. Both read it from a one-shot owner-only (`0600`) file, so it cannot be recovered from `ps` or `/proc/<pid>/cmdline`, which on Linux is readable by every local account.
+
+Passing the key on the serve command line now only happens against a CLI too old for `--api-key-file`, which the provider detects and falls back to, or behind a `serveBinPath` override, whose version cannot be determined. Install `@qvac/cli` 0.11.0 or newer to keep the key out of the process list in every case.
+
+### Serves from before managed authentication are reaped
+
+The registry sweep that runs at the start of every `createQvac` now also cleans up after older provider versions. A record carrying no key belongs to a serve that is listening without authentication, so the sweep probes it anonymously and shuts it down rather than leaving it running. Abandoned one-shot runner handoff files are removed once no runner could still be waiting to read one.
+
+## Compatibility
+
+The `@qvac/cli` peer range widens to `^0.10.0 || ^0.11.0`. Both work; 0.11.0 is what enables the file-based credential described above.
+
 ## [0.5.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.5.0

--- a/packages/ai-sdk-provider/NOTICE
+++ b/packages/ai-sdk-provider/NOTICE
@@ -17,9 +17,9 @@ JavaScript Dependencies
 
 --- apache-2.0 (Apache License 2.0) ---
 
-  @ai-sdk/provider@4.0.3
+  @ai-sdk/provider@4.0.7
     https://github.com/vercel/ai
-  @ai-sdk/provider-utils@5.0.12
+  @ai-sdk/provider-utils@5.0.26
     https://github.com/vercel/ai
   @workflow/serde@4.1.0
     https://github.com/vercel/workflow
@@ -28,8 +28,10 @@ JavaScript Dependencies
 
   @standard-schema/spec@1.1.0
     https://github.com/standard-schema/standard-schema
-  eventsource-parser@3.1.0
+  eventsource-parser@3.1.1
     https://github.com/rexxars/eventsource-parser
+  undici@7.29.0
+    https://github.com/nodejs/undici
   zod@4.4.3
     https://github.com/colinhacks/zod
 

--- a/packages/ai-sdk-provider/changelog/0.6.0/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.6.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.6.0
+
+Release Date: 2026-08-13
+
+## 🐞 Fixes
+
+- Harden serve CORS and managed authentication. (see PR [#3744](https://github.com/tetherto/qvac/pull/3744)) - See [breaking changes](./breaking.md)

--- a/packages/ai-sdk-provider/changelog/0.6.0/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.6.0/CHANGELOG_LLM.md
@@ -1,0 +1,69 @@
+# QVAC AI SDK Provider v0.6.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.0
+
+Managed mode now authenticates. The provider generates a random API key for every serve it starts, enforces it on outgoing requests, and keeps it out of the process command line. Callers no longer supply a managed key — they read the live one from the provider when they need it.
+
+## Breaking Changes
+
+### Managed mode owns the API key
+
+`QvacManagedOptions.apiKey` is gone. Passing a key was misleading: the previous `qvac serve` did not validate it, so the option gave the appearance of authentication without any. Managed mode now generates a cryptographically random key per serve fleet, stores it in the private managed registry record, and reuses that record's key when attaching to an existing fleet.
+
+Because the provider owns the credential, a caller-supplied `authorization` header on a managed provider is replaced with the resolved managed key. Custom `fetch` wrappers still run, but they receive requests that are already authorized — treat the `Authorization` header they see as secret material and keep it out of logs.
+
+**Before:**
+
+```ts
+const qvac = await createQvac({
+  mode: 'managed',
+  models: ['QWEN3_8B_INST_Q4_K_M'],
+  apiKey: 'local-key'
+})
+```
+
+**After:**
+
+```ts
+const qvac = await createQvac({
+  mode: 'managed',
+  models: ['QWEN3_8B_INST_Q4_K_M']
+})
+```
+
+### External mode keys are now enforced by serve
+
+In external mode the provider's default `apiKey` is still the literal string `'qvac'`, but `qvac serve` no longer ignores it. If the server was started with `--api-key` or `--api-key-file`, the value passed to `createQvac` must match it, or requests are rejected with a 401.
+
+## New APIs
+
+### `provider.apiKey` exposes the live managed credential
+
+Trusted in-process adapters that need to reach the managed serve outside the provider's own `fetch` can read the key it is currently using:
+
+```ts
+await using qvac = await createQvac({ mode: 'managed', models: ['QWEN3_8B_INST_Q4_K_M'] })
+
+// Read it fresh per request: crash recovery respawns the serve with a new key.
+const res = await fetch(`${qvac.baseURL}/models`, {
+  headers: { authorization: `Bearer ${qvac.apiKey}` }
+})
+```
+
+The property is deliberately non-enumerable, so `{ ...provider }`, `Object.keys(provider)`, and casual object dumps never carry it. Never log it or hand it to an untrusted process.
+
+## Security
+
+### The key never appears in a process argument list
+
+Neither the detached runner nor the `qvac serve` process it starts receives the key through argv. Both read it from a one-shot owner-only (`0600`) file, so it cannot be recovered from `ps` or `/proc/<pid>/cmdline`, which on Linux is readable by every local account.
+
+Passing the key on the serve command line now only happens against a CLI too old for `--api-key-file`, which the provider detects and falls back to, or behind a `serveBinPath` override, whose version cannot be determined. Install `@qvac/cli` 0.11.0 or newer to keep the key out of the process list in every case.
+
+### Serves from before managed authentication are reaped
+
+The registry sweep that runs at the start of every `createQvac` now also cleans up after older provider versions. A record carrying no key belongs to a serve that is listening without authentication, so the sweep probes it anonymously and shuts it down rather than leaving it running. Abandoned one-shot runner handoff files are removed once no runner could still be waiting to read one.
+
+## Compatibility
+
+The `@qvac/cli` peer range widens to `^0.10.0 || ^0.11.0`. Both work; 0.11.0 is what enables the file-based credential described above.

--- a/packages/ai-sdk-provider/changelog/0.6.0/breaking.md
+++ b/packages/ai-sdk-provider/changelog/0.6.0/breaking.md
@@ -1,0 +1,43 @@
+# 💥 Breaking Changes v0.6.0
+
+## Harden serve CORS and managed authentication
+
+PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
+
+**BEFORE:**
+
+```typescript
+// --cors enabled wildcard browser access; --docs inherited it.
+qvac serve openai --cors --docs
+
+// A non-loopback bind logged a warning and started anyway.
+qvac serve openai --host 0.0.0.0
+
+// Managed callers could pass an apiKey option that was not enforced by serve.
+await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
+```
+
+**AFTER:**
+
+```typescript
+// Name every trusted browser origin. --docs adds same-port loopback origins only.
+qvac serve openai --cors --cors-origin https://app.example.com
+
+// A non-loopback bind must authenticate, or say out loud that it will not.
+qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
+qvac serve openai --host 0.0.0.0 --allow-unauthenticated
+
+// Managed mode generates the enforced key; consumers may read the live value.
+const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
+provider.apiKey
+```
+
+- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
+- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
+- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
+- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
+- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
+- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
+- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+
+---

--- a/packages/ai-sdk-provider/changelog/0.6.0/breaking.md
+++ b/packages/ai-sdk-provider/changelog/0.6.0/breaking.md
@@ -6,38 +6,28 @@ PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
 
 **BEFORE:**
 
-```typescript
-// --cors enabled wildcard browser access; --docs inherited it.
-qvac serve openai --cors --docs
-
-// A non-loopback bind logged a warning and started anyway.
-qvac serve openai --host 0.0.0.0
-
-// Managed callers could pass an apiKey option that was not enforced by serve.
-await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
+```ts
+// Managed callers could pass an apiKey option that serve never enforced.
+const qvac = await createQvac({
+  mode: 'managed',
+  models: ['QWEN3_8B_INST_Q4_K_M'],
+  apiKey: 'local-key'
+})
 ```
 
 **AFTER:**
 
-```typescript
-// Name every trusted browser origin. --docs adds same-port loopback origins only.
-qvac serve openai --cors --cors-origin https://app.example.com
-
-// A non-loopback bind must authenticate, or say out loud that it will not.
-qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
-qvac serve openai --host 0.0.0.0 --allow-unauthenticated
-
-// Managed mode generates the enforced key; consumers may read the live value.
-const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
-provider.apiKey
+```ts
+// Managed mode generates the enforced key; read the live value when needed.
+const qvac = await createQvac({
+  mode: 'managed',
+  models: ['QWEN3_8B_INST_Q4_K_M']
+})
+qvac.apiKey
 ```
 
-- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
-- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
-- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
-- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
-- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
-- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
-- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential, and is non-enumerable so object dumps do not carry it.
+- A caller-supplied `authorization` header on a managed provider is replaced with the managed key. Custom `fetch` wrappers now see already-authorized requests.
+- In external mode `qvac serve` enforces the key instead of ignoring it, so the `apiKey` passed to `createQvac` must match what the server was started with or requests fail with a 401.
 
 ---

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^3.0",
-    "@qvac/cli": "^0.10.0",
+    "@qvac/cli": "^0.10.0 || ^0.11.0",
     "ai": "^7.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Cuts `@qvac/ai-sdk-provider` 0.6.0, which publishes the managed-authentication work from #3744. Managed mode previously accepted an `apiKey` option that `qvac serve` never validated, so it looked authenticated without being so. This release makes the provider generate and enforce a real key, and exposes the live value to trusted in-process callers.

Second step of the agent-stack cascade, after `@qvac/cli` 0.11.0 (#3833). Both plugins at 0.2.0 follow once this is on npm.

## 📝 How does it solve it?

- `packages/ai-sdk-provider/package.json` — version `0.5.0` → `0.6.0`, and `peerDependencies["@qvac/cli"]` widens from `^0.10.0` to `^0.10.0 || ^0.11.0`.
- `packages/ai-sdk-provider/changelog/0.6.0/` — new changelog folder (`CHANGELOG.md`, `CHANGELOG_LLM.md`, `breaking.md`).
- `packages/ai-sdk-provider/CHANGELOG.md` — aggregated entry prepended.
- `packages/ai-sdk-provider/NOTICE` — regenerated; picks up transitive drift in `@ai-sdk/provider`, `@ai-sdk/provider-utils`, `eventsource-parser`, and adds `undici`.

The peer range is widened rather than moved to `^0.11.0` because the provider is built to work with both: it resolves the CLI version and falls back to `--api-key` when the installed CLI predates `--api-key-file`. Requiring 0.11.0 would break installs that pin the older CLI for no functional gain.

Merging this publishes to GPR; npm publish follows when the release branch reaches `main` via the companion backmerge PR.

## 🧪 How was it tested?

From `packages/ai-sdk-provider`, all green:

- `npm run lint` (lunte) — no issues
- `npm run format` (prettier) — clean
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run test:unit` — 101 tests, 99 pass, 0 fail, 2 skipped
- `prettier --check` over `changelog/**/*.md` and `CHANGELOG.md` — clean

## 💥 Breaking Changes

**BEFORE:**

```ts
// The key was accepted but never enforced — serve ignored it.
const qvac = await createQvac({
  mode: 'managed',
  models: ['QWEN3_8B_INST_Q4_K_M'],
  apiKey: 'local-key'
})
```

**AFTER:**

```ts
// Managed mode generates, owns, and enforces the key.
await using qvac = await createQvac({
  mode: 'managed',
  models: ['QWEN3_8B_INST_Q4_K_M']
})

// Read it fresh per request: crash recovery respawns the serve with a new key.
const res = await fetch(`${qvac.baseURL}/models`, {
  headers: { authorization: `Bearer ${qvac.apiKey}` }
})
```

- `QvacManagedOptions.apiKey` is removed. A caller-supplied `authorization` header on a managed provider is replaced with the resolved managed key.
- `ManagedQvacProvider.apiKey` is added as a read-only, non-enumerable getter for the live credential.
- In external mode, the `apiKey` passed to `createQvac` must now match the serve's `--api-key` / `--api-key-file` value; serve no longer ignores it.
- Managed serves recorded by a pre-authentication provider version are probed anonymously and shut down by the registry sweep rather than left listening.

## 🔌 API Changes

`ManagedQvacProvider.apiKey` — read-only getter returning the API key of the serve currently in use. Deliberately non-enumerable, so `{ ...provider }` and `Object.keys(provider)` do not carry it.

```ts
await using qvac = await createQvac({ mode: 'managed', models: ['QWEN3_8B_INST_Q4_K_M'] })

const res = await fetch(`${qvac.baseURL}/models`, {
  headers: { authorization: `Bearer ${qvac.apiKey}` }
})
```