### PR TITLE
QVAC-23222 chore[bc|notask]: release @qvac/openclaw-plugin 0.2.0

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.2.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.0
+
+The local QVAC service now runs authenticated. The launcher reads a bearer key from a private owner-only file and hands it to `qvac serve` without ever placing it in a process argument list. Existing installs must re-onboard once.
+
+## Breaking Changes
+
+### Re-onboard to migrate an existing install
+
+The key reaches the launcher as an `--api-key-file` path in `localService.args`, and that argument list is persisted in `openclaw.json` by onboarding. An install configured before this release has a persisted list without it, so upgrading the plugin alone is not enough:
+
+```bash
+openclaw onboard --auth-choice qvac
+```
+
+Until you run it, starting the local QVAC service fails with `--api-key-file requires a value …`, which names the same remedy. This is deliberate: the launcher will not fall back to an unauthenticated serve, and it will not guess a key-file path that onboarding never wrote. Re-onboarding is idempotent for installs that have already migrated — it reuses the existing key file, refreshes the provider entry, and leaves your model choice alone.
+
+### The key file is validated on every launch
+
+A key file that is not a regular file, or whose permissions let anyone but the owner read it, now stops the launcher instead of being used. The check runs on every read rather than only at onboarding, because the path is long-lived: a file swapped for a symlink or loosened to group-readable between runs would otherwise be picked up silently. Recover with `chmod 600` on the file, or by re-running onboarding.
+
+## Security
+
+### The key stays out of the process list
+
+Neither the launcher nor the `qvac serve` process it starts receives the key in its arguments. The serve is started with `--api-key-file` pointing at the same owner-only file, so the credential cannot be recovered from `ps` or `/proc/<pid>/cmdline`, which on Linux is readable by every local account.
+
+Whether that is possible depends on the CLI in use, so the launcher runs the `@qvac/cli` installed alongside the plugin — the same install it reads the version from — through the current Node executable. A `qvacCommand` set to an explicit path is spawned verbatim instead and its version cannot be determined; that case falls back to `--api-key`, where the key is visible to local process inspection.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog
+- `@qvac/cli@^0.11.0` for `qvac serve` (SDK 0.17 runtime), the first CLI that accepts `--api-key-file`
+
 ## [0.1.3]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.3

--- a/plugins/openclaw/changelog/0.2.0/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.2.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.0
+
+Release Date: 2026-08-13
+
+## 🐞 Fixes
+
+- Harden serve CORS and managed authentication. (see PR [#3744](https://github.com/tetherto/qvac/pull/3744)) - See [breaking changes](./breaking.md)

--- a/plugins/openclaw/changelog/0.2.0/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.2.0/CHANGELOG_LLM.md
@@ -1,0 +1,36 @@
+# QVAC OpenClaw Plugin v0.2.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.0
+
+The local QVAC service now runs authenticated. The launcher reads a bearer key from a private owner-only file and hands it to `qvac serve` without ever placing it in a process argument list. Existing installs must re-onboard once.
+
+## Breaking Changes
+
+### Re-onboard to migrate an existing install
+
+The key reaches the launcher as an `--api-key-file` path in `localService.args`, and that argument list is persisted in `openclaw.json` by onboarding. An install configured before this release has a persisted list without it, so upgrading the plugin alone is not enough:
+
+```bash
+openclaw onboard --auth-choice qvac
+```
+
+Until you run it, starting the local QVAC service fails with `--api-key-file requires a value …`, which names the same remedy. This is deliberate: the launcher will not fall back to an unauthenticated serve, and it will not guess a key-file path that onboarding never wrote. Re-onboarding is idempotent for installs that have already migrated — it reuses the existing key file, refreshes the provider entry, and leaves your model choice alone.
+
+### The key file is validated on every launch
+
+A key file that is not a regular file, or whose permissions let anyone but the owner read it, now stops the launcher instead of being used. The check runs on every read rather than only at onboarding, because the path is long-lived: a file swapped for a symlink or loosened to group-readable between runs would otherwise be picked up silently. Recover with `chmod 600` on the file, or by re-running onboarding.
+
+## Security
+
+### The key stays out of the process list
+
+Neither the launcher nor the `qvac serve` process it starts receives the key in its arguments. The serve is started with `--api-key-file` pointing at the same owner-only file, so the credential cannot be recovered from `ps` or `/proc/<pid>/cmdline`, which on Linux is readable by every local account.
+
+Whether that is possible depends on the CLI in use, so the launcher runs the `@qvac/cli` installed alongside the plugin — the same install it reads the version from — through the current Node executable. A `qvacCommand` set to an explicit path is spawned verbatim instead and its version cannot be determined; that case falls back to `--api-key`, where the key is visible to local process inspection.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog
+- `@qvac/cli@^0.11.0` for `qvac serve` (SDK 0.17 runtime), the first CLI that accepts `--api-key-file`

--- a/plugins/openclaw/changelog/0.2.0/breaking.md
+++ b/plugins/openclaw/changelog/0.2.0/breaking.md
@@ -4,40 +4,14 @@
 
 PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
 
-**BEFORE:**
-
-```typescript
-// --cors enabled wildcard browser access; --docs inherited it.
-qvac serve openai --cors --docs
-
-// A non-loopback bind logged a warning and started anyway.
-qvac serve openai --host 0.0.0.0
-
-// Managed callers could pass an apiKey option that was not enforced by serve.
-await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
-```
-
 **AFTER:**
 
-```typescript
-// Name every trusted browser origin. --docs adds same-port loopback origins only.
-qvac serve openai --cors --cors-origin https://app.example.com
-
-// A non-loopback bind must authenticate, or say out loud that it will not.
-qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
-qvac serve openai --host 0.0.0.0 --allow-unauthenticated
-
-// Managed mode generates the enforced key; consumers may read the live value.
-const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
-provider.apiKey
+```bash
+# Run once per existing install, before starting the local QVAC service again.
+openclaw onboard --auth-choice qvac
 ```
 
-- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
-- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
-- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
-- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
-- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
-- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
-- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+- Existing installs must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and the `--api-key-file` argument that onboarding persists in `openclaw.json`. Until then the local QVAC service fails with `--api-key-file requires a value …`; the launcher will not fall back to an unauthenticated serve.
+- A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher. The check runs on every read rather than only at onboarding. Recover with `chmod 600` on the file, or by re-running onboarding.
 
 ---

--- a/plugins/openclaw/changelog/0.2.0/breaking.md
+++ b/plugins/openclaw/changelog/0.2.0/breaking.md
@@ -1,0 +1,43 @@
+# 💥 Breaking Changes v0.2.0
+
+## Harden serve CORS and managed authentication
+
+PR: [#3744](https://github.com/tetherto/qvac/pull/3744)
+
+**BEFORE:**
+
+```typescript
+// --cors enabled wildcard browser access; --docs inherited it.
+qvac serve openai --cors --docs
+
+// A non-loopback bind logged a warning and started anyway.
+qvac serve openai --host 0.0.0.0
+
+// Managed callers could pass an apiKey option that was not enforced by serve.
+await createQvac({ managed: { models: ["qwen3-0.6b"], apiKey: "local-key" } })
+```
+
+**AFTER:**
+
+```typescript
+// Name every trusted browser origin. --docs adds same-port loopback origins only.
+qvac serve openai --cors --cors-origin https://app.example.com
+
+// A non-loopback bind must authenticate, or say out loud that it will not.
+qvac serve openai --host 0.0.0.0 --api-key-file ~/.qvac/serve-key
+qvac serve openai --host 0.0.0.0 --allow-unauthenticated
+
+// Managed mode generates the enforced key; consumers may read the live value.
+const provider = await createQvac({ managed: { models: ["qwen3-0.6b"] } })
+provider.apiKey
+```
+
+- `--cors` now fails startup without `--cors-origin` or `serve.cors.origins`; `*` is rejected, as is an origin ending in a trailing dot.
+- `--docs` no longer enables wildcard CORS and rejects `--port 0`.
+- A non-loopback `--host` now fails startup unless `--api-key` or `--api-key-file` is given. `--allow-unauthenticated` restores the previous warn-and-start behaviour.
+- `--api-key-file <path>` is added as the recommended alternative to `--api-key`, which leaves the credential in the process command line.
+- `QvacManagedOptions.apiKey` is removed. `ManagedQvacProvider.apiKey` is the generated live credential.
+- Existing OpenClaw installations must rerun `openclaw onboard --auth-choice qvac` to materialize the private key file and SecretRef. A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher.
+- The private OpenCode host handshake now carries a per-session `proxyToken` instead of the managed serve key.
+
+---

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qvac",
   "name": "QVAC",
   "description": "Local QVAC provider for OpenClaw",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "providers": ["qvac"],
   "modelSupport": {
     "modelPrefixes": ["qwen3.5-", "qwen3.6-", "gpt-oss-", "gemma4-"]

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -60,8 +60,8 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@qvac/ai-sdk-provider": "^0.5.0",
-    "@qvac/cli": "^0.10.0"
+    "@qvac/ai-sdk-provider": "^0.6.0",
+    "@qvac/cli": "^0.11.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Cuts `@qvac/openclaw-plugin` 0.2.0, which publishes the authenticated local-service launcher from #3744. The launcher now reads the bearer key from a private owner-only file and passes it to `qvac serve` as `--api-key-file`, so it never appears in a process argument list.

Final step of the agent-stack cascade, after `@qvac/cli` 0.11.0 (#3833) and `@qvac/ai-sdk-provider` 0.6.0 (#3836). Both floors are live on npm.

## 📝 How does it solve it?

- `plugins/openclaw/package.json` — version `0.1.3` → `0.2.0`; `@qvac/ai-sdk-provider` `^0.5.0` → `^0.6.0`; `@qvac/cli` `^0.10.0` → `^0.11.0`.
- `plugins/openclaw/openclaw.plugin.json` — manifest version `0.1.3` → `0.2.0`, kept in step with the package.
- `plugins/openclaw/changelog/0.2.0/` — new changelog folder (`CHANGELOG.md`, `CHANGELOG_LLM.md`, `breaking.md`).
- `plugins/openclaw/CHANGELOG.md` — aggregated entry prepended.

The `@qvac/cli` floor moves to `^0.11.0` rather than widening because the launcher resolves and spawns that exact install through the current Node executable — it is the version whose `--api-key-file` support the version gate is testing for. Keeping the older range would leave the default path on the argv-based credential.

No README changes were needed: the Upgrading section already documents the re-onboarding step and the 0.11.0 threshold, and the install snippets carry no version pins.

No NOTICE update — `qv-notice-generate` only covers `packages/*` and has no entry for either plugin, which is why previous plugin releases did not touch it either.

Merging this publishes to GPR; npm publish follows when the release branch reaches `main` via the companion backmerge PR.

## 🧪 How was it tested?

From `plugins/openclaw`, all green:

- `npm run lint` (lunte) — no issues
- `npm run format` (prettier) — clean
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run test:unit` — 35 tests, 35 pass, 0 fail
- `prettier --check` over `changelog/**/*.md` and `CHANGELOG.md` — clean

## 💥 Breaking Changes

**BEFORE:** `localService.args` had no `--api-key-file`; serve started unauthenticated.

**AFTER:** onboard persists `--api-key-file`; existing installs must re-onboard.

### Existing installs must re-onboard once

The key reaches the launcher as an `--api-key-file` path in `localService.args`, and onboarding is what persists that argument list into `openclaw.json`. An install configured before this release has a list without it, so a plugin upgrade alone is not enough:

```bash
openclaw onboard --auth-choice qvac
```

Until then, starting the local QVAC service fails with `--api-key-file requires a value …`, naming the same remedy. The launcher fails closed on purpose: it will not fall back to an unauthenticated serve, and it will not guess a key-file path that onboarding never wrote. Re-onboarding is idempotent for already-migrated installs.

### The key file is re-validated on every launch

A key file that is not a regular file, or that is readable beyond its owner, now stops the launcher rather than being used. The check runs on every read, not only at onboarding, because the path is long-lived and could otherwise be swapped for a symlink or loosened between runs. Recover with `chmod 600` or by re-running onboarding.
