### PR TITLE
QVAC-23222 chore[bc|notask]: release @qvac/opencode-plugin 0.2.0

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.2.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.2.0
+
+The managed serve the plugin starts is now authenticated, and the host that proxies to it has been hardened. Requests are pinned to a loopback upstream, hop-by-hop headers are no longer relayed, and a managed serve that fails to start now returns an error instead of leaving requests waiting.
+
+## Breaking Changes
+
+### The host handshake carries a session token, not the serve key
+
+The private handshake between the plugin and its managed serve host now passes a per-session `proxyToken` instead of the managed serve's own API key. The host authenticates incoming proxy requests with that token and applies the real serve credential itself, so the serve key never leaves the host process.
+
+This is internal to the plugin and its bundled host; no configuration changes. A plugin and a host from different releases cannot hand off to each other, so upgrade them together — which a normal `npm install` of this package does.
+
+## Reliability
+
+### A failed managed startup fails the request
+
+If the managed provider cannot start — for example because the resolved provider is too old to expose the serve credential — proxied requests used to wait indefinitely on a readiness promise that would never settle. They now reject with a `503` naming the cause. Stopping the host while a startup is still in flight releases anything queued behind it rather than dropping the connections silently.
+
+A host that exits after a successful handshake also now writes a line to stderr saying the `qvac` provider is gone and that OpenCode needs restarting, instead of failing quietly on the next request.
+
+## Security
+
+### The proxy will only talk to a loopback upstream
+
+The host verifies that the managed serve it was handed is on a loopback address before forwarding anything to it, and refuses with an `UntrustedUpstreamError` otherwise. Hop-by-hop headers such as `proxy-connection` and `proxy-authorization` are stripped from forwarded requests, and `content-length` is always recomputed rather than copied from the incoming request.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.6.0` for managed mode, which generates and enforces the serve API key
+- `@qvac/cli@^0.11.0` for `qvac serve` (SDK 0.17 runtime), the first CLI that accepts `--api-key-file` and so keeps the bearer key out of the process command line
+
 ## [0.1.2]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.1.2

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -144,12 +144,14 @@ running `opencode` from the terminal.
 
 ## Requirements
 
-- [`@qvac/ai-sdk-provider@^0.5.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)
+- [`@qvac/ai-sdk-provider@^0.6.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)
   for managed mode (AI SDK 7). The host proxies on behalf of the managed serve,
   so it needs the provider's `ManagedQvacProvider.apiKey` getter — see
   [Provider compatibility](#provider-compatibility).
-- [`@qvac/cli@^0.10.0`](https://www.npmjs.com/package/@qvac/cli) available so the
-  host can run `qvac serve` (SDK 0.16 runtime).
+- [`@qvac/cli@^0.11.0`](https://www.npmjs.com/package/@qvac/cli) available so the
+  host can run `qvac serve` (SDK 0.17 runtime). 0.11.0 is also the first CLI that
+  accepts `--api-key-file`, which keeps the managed serve's bearer key out of the
+  process command line.
 - Node.js 22 or newer.
 
 ### Provider compatibility

--- a/plugins/opencode/changelog/0.2.0/CHANGELOG.md
+++ b/plugins/opencode/changelog/0.2.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.0
+
+Release Date: 2026-08-13
+
+## 🐞 Fixes
+
+- Harden serve CORS and managed authentication. (see PR [#3744](https://github.com/tetherto/qvac/pull/3744)) - See [breaking changes](./breaking.md)

--- a/plugins/opencode/changelog/0.2.0/CHANGELOG_LLM.md
+++ b/plugins/opencode/changelog/0.2.0/CHANGELOG_LLM.md
@@ -1,0 +1,34 @@
+# QVAC OpenCode Plugin v0.2.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.2.0
+
+The managed serve the plugin starts is now authenticated, and the host that proxies to it has been hardened. Requests are pinned to a loopback upstream, hop-by-hop headers are no longer relayed, and a managed serve that fails to start now returns an error instead of leaving requests waiting.
+
+## Breaking Changes
+
+### The host handshake carries a session token, not the serve key
+
+The private handshake between the plugin and its managed serve host now passes a per-session `proxyToken` instead of the managed serve's own API key. The host authenticates incoming proxy requests with that token and applies the real serve credential itself, so the serve key never leaves the host process.
+
+This is internal to the plugin and its bundled host; no configuration changes. A plugin and a host from different releases cannot hand off to each other, so upgrade them together — which a normal `npm install` of this package does.
+
+## Reliability
+
+### A failed managed startup fails the request
+
+If the managed provider cannot start — for example because the resolved provider is too old to expose the serve credential — proxied requests used to wait indefinitely on a readiness promise that would never settle. They now reject with a `503` naming the cause. Stopping the host while a startup is still in flight releases anything queued behind it rather than dropping the connections silently.
+
+A host that exits after a successful handshake also now writes a line to stderr saying the `qvac` provider is gone and that OpenCode needs restarting, instead of failing quietly on the next request.
+
+## Security
+
+### The proxy will only talk to a loopback upstream
+
+The host verifies that the managed serve it was handed is on a loopback address before forwarding anything to it, and refuses with an `UntrustedUpstreamError` otherwise. Hop-by-hop headers such as `proxy-connection` and `proxy-authorization` are stripped from forwarded requests, and `content-length` is always recomputed rather than copied from the incoming request.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.6.0` for managed mode, which generates and enforces the serve API key
+- `@qvac/cli@^0.11.0` for `qvac serve` (SDK 0.17 runtime), the first CLI that accepts `--api-key-file` and so keeps the bearer key out of the process command line

--- a/plugins/opencode/changelog/0.2.0/breaking.md
+++ b/plugins/opencode/changelog/0.2.0/breaking.md
@@ -4,40 +4,9 @@
 
 PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
 
-**BEFORE:**
+_No migration code — the handshake is private to the plugin and the host it bundles._
 
-```typescript
-// --cors enabled wildcard browser access; --docs inherited it.
-qvac serve openai --cors --docs
-
-// A non-loopback bind logged a warning and started anyway.
-qvac serve openai --host 0.0.0.0
-
-// Managed callers could pass an apiKey option that was not enforced by serve.
-await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
-```
-
-**AFTER:**
-
-```typescript
-// Name every trusted browser origin. --docs adds same-port loopback origins only.
-qvac serve openai --cors --cors-origin https://app.example.com
-
-// A non-loopback bind must authenticate, or say out loud that it will not.
-qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
-qvac serve openai --host 0.0.0.0 --allow-unauthenticated
-
-// Managed mode generates the enforced key; consumers may read the live value.
-const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
-provider.apiKey
-```
-
-- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
-- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
-- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
-- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
-- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
-- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
-- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+- The private host handshake now carries a per-session `proxyToken` instead of the managed serve's own API key. The host authenticates proxy requests with that token and applies the serve credential itself, so the key never leaves the host process.
+- A plugin and a host from different releases cannot hand off to each other, so upgrade them together — installing this package does that.
 
 ---

--- a/plugins/opencode/changelog/0.2.0/breaking.md
+++ b/plugins/opencode/changelog/0.2.0/breaking.md
@@ -1,0 +1,43 @@
+# 💥 Breaking Changes v0.2.0
+
+## Harden serve CORS and managed authentication
+
+PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
+
+**BEFORE:**
+
+```typescript
+// --cors enabled wildcard browser access; --docs inherited it.
+qvac serve openai --cors --docs
+
+// A non-loopback bind logged a warning and started anyway.
+qvac serve openai --host 0.0.0.0
+
+// Managed callers could pass an apiKey option that was not enforced by serve.
+await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
+```
+
+**AFTER:**
+
+```typescript
+// Name every trusted browser origin. --docs adds same-port loopback origins only.
+qvac serve openai --cors --cors-origin https://app.example.com
+
+// A non-loopback bind must authenticate, or say out loud that it will not.
+qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
+qvac serve openai --host 0.0.0.0 --allow-unauthenticated
+
+// Managed mode generates the enforced key; consumers may read the live value.
+const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
+provider.apiKey
+```
+
+- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
+- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
+- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
+- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
+- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
+- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
+- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+
+---

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/opencode-plugin",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "OpenCode plugin that runs a local, managed QVAC serve so `opencode` works against on-device models with no second terminal",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.0",
-    "@qvac/ai-sdk-provider": "^0.5.0",
-    "@qvac/cli": "^0.10.0",
+    "@qvac/ai-sdk-provider": "^0.6.0",
+    "@qvac/cli": "^0.11.0",
     "ai": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Cuts `@qvac/opencode-plugin` 0.2.0, which publishes the host and proxy hardening from #3744 and moves the plugin onto the authenticated managed serve. Until it ships, installs resolve `@qvac/ai-sdk-provider@^0.5.0`, which has no way to hand the host a serve credential.

Third step of the agent-stack cascade, after `@qvac/cli` 0.11.0 (#3833) and `@qvac/ai-sdk-provider` 0.6.0 (#3836). This one must not be promoted until both of those are live on npm, since its dependency ranges name versions that do not exist yet.

## 📝 How does it solve it?

- `plugins/opencode/package.json` — version `0.1.2` → `0.2.0`; `@qvac/ai-sdk-provider` `^0.5.0` → `^0.6.0`; `@qvac/cli` `^0.10.0` → `^0.11.0`.
- `plugins/opencode/README.md` — Requirements section updated to the new floors, noting that 0.11.0 is the first CLI accepting `--api-key-file` and correcting the runtime line to SDK 0.17.
- `plugins/opencode/changelog/0.2.0/` — new changelog folder (`CHANGELOG.md`, `CHANGELOG_LLM.md`, `breaking.md`).
- `plugins/opencode/CHANGELOG.md` — aggregated entry prepended.

Both dependency floors move rather than widen: the plugin resolves and spawns these packages itself, so pinning the older range would leave it on the argv-based credential path indefinitely.

No NOTICE update — `qv-notice-generate` only covers `packages/*` and has no entry for either plugin, which is why previous plugin releases did not touch it either.

Merging this publishes to GPR; npm publish follows when the release branch reaches `main` via the companion backmerge PR.

## 🧪 How was it tested?

From `plugins/opencode`, all green:

- `npm run lint` (lunte) — no issues
- `npm run format` (prettier) — clean
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run test:unit` — 63 tests, 62 pass, 0 fail, 1 skipped
- `prettier --check` over `changelog/**/*.md` and `CHANGELOG.md` — clean

The AI SDK majors already line up, so nothing is blocked: this package depends on `ai@^7.0.0` and `@ai-sdk/openai-compatible@^3.0.0`, matching the provider's `ai@^7.0` / `^3.0` peers.

## 💥 Breaking Changes

The private handshake between the plugin and its bundled managed serve host now carries a per-session `proxyToken` instead of the managed serve's API key. The host authenticates proxy requests with that token and applies the real serve credential itself, so the serve key never leaves the host process.

**BEFORE:** the handshake handed out the managed serve key, and the plugin authenticated to the host with it.

**AFTER:** the handshake hands out a per-session `proxyToken` scoped to the host; the serve key stays inside the host.

No user configuration changes. A plugin and host from different releases cannot hand off to each other, but they are published together in this package, so a normal `npm install` upgrades both.