### PR TITLE
QVAC-23075 feat: add VisionPsy Nano to the VLM benchmark

### DIFF
--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: ""
+      allow_unverified_models:
+        description: "  allow a CLI leg to run a blob with no sha256 pin (a json: spec whose modelName is not a manifest key and that carries no sha256). Off by default: an unverified GGUF's own chat template reaches --chat-template."
+        required: false
+        type: boolean
+        default: false
       matrix_mobile:
         description: "  mobile (AWS Device Farm) legs, comma-sep <device>[any][-<backend>]: s26,s25,pixel9,iphone16,iphone17,iphone17pro — plain token = that EXACT model; 'any' suffix (e.g. pixel9any) = any subfamily variant, availability-picked. e.g. 's26-cpu,pixel9any,iphone17pro' (bare device = cpu+gpu in one session; empty = no mobile)"
         required: false
@@ -115,15 +120,26 @@ jobs:
         run: |
           repo="$REPO"
           ref="${INPUT_REF:-$REF_NAME}"
-          # Delimited form, because `ref` comes from a workflow input: a newline in a plain
-          # `key=value` line would let the dispatcher append step outputs of its own.
+          # `ref` is a workflow input, so it is untrusted. A git ref cannot contain
+          # whitespace anyway, so reject it outright rather than trying to encode it: that
+          # closes the newline-injection route into GITHUB_OUTPUT at the source, instead of
+          # relying on a delimiter the value might also contain.
+          case "$ref" in
+            *[[:space:]]*|"")
+              echo "::error::ref must be a single git ref with no whitespace"
+              exit 1
+              ;;
+          esac
+          # Belt and braces: a per-run random delimiter, so even a value that somehow
+          # carried a newline could not terminate the block and append its own output.
+          delim="EOF_$(openssl rand -hex 16)"
           {
-            echo "repository<<__EOF_REPO__"
+            echo "repository<<$delim"
             echo "$repo"
-            echo "__EOF_REPO__"
-            echo "ref<<__EOF_REF__"
+            echo "$delim"
+            echo "ref<<$delim"
             echo "$ref"
-            echo "__EOF_REF__"
+            echo "$delim"
           } >> "$GITHUB_OUTPUT"
       # Resolve the mobile timeout (minutes) so matrix-mobile can forward it to the
       # reusable workflow's mocha_timeout_ms / per_test_timeout_minutes inputs.
@@ -666,6 +682,7 @@ jobs:
           SAMPLES: ${{ inputs.matrix_samples }}
           PRESET: ${{ inputs.matrix_preset }}
           MATRIX_SOURCES: ${{ inputs.matrix_sources }}
+          ALLOW_UNVERIFIED: ${{ inputs.allow_unverified_models }}
           QVAC_VLM_MODELS: ${{ inputs.matrix_models }} # '' → config.sourcesModel (same resolution as harness.cjs)
         run: |
           # Match the addon leg's run size: samples + repeats come from the active
@@ -733,7 +750,7 @@ jobs:
             [ -s "$1" ] && return 0
             if [ -z "$2" ]; then
               echo "::error::$1 is missing and its source has no download URL. Registry sources are addon-only: they need an addon leg in this same job, which leaves the blob in $ADDON_MODEL_DIR. A CLI-only dispatch cannot fetch one."
-              exit 1
+              return 1
             fi
             echo ">> fetching $1"
             # Only attach the HF token to an actual huggingface.co URL. matrix_models'
@@ -755,8 +772,14 @@ jobs:
                   if [ -n "$hf_redirect" ]; then
                     curl -fL --retry 3 -o "$1" "$hf_redirect"
                   else
-                    # Served inline, no redirect to follow, so no hop the token could leak on.
-                    curl -f --retry 3 -H "Authorization: Bearer $HF_TOKEN" -o "$1" "$2"
+                    # No redirect on the probe, so fetch inline with the token. --max-redirs 0
+                    # keeps the token off any hop the probe did not predict: if the GET
+                    # redirects anyway, curl fails here with a clear message instead of saving
+                    # the redirect body and failing later at the sha check.
+                    if ! curl -f --retry 3 --max-redirs 0 -H "Authorization: Bearer $HF_TOKEN" -o "$1" "$2"; then
+                      echo "::error::$1 redirected on the tokenized GET after the HEAD probe reported none, refusing to follow it with the token attached"
+                      return 1
+                    fi
                   fi
                 else
                   curl -fL --retry 3 -o "$1" "$2"
@@ -767,14 +790,6 @@ jobs:
                 ;;
             esac
           }
-          # Both at once. These are multi-GB and bandwidth-bound, and a stalled download is
-          # the usual way this leg dies, so do not serialise the two exposure windows.
-          fetch_blob "$LLM" "$LLM_URL" &
-          llm_pid=$!
-          fetch_blob "$MMPROJ" "$MMPROJ_URL" &
-          mmproj_pid=$!
-          wait "$llm_pid" || { echo "::error::could not fetch $LLM_NAME"; exit 1; }
-          wait "$mmproj_pid" || { echo "::error::could not fetch $MMPROJ_NAME"; exit 1; }
           # Check the bytes against the pin. The addon leg gets this from ensureModel(), but a
           # CLI-only dispatch fetches the URL itself, so without this it benchmarks whatever
           # the host served, and a GGUF's own chat template goes on to reach --chat-template.
@@ -785,20 +800,43 @@ jobs:
               echo "$2  $1" | shasum -a 256 -c - >/dev/null 2>&1
             fi
           }
-          verify_blob () {
-            if [ -z "$3" ]; then
-              echo "::warning::$2 has no sha256 pin, so the fetched bytes cannot be verified"
+          # Fetch, verify, and on a mismatch delete and refetch once before giving up. A
+          # truncated blob left in MODEL_DIR by an earlier cancelled run would otherwise fail
+          # this leg on every rerun, since fetch_blob skips a file that is merely non-empty,
+          # and on a self-hosted runner nothing clears it.
+          fetch_verified_blob () {
+            path=$1; name=$2; url=$3; want=$4
+            fetch_blob "$path" "$url" || return 1
+            if [ -z "$want" ]; then
+              if [ "$ALLOW_UNVERIFIED" = "true" ]; then
+                echo "::warning::$name has no sha256 pin and allow_unverified_models is set, using it unverified"
+                return 0
+              fi
+              echo "::error::$name has no sha256 pin, so its bytes cannot be verified. Give the blob a modelName that models.manifest.json pins, or an explicit sha256 in the json: spec. Set allow_unverified_models to override."
+              return 1
+            fi
+            if sha256_check "$path" "$want"; then
+              echo ">> verified $name against its sha256 pin"
               return 0
             fi
-            if sha256_check "$1" "$3"; then
-              echo ">> verified $2 against its sha256 pin"
-            else
-              echo "::error::$2 does not match its pinned sha256 ($3)"
-              exit 1
+            echo "::warning::$name does not match its pinned sha256, discarding it and fetching once more"
+            rm -f "$path"
+            fetch_blob "$path" "$url" || return 1
+            if sha256_check "$path" "$want"; then
+              echo ">> verified $name against its sha256 pin after refetch"
+              return 0
             fi
+            echo "::error::$name does not match its pinned sha256 ($want) after a refetch"
+            return 1
           }
-          verify_blob "$LLM" "$LLM_NAME" "$LLM_SHA256"
-          verify_blob "$MMPROJ" "$MMPROJ_NAME" "$MMPROJ_SHA256"
+          # Both at once. These are multi-GB and bandwidth-bound, and a stalled download is
+          # the usual way this leg dies, so do not serialise the two exposure windows.
+          fetch_verified_blob "$LLM" "$LLM_NAME" "$LLM_URL" "$LLM_SHA256" &
+          llm_pid=$!
+          fetch_verified_blob "$MMPROJ" "$MMPROJ_NAME" "$MMPROJ_URL" "$MMPROJ_SHA256" &
+          mmproj_pid=$!
+          wait "$llm_pid" || { echo "::error::could not fetch or verify $LLM_NAME"; exit 1; }
+          wait "$mmproj_pid" || { echo "::error::could not fetch or verify $MMPROJ_NAME"; exit 1; }
           run_src () {
             echo ">> $1 over fixture ($2)"
             # Model-specific flags (e.g. VisionPsy Flash's --image-no-upscale) are fabric-fork

--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -690,7 +690,10 @@ jobs:
           # Hardcoding the qwen registry filenames here made every several-sources run
           # measure qwen even when matrix_models asked for something else.
           node resolve-cli-model.cjs > cli-model.env
-          cat cli-model.env
+          # Everything except the URLs, which a json: spec can point at a presigned S3 link
+          # whose signature is in the query string. Names, origins and sources still print,
+          # so the log still says what ran and where it came from.
+          grep -v '_URL=' cli-model.env
           . ./cli-model.env
           LLM="$MODEL_DIR/$LLM_NAME"
           MMPROJ="$MODEL_DIR/$MMPROJ_NAME"

--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -753,17 +753,14 @@ jobs:
               return 1
             fi
             echo ">> fetching $1"
-            # Only attach the HF token to an actual huggingface.co URL. matrix_models'
-            # json: escape hatch lets a caller point downloadUrl anywhere, and this secret
-            # must never ride along to a non-HF host.
+            # Attach the HF token only to a huggingface.co URL: matrix_models' json: escape
+            # hatch lets a caller point downloadUrl anywhere, and the secret must not follow.
             #
-            # The host check alone is not enough, because -L would carry the token past it:
-            # curl sends a -H header on every hop of a redirect chain, its own docs for -H
-            # say so, and the credential-scoping that --location-trusted gates covers only
-            # -u, not -H. HF resolve URLs always 302 to a separate CDN host, so -L plus the
-            # token hands it to whatever that redirect names. Resolve the hop with the token
-            # and no -L, then fetch the target without it. The CDN link is presigned and
-            # needs no auth, so nothing is lost.
+            # The host check alone is not enough, because curl sends a -H header on every hop
+            # of a redirect chain, and --location-trusted scopes only -u, not -H. HF resolve
+            # URLs always 302 to a CDN host, so -L plus the token would hand it over. Hence
+            # the two calls below: resolve the hop with the token and no -L, then fetch the
+            # presigned target without it.
             case "$2" in
               https://huggingface.co/*)
                 if [ -n "$HF_TOKEN" ]; then

--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -579,8 +579,14 @@ jobs:
           # = the pinned npm pack — symlinked into ./prebuilds before its run (a fresh `bare`
           # process per source picks up the swap). Run the plain published addon (no swap)
           # first so the original prebuilds is intact for it.
+          # No addon-type token in matrix_sources means the dispatch asked for CLI
+          # sources only, so run no addon leg. Defaulting to the published addon here
+          # forced it into every CLI-only comparison, and for a model the published
+          # prebuild cannot load (new projector type on a fabric branch) that failure
+          # exits this step and the CLI step below never runs.
           if [ "$QVAC_VLM_MODE" = "several-sources" ]; then
-            SRCS=$(node -e "const s=require('./benchmarks/vlm-benchmark/sources.cjs');const a=s.parseSources(process.env.QVAC_VLM_SOURCES||'addon').filter(x=>x.type==='addon').map(x=>x.id);process.stdout.write((a.length?a:['addon']).join(' '))")
+            SRCS=$(node -e "const s=require('./benchmarks/vlm-benchmark/sources.cjs');const a=s.parseSources(process.env.QVAC_VLM_SOURCES||'addon').filter(x=>x.type==='addon').map(x=>x.id);process.stdout.write(a.join(' '))")
+            [ -z "$SRCS" ] && echo "no addon-type source requested, skipping the addon leg (CLI sources only)"
           else
             SRCS=addon
           fi
@@ -652,6 +658,7 @@ jobs:
           SAMPLES: ${{ inputs.matrix_samples }}
           PRESET: ${{ inputs.matrix_preset }}
           MATRIX_SOURCES: ${{ inputs.matrix_sources }}
+          QVAC_VLM_MODELS: ${{ inputs.matrix_models }} # '' → config.sourcesModel (same resolution as harness.cjs)
         run: |
           # Match the addon leg's run size: samples + repeats come from the active
           # preset in config.cjs (matrix_samples still overrides samples). CLI build +
@@ -678,19 +685,60 @@ jobs:
           node build-cli-sources.js --sources="$CLI_SRCS" \
             --fabric-ref=${{ needs.context.outputs.fabric_ref }} --upstream-ref=${{ needs.context.outputs.upstream_ref }} \
             --backend=${{ matrix.backend }}
-          # Model files were downloaded by the addon leg (names from config.cjs).
-          LLM="$MODEL_DIR/reg-qwen-unsloth-Q8_0.gguf"
-          MMPROJ="$MODEL_DIR/reg-qwen-mradermacher-mmproj-Q8_0.gguf"
+          # Blob names, URLs and provenance for the model under comparison, resolved the
+          # same way harness.cjs does (matrix_models first token, else config.sourcesModel).
+          # Hardcoding the qwen registry filenames here made every several-sources run
+          # measure qwen even when matrix_models asked for something else.
+          node resolve-cli-model.cjs > cli-model.env
+          cat cli-model.env
+          . ./cli-model.env
+          LLM="$MODEL_DIR/$LLM_NAME"
+          MMPROJ="$MODEL_DIR/$MMPROJ_NAME"
+          # The addon leg normally downloads these. A CLI-only comparison runs no addon
+          # leg, so fetch what is missing here.
+          mkdir -p "$MODEL_DIR"
+          fetch_blob () {
+            [ -s "$1" ] && return 0
+            if [ -z "$2" ]; then
+              echo "::error::$1 is missing and its source has no download URL (registry sources need an addon leg)"
+              exit 1
+            fi
+            echo ">> fetching $1"
+            # Only attach the HF token to an actual huggingface.co URL. matrix_models'
+            # json: escape hatch lets a caller point downloadUrl anywhere, and this secret
+            # must never ride along to a non-HF host.
+            case "$2" in
+              https://huggingface.co/*)
+                if [ -n "$HF_TOKEN" ]; then
+                  curl -fL --retry 3 -H "Authorization: Bearer $HF_TOKEN" -o "$1" "$2"
+                else
+                  curl -fL --retry 3 -o "$1" "$2"
+                fi
+                ;;
+              *)
+                curl -fL --retry 3 -o "$1" "$2"
+                ;;
+            esac
+          }
+          fetch_blob "$LLM" "$LLM_URL"
+          fetch_blob "$MMPROJ" "$MMPROJ_URL"
           run_src () {
             echo ">> $1 over fixture ($2)"
+            # Model-specific flags (e.g. VisionPsy Flash's --image-no-upscale) are fabric-fork
+            # additions; upstream-cli aborts on an unknown argument, so only fabric gets them.
+            EXTRA=""
+            [ "$2" = "fabric" ] && EXTRA="$CLI_EXTRA_ARGS"
             node cli-fixture-runner.cjs \
               --binary "$3" --source "$1" --llm "$LLM" --mmproj "$MMPROJ" \
+              --extra-args "$EXTRA" \
+              --ctx-size "$CTX_SIZE" \
               --backend "${{ matrix.backend }}" --samples "$SAMPLES" --repeats "$REPEATS" \
               --tasks "${PRESET_TASKS:-textvqa,vizwiz,gqa,docvqa,ai2d,ocr-small,ocr-page}" \
               --ids "$PRESET_IDS" \
               --task-samples "$TASK_SAMPLES" --max-tasks "$MAX_TASKS" \
-              --main-origin "Qwen3.5-0.8B-Q8_0 (Registry)" \
-              --mmproj-origin "Qwen3.5-0.8B mmproj-Q8_0 (Registry)" >> "$LOG" 2>&1 || echo "::warning::$1 run had errors"
+              --main-origin "$MAIN_ORIGIN" --main-source "$MAIN_SOURCE" \
+              --mmproj-origin "$MMPROJ_ORIGIN" --mmproj-source "$MMPROJ_SOURCE" \
+              --model-label "$MODEL_LABEL" >> "$LOG" 2>&1 || echo "::warning::$1 run had errors"
           }
           case ",$CLI_SRCS," in *,fabric,*) run_src fabric-cli fabric "$(node -e "console.log(require('./cli-sources-resolved.json').fabric.binaryPath)")" ;; esac
           case ",$CLI_SRCS," in *,upstream,*) run_src upstream-cli upstream "$(node -e "console.log(require('./cli-sources-resolved.json').upstream.binaryPath)")" ;; esac

--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -710,10 +710,25 @@ jobs:
             # Only attach the HF token to an actual huggingface.co URL. matrix_models'
             # json: escape hatch lets a caller point downloadUrl anywhere, and this secret
             # must never ride along to a non-HF host.
+            #
+            # The host check alone is not enough, because -L would carry the token past it:
+            # curl sends a -H header on every hop of a redirect chain, its own docs for -H
+            # say so, and the credential-scoping that --location-trusted gates covers only
+            # -u, not -H. HF resolve URLs always 302 to a separate CDN host, so -L plus the
+            # token hands it to whatever that redirect names. Resolve the hop with the token
+            # and no -L, then fetch the target without it. The CDN link is presigned and
+            # needs no auth, so nothing is lost.
             case "$2" in
               https://huggingface.co/*)
                 if [ -n "$HF_TOKEN" ]; then
-                  curl -fL --retry 3 -H "Authorization: Bearer $HF_TOKEN" -o "$1" "$2"
+                  hf_redirect=$(curl -fsS -I --retry 3 -H "Authorization: Bearer $HF_TOKEN" \
+                    -o /dev/null -w '%{redirect_url}' "$2")
+                  if [ -n "$hf_redirect" ]; then
+                    curl -fL --retry 3 -o "$1" "$hf_redirect"
+                  else
+                    # Served inline, no redirect to follow, so no hop the token could leak on.
+                    curl -f --retry 3 -H "Authorization: Bearer $HF_TOKEN" -o "$1" "$2"
+                  fi
                 else
                   curl -fL --retry 3 -o "$1" "$2"
                 fi

--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -115,8 +115,16 @@ jobs:
         run: |
           repo="$REPO"
           ref="${INPUT_REF:-$REF_NAME}"
-          echo "repository=$repo" >> "$GITHUB_OUTPUT"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          # Delimited form, because `ref` comes from a workflow input: a newline in a plain
+          # `key=value` line would let the dispatcher append step outputs of its own.
+          {
+            echo "repository<<__EOF_REPO__"
+            echo "$repo"
+            echo "__EOF_REPO__"
+            echo "ref<<__EOF_REF__"
+            echo "$ref"
+            echo "__EOF_REF__"
+          } >> "$GITHUB_OUTPUT"
       # Resolve the mobile timeout (minutes) so matrix-mobile can forward it to the
       # reusable workflow's mocha_timeout_ms / per_test_timeout_minutes inputs.
       # Precedence: workflow input > config.cjs `mobileTimeoutMin` > '' (pipeline default).
@@ -663,20 +671,23 @@ jobs:
           # Match the addon leg's run size: samples + repeats come from the active
           # preset in config.cjs (matrix_samples still overrides samples). CLI build +
           # runner are vendored into this folder (no vlm-performance dependency).
-          PRESET_SAMPLES=$(node -e "console.log((require('./config.cjs').presets['$PRESET']||{}).samplesPerTask||3)")
-          REPEATS=$(node -e "console.log((require('./config.cjs').presets['$PRESET']||{}).repeats||1)")
+          # $PRESET is read through process.env inside each -e script, never spliced into the
+          # source: it comes from a workflow input, and a value carrying a quote would
+          # otherwise close the string literal and run as JavaScript on the runner.
+          PRESET_SAMPLES=$(node -e "console.log((require('./config.cjs').presets[process.env.PRESET]||{}).samplesPerTask||3)")
+          REPEATS=$(node -e "console.log((require('./config.cjs').presets[process.env.PRESET]||{}).repeats||1)")
           SAMPLES="${SAMPLES:-$PRESET_SAMPLES}"
           # Per-task sample caps from the preset (e.g. full caps ocr-page to 1) so the
           # CLI legs run the SAME items as the addon leg.
-          TASK_SAMPLES=$(node -e "console.log(JSON.stringify((require('./config.cjs').presets['$PRESET']||{}).taskSamples||{}))")
+          TASK_SAMPLES=$(node -e "console.log(JSON.stringify((require('./config.cjs').presets[process.env.PRESET]||{}).taskSamples||{}))")
           # Distinct-task cap from the preset (e.g. smoke=1) so the CLI legs cover the
           # SAME tasks as the addon leg — otherwise smoke mismatches (addon 1 task, CLI all).
-          MAX_TASKS=$(node -e "console.log((require('./config.cjs').presets['$PRESET']||{}).maxTasks||0)")
+          MAX_TASKS=$(node -e "console.log((require('./config.cjs').presets[process.env.PRESET]||{}).maxTasks||0)")
           # Task list + id allowlist from the preset so the CLI legs run the SAME items as the
           # addon: preset.tasks (e.g. cognitive's 5 VQA) restricts tasks; preset.ids
           # (ocr1page/ocr5pages) pins exact items and wins over --tasks. Empty → all tasks.
-          PRESET_TASKS=$(node -e "const t=(require('./config.cjs').presets['$PRESET']||{}).tasks; console.log(Array.isArray(t)?t.join(','):'')")
-          PRESET_IDS=$(node -e "const i=(require('./config.cjs').presets['$PRESET']||{}).ids; console.log(Array.isArray(i)?i.join(','):'')")
+          PRESET_TASKS=$(node -e "const t=(require('./config.cjs').presets[process.env.PRESET]||{}).tasks; console.log(Array.isArray(t)?t.join(','):'')")
+          PRESET_IDS=$(node -e "const i=(require('./config.cjs').presets[process.env.PRESET]||{}).ids; console.log(Array.isArray(i)?i.join(','):'')")
           # Build only the CLI engines actually requested in matrix_sources (don't build or
           # report a source the user didn't ask for).
           CLI_SRCS=""
@@ -689,21 +700,39 @@ jobs:
           # same way harness.cjs does (matrix_models first token, else config.sourcesModel).
           # Hardcoding the qwen registry filenames here made every several-sources run
           # measure qwen even when matrix_models asked for something else.
-          node resolve-cli-model.cjs > cli-model.env
+          # Under RUNNER_TEMP, not the workspace: a json: spec's URL can be a presigned link,
+          # which is a bearer credential, and the workspace on a self-hosted runner outlives
+          # this job. Removed as soon as the values are in the environment.
+          ENV_FILE="$RUNNER_TEMP/cli-model.env"
+          node resolve-cli-model.cjs > "$ENV_FILE"
           # Everything except the URLs, which a json: spec can point at a presigned S3 link
           # whose signature is in the query string. Names, origins and sources still print,
           # so the log still says what ran and where it came from.
-          grep -v '_URL=' cli-model.env
-          . ./cli-model.env
+          grep -v '_URL=' "$ENV_FILE"
+          . "$ENV_FILE"
+          rm -f "$ENV_FILE"
           LLM="$MODEL_DIR/$LLM_NAME"
           MMPROJ="$MODEL_DIR/$MMPROJ_NAME"
           # The addon leg normally downloads these. A CLI-only comparison runs no addon
           # leg, so fetch what is missing here.
           mkdir -p "$MODEL_DIR"
+          # A registry source has no URL, and the addon leg puts those blobs in
+          # benchmarks/model/ rather than MODEL_DIR (harness.cjs ensureBlob's custom-fetch
+          # path), so look there before calling a blob missing. Hard-linked so a multi-GB
+          # blob is not copied when both directories sit on the same filesystem.
+          ADDON_MODEL_DIR="$(cd .. && pwd)/model"
+          adopt_addon_blob () {
+            [ -s "$1" ] && return 0
+            [ -s "$ADDON_MODEL_DIR/$2" ] || return 0
+            echo ">> reusing $2 fetched by the addon leg ($ADDON_MODEL_DIR)"
+            ln "$ADDON_MODEL_DIR/$2" "$1" 2>/dev/null || cp "$ADDON_MODEL_DIR/$2" "$1"
+          }
+          adopt_addon_blob "$LLM" "$LLM_NAME"
+          adopt_addon_blob "$MMPROJ" "$MMPROJ_NAME"
           fetch_blob () {
             [ -s "$1" ] && return 0
             if [ -z "$2" ]; then
-              echo "::error::$1 is missing and its source has no download URL (registry sources need an addon leg)"
+              echo "::error::$1 is missing and its source has no download URL. Registry sources are addon-only: they need an addon leg in this same job, which leaves the blob in $ADDON_MODEL_DIR. A CLI-only dispatch cannot fetch one."
               exit 1
             fi
             echo ">> fetching $1"
@@ -738,8 +767,38 @@ jobs:
                 ;;
             esac
           }
-          fetch_blob "$LLM" "$LLM_URL"
-          fetch_blob "$MMPROJ" "$MMPROJ_URL"
+          # Both at once. These are multi-GB and bandwidth-bound, and a stalled download is
+          # the usual way this leg dies, so do not serialise the two exposure windows.
+          fetch_blob "$LLM" "$LLM_URL" &
+          llm_pid=$!
+          fetch_blob "$MMPROJ" "$MMPROJ_URL" &
+          mmproj_pid=$!
+          wait "$llm_pid" || { echo "::error::could not fetch $LLM_NAME"; exit 1; }
+          wait "$mmproj_pid" || { echo "::error::could not fetch $MMPROJ_NAME"; exit 1; }
+          # Check the bytes against the pin. The addon leg gets this from ensureModel(), but a
+          # CLI-only dispatch fetches the URL itself, so without this it benchmarks whatever
+          # the host served, and a GGUF's own chat template goes on to reach --chat-template.
+          sha256_check () {
+            if command -v sha256sum >/dev/null 2>&1; then
+              echo "$2  $1" | sha256sum -c - >/dev/null 2>&1
+            else
+              echo "$2  $1" | shasum -a 256 -c - >/dev/null 2>&1
+            fi
+          }
+          verify_blob () {
+            if [ -z "$3" ]; then
+              echo "::warning::$2 has no sha256 pin, so the fetched bytes cannot be verified"
+              return 0
+            fi
+            if sha256_check "$1" "$3"; then
+              echo ">> verified $2 against its sha256 pin"
+            else
+              echo "::error::$2 does not match its pinned sha256 ($3)"
+              exit 1
+            fi
+          }
+          verify_blob "$LLM" "$LLM_NAME" "$LLM_SHA256"
+          verify_blob "$MMPROJ" "$MMPROJ_NAME" "$MMPROJ_SHA256"
           run_src () {
             echo ">> $1 over fixture ($2)"
             # Model-specific flags (e.g. VisionPsy Flash's --image-no-upscale) are fabric-fork
@@ -925,15 +984,23 @@ jobs:
       # this workflow. See CONTRACT.md for the marker schema it consumes.
       - name: Aggregate matrix logs
         shell: bash
+        # Through env, not textual substitution: a quote in either input would otherwise
+        # close the shell string it lands in and run as a command on the runner.
+        env:
+          MATRIX_MODE: ${{ inputs.matrix_mode }}
+          MATRIX_PRESET: ${{ inputs.matrix_preset }}
+          ENGINE: ${{ needs.context.outputs.engine }}
+          VERSIONS_B64: ${{ needs.context.outputs.versions_b64 }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           node packages/llm-llamacpp/benchmarks/vlm-benchmark/combine.cjs \
             --dir matrix-logs \
             --out consolidated/vlm-matrix-consolidated.md \
-            --title "VLM Matrix — ${{ inputs.matrix_mode }} / ${{ inputs.matrix_preset }} (run #${{ github.run_number }})" \
-            --mode "${{ inputs.matrix_mode }}" --engine "${{ needs.context.outputs.engine }}" \
-            --preset "${{ inputs.matrix_preset }}" \
-            --versions-b64 "${{ needs.context.outputs.versions_b64 }}" \
-            --run-number "${{ github.run_number }}"
+            --title "VLM Matrix — $MATRIX_MODE / $MATRIX_PRESET (run #$RUN_NUMBER)" \
+            --mode "$MATRIX_MODE" --engine "$ENGINE" \
+            --preset "$MATRIX_PRESET" \
+            --versions-b64 "$VERSIONS_B64" \
+            --run-number "$RUN_NUMBER"
 
       - name: Post step summary
         if: always()

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
@@ -28,7 +28,7 @@ validates it (and the config wiring) without running any model.
 | `source_id` | which build produced the row: `addon`, `addon@candidate`, `addon@baseline`, `fabric@<ref>`, `upstream@<ref>` |
 | `source_ref` | resolved version: `npm:<ver>` \| `git:<sha>` \| tag |
 | `block` | measurement round: `0` = warmup (excluded from stats), `1..N` = measured; report takes the **median** across blocks |
-| `rss_mb` | peak process memory so far (MB); populated on desktop and mobile (Android + iOS), `null` only where the platform doesn't expose it |
+| `rss_mb` | peak process memory so far (MB); populated on desktop and mobile (Android + iOS), `null` only where the platform doesn't expose it. CLI legs read it from the `/usr/bin/time -v` wrapper, which is Linux-only, so they report `null` on macOS and Windows |
 
 `[VLMSEG]`/`[VLMMETA]` gain `v`, `scenario`, `source_id`, `source_ref` (SEG also `block`).
 New optional `[VLMBLOCK]{json}` — one per measurement round: `{scenario, source_id,
@@ -60,15 +60,21 @@ which resolves the blob by `modelName` against `models.manifest.json` and verifi
 pinned there, so a URL it has never seen has no integrity pin and is refused. Use the pair form
 for a CLI-only dispatch (`matrix_sources=fabric@<ref>`); anything with an addon leg needs a
 catalog name, or a `json:` spec whose `modelName` matches a manifest key.
-Registry-type sources: `json:` form only, desktop-only (no registry client in the mobile app).
-Presigned S3 URLs work for a one-off dispatch but expire — don't commit them to the catalog.
+Registry-type sources: `json:` form only, desktop-only (no registry client in the mobile app),
+and addon-only. Only the addon leg has a registry client, so a registry blob reaches a CLI leg
+only when an addon leg in the same job already fetched it; a CLI-only dispatch cannot compare
+one. Presigned S3 URLs work for a one-off dispatch but expire, so don't commit them to the
+catalog.
 
 In **several-sources** mode the model axis is fixed, so only the FIRST token is used; empty
 falls back to `config.sourcesModel`. Both legs resolve it identically (`harness.cjs runAll()`
 for the addon, `resolve-cli-model.cjs` for the native CLIs), so a model with no catalog entry
 can be compared across engines with no config commit. A dispatch with CLI sources only
 (`matrix_sources=fabric@<ref>`) runs no addon leg at all, and the CLI step downloads the two
-blobs itself, which is what a model the published addon cannot load yet needs.
+blobs itself, which is what a model the published addon cannot load yet needs. Those downloads
+are checked against a sha256 pin, taken from `models.manifest.json` when the `modelName` is a
+manifest key and otherwise from a `sha256` field on the blob; a blob with neither is fetched
+with a warning and no integrity check.
 
 A model needing a per-model flag (VisionPsy Flash needs `--image-no-upscale on`, else it runs
 base preprocessing and the run measures the wrong thing) carries it as `cliArgs` for the native
@@ -78,10 +84,25 @@ such a model, not the pair form.
 
 Both are restricted to per-model **multimodal** settings and nothing else, checked at parse
 time on both sides. `cliArgs` accepts only `--image-no-upscale`, `--image-tile-mode`,
-`--image-max-tiles`, `--image-max-tokens`, `--image-min-tokens`; `addonConfig` the `image-*`
-keys plus `mmproj-use-gpu`, in either spelling. Everything else is rejected, including the
-model files, device, sampling params, context size and `reasoning-budget`, all of which the
-harness fixes so that the legs stay comparable.
+`--image-max-tokens`, `--image-min-tokens`; `addonConfig` the same `image-*` keys plus
+`mmproj-use-gpu`, in either spelling. Everything else is rejected, including the model files,
+device, sampling params, context size and `reasoning-budget`, all of which the harness fixes
+so that the legs stay comparable.
+
+This is an allowlist on purpose: llama.cpp gives most options several spellings (`-n` /
+`--predict` / `--n-predict`, `-ngl` / `--gpu-layers` / `--n-gpu-layers`, `--temp` /
+`--temperature`), extra args are appended after the harness's own, so a late alias would win,
+and a fabric bump can add a spelling at any time. Widening the list is a deliberate code
+change, and the two lists move together: a flag with no `addonConfig` twin cannot be set on
+both legs, so a spec using it would compare different preprocessing under one model label.
+`--image-max-tiles` is on neither list for that reason, since arg.cpp takes it but the addon
+has no handler.
+
+Write `cliArgs` in the split form, `['--image-no-upscale', 'on']`. arg.cpp looks the whole
+argv token up and never splits on `=`, so `--image-no-upscale=on` is an unknown argument to
+it; models.cjs rejects that form rather than letting the CLI abort mid-run. Values must also
+match on both sides: `--image-tile-mode` takes only `batched` / `sequential` / `disabled` on
+the CLI, while the addon additionally accepts `0` / `1` / `2`, so use the words.
 
 `mmproj-use-gpu` is allowed because it selects the backend for the **projector only**, which
 `device` does not control. On Android the addon auto-defaults it by GPU class: GPU on Adreno
@@ -89,11 +110,7 @@ harness fixes so that the legs stay comparable.
 phone therefore runs the language model on Vulkan and the vision encoder on CPU, so exercising
 the Mali Vulkan encoder requires setting this explicitly. The addon logs which it picked,
 `[LlamaModel] multimodal projector backend: GPU|CPU (<reason>)`, and that line is the only
-reliable way to tell from a run which path was measured. This is an allowlist on purpose: llama.cpp gives most options
-several spellings (`-n` / `--predict` / `--n-predict`, `-ngl` / `--gpu-layers` /
-`--n-gpu-layers`, `--temp` / `--temperature`), extra args are appended after the harness's own,
-so a late alias would win, and a fabric bump can add a spelling at any time. Widening the list
-is a deliberate code change.
+reliable way to tell from a run which path was measured.
 
 **`matrix_sources`** — comma-separated builds-under-comparison: `addon` (published, default) ·
 `addon@candidate` / `addon@baseline` *(build comparison)* · `fabric@<ref>` ·

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
@@ -31,6 +31,12 @@ validates it (and the config wiring) without running any model.
 | `rss_mb` | peak process memory so far (MB); populated on desktop and mobile (Android + iOS), `null` only where the platform doesn't expose it. CLI legs read it from the `/usr/bin/time -v` wrapper, which is Linux-only, so they report `null` on macOS and Windows |
 
 `[VLMSEG]`/`[VLMMETA]` gain `v`, `scenario`, `source_id`, `source_ref` (SEG also `block`).
+`[VLMMETA]` also carries `preproc`: the per-model preprocessing that leg actually applied, as
+a sorted `key=value` string on the addon spelling, so an addon leg configured through
+`addonConfig` and a CLI leg configured through `cliArgs` are directly comparable. An empty
+string means base preprocessing; absent means the log predates the field. Where the legs of one
+model disagree, the report says so under the origins table rather than letting the rows read as
+like for like.
 New optional `[VLMBLOCK]{json}` — one per measurement round: `{scenario, source_id,
 source_ref, model, device, block, stability:{kind:'temp'|'probe', value_ms?, waited_ms}}`.
 

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
@@ -73,8 +73,11 @@ can be compared across engines with no config commit. A dispatch with CLI source
 (`matrix_sources=fabric@<ref>`) runs no addon leg at all, and the CLI step downloads the two
 blobs itself, which is what a model the published addon cannot load yet needs. Those downloads
 are checked against a sha256 pin, taken from `models.manifest.json` when the `modelName` is a
-manifest key and otherwise from a `sha256` field on the blob; a blob with neither is fetched
-with a warning and no integrity check.
+manifest key and otherwise from a `sha256` field on the blob. A blob with neither fails the
+leg, because an unverified GGUF's own chat template goes on to reach `--chat-template`; set the
+`allow_unverified_models` dispatch input to run one anyway. A blob that fails the check is
+deleted and fetched once more before the leg gives up, so a truncated file left behind by a
+cancelled run recovers by itself instead of failing every rerun.
 
 A model needing a per-model flag (VisionPsy Flash needs `--image-no-upscale on`, else it runs
 base preprocessing and the run measures the wrong thing) carries it as `cliArgs` for the native
@@ -92,11 +95,22 @@ so that the legs stay comparable.
 This is an allowlist on purpose: llama.cpp gives most options several spellings (`-n` /
 `--predict` / `--n-predict`, `-ngl` / `--gpu-layers` / `--n-gpu-layers`, `--temp` /
 `--temperature`), extra args are appended after the harness's own, so a late alias would win,
-and a fabric bump can add a spelling at any time. Widening the list is a deliberate code
-change, and the two lists move together: a flag with no `addonConfig` twin cannot be set on
-both legs, so a spec using it would compare different preprocessing under one model label.
-`--image-max-tiles` is on neither list for that reason, since arg.cpp takes it but the addon
-has no handler.
+and a fabric bump can add a spelling at any time. Widening it is a deliberate code change to
+the single `MODEL_OPTIONS` descriptor in `models.cjs`, which both allowlists are derived from,
+so the CLI and addon sides cannot drift apart. `--image-max-tiles` is absent from it because
+arg.cpp takes it and the addon has no handler, so it could only ever be set on one leg.
+
+**An option with a twin must be set on both legs, with the same value.** This is enforced per
+spec, not merely documented: a `json:` spec with `cliArgs: ['--image-no-upscale', 'on']` and no
+matching `addonConfig` is rejected at parse time, as is one where the two values disagree. A
+one-sided flag would otherwise have the CLI leg and the addon leg run different preprocessing
+under a single model label, which is the exact failure the pairing exists to prevent.
+`mmproj-use-gpu` is exempt because it has no CLI equivalent to match.
+
+Note that `fabric` and `upstream` remain deliberately asymmetric: `cliArgs` reach the fabric
+CLI only, since these flags are fork additions and `upstream-cli` aborts on an unknown
+argument. So an `upstream-cli` leg of a model needing a flag runs base preprocessing by
+design. Read that leg as a baseline, not as the same configuration.
 
 Write `cliArgs` in the split form, `['--image-no-upscale', 'on']`. arg.cpp looks the whole
 argv token up and never splits on `=`, so `--image-no-upscale=on` is an unknown argument to

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/CONTRACT.md
@@ -49,14 +49,51 @@ source_ref, model, device, block, stability:{kind:'temp'|'probe', value_ms?, wai
 
 ```
 qwen3.5-q8                                        # catalog name (config.cjs catalog)
-[label=]<llm-url>|<mmproj-url>[@ctx=N]            # ANY new model: two https URLs, zero code changes
+[label=]<llm-url>|<mmproj-url>[@ctx=N]            # CLI legs only: two https URLs, zero code changes
 json:[{label, ctx_size, llm:{source}, mmproj:{source}}, …]   # escape hatch (registry sources etc.)
 ```
 
 `|` separates the blobs (never appears unencoded in URLs). `huggingface.co/...resolve/<ref>/...`
 URLs are reported as Source=HF with repo+ref (unpinned refs flagged); other URLs as URL/S3.
+The pair form reaches the **CLI legs only**. The addon leg downloads through `ensureModel()`,
+which resolves the blob by `modelName` against `models.manifest.json` and verifies the sha256
+pinned there, so a URL it has never seen has no integrity pin and is refused. Use the pair form
+for a CLI-only dispatch (`matrix_sources=fabric@<ref>`); anything with an addon leg needs a
+catalog name, or a `json:` spec whose `modelName` matches a manifest key.
 Registry-type sources: `json:` form only, desktop-only (no registry client in the mobile app).
 Presigned S3 URLs work for a one-off dispatch but expire — don't commit them to the catalog.
+
+In **several-sources** mode the model axis is fixed, so only the FIRST token is used; empty
+falls back to `config.sourcesModel`. Both legs resolve it identically (`harness.cjs runAll()`
+for the addon, `resolve-cli-model.cjs` for the native CLIs), so a model with no catalog entry
+can be compared across engines with no config commit. A dispatch with CLI sources only
+(`matrix_sources=fabric@<ref>`) runs no addon leg at all, and the CLI step downloads the two
+blobs itself, which is what a model the published addon cannot load yet needs.
+
+A model needing a per-model flag (VisionPsy Flash needs `--image-no-upscale on`, else it runs
+base preprocessing and the run measures the wrong thing) carries it as `cliArgs` for the native
+CLIs and `addonConfig` for the addon. Both live on the spec, so a catalog entry or a `json:`
+spec can set them; a bare `<llm-url>|<mmproj-url>` pair cannot. Use `json:` for a one-off run of
+such a model, not the pair form.
+
+Both are restricted to per-model **multimodal** settings and nothing else, checked at parse
+time on both sides. `cliArgs` accepts only `--image-no-upscale`, `--image-tile-mode`,
+`--image-max-tiles`, `--image-max-tokens`, `--image-min-tokens`; `addonConfig` the `image-*`
+keys plus `mmproj-use-gpu`, in either spelling. Everything else is rejected, including the
+model files, device, sampling params, context size and `reasoning-budget`, all of which the
+harness fixes so that the legs stay comparable.
+
+`mmproj-use-gpu` is allowed because it selects the backend for the **projector only**, which
+`device` does not control. On Android the addon auto-defaults it by GPU class: GPU on Adreno
+800+, CPU on Mali and on any tier it cannot identify. A plain `device: gpu` leg on a Mali
+phone therefore runs the language model on Vulkan and the vision encoder on CPU, so exercising
+the Mali Vulkan encoder requires setting this explicitly. The addon logs which it picked,
+`[LlamaModel] multimodal projector backend: GPU|CPU (<reason>)`, and that line is the only
+reliable way to tell from a run which path was measured. This is an allowlist on purpose: llama.cpp gives most options
+several spellings (`-n` / `--predict` / `--n-predict`, `-ngl` / `--gpu-layers` /
+`--n-gpu-layers`, `--temp` / `--temperature`), extra args are appended after the harness's own,
+so a late alias would win, and a fabric bump can add a spelling at any time. Widening the list
+is a deliberate code change.
 
 **`matrix_sources`** — comma-separated builds-under-comparison: `addon` (published, default) ·
 `addon@candidate` / `addon@baseline` *(build comparison)* · `fabric@<ref>` ·

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/README.md
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/README.md
@@ -113,7 +113,7 @@ shows the dispatch flag; most also have a `config.cjs` field and/or a `QVAC_VLM_
 | OCR CER/WER/BLEU | ✅ | ✅ | OCR presets | Separate table (↓CER/WER, ↑BLEU), never folded into Overall %. |
 | Speed: mmproj vision-encode | ✅ | ❌ | always | From llama.cpp stderr — **not captured on mobile**; the report shows `—` and uses **TTFT** as the mobile proxy. |
 | Speed: TTFT / decode TPS / wall | ✅ | ✅ | always | |
-| **Peak RSS** | ✅ | ✅ | Details table | Process high-water (`getrusage`). Populated on Linux/macOS/Windows **and Android + iOS**. ⚠️ CLI engine sources show `—` (separate subprocess). |
+| **Peak RSS** | ✅ | ✅ | Details table | Process high-water (`getrusage`). Populated on Linux/macOS/Windows **and Android + iOS**. ⚠️ CLI engine sources are separate subprocesses, measured by the `/usr/bin/time -v` wrapper, so they report on Linux only and show `—` on macOS/Windows. |
 | **Δ % column** | ✅ | ✅ | **two-models** Highlights | Relative %, next to the absolute Δ, in all 3 comparison tables. `—` when baseline = 0. |
 | Summary one-liner | ✅ | ✅ | **two-models** Highlights | 🚀/⚖️/🐢 + avg speed & quality across legs. Quality **blends VQA + OCR**. |
 | **Engine versions table** | ✅ | — | **several-sources** Details | Build used + most-recent per source; *chosen automatically* / *set manually*. |
@@ -213,8 +213,10 @@ Tuning lives in `config.cjs` `methodology`.
   mobile only works with **direct download links** (hf/url/s3).
 - **mmproj vision-encode time is unavailable on mobile** — neither Android logcat nor the
   iOS console carry llama.cpp's native stderr; the report shows `—` and uses **TTFT**.
-- **CLI-source Peak RSS shows `—`** — the CLIs are separate subprocesses; the in-process
-  `getrusage` sampler measures the addon (and mobile addon), not a spawned CLI.
+- **CLI-source Peak RSS is Linux-only.** The CLIs are separate subprocesses, so the
+  in-process `getrusage` sampler cannot see them; `cli-case-runner.js` wraps them in
+  `/usr/bin/time -v` instead, which exists on the Linux runners only. macOS and Windows
+  CLI legs report nothing.
 - **Candidate-vs-baseline on mobile can be flaky.** The desktop comparison and the mobile
   `addon@baseline` leg are solid; the mobile `addon@candidate` leg has timed out at the
   Device-Farm monitor under the candidate's longer pipeline (a fresh prebuild build) plus

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/aggregate.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/aggregate.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// aggregate.js turns [VLMROW] markers into the report tables. markers-v2.sample.txt is the
+// committed contract fixture, covering two sources, two backends, VQA and OCR tasks, a warmup
+// block, an error row, a phone-shaped row and one legacy v1 row. Locking its numbers here
+// catches an aggregation regression, e.g. warmup rows leaking into the average or a rep being
+// counted twice, which the marker-level selfcheck in run-desktop.cjs cannot see.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const DIR = path.resolve(__dirname, '..')
+const SAMPLE = path.join(DIR, 'markers-v2.sample.txt')
+
+function runAggregate (args) {
+  return execFileSync(process.execPath, [path.join(DIR, 'aggregate.js'), ...args], {
+    cwd: DIR,
+    encoding: 'utf8'
+  })
+}
+
+const OUT = runAggregate(['--title', 'probe', SAMPLE])
+
+test('the sample resolves to two-models mode with the expected base and candidate', () => {
+  assert.match(OUT, /two models \(qwen3\.5-f16 vs qwen3\.5-q8; engine fixed\)/)
+})
+
+test('quality per leg is stable', () => {
+  const gpu = OUT.split('\n').find(l => l.startsWith('| — · GPU | 100.0 |'))
+  assert.ok(gpu, 'expected a GPU quality row')
+  assert.match(gpu, /\| 91\.7 \| -8\.3 \|/)
+})
+
+test('speed per leg is stable and the delta keeps its sign convention', () => {
+  const gpu = OUT.split('\n').find(l => l.includes('TTFT ms (incl. enc) | 834 |'))
+  assert.ok(gpu, 'expected a GPU speed row')
+  assert.match(gpu, /\| 658 \| -175 \| -21\.0% \|/)
+})
+
+test('the warmup block does not reach the averages', () => {
+  // The sample's block 0 row carries pred "warmup" against gold "philippe molitor". Counting
+  // it would drag candidate quality below the locked 91.7 above, so that assertion plus this
+  // one pin the warmup handling from both sides.
+  assert.doesNotMatch(OUT, /warmup/i)
+})
+
+test('passing the same log twice does not change the aggregate', () => {
+  // Reps are averaged per item, so a duplicated input must not shift the numbers. If it does,
+  // rows are being summed somewhere they should be pooled.
+  const twice = runAggregate(['--title', 'probe', SAMPLE, SAMPLE])
+  const numbers = (s) => s.split('\n').filter(l => l.startsWith('| — · '))
+  assert.deepEqual(numbers(twice), numbers(OUT))
+})

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/aggregate.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/aggregate.test.js
@@ -39,11 +39,15 @@ test('speed per leg is stable and the delta keeps its sign convention', () => {
   assert.match(gpu, /\| 658 \| -175 \| -21\.0% \|/)
 })
 
-test('the warmup block does not reach the averages', () => {
-  // The sample's block 0 row carries pred "warmup" against gold "philippe molitor". Counting
-  // it would drag candidate quality below the locked 91.7 above, so that assertion plus this
-  // one pin the warmup handling from both sides.
-  assert.doesNotMatch(OUT, /warmup/i)
+test('the warmup block is excluded from the measured row count', () => {
+  // The sample's one block 0 row belongs to qwen3.5-q8 on GPU, so the Details table's n for
+  // that leg is 5 with the warmup dropped and 6 without. Asserting on n rather than on the
+  // absence of the word "warmup": aggregate.js scores `pred` but never prints it, so a text
+  // match cannot tell a dropped warmup row from a counted one.
+  const details = OUT.split('\n').filter(l => l.startsWith('| `qwen3.5-q8` · GPU |'))
+  const row = details[details.length - 1]
+  assert.ok(row, 'expected a q8 GPU details row')
+  assert.equal(row.split('|')[3].trim(), '5')
 })
 
 test('passing the same log twice does not change the aggregate', () => {

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/aggregate.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/aggregate.test.js
@@ -9,6 +9,8 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 const path = require('path')
+const fs = require('fs')
+const os = require('os')
 const { execFileSync } = require('child_process')
 
 const DIR = path.resolve(__dirname, '..')
@@ -48,6 +50,41 @@ test('the warmup block is excluded from the measured row count', () => {
   const row = details[details.length - 1]
   assert.ok(row, 'expected a q8 GPU details row')
   assert.equal(row.split('|')[3].trim(), '5')
+})
+
+// An upstream-cli leg never receives cliArgs, because they are fabric-fork flags, so it can
+// run base preprocessing under the same model label as an addon leg that applied them. The
+// numbers alone give no hint of that, which is what these two assertions guard.
+const ASYM = (() => {
+  const meta = (cell, preproc) => '[VLMMETA]' + JSON.stringify({
+    v: 2, scenario: 'default', cell, source: cell, model: 'flash-q4',
+    main_origin: 'repo@sha', main_source: 'HF', mmproj_origin: 'repo@sha · mmproj', mmproj_source: 'HF', preproc
+  }) + '[/VLMMETA]'
+  const row = (cell, ms) => '[VLMROW]' + JSON.stringify({
+    v: 2, scenario: 'default', block: 1, cell, source: cell, model: 'flash-q4', device: 'gpu', rep: 0,
+    task: 'textvqa', id: 'textvqa_0', metric: 'vqa', gold: ['paris'], pred: 'paris', ms, ttft_ms: 100,
+    decode_tps: 10, gen_tokens: 5, prompt_tokens: 30
+  }) + '[/VLMROW]'
+  const file = path.join(os.tmpdir(), 'vlm-aggregate-asym.log')
+  fs.writeFileSync(file, [meta('addon', 'image-no-upscale=on'), row('addon', 500), meta('upstream-cli', ''), row('upstream-cli', 600)].join('\n') + '\n')
+  const out = runAggregate(['--title', 'probe', file])
+  fs.unlinkSync(file)
+  return out
+})()
+
+test('the origins table reports what preprocessing each leg applied', () => {
+  assert.match(ASYM, /\| `addon` \|.*\| `image-no-upscale=on` \|/)
+  assert.match(ASYM, /\| `upstream-cli` \|.*\| base \|/)
+})
+
+test('legs of one model that preprocessed differently are called out', () => {
+  assert.match(ASYM, /Preprocessing differs across the legs of `flash-q4`/)
+  assert.match(ASYM, /`upstream-cli` ran base preprocessing/)
+})
+
+test('a log with no preproc field gets no mismatch warning', () => {
+  // Older logs predate the field, and absent must not read as "ran base preprocessing".
+  assert.doesNotMatch(OUT, /Preprocessing differs/)
 })
 
 test('passing the same log twice does not change the aggregate', () => {

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/cli-args.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/cli-args.test.js
@@ -24,11 +24,10 @@ function parseSpec (cliArgs) {
 
 const ACCEPTED = [
   ['split form', ['--image-no-upscale', 'on']],
-  ['equals form', ['--image-no-upscale=on']],
   // llama.cpp rewrites `_` to `-` before looking an option up, so the allowlist canonicalises
   // it the same way instead of comparing the literal spelling.
-  ['underscore form', ['--image_no_upscale=on']],
-  ['negative number value', ['--image-max-tiles', '-1']],
+  ['underscore form', ['--image_no_upscale', 'on']],
+  ['negative number value', ['--image-max-tokens', '-1']],
   ['no args at all', []]
 ]
 
@@ -41,10 +40,10 @@ for (const [name, args] of ACCEPTED) {
 }
 
 const REJECTED = [
-  ['a space', ['--image-no-upscale=on --ctx-size=1']],
-  ['a tab', ['--image-no-upscale=on\t--ctx-size=1']],
+  ['a space', ['--image-no-upscale on --ctx-size 1']],
+  ['a tab', ['--image-no-upscale\t--ctx-size']],
   ['a trailing space', ['--image-no-upscale ']],
-  ['a newline', ['--image-no-upscale=on\n--ctx-size=1']]
+  ['a newline', ['--image-no-upscale\n--ctx-size']]
 ]
 
 for (const [name, args] of REJECTED) {
@@ -53,12 +52,40 @@ for (const [name, args] of REJECTED) {
   })
 }
 
+// arg.cpp looks the whole argv token up in arg_to_options and never splits on `=`, so the
+// equals form reaches llama.cpp as an unknown argument and aborts the run. The workflow logs
+// that as a warning, so the only visible symptom is an engine leg with no rows.
+const EQUALS_FORM = [
+  ['a flag on the allowlist', ['--image-no-upscale=on']],
+  ['the underscore spelling', ['--image_no_upscale=on']],
+  ['a value element', ['--image-no-upscale', 'on=off']]
+]
+
+for (const [name, args] of EQUALS_FORM) {
+  test(`cliArgs rejects the equals form on ${name}`, () => {
+    assert.throws(() => parseSpec(args), /must use the split form/)
+  })
+}
+
 test('cliArgs rejects a flag that is not on the allowlist', () => {
   assert.throws(() => parseSpec(['--ctx-size', '1']), /may only carry per-model image preprocessing flags/)
 })
 
 test('cliArgs rejects a forbidden flag hidden behind an accepted one', () => {
-  assert.throws(() => parseSpec(['--image-no-upscale=on', '--ctx-size=1']),
+  assert.throws(() => parseSpec(['--image-no-upscale', 'on', '--ctx-size', '1']),
+    /may only carry per-model image preprocessing flags/)
+})
+
+test('cliArgs checks a token that only looks like a negative number', () => {
+  // isFlagToken exempts negative numbers because `-1` is a legitimate value. The exemption is
+  // anchored to a complete number so a token like this is still checked, not waved through.
+  assert.throws(() => parseSpec(['-1--ctx-size']), /may only carry per-model image preprocessing flags/)
+})
+
+test('cliArgs rejects a flag with no addonConfig twin', () => {
+  // The two allowlists move together: a flag the addon cannot be told to match would put the
+  // CLI leg on different preprocessing from the addon leg under one model label.
+  assert.throws(() => parseSpec(['--image-max-tiles', '8']),
     /may only carry per-model image preprocessing flags/)
 })
 

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/cli-args.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/cli-args.test.js
@@ -9,7 +9,7 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 
-const { parseModels } = require('../models.cjs')
+const { parseModels, assertTwinsMatch } = require('../models.cjs')
 const { serializeCliArgs, parseCliArgs } = require('../cli-args.cjs')
 
 const BLOBS = {
@@ -17,23 +17,26 @@ const BLOBS = {
   mmproj: { source: { type: 'url', url: 'https://example.com/mmproj.gguf' }, modelName: 'mmproj.gguf' }
 }
 
-function parseSpec (cliArgs) {
+function parseSpec (cliArgs, addonConfig) {
   const spec = Object.assign({ label: 'probe', cliArgs }, BLOBS)
+  if (addonConfig !== undefined) spec.addonConfig = addonConfig
   return parseModels('json:' + JSON.stringify([spec]), null, null)[0]
 }
 
+// Every accepted case carries the addonConfig twin, because a flag set on one leg only is
+// rejected now. The twin rule has its own cases further down.
 const ACCEPTED = [
-  ['split form', ['--image-no-upscale', 'on']],
+  ['split form', ['--image-no-upscale', 'on'], { 'image-no-upscale': 'on' }],
   // llama.cpp rewrites `_` to `-` before looking an option up, so the allowlist canonicalises
-  // it the same way instead of comparing the literal spelling.
-  ['underscore form', ['--image_no_upscale', 'on']],
-  ['negative number value', ['--image-max-tokens', '-1']],
-  ['no args at all', []]
+  // it the same way instead of comparing the literal spelling. Same for the addon key.
+  ['underscore form', ['--image_no_upscale', 'on'], { image_no_upscale: 'on' }],
+  ['negative number value', ['--image-max-tokens', '-1'], { 'image-max-tokens': '-1' }],
+  ['no args at all', [], undefined]
 ]
 
-for (const [name, args] of ACCEPTED) {
+for (const [name, args, addonConfig] of ACCEPTED) {
   test(`cliArgs accepts the ${name} and survives the env round trip`, () => {
-    const spec = parseSpec(args)
+    const spec = parseSpec(args, addonConfig)
     assert.deepEqual(spec.cliArgs, args)
     assert.deepEqual(parseCliArgs(serializeCliArgs(spec.cliArgs)), args)
   })
@@ -83,10 +86,48 @@ test('cliArgs checks a token that only looks like a negative number', () => {
 })
 
 test('cliArgs rejects a flag with no addonConfig twin', () => {
-  // The two allowlists move together: a flag the addon cannot be told to match would put the
-  // CLI leg on different preprocessing from the addon leg under one model label.
-  assert.throws(() => parseSpec(['--image-max-tiles', '8']),
+  // Both allowlists come off one descriptor: a flag the addon cannot be told to match is on
+  // neither, so it cannot put the two legs on different preprocessing under one label.
+  assert.throws(() => parseSpec(['--image-max-tiles', '8'], { 'image-max-tiles': '8' }),
     /may only carry per-model image preprocessing flags/)
+})
+
+// The pairing is what keeps a several-sources comparison honest, so it is enforced per spec
+// and not just documented. Without it a Flash leg on upstream-cli silently runs base
+// preprocessing under the same model label as the addon leg.
+test('a cliArgs flag with no addonConfig entry is rejected', () => {
+  assert.throws(() => parseSpec(['--image-no-upscale', 'on'], {}),
+    /must set the same preprocessing on both legs/)
+})
+
+test('a cliArgs flag with no addonConfig at all is rejected', () => {
+  assert.throws(() => parseSpec(['--image-no-upscale', 'on']),
+    /addonConfig has no 'image-no-upscale'/)
+})
+
+test('an addonConfig key with no cliArgs flag is rejected', () => {
+  assert.throws(() => parseSpec([], { 'image-no-upscale': 'on' }),
+    /cliArgs has no --image-no-upscale/)
+})
+
+test('the two legs disagreeing on a value is rejected', () => {
+  assert.throws(() => parseSpec(['--image-tile-mode', 'batched'], { 'image-tile-mode': 'sequential' }),
+    /is 'batched' but addonConfig 'image-tile-mode' is 'sequential'/)
+})
+
+test('mmproj-use-gpu needs no cliArgs twin', () => {
+  // Addon-only by design: it picks the projector backend, which the CLI legs have no flag for.
+  const spec = parseSpec([], { 'mmproj-use-gpu': 'on' })
+  assert.deepEqual(spec.addonConfig, { 'mmproj-use-gpu': 'on' })
+})
+
+test('every committed catalog entry satisfies the twin rule', () => {
+  // normalizeSpec only runs on json: specs, so the catalog would otherwise never be checked,
+  // and it is exactly where a silent one-leg flag would ship.
+  const { catalog } = require('../config.cjs')
+  for (const [name, spec] of Object.entries(catalog)) {
+    assert.doesNotThrow(() => assertTwinsMatch(spec, name), `catalog entry ${name}`)
+  }
 })
 
 test('the env round trip preserves token count for every accepted spelling', () => {

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/cli-args.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/cli-args.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+// cliArgs travels from a json: spec through models.cjs validation, into cli-model.env as one
+// joined string, and back out as an argv array in cli-fixture-runner.cjs. The flag allowlist
+// is checked on the array, so anything that changes the token count between those two points
+// escapes it: extra args are appended after the fixed ones in cli-case-runner.js, which is
+// enough to override a benchmark-controlled flag such as --ctx-size.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { parseModels } = require('../models.cjs')
+const { serializeCliArgs, parseCliArgs } = require('../cli-args.cjs')
+
+const BLOBS = {
+  llm: { source: { type: 'url', url: 'https://example.com/llm.gguf' }, modelName: 'llm.gguf' },
+  mmproj: { source: { type: 'url', url: 'https://example.com/mmproj.gguf' }, modelName: 'mmproj.gguf' }
+}
+
+function parseSpec (cliArgs) {
+  const spec = Object.assign({ label: 'probe', cliArgs }, BLOBS)
+  return parseModels('json:' + JSON.stringify([spec]), null, null)[0]
+}
+
+const ACCEPTED = [
+  ['split form', ['--image-no-upscale', 'on']],
+  ['equals form', ['--image-no-upscale=on']],
+  // llama.cpp rewrites `_` to `-` before looking an option up, so the allowlist canonicalises
+  // it the same way instead of comparing the literal spelling.
+  ['underscore form', ['--image_no_upscale=on']],
+  ['negative number value', ['--image-max-tiles', '-1']],
+  ['no args at all', []]
+]
+
+for (const [name, args] of ACCEPTED) {
+  test(`cliArgs accepts the ${name} and survives the env round trip`, () => {
+    const spec = parseSpec(args)
+    assert.deepEqual(spec.cliArgs, args)
+    assert.deepEqual(parseCliArgs(serializeCliArgs(spec.cliArgs)), args)
+  })
+}
+
+const REJECTED = [
+  ['a space', ['--image-no-upscale=on --ctx-size=1']],
+  ['a tab', ['--image-no-upscale=on\t--ctx-size=1']],
+  ['a trailing space', ['--image-no-upscale ']],
+  ['a newline', ['--image-no-upscale=on\n--ctx-size=1']]
+]
+
+for (const [name, args] of REJECTED) {
+  test(`cliArgs rejects an element carrying ${name}`, () => {
+    assert.throws(() => parseSpec(args), /must not contain whitespace/)
+  })
+}
+
+test('cliArgs rejects a flag that is not on the allowlist', () => {
+  assert.throws(() => parseSpec(['--ctx-size', '1']), /may only carry per-model image preprocessing flags/)
+})
+
+test('cliArgs rejects a forbidden flag hidden behind an accepted one', () => {
+  assert.throws(() => parseSpec(['--image-no-upscale=on', '--ctx-size=1']),
+    /may only carry per-model image preprocessing flags/)
+})
+
+test('the env round trip preserves token count for every accepted spelling', () => {
+  // The property the allowlist depends on: one element in, one argument out. Whitespace is
+  // the only way to break it, which is why validation rejects it rather than escaping it.
+  for (const [, args] of ACCEPTED) {
+    assert.equal(parseCliArgs(serializeCliArgs(args)).length, args.length)
+  }
+})
+
+test('parseCliArgs drops empty input rather than emitting a blank argument', () => {
+  // An empty CLI_EXTRA_ARGS is the normal case for every model that needs no flag, and a
+  // stray '' in argv would reach llama.cpp as an unknown empty option.
+  assert.deepEqual(parseCliArgs(''), [])
+  assert.deepEqual(parseCliArgs(undefined), [])
+  assert.deepEqual(parseCliArgs('   '), [])
+})

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/model-name.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/model-name.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+// modelName from a json: spec is concatenated into a path, "$MODEL_DIR/$LLM_NAME" in
+// benchmark-vlm-model-comparison.yml, and handed to curl -o. The validation in models.cjs is
+// the only thing standing between a caller-supplied string and that path, so the cases that
+// matter are the ones that are a path segment without containing a slash.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { parseModels } = require('../models.cjs')
+
+function parseWithName (modelName) {
+  const spec = {
+    label: 'probe',
+    llm: { source: { type: 'url', url: 'https://example.com/llm.gguf' }, modelName },
+    mmproj: { source: { type: 'url', url: 'https://example.com/mmproj.gguf' }, modelName: 'mmproj.gguf' }
+  }
+  return parseModels('json:' + JSON.stringify([spec]), null, null)[0]
+}
+
+const REJECTED = [
+  ['parent directory', '..'],
+  ['current directory', '.'],
+  ['three dots is still all dots', '...'],
+  ['explicit traversal', '../escape.gguf'],
+  ['absolute path', '/etc/passwd'],
+  ['nested path', 'sub/dir.gguf']
+]
+
+for (const [why, modelName] of REJECTED) {
+  test(`modelName rejected: ${why}`, () => {
+    assert.throws(() => parseWithName(modelName), /must be a bare filename/)
+  })
+}
+
+const ACCEPTED = [
+  ['plain gguf', 'visionpsy-nano-460m-q8_0.gguf'],
+  ['leading dot is a hidden file, not a traversal', '.hidden.gguf'],
+  ['dots inside a name', 'a..b.gguf'],
+  ['dashes and underscores', 'mmproj-Qwen3.5-0.8B-F16.gguf']
+]
+
+for (const [why, modelName] of ACCEPTED) {
+  test(`modelName accepted: ${why}`, () => {
+    assert.equal(parseWithName(modelName).llm.modelName, modelName)
+  })
+}

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/resolve-cli-model.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/resolve-cli-model.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+// resolve-cli-model.cjs is the only thing standing between a json: spec and the URL the
+// workflow hands to curl with the HF token attached, so its URL construction is worth
+// pinning: a nested HF path must survive, a traversal must not, and a registry source must
+// come out with no URL at all so the workflow knows to look for an addon leg instead.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const DIR = path.resolve(__dirname, '..')
+const SCRIPT = path.join(DIR, 'resolve-cli-model.cjs')
+
+function resolve (spec) {
+  const out = execFileSync(process.execPath, [SCRIPT], {
+    cwd: DIR,
+    encoding: 'utf8',
+    env: { ...process.env, QVAC_VLM_MODELS: 'json:' + JSON.stringify([spec]) }
+  })
+  const env = {}
+  for (const line of out.split('\n')) {
+    const m = line.match(/^(\w+)='(.*)'$/)
+    if (m) env[m[1]] = m[2].replace(/'\\''/g, "'")
+  }
+  return env
+}
+
+const hf = (file) => ({ type: 'hf', repo: 'owner/repo', sha: 'a'.repeat(40), file })
+
+function specWith (llmSource, mmprojSource) {
+  return {
+    label: 'probe',
+    llm: { source: llmSource, modelName: 'llm.gguf' },
+    mmproj: { source: mmprojSource || hf('mmproj.gguf'), modelName: 'mmproj.gguf' }
+  }
+}
+
+test('a nested hf file path resolves instead of being rejected', () => {
+  // HF repos nest, and the pair form accepts these, so rejecting them here would refuse a
+  // spec the rest of the pipeline considers valid.
+  const env = resolve(specWith(hf('tinyllamas/stories260K.gguf')))
+  assert.equal(env.LLM_URL, `https://huggingface.co/owner/repo/resolve/${'a'.repeat(40)}/tinyllamas/stories260K.gguf`)
+})
+
+test('a plain hf file path still resolves', () => {
+  const env = resolve(specWith(hf('model-Q8_0.gguf')))
+  assert.match(env.LLM_URL, /\/resolve\/a{40}\/model-Q8_0\.gguf$/)
+})
+
+for (const [name, file] of [
+  ['parent traversal', '../../etc/passwd'],
+  ['a dot segment', 'weights/./model.gguf'],
+  ['a parent segment mid-path', 'weights/../../model.gguf'],
+  ['an empty segment', 'weights//model.gguf'],
+  ['a trailing slash', 'weights/']
+]) {
+  test(`an hf file path with ${name} is rejected`, () => {
+    assert.throws(() => resolve(specWith(hf(file))))
+  })
+}
+
+test('a registry source resolves to an empty URL', () => {
+  // The workflow keys off this: no URL means the blob must already be on disk from an addon
+  // leg, and a CLI-only dispatch has to fail with that explanation rather than curl ''.
+  const env = resolve(specWith({ type: 'registry', source: 'core', path: 'visionpsy/q4' }))
+  assert.equal(env.LLM_URL, '')
+  assert.equal(env.LLM_NAME, 'llm.gguf')
+})
+
+test('a manifest-pinned modelName emits its sha256', () => {
+  // The CLI legs verify against this, so an entry the manifest pins must carry the pin
+  // through even when the spec itself gives no sha256.
+  const spec = {
+    label: 'probe',
+    llm: { source: hf('x.gguf'), modelName: 'Qwen3.5-0.8B-Q8_0.gguf' },
+    mmproj: { source: hf('y.gguf'), modelName: 'mmproj-Qwen3.5-0.8B-F16.gguf' }
+  }
+  const env = resolve(spec)
+  assert.match(env.LLM_SHA256, /^[0-9a-f]{64}$/)
+  assert.match(env.MMPROJ_SHA256, /^[0-9a-f]{64}$/)
+})
+
+test('an unpinned blob emits an empty sha256 rather than inventing one', () => {
+  const env = resolve(specWith(hf('x.gguf')))
+  assert.equal(env.LLM_SHA256, '')
+})

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/stdout-parser.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/stdout-parser.test.js
@@ -1,0 +1,94 @@
+'use strict'
+
+// Fixtures below are copied verbatim from llama-mtmd-cli output (VisionPsy Flash q8_0, Metal,
+// 640x480 input) and from the addon marker sample in markers-v2.sample.txt. The parser reads
+// two different encode logs, and the risk it carries is double counting: the addon path logs
+// one "image slice encoded" line per slice through mtmd_helper_eval_chunks, while the CLI path
+// runs its own loop and logs a batch line instead, so a stream carrying both must not add up
+// to the sum of the two.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { parseStdoutMetrics } = require('../stdout-parser')
+
+// Real CLI encode log. Three batches, one chunk each, 38 + 27 + 27 ms.
+const CLI_BATCH_LOG = [
+  '0.00.239.977 I encoding mtmd batch, n_chunks = 1 (done = 1, total = 7)',
+  '0.00.278.177 I mtmd batch encoding done in 38 ms',
+  '0.00.288.674 I encoding mtmd batch, n_chunks = 1 (done = 3, total = 7)',
+  '0.00.316.229 I mtmd batch encoding done in 27 ms',
+  '0.00.326.419 I encoding mtmd batch, n_chunks = 1 (done = 5, total = 7)',
+  '0.00.353.442 I mtmd batch encoding done in 27 ms'
+].join('\n')
+
+// Real addon encode log lines, one per slice.
+const ADDON_HELPER_LOG = [
+  'image slice encoded in 150 ms',
+  'image slice encoded in 142 ms',
+  'image encoded in 120 ms'
+].join('\n')
+
+// Real llama.cpp timing block, same run as CLI_BATCH_LOG.
+const PERF_LOG = [
+  '0.00.495.670 I llama_perf_context_print:        load time =     155.25 ms',
+  '0.00.495.671 I llama_perf_context_print: prompt eval time =     132.35 ms /   205 tokens (    0.65 ms per token,  1548.92 tokens per second)',
+  '0.00.495.672 I llama_perf_context_print:        eval time =      20.14 ms /     7 runs   (    2.88 ms per token,   347.60 tokens per second)',
+  '0.00.495.673 I llama_perf_context_print:       total time =     260.39 ms /   212 tokens'
+].join('\n')
+
+test('CLI batch lines sum the encode time and count chunks, not batches', () => {
+  const out = parseStdoutMetrics(CLI_BATCH_LOG)
+  assert.equal(out.visionEncodeMs, 92)
+  assert.equal(out.visionEncodeSliceCount, 3)
+})
+
+test('chunk counts come from n_chunks, so one batch can carry several slices', () => {
+  // mtmd-cli breaks its encode batch on every text chunk, so it only ever logs n_chunks = 1.
+  // The server path batches, and the count has to follow the field rather than the line count.
+  const batched = [
+    '0.00.100.000 I encoding mtmd batch, n_chunks = 4 (done = 1, total = 9)',
+    '0.00.400.000 I mtmd batch encoding done in 300 ms',
+    '0.00.500.000 I encoding mtmd batch, n_chunks = 2 (done = 5, total = 9)',
+    '0.00.650.000 I mtmd batch encoding done in 150 ms'
+  ].join('\n')
+  const out = parseStdoutMetrics(batched)
+  assert.equal(out.visionEncodeMs, 450)
+  assert.equal(out.visionEncodeSliceCount, 6)
+})
+
+test('addon helper lines sum across every slice', () => {
+  const out = parseStdoutMetrics(ADDON_HELPER_LOG)
+  assert.equal(out.visionEncodeMs, 412)
+  assert.equal(out.visionEncodeSliceCount, 3)
+})
+
+test('a stream with both helper and batch lines does not double count', () => {
+  const out = parseStdoutMetrics(ADDON_HELPER_LOG + '\n' + CLI_BATCH_LOG)
+  // Helper lines win outright. 412 + 92 would be the double-counted answer.
+  assert.equal(out.visionEncodeMs, 412)
+  assert.equal(out.visionEncodeSliceCount, 3)
+})
+
+test('prompt eval is not read as decode eval', () => {
+  const out = parseStdoutMetrics(PERF_LOG)
+  assert.equal(out.promptEvalMs, 132.35)
+  assert.equal(out.promptTokens, 205)
+  assert.equal(out.promptTps, 1548.92)
+  assert.equal(out.decodeMs, 20.14)
+  assert.equal(out.decodeTokens, 7)
+  assert.equal(out.decodeTps, 347.6)
+  assert.equal(out.loadMs, 155.25)
+  assert.equal(out.totalMs, 260.39)
+})
+
+test('a log with no encode lines reports no encode fields', () => {
+  const out = parseStdoutMetrics(PERF_LOG)
+  assert.equal(out.visionEncodeMs, undefined)
+  assert.equal(out.visionEncodeSliceCount, undefined)
+})
+
+test('empty input parses to an empty object', () => {
+  assert.deepEqual(parseStdoutMetrics(''), {})
+  assert.deepEqual(parseStdoutMetrics(null), {})
+})

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/stdout-parser.test.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/__tests__/stdout-parser.test.js
@@ -22,7 +22,9 @@ const CLI_BATCH_LOG = [
   '0.00.353.442 I mtmd batch encoding done in 27 ms'
 ].join('\n')
 
-// Real addon encode log lines, one per slice.
+// Addon encode log lines, one per slice. mtmd-helper.cpp always emits the `slice encoded`
+// form; the sliceless third line is not a shape fabric produces, and is here only to hold the
+// regex's tolerance for it in place.
 const ADDON_HELPER_LOG = [
   'image slice encoded in 150 ms',
   'image slice encoded in 142 ms',

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
@@ -202,6 +202,13 @@ function parseArgs (argv) {
 // llama.cpp/mtmd print these on native stderr (captured by `2>&1 | tee`), NOT via the
 // JS logger — so we attribute the timing lines that precede each [VLMROW] to that row.
 const VISION_RE = /image (?:slice )?encoded in\s+(\d+(?:\.\d+)?)\s*ms/i
+// The line above is logged by mtmd_helper_eval_chunks. llama-mtmd-cli does NOT call that
+// helper, it runs its own encode loop and logs these two instead, so CLI legs reported an
+// empty `mmproj enc` / `tiles` column. Tiles come from n_chunks: one batch can carry
+// several slices. Mirrors the fallback in stdout-parser.js. Per segment the helper line
+// wins where both appear, so addon legs are unaffected.
+const VISION_BATCH_MS_RE = /mtmd batch encoding done in\s+(\d+(?:\.\d+)?)\s*ms/i
+const VISION_BATCH_CHUNKS_RE = /encoding mtmd batch,\s*n_chunks\s*=\s*(\d+)/i
 const ROW_RE = /\[VLMROW\](.*?)\[\/VLMROW\]/
 const SEG_RE = /\[VLMSEG\](.*?)\[\/VLMSEG\]/
 const META_RE = /\[VLMMETA\](.*?)\[\/VLMMETA\]/
@@ -211,7 +218,7 @@ const META_RE = /\[VLMMETA\](.*?)\[\/VLMMETA\]/
 // the [VLMROW] markers (stdout). They're joined on the cell|device key, not position.
 function parseLog (inputs) {
   const rows = []
-  const vision = {} // host|cell|device -> { segMs: [perSegmentSummedMs], segTiles: [perSegmentEncodeCount] }
+  const vision = {} // host|cell|device -> { segMs: [perSegmentSummedMs], segTiles: [perSegmentEncodeCount], segHelper: [sawHelperLine] }
   const meta = {} // cell -> { main_origin, mmproj_origin, ... }
   // Android logcat captures each printed line twice (live + flushed bare buffer),
   // so the same [VLMROW] appears more than once. Dedup exact rows per host.
@@ -229,16 +236,28 @@ function parseLog (inputs) {
         try {
           const s = JSON.parse(sm[1])
           cur = `${host}|${s.cell}|${s.device}`
-          if (!vision[cur]) vision[cur] = { segMs: [], segTiles: [] }
-          vision[cur].segMs.push(0); vision[cur].segTiles.push(0)
+          if (!vision[cur]) vision[cur] = { segMs: [], segTiles: [], segHelper: [] }
+          vision[cur].segMs.push(0); vision[cur].segTiles.push(0); vision[cur].segHelper.push(false)
         } catch (_) {}
         continue
       }
       const vm = line.match(VISION_RE)
       if (vm && cur && vision[cur] && vision[cur].segMs.length) {
         const v = vision[cur]
-        v.segMs[v.segMs.length - 1] += Number(vm[1]); v.segTiles[v.segTiles.length - 1]++
+        const last = v.segMs.length - 1
+        // Helper line wins: discard whatever the batch fallback below already summed for
+        // this segment, otherwise a segment carrying both line shapes double-counts.
+        if (!v.segHelper[last]) { v.segMs[last] = 0; v.segTiles[last] = 0; v.segHelper[last] = true }
+        v.segMs[last] += Number(vm[1]); v.segTiles[last]++
         continue
+      }
+      if (cur && vision[cur] && vision[cur].segMs.length && !vision[cur].segHelper[vision[cur].segMs.length - 1]) {
+        const v = vision[cur]
+        const last = v.segMs.length - 1
+        const bm = line.match(VISION_BATCH_MS_RE)
+        if (bm) { v.segMs[last] += Number(bm[1]); continue }
+        const bc = line.match(VISION_BATCH_CHUNKS_RE)
+        if (bc) { v.segTiles[last] += Number(bc[1]); continue }
       }
       const rm = line.match(ROW_RE)
       if (rm) {
@@ -673,7 +692,8 @@ function build (rows, vision, meta, provText, title, opts = {}) {
   }
   L.push('')
   L.push('> **mmproj enc** is the pure ViT vision-encode time (and **tiles** its slice count). ' +
-    'CLI legs parse llama.cpp\'s native stderr (`slice encoded in N ms`); addon legs read the ' +
+    'CLI legs parse llama.cpp\'s native stderr (`slice encoded in N ms`, or `mtmd batch encoding ' +
+    'done in N ms` when the CLI runs its own encode loop); addon legs read the ' +
     'in-process `visionEncodeMs`/`visionEncodeTiles` runtime stats (same ViT encode) — so both ' +
     'columns are populated on every platform, including mobile (Device Farm), where the native ' +
     'stderr line is not captured. ' +

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
@@ -613,15 +613,37 @@ function build (rows, vision, meta, provText, title, opts = {}) {
   }
   if (Object.keys(meta).length) {
     L.push('### Models & origins (Source = Registry / HF / S3 / URL · pinned commits)\n')
-    L.push('| Cell | main model | mmproj |')
-    L.push('|---|---|---|')
+    L.push('| Cell | main model | mmproj | preprocessing |')
+    L.push('|---|---|---|---|')
     for (const cell of Object.keys(meta).sort()) {
       const m = meta[cell]
       const main = `**${m.main_source || '—'}** · ${m.main_origin || '—'}`
       const proj = `**${m.mmproj_source || '—'}** · ${m.mmproj_origin || '—'}`
-      L.push(`| \`${cell}\` | ${main} | ${proj} |`)
+      const pre = m.preproc ? `\`${m.preproc}\`` : (m.preproc === '' ? 'base' : '—')
+      L.push(`| \`${cell}\` | ${main} | ${proj} | ${pre} |`)
     }
     L.push('')
+    // Two legs of one model that applied different preprocessing are not comparable, and the
+    // numbers give no hint of it. The usual cause is an upstream-cli leg, which never receives
+    // cliArgs because they are fabric-fork flags, so say so instead of letting a reader treat
+    // the rows as like for like.
+    const byModel = {}
+    for (const [cell, m] of Object.entries(meta)) {
+      if (m.preproc == null) continue
+      const key = m.model || cell
+      byModel[key] = byModel[key] || {}
+      byModel[key][m.preproc] = byModel[key][m.preproc] || []
+      byModel[key][m.preproc].push(cell)
+    }
+    const split = Object.entries(byModel).filter(([, v]) => Object.keys(v).length > 1)
+    if (split.length) {
+      for (const [model, variants] of split) {
+        const parts = Object.entries(variants).map(([pre, cells]) =>
+          `${cells.map(c => `\`${c}\``).join(', ')} ran ${pre ? `\`${pre}\`` : 'base preprocessing'}`)
+        L.push(`> **Preprocessing differs across the legs of \`${model}\`**: ${parts.join('; ')}. Those rows are not like for like.`)
+      }
+      L.push('')
+    }
   }
   if (provText && provText.trim()) {
     L.push('### Provenance — hardware & software\n')

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-args.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-args.cjs
@@ -1,0 +1,18 @@
+'use strict'
+
+// One cliArgs element is one CLI argument, and it has to survive a round trip through a
+// shell variable: resolve-cli-model.cjs joins the array into cli-model.env and
+// cli-fixture-runner.cjs splits it back. That only stays lossless while no element carries
+// whitespace, which is what models.cjs enforces at parse time. Both halves live here so
+// they cannot drift apart, since a drift is silent: an element with a space would pass the
+// flag allowlist as one token and arrive as two.
+
+function serializeCliArgs (args) {
+  return (args || []).join(' ')
+}
+
+function parseCliArgs (value) {
+  return String(value || '').split(/\s+/).filter(Boolean)
+}
+
+module.exports = { serializeCliArgs, parseCliArgs }

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-case-runner.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-case-runner.js
@@ -149,6 +149,12 @@ function buildCliArgs (spec) {
   // parses its output (metrics come from the timing lines, not the prompt dump), so it is
   // simply gone rather than gated on a build check.
 
+  // Model-specific flags from the catalog entry's `cliArgs`, e.g. VisionPsy Flash's
+  // --image-no-upscale. Pushed before -p so the prompt stays last.
+  if (Array.isArray(spec.extraArgs) && spec.extraArgs.length) {
+    args.push(...spec.extraArgs)
+  }
+
   args.push('-p', spec.prompt)
 
   return args

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
@@ -16,6 +16,7 @@ const fs = require('fs')
 const path = require('path')
 const { runOnceCli } = require('./cli-case-runner')
 const { parseStdoutMetrics } = require('./stdout-parser')
+const { parseCliArgs } = require('./cli-args.cjs')
 const fixture = require('./fixture.data.cjs')
 
 function arg (name, def) { const i = process.argv.indexOf(`--${name}`); return i >= 0 ? process.argv[i + 1] : def }
@@ -25,7 +26,7 @@ const LLM = arg('llm')
 const MMPROJ = arg('mmproj')
 // Space-separated extra flags for the CLI, from the catalog entry's `cliArgs`. Empty for
 // every model that does not need one.
-const EXTRA_ARGS = String(arg('extra-args', '') || '').split(/\s+/).filter(Boolean)
+const EXTRA_ARGS = parseCliArgs(arg('extra-args', ''))
 const BACKEND = arg('backend', 'cpu')
 // Context size for the run, from the spec the addon leg also uses (catalog ctx_size,
 // a json: spec's, or @ctx=N on a URL pair). Both engines must see the same one.

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
@@ -17,6 +17,7 @@ const path = require('path')
 const { runOnceCli } = require('./cli-case-runner')
 const { parseStdoutMetrics } = require('./stdout-parser')
 const { parseCliArgs } = require('./cli-args.cjs')
+const { preprocLabel } = require('./models.cjs')
 const fixture = require('./fixture.data.cjs')
 
 function arg (name, def) { const i = process.argv.indexOf(`--${name}`); return i >= 0 ? process.argv[i + 1] : def }
@@ -90,7 +91,10 @@ function main () {
     main_origin: MAIN_ORIGIN,
     main_source: MAIN_SOURCE,
     mmproj_origin: MMPROJ_ORIGIN,
-    mmproj_source: MMPROJ_SOURCE
+    mmproj_source: MMPROJ_SOURCE,
+    // What this leg actually applied. Empty on upstream-cli by design, and the report marks
+    // that rather than leaving two legs looking like the same configuration.
+    preproc: preprocLabel({ cliArgs: EXTRA_ARGS })
   }) + '[/VLMMETA]')
 
   const items = selectedItems()

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
@@ -30,10 +30,9 @@ const EXTRA_ARGS = parseCliArgs(arg('extra-args', ''))
 const BACKEND = arg('backend', 'cpu')
 // Context size for the run, from the spec the addon leg also uses (catalog ctx_size,
 // a json: spec's, or @ctx=N on a URL pair). Both engines must see the same one.
-// 0 is a real value here, not a missing one: it means "let the engine pick the model
-// default", and the addon leg keeps it (LlamaModel.cpp guards on n_ctx != 0). Falling back
-// on it would put the two legs on different context sizes, which is what this flag exists
-// to prevent, so only a non-number falls back.
+// 0 means "let the engine pick the model default", so only a non-number falls back. Note
+// that models.cjs normalizeSpec already rewrites a falsy ctx_size to 4096, so 0 only ever
+// arrives here from @ctx=0 on a URL pair.
 const CTX_SIZE_ARG = parseInt(arg('ctx-size', '4096'), 10)
 const CTX_SIZE = Number.isNaN(CTX_SIZE_ARG) ? 4096 : CTX_SIZE_ARG
 const SAMPLES = parseInt(arg('samples', '3'), 10)
@@ -140,8 +139,9 @@ function main () {
           ttft_ms: ttft,
           gen_tokens: m.decodeTokens != null ? m.decodeTokens : null,
           prompt_tokens: m.promptTokens != null ? m.promptTokens : null,
-          // runOnceCli reads this from the `/usr/bin/time -v` wrapper. It was being
-          // dropped here, so the report's peak-RSS row was empty for every CLI leg.
+          // runOnceCli reads this from the `/usr/bin/time -v` wrapper, so it is Linux-only
+          // and stays null on macOS and Windows. It was being dropped here even on Linux,
+          // so the report's peak-RSS row was empty for every CLI leg.
           rss_mb: r.peakRssMb != null ? r.peakRssMb : null,
           // Per-row encode time and slice count, the same fields the addon harness
           // emits, so the report has them even when the log-scraping path misses.

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
@@ -30,7 +30,12 @@ const EXTRA_ARGS = parseCliArgs(arg('extra-args', ''))
 const BACKEND = arg('backend', 'cpu')
 // Context size for the run, from the spec the addon leg also uses (catalog ctx_size,
 // a json: spec's, or @ctx=N on a URL pair). Both engines must see the same one.
-const CTX_SIZE = parseInt(arg('ctx-size', '4096'), 10) || 4096
+// 0 is a real value here, not a missing one: it means "let the engine pick the model
+// default", and the addon leg keeps it (LlamaModel.cpp guards on n_ctx != 0). Falling back
+// on it would put the two legs on different context sizes, which is what this flag exists
+// to prevent, so only a non-number falls back.
+const CTX_SIZE_ARG = parseInt(arg('ctx-size', '4096'), 10)
+const CTX_SIZE = Number.isNaN(CTX_SIZE_ARG) ? 4096 : CTX_SIZE_ARG
 const SAMPLES = parseInt(arg('samples', '3'), 10)
 const REPEATS = parseInt(arg('repeats', '3'), 10)
 const TASKS = (arg('tasks', '') || '').split(',').map(s => s.trim()).filter(Boolean)

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/cli-fixture-runner.cjs
@@ -23,7 +23,13 @@ const BINARY = arg('binary')
 const SOURCE = arg('source', 'cli')
 const LLM = arg('llm')
 const MMPROJ = arg('mmproj')
+// Space-separated extra flags for the CLI, from the catalog entry's `cliArgs`. Empty for
+// every model that does not need one.
+const EXTRA_ARGS = String(arg('extra-args', '') || '').split(/\s+/).filter(Boolean)
 const BACKEND = arg('backend', 'cpu')
+// Context size for the run, from the spec the addon leg also uses (catalog ctx_size,
+// a json: spec's, or @ctx=N on a URL pair). Both engines must see the same one.
+const CTX_SIZE = parseInt(arg('ctx-size', '4096'), 10) || 4096
 const SAMPLES = parseInt(arg('samples', '3'), 10)
 const REPEATS = parseInt(arg('repeats', '3'), 10)
 const TASKS = (arg('tasks', '') || '').split(',').map(s => s.trim()).filter(Boolean)
@@ -46,6 +52,11 @@ const MAX_TASKS = parseInt(arg('max-tasks', '0'), 10) || 0
 const IDS = (arg('ids', '') || '').split(',').map(s => s.trim()).filter(Boolean)
 const MAIN_ORIGIN = arg('main-origin', 'Qwen3.5-0.8B-Q8_0')
 const MMPROJ_ORIGIN = arg('mmproj-origin', 'Qwen3.5-0.8B mmproj-Q8_0')
+// Model identity for the markers. Was hardcoded to qwen, which mislabelled every
+// several-sources run of any other model. Defaults keep old logs readable.
+const MODEL_LABEL = arg('model-label', 'qwen')
+const MAIN_SOURCE = arg('main-source', 'Registry')
+const MMPROJ_SOURCE = arg('mmproj-source', 'Registry')
 
 if (!BINARY || !fs.existsSync(BINARY)) { console.error(`[cli-fixture] binary not found: ${BINARY}`); process.exit(2) }
 if (!LLM || !MMPROJ) { console.error('[cli-fixture] --llm and --mmproj are required'); process.exit(2) }
@@ -70,12 +81,11 @@ function main () {
   console.error('[VLMMETA]' + JSON.stringify({
     cell: SOURCE,
     source: SOURCE,
-    model: 'qwen',
-    mmproj: 'q8',
+    model: MODEL_LABEL,
     main_origin: MAIN_ORIGIN,
-    main_source: 'Registry',
+    main_source: MAIN_SOURCE,
     mmproj_origin: MMPROJ_ORIGIN,
-    mmproj_source: 'Registry'
+    mmproj_source: MMPROJ_SOURCE
   }) + '[/VLMMETA]')
 
   const items = selectedItems()
@@ -85,9 +95,10 @@ function main () {
       cliBinaryPath: BINARY,
       llmPath: LLM,
       mmprojPath: MMPROJ,
+      extraArgs: EXTRA_ARGS,
       imagePath: mediaPath(item.image),
       prompt: item.prompt,
-      ctxSize: 4096,
+      ctxSize: CTX_SIZE,
       nPredict: TASK_NPREDICT[item.task] || DEFAULT_NPREDICT,
       backend: BACKEND,
       temperature: 0,
@@ -96,7 +107,7 @@ function main () {
       perRunTimeoutMs: 5 * 60 * 1000
     }
     for (let rep = 0; rep < REPEATS; rep++) {
-      console.error('[VLMSEG]' + JSON.stringify({ cell: SOURCE, source: SOURCE, model: 'qwen', mmproj: 'q8', device: BACKEND, id: item.id, rep }) + '[/VLMSEG]')
+      console.error('[VLMSEG]' + JSON.stringify({ cell: SOURCE, source: SOURCE, model: MODEL_LABEL, device: BACKEND, id: item.id, rep }) + '[/VLMSEG]')
       try {
         const r = runOnceCli(spec)
         if (r.stderr) process.stderr.write(r.stderr + '\n') // surfaces `image ... encoded in N ms` after the [VLMSEG]
@@ -107,8 +118,7 @@ function main () {
         console.log('[VLMROW]' + JSON.stringify({
           cell: SOURCE,
           source: SOURCE,
-          model: 'qwen',
-          mmproj: 'q8',
+          model: MODEL_LABEL,
           device: BACKEND,
           rep,
           task: item.task,
@@ -123,15 +133,21 @@ function main () {
           decode_tps: m.decodeTps != null ? m.decodeTps : null,
           ttft_ms: ttft,
           gen_tokens: m.decodeTokens != null ? m.decodeTokens : null,
-          prompt_tokens: m.promptTokens != null ? m.promptTokens : null
+          prompt_tokens: m.promptTokens != null ? m.promptTokens : null,
+          // runOnceCli reads this from the `/usr/bin/time -v` wrapper. It was being
+          // dropped here, so the report's peak-RSS row was empty for every CLI leg.
+          rss_mb: r.peakRssMb != null ? r.peakRssMb : null,
+          // Per-row encode time and slice count, the same fields the addon harness
+          // emits, so the report has them even when the log-scraping path misses.
+          vision_enc_ms: m.visionEncodeMs != null ? m.visionEncodeMs : null,
+          vision_enc_tiles: m.visionEncodeSliceCount != null ? m.visionEncodeSliceCount : null
         }) + '[/VLMROW]')
         ok++
       } catch (e) {
         console.log('[VLMROW]' + JSON.stringify({
           cell: SOURCE,
           source: SOURCE,
-          model: 'qwen',
-          mmproj: 'q8',
+          model: MODEL_LABEL,
           device: BACKEND,
           rep,
           task: item.task,

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -107,9 +107,9 @@ const GEMMA4_Q4 = {
 // upscales the long side to 2048, hence separate entries rather than one with a flag.
 // modelNames must be models.manifest.json keys or the addon leg aborts (see #3195).
 //
-// These need a fabric addon: the published prebuild has neither the VisionPsy projector type
-// nor the image-no-upscale load-config key, so a two-models dispatch on it fails at load,
-// after both blobs have downloaded. Use several-sources against `fabric@<ref>`.
+// The addon leg can run these: the projector arrived in qvac-fabric 10069.1.0 and vcpkg.json
+// pins >= 10069.1.1, and the addon accepts image-no-upscale (LoadConfigHandlers.cpp, #3725).
+// So two-models works here, not only several-sources against a fabric branch.
 const VISIONPSY_BASE = {
   id: 'visionpsy',
   name: 'VisionPsy-Nano-460M',

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -30,7 +30,9 @@ const SHA = {
   qwenUnsloth: '6ab461498e2023f6e3c1baea90a8f0fe38ab64d0', // registry: Qwen3.5 main + f16 mmproj
   qwenMrader: '9d48fdbc0d8f133716da87ec1d904e5d2c7175a6', //  registry: Qwen3.5 q8 mmproj
   gemmaBart: 'b5e99bd964eaacc27ba484bb2eb3e9f6160b9143', //   registry: Gemma-4-E2B q4 main (+ f16/bf16 mmproj)
-  gemmaGgml: 'a1dac71d3ab220618f5a7573a52acdc4baf3ae3b' //    registry: Gemma-4-E2B q8 mmproj
+  gemmaGgml: 'a1dac71d3ab220618f5a7573a52acdc4baf3ae3b', //   registry: Gemma-4-E2B q8 mmproj
+  visionpsyBase: '4138c5bd6e026d67cebf2dbd2d81c6229c14cdc1', // VisionPsy-Nano base q4_0 + q8 mmproj
+  visionpsyFlash: 'a24fb9cdd1119406b15ff60b06a51f8438a931c1' // VisionPsy-Nano Flash q4_0 + q8 mmproj
 }
 
 // Apache-2.0 Qwen mmproj blobs are published in the QVAC registry; the pinned HF URL
@@ -97,6 +99,84 @@ const GEMMA4_Q4 = {
     { license: 'Gemma', link: 'https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF' })
 }
 
+// VisionPsy-Nano-460M (QVAC-23075). Two checkpoints, base and Flash, differ ONLY in
+// whether the preprocessor upscales the long side to 2048, so they need separate
+// entries, and three main-model quants each so a run is a quant sweep. Not
+// registry-published, so no `registry` annotation: the report shows Source = HF.
+// blob modelNames are the models.manifest.json keys, which is where the sha256/bytes
+// pins live; a name absent from the manifest aborts the addon leg (see #3195).
+const VISIONPSY_BASE = {
+  id: 'visionpsy',
+  name: 'VisionPsy-Nano-460M',
+  repo: 'qvac/VisionPsy-Nano-460M-GGUFs',
+  sha: SHA.visionpsyBase,
+  prefix: 'visionpsy-nano-460m',
+  mmproj: 'mmproj-visionpsy-nano-460m-q8.gguf'
+}
+
+// Flash needs its own preprocessing rule and the published mmproj carries no key saying
+// so, so the flag is what selects it. Two spellings of the same thing because the legs
+// run different engines: `cliArgs` for the native CLI, `addonConfig` for the addon, which
+// is what the phones run. Without both, a Flash leg measures Flash weights under base
+// preprocessing.
+const VISIONPSY_FLASH = {
+  id: 'visionpsy-flash',
+  name: 'VisionPsy-Nano-460M-Flash',
+  repo: 'qvac/VisionPsy-Nano-460M-Flash-GGUFs',
+  sha: SHA.visionpsyFlash,
+  prefix: 'visionpsy-nano-460m-flash',
+  mmproj: 'mmproj-visionpsy-nano-460m-flash-q8.gguf',
+  cliArgs: ['--image-no-upscale', 'on'],
+  addonConfig: { 'image-no-upscale': 'on' }
+}
+
+// One catalog entry per (checkpoint, main-model quant); the mmproj stays Q8 throughout
+// because that is the only projector quant either repo publishes, so all three quants of
+// a checkpoint share one downloaded projector. `quantId` is the catalog-name suffix and
+// `fileQuant` the on-HF filename fragment, which differ where the upstream name carries
+// the imatrix suffix. bf16 and fp32 are deliberately absent: 820 MB and 1.6 GB, and the
+// mobile legs download their blobs mid-test.
+function visionpsy (ckpt, quantId, fileQuant) {
+  const main = `${ckpt.prefix}-${fileQuant}.gguf`
+  const at = `${ckpt.repo}@${ckpt.sha.slice(0, 10)}`
+  return {
+    label: `${ckpt.id}-${quantId}`,
+    name: `${ckpt.name} · ${quantOf(main).toUpperCase()} + mmproj-Q8`,
+    ctx_size: '4096',
+    cliArgs: ckpt.cliArgs,
+    addonConfig: ckpt.addonConfig,
+    llm: hf(main, at, ckpt.repo, ckpt.sha, main),
+    mmproj: hf(ckpt.mmproj, `${at} · mmproj-Q8`, ckpt.repo, ckpt.sha, ckpt.mmproj)
+  }
+}
+
+const VISIONPSY_Q4 = visionpsy(VISIONPSY_BASE, 'q4', 'q4_0')
+const VISIONPSY_Q8 = visionpsy(VISIONPSY_BASE, 'q8', 'q8_0')
+const VISIONPSY_IQ3M = visionpsy(VISIONPSY_BASE, 'iq3m', 'iq3_m-imat')
+const VISIONPSY_FLASH_Q4 = visionpsy(VISIONPSY_FLASH, 'q4', 'q4_0')
+const VISIONPSY_FLASH_Q8 = visionpsy(VISIONPSY_FLASH, 'q8', 'q8_0')
+const VISIONPSY_FLASH_IQ3M = visionpsy(VISIONPSY_FLASH, 'iq3m', 'iq3_m-imat')
+
+// Same model and same preprocessing as visionpsy-flash-q4, with the projector forced
+// onto the GPU. It exists to reach ONE path no other entry can: on Android the addon
+// auto-defaults the projector backend by GPU class (LlamaModel.cpp), GPU on Adreno 800+
+// and CPU on Mali, so a plain `device: gpu` leg on a Mali phone runs the vision encoder
+// on CPU and never exercises Vulkan for it. Run 31409445243 shows exactly that,
+// `multimodal projector backend: CPU (auto-default, Mali GPU)` on pixel9 against
+// `GPU (auto-default, Adreno 800+)` on s25.
+//
+// Deliberately a SEPARATE entry rather than a flag on the existing one. The auto-default
+// is there because the Mali projector encodes slower on GPU than on CPU (QVAC-21257), so
+// forcing it in the standard entry would make every routine Pixel run measure a
+// configuration nobody ships. Dispatch this one to validate the Mali Vulkan encoder, and
+// check the log line rather than the timing: it must read `GPU (mmproj-use-gpu override)`.
+const VISIONPSY_FLASH_Q4_MMPROJ_GPU = {
+  ...VISIONPSY_FLASH_Q4,
+  label: 'visionpsy-flash-q4-mmproj-gpu',
+  name: `${VISIONPSY_FLASH_Q4.name} · projector forced to GPU`,
+  addonConfig: { ...VISIONPSY_FLASH_Q4.addonConfig, 'mmproj-use-gpu': 'on' }
+}
+
 // ════════════════════ THE MODEL FOR SOURCE COMPARISON (several-sources mode) ════════════════════
 // One fixed VLM, run through every engine. Its blob filenames must match the names the
 // workflow's CLI step feeds to fabric-cli/upstream-cli.
@@ -141,7 +221,14 @@ module.exports = {
     'qwen3.5-f16': MODEL_1,
     'qwen3.5-q8': MODEL_2,
     'qwen3.5-0.8b-q8': SOURCES_MODEL,
-    'gemma4-q4': GEMMA4_Q4
+    'gemma4-q4': GEMMA4_Q4,
+    'visionpsy-q4': VISIONPSY_Q4,
+    'visionpsy-q8': VISIONPSY_Q8,
+    'visionpsy-iq3m': VISIONPSY_IQ3M,
+    'visionpsy-flash-q4': VISIONPSY_FLASH_Q4,
+    'visionpsy-flash-q8': VISIONPSY_FLASH_Q8,
+    'visionpsy-flash-iq3m': VISIONPSY_FLASH_IQ3M,
+    'visionpsy-flash-q4-mmproj-gpu': VISIONPSY_FLASH_Q4_MMPROJ_GPU
   },
   // What runs when matrix_models is empty (two-models mode).
   defaultModels: ['qwen3.5-f16', 'qwen3.5-q8'],

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -109,6 +109,11 @@ const GEMMA4_Q4 = {
 // registry-published, so no `registry` annotation: the report shows Source = HF.
 // blob modelNames are the models.manifest.json keys, which is where the sha256/bytes
 // pins live; a name absent from the manifest aborts the addon leg (see #3195).
+//
+// These need a fabric addon: the published prebuild has neither the VisionPsy projector
+// type nor the image-no-upscale load-config key. A two-models dispatch on the published
+// addon therefore fails at model load, and only after both blobs have downloaded. Compare
+// them with several-sources against `fabric@<ref>`, or wait for the addon to ship it.
 const VISIONPSY_BASE = {
   id: 'visionpsy',
   name: 'VisionPsy-Nano-460M',
@@ -164,19 +169,17 @@ const VISIONPSY_FLASH_Q4 = visionpsy(VISIONPSY_FLASH, 'q4', 'q4_0')
 const VISIONPSY_FLASH_Q8 = visionpsy(VISIONPSY_FLASH, 'q8', 'q8_0')
 const VISIONPSY_FLASH_IQ3M = visionpsy(VISIONPSY_FLASH, 'iq3m', 'iq3_m-imat')
 
-// Same model and same preprocessing as visionpsy-flash-q4, with the projector forced
-// onto the GPU. It exists to reach ONE path no other entry can: on Android the addon
-// auto-defaults the projector backend by GPU class (LlamaModel.cpp), GPU on Adreno 800+
-// and CPU on Mali, so a plain `device: gpu` leg on a Mali phone runs the vision encoder
-// on CPU and never exercises Vulkan for it. Run 31409445243 shows exactly that,
-// `multimodal projector backend: CPU (auto-default, Mali GPU)` on pixel9 against
-// `GPU (auto-default, Adreno 800+)` on s25.
+// Same model and preprocessing as visionpsy-flash-q4, with the projector forced onto the
+// GPU. It reaches one path no other entry can: the addon auto-defaults the projector
+// backend by GPU class (LlamaModel.cpp), GPU on Adreno 800+ and CPU on Mali, so a plain
+// `device: gpu` leg on a Mali phone runs the vision encoder on CPU and never exercises
+// Vulkan for it.
 //
-// Deliberately a SEPARATE entry rather than a flag on the existing one. The auto-default
-// is there because the Mali projector encodes slower on GPU than on CPU (QVAC-21257), so
+// A separate entry rather than a flag on the existing one, because the auto-default exists
+// for a reason: the Mali projector encodes slower on GPU than on CPU (QVAC-21257), so
 // forcing it in the standard entry would make every routine Pixel run measure a
-// configuration nobody ships. Dispatch this one to validate the Mali Vulkan encoder, and
-// check the log line rather than the timing: it must read `GPU (mmproj-use-gpu override)`.
+// configuration nobody ships. Check the log line rather than the timing, it must read
+// `GPU (mmproj-use-gpu override)`.
 const VISIONPSY_FLASH_Q4_MMPROJ_GPU = {
   ...VISIONPSY_FLASH_Q4,
   label: 'visionpsy-flash-q4-mmproj-gpu',

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -24,6 +24,10 @@
 //     source.type 'hf'  : { type:'hf', repo, sha, file } -> pinned HuggingFace commit
 //     source.type 'url' : { type:'url', url }             -> arbitrary direct link
 //     source.type 's3'  : { type:'s3', url }              -> S3 (presigned URL)
+//   Two optional per-model fields carry preprocessing a model needs but its mmproj does
+//   not declare: `cliArgs` for the native CLI legs and `addonConfig`, its addon-side twin.
+//   Both are allowlisted in models.cjs and must be set together or the legs diverge.
+//   See CONTRACT.md section 3.
 
 // Pinned commit SHAs (immutable provenance).
 const SHA = {
@@ -141,7 +145,10 @@ function visionpsy (ckpt, quantId, fileQuant) {
   const at = `${ckpt.repo}@${ckpt.sha.slice(0, 10)}`
   return {
     label: `${ckpt.id}-${quantId}`,
-    name: `${ckpt.name} · ${quantOf(main).toUpperCase()} + mmproj-Q8`,
+    // quantOf returns null for a quant its regex does not know (fp32, mxfp4), and this
+    // runs at require time, so falling back to quantId degrades the label instead of
+    // taking down every consumer of config.cjs on a one-token edit.
+    name: `${ckpt.name} · ${(quantOf(main) || quantId).toUpperCase()} + mmproj-Q8`,
     ctx_size: '4096',
     cliArgs: ckpt.cliArgs,
     addonConfig: ckpt.addonConfig,

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -66,9 +66,9 @@ const MODEL_1 = {
   label: 'qwen3.5-f16', //    short id — report column + marker key (keep filesystem-safe)
   name: 'Qwen3.5-0.8B · mmproj-F16', // display name
   ctx_size: '4096',
-  llm: hf('reg-qwen-unsloth-Q8_0.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)}`,
+  llm: hf('Qwen3.5-0.8B-Q8_0.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)}`,
     'unsloth/Qwen3.5-0.8B-GGUF', SHA.qwenUnsloth, 'Qwen3.5-0.8B-Q8_0.gguf', QWEN_REG),
-  mmproj: hf('reg-qwen-unsloth-mmproj-F16.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)} · mmproj-F16`,
+  mmproj: hf('mmproj-Qwen3.5-0.8B-F16.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)} · mmproj-F16`,
     'unsloth/Qwen3.5-0.8B-GGUF', SHA.qwenUnsloth, 'mmproj-F16.gguf', QWEN_REG)
 }
 
@@ -76,9 +76,9 @@ const MODEL_2 = {
   label: 'qwen3.5-q8', //     short id
   name: 'Qwen3.5-0.8B · mmproj-Q8', // display name
   ctx_size: '4096',
-  llm: hf('reg-qwen-unsloth-Q8_0.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)}`,
+  llm: hf('Qwen3.5-0.8B-Q8_0.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)}`,
     'unsloth/Qwen3.5-0.8B-GGUF', SHA.qwenUnsloth, 'Qwen3.5-0.8B-Q8_0.gguf', QWEN_REG),
-  mmproj: hf('reg-qwen-mradermacher-mmproj-Q8_0.gguf', `mradermacher/Qwen3.5-0.8B-GGUF@${SHA.qwenMrader.slice(0, 10)} · mmproj-Q8_0`,
+  mmproj: hf('mmproj-Qwen3.5-0.8B-Q8_0.gguf', `mradermacher/Qwen3.5-0.8B-GGUF@${SHA.qwenMrader.slice(0, 10)} · mmproj-Q8_0`,
     'mradermacher/Qwen3.5-0.8B-GGUF', SHA.qwenMrader, 'Qwen3.5-0.8B.mmproj-Q8_0.gguf',
     { license: 'Apache-2.0', link: 'https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF' })
 }
@@ -91,10 +91,10 @@ const GEMMA4_Q4 = {
   label: 'gemma4-q4',
   name: 'Gemma-4-E2B-it · Q4_K_M + mmproj-Q8',
   ctx_size: '4096',
-  llm: hf('reg-gemma4-e2b-Q4_K_M.gguf', `bartowski/google_gemma-4-E2B-it-GGUF@${SHA.gemmaBart.slice(0, 10)}`,
+  llm: hf('google_gemma-4-E2B-it-Q4_K_M.gguf', `bartowski/google_gemma-4-E2B-it-GGUF@${SHA.gemmaBart.slice(0, 10)}`,
     'bartowski/google_gemma-4-E2B-it-GGUF', SHA.gemmaBart, 'google_gemma-4-E2B-it-Q4_K_M.gguf',
     { license: 'Gemma', link: 'https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF' }),
-  mmproj: hf('reg-gemma4-e2b-mmproj-Q8_0.gguf', `ggml-org/gemma-4-E2B-it-GGUF@${SHA.gemmaGgml.slice(0, 10)} · mmproj-Q8_0`,
+  mmproj: hf('mmproj-gemma-4-E2B-it-Q8_0.gguf', `ggml-org/gemma-4-E2B-it-GGUF@${SHA.gemmaGgml.slice(0, 10)} · mmproj-Q8_0`,
     'ggml-org/gemma-4-E2B-it-GGUF', SHA.gemmaGgml, 'mmproj-gemma-4-E2B-it-Q8_0.gguf',
     { license: 'Gemma', link: 'https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF' })
 }
@@ -184,9 +184,9 @@ const SOURCES_MODEL = {
   label: 'qwen3.5-0.8b-q8',
   name: 'Qwen3.5-0.8B (mmproj Q8)',
   ctx_size: '4096',
-  llm: hf('reg-qwen-unsloth-Q8_0.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)}`,
+  llm: hf('Qwen3.5-0.8B-Q8_0.gguf', `unsloth/Qwen3.5-0.8B-GGUF@${SHA.qwenUnsloth.slice(0, 10)}`,
     'unsloth/Qwen3.5-0.8B-GGUF', SHA.qwenUnsloth, 'Qwen3.5-0.8B-Q8_0.gguf', QWEN_REG),
-  mmproj: hf('reg-qwen-mradermacher-mmproj-Q8_0.gguf', `mradermacher/Qwen3.5-0.8B-GGUF@${SHA.qwenMrader.slice(0, 10)} · mmproj-Q8_0`,
+  mmproj: hf('mmproj-Qwen3.5-0.8B-Q8_0.gguf', `mradermacher/Qwen3.5-0.8B-GGUF@${SHA.qwenMrader.slice(0, 10)} · mmproj-Q8_0`,
     'mradermacher/Qwen3.5-0.8B-GGUF', SHA.qwenMrader, 'Qwen3.5-0.8B.mmproj-Q8_0.gguf',
     { license: 'Apache-2.0', link: 'https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF' })
 }

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -103,17 +103,13 @@ const GEMMA4_Q4 = {
     { license: 'Gemma', link: 'https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF' })
 }
 
-// VisionPsy-Nano-460M (QVAC-23075). Two checkpoints, base and Flash, differ ONLY in
-// whether the preprocessor upscales the long side to 2048, so they need separate
-// entries, and three main-model quants each so a run is a quant sweep. Not
-// registry-published, so no `registry` annotation: the report shows Source = HF.
-// blob modelNames are the models.manifest.json keys, which is where the sha256/bytes
-// pins live; a name absent from the manifest aborts the addon leg (see #3195).
+// VisionPsy-Nano-460M (QVAC-23075). Base and Flash differ ONLY in whether the preprocessor
+// upscales the long side to 2048, hence separate entries rather than one with a flag.
+// modelNames must be models.manifest.json keys or the addon leg aborts (see #3195).
 //
-// These need a fabric addon: the published prebuild has neither the VisionPsy projector
-// type nor the image-no-upscale load-config key. A two-models dispatch on the published
-// addon therefore fails at model load, and only after both blobs have downloaded. Compare
-// them with several-sources against `fabric@<ref>`, or wait for the addon to ship it.
+// These need a fabric addon: the published prebuild has neither the VisionPsy projector type
+// nor the image-no-upscale load-config key, so a two-models dispatch on it fails at load,
+// after both blobs have downloaded. Use several-sources against `fabric@<ref>`.
 const VISIONPSY_BASE = {
   id: 'visionpsy',
   name: 'VisionPsy-Nano-460M',
@@ -169,16 +165,12 @@ const VISIONPSY_FLASH_Q4 = visionpsy(VISIONPSY_FLASH, 'q4', 'q4_0')
 const VISIONPSY_FLASH_Q8 = visionpsy(VISIONPSY_FLASH, 'q8', 'q8_0')
 const VISIONPSY_FLASH_IQ3M = visionpsy(VISIONPSY_FLASH, 'iq3m', 'iq3_m-imat')
 
-// Same model and preprocessing as visionpsy-flash-q4, with the projector forced onto the
-// GPU. It reaches one path no other entry can: the addon auto-defaults the projector
-// backend by GPU class (LlamaModel.cpp), GPU on Adreno 800+ and CPU on Mali, so a plain
-// `device: gpu` leg on a Mali phone runs the vision encoder on CPU and never exercises
-// Vulkan for it.
-//
-// A separate entry rather than a flag on the existing one, because the auto-default exists
-// for a reason: the Mali projector encodes slower on GPU than on CPU (QVAC-21257), so
-// forcing it in the standard entry would make every routine Pixel run measure a
-// configuration nobody ships. Check the log line rather than the timing, it must read
+// visionpsy-flash-q4 with the projector forced onto the GPU, which reaches a path no other
+// entry can: the addon auto-defaults the projector backend by GPU class (LlamaModel.cpp),
+// CPU on Mali, so a plain `device: gpu` leg on a Mali phone never runs the vision encoder on
+// Vulkan. Kept separate because that auto-default is deliberate, the Mali projector being
+// slower on GPU than CPU (QVAC-21257), so forcing it everywhere would have routine Pixel runs
+// measure a configuration nobody ships. Check the log line, not the timing: it must read
 // `GPU (mmproj-use-gpu override)`.
 const VISIONPSY_FLASH_Q4_MMPROJ_GPU = {
   ...VISIONPSY_FLASH_Q4,

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -229,10 +229,21 @@ async function ensureBlob (blob) {
   return [plan.modelName, modelDir]
 }
 
-// Human-readable origin URL for the [VLMMETA] provenance marker.
+// Human-readable origin URL for the [VLMMETA] provenance marker. On this leg ensureBlob()
+// hands the name to ensureModel(), which fetches and sha256-verifies the manifest entry and
+// never looks at downloadUrl, so report the manifest's URL. Reporting the caller's would name
+// bytes that were never fetched: a json: spec can pair modelName Qwen3.5-0.8B-Q8_0.gguf with
+// any URL it likes, and the manifest bytes are what actually run.
 function displayUrl (blob) {
   const plan = resolveBlob(blob)
-  if (plan.downloadUrl) return plan.downloadUrl
+  if (plan.downloadUrl) {
+    try {
+      const entry = resolveModelEntry(plan.modelName)
+      return entry.urls[0]
+    } catch (_) {
+      return plan.downloadUrl
+    }
+  }
   const s = blob.source || {}
   return `registry:${s.source || ''}/${s.path || ''}`
 }

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -18,7 +18,7 @@ const test = require('brittle')
 const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
-const { ensureModel } = require('../../test/integration/utils')
+const { ensureModel, resolveModelEntry } = require('../../test/integration/utils')
 const LlmLlamacpp = require('../../index.js')
 const fixture = require('./fixture.data.cjs')
 const config = require('./config.cjs')
@@ -203,7 +203,23 @@ async function fetchFromRegistry (source, destPath) {
 // ensureModel()'s cache-by-name behaviour for the custom-fetch (registry) path.
 async function ensureBlob (blob) {
   const plan = resolveBlob(blob)
-  if (plan.downloadUrl) return ensureModel({ modelName: plan.modelName, downloadUrl: plan.downloadUrl })
+  if (plan.downloadUrl) {
+    // ensureModel() resolves modelName against models.manifest.json and verifies the
+    // sha256 pinned there; it never reads downloadUrl. So the addon leg can only run
+    // blobs the manifest pins, and a generated adhoc-* name never is one. Fail with
+    // that, rather than letting resolveModelEntry report a missing manifest entry as
+    // if the manifest were at fault.
+    try {
+      resolveModelEntry(plan.modelName)
+    } catch (_) {
+      throw new Error(
+        `${plan.modelName}: the addon leg runs only blobs pinned in models.manifest.json, so a bare ` +
+        '<llm-url>|<mmproj-url> pair cannot run on it. Use a catalog name, or a json: spec whose ' +
+        'modelName matches a manifest key. CLI-only dispatches fetch the URL directly and are unaffected.'
+      )
+    }
+    return ensureModel({ modelName: plan.modelName })
+  }
   const modelDir = path.resolve(__dirname, '../model')
   const modelPath = path.join(modelDir, plan.modelName)
   if (fs.existsSync(modelPath) && fs.statSync(modelPath).size > 0) return [plan.modelName, modelDir]
@@ -350,6 +366,11 @@ function runModel (spec) {
           n_predict: String(nPredict),
           verbosity: '2', // surfaces `image slice encoded in N ms` on native stderr
           'reasoning-budget': '0', // disable Qwen3.5 thinking -> clean direct answers
+          // Per-model load config, the addon-side twin of the catalog's `cliArgs`
+          // (e.g. VisionPsy Flash needs image-no-upscale, which nothing in its mmproj
+          // declares). Omitted entirely for models that define none, so the addon keeps
+          // its own defaults.
+          ...(spec.addonConfig || {}),
           ...(BACKENDS_DIR ? { backendsDir: BACKENDS_DIR } : {}) // candidate/baseline build swap (scheduler)
         },
         logger: console,
@@ -452,13 +473,18 @@ function runModel (spec) {
 }
 
 // One test file -> one mobile test function -> one Device Farm spec -> one phone.
-// two-models runs the QVAC_VLM_MODELS launch param (catalog names, ad-hoc
-// <llm-url>|<mmproj-url> pairs, or json: specs — see models.cjs / CONTRACT.md §3),
-// falling back to the committed config.models pair; several-sources loads the one
-// sourcesModel (the other engines run via cli-fixture-runner.cjs, same log).
+// two-models runs the QVAC_VLM_MODELS launch param (catalog names, or json: specs; see
+// models.cjs / CONTRACT.md §3. Ad-hoc <llm-url>|<mmproj-url> pairs parse here but reach the
+// CLI legs only, since the addon leg downloads only manifest-pinned blobs),
+// falling back to the committed config.models pair; several-sources runs ONE model
+// across the engines (the other engines run via cli-fixture-runner.cjs, same log).
+// several-sources honours the same launch param, first token only, so a model that
+// has no catalog entry can be compared across engines without a config commit;
+// empty falls back to config.sourcesModel. The workflow's CLI step resolves the
+// blob filenames the same way, so both legs read the same two files.
 function runAll () {
   const models = MODE === 'several-sources'
-    ? [config.sourcesModel]
+    ? parseModels(env('QVAC_VLM_MODELS'), config.catalog, [config.sourcesModel]).slice(0, 1)
     : parseModels(env('QVAC_VLM_MODELS'), config.catalog, config.models)
   // When the desktop scheduler drives one (source × model × block) per process it pins
   // the model by index (QVAC_VLM_MODEL_INDEX); otherwise run the whole list.

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -492,15 +492,10 @@ function runModel (spec) {
 }
 
 // One test file -> one mobile test function -> one Device Farm spec -> one phone.
-// two-models runs the QVAC_VLM_MODELS launch param (catalog names, or json: specs; see
-// models.cjs / CONTRACT.md §3. Ad-hoc <llm-url>|<mmproj-url> pairs parse here but reach the
-// CLI legs only, since the addon leg downloads only manifest-pinned blobs),
-// falling back to the committed config.models pair; several-sources runs ONE model
-// across the engines (the other engines run via cli-fixture-runner.cjs, same log).
-// several-sources honours the same launch param, first token only, so a model that
-// has no catalog entry can be compared across engines without a config commit;
-// empty falls back to config.sourcesModel. The workflow's CLI step resolves the
-// blob filenames the same way, so both legs read the same two files.
+// two-models takes the pair from QVAC_VLM_MODELS, several-sources one model across the
+// engines from its first token; empty falls back to the committed config. See CONTRACT.md §3.
+// The gotcha: an ad-hoc <llm-url>|<mmproj-url> pair parses here but reaches the CLI legs
+// only, because the addon leg runs manifest-pinned blobs exclusively.
 function runAll () {
   const models = MODE === 'several-sources'
     ? parseModels(env('QVAC_VLM_MODELS'), config.catalog, [config.sourcesModel]).slice(0, 1)

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -22,7 +22,7 @@ const { ensureModel, resolveModelEntry, loadManifest } = require('../../test/int
 const LlmLlamacpp = require('../../index.js')
 const fixture = require('./fixture.data.cjs')
 const config = require('./config.cjs')
-const { parseModels } = require('./models.cjs')
+const { parseModels, preprocLabel } = require('./models.cjs')
 const { stabilityGuard } = require('./methodology.cjs')
 
 // Resolve a fixture image. Images live in a fixture object store (not git): CI syncs
@@ -366,7 +366,10 @@ function runModel (spec) {
         main_source: sourceType(spec.llm),
         mmproj_origin: spec.mmproj.origin,
         mmproj_url: displayUrl(spec.mmproj),
-        mmproj_source: sourceType(spec.mmproj)
+        mmproj_source: sourceType(spec.mmproj),
+        // Same canonical form the CLI legs emit, so the report can tell a leg that applied
+        // the model's preprocessing from one that ran the weights without it.
+        preproc: preprocLabel({ addonConfig: spec.addonConfig })
       })) + '[/VLMMETA]')
       // Size the output cap to the heaviest task in this run (ocr-page needs ~768).
       const items = selectedItems()

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -18,7 +18,7 @@ const test = require('brittle')
 const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
-const { ensureModel, resolveModelEntry } = require('../../test/integration/utils')
+const { ensureModel, resolveModelEntry, loadManifest } = require('../../test/integration/utils')
 const LlmLlamacpp = require('../../index.js')
 const fixture = require('./fixture.data.cjs')
 const config = require('./config.cjs')
@@ -199,23 +199,28 @@ async function fetchFromRegistry (source, destPath) {
   }
 }
 
-// Download a blob to test/model/, honouring its source descriptor. Mirrors
-// ensureModel()'s cache-by-name behaviour for the custom-fetch (registry) path.
+// Honour a blob's source descriptor. Manifest-pinned blobs go to ensureModel()'s own
+// directory (test/model/); the custom-fetch (registry) path lands in benchmarks/model/
+// and mirrors ensureModel()'s cache-by-name behaviour there.
 async function ensureBlob (blob) {
   const plan = resolveBlob(blob)
   if (plan.downloadUrl) {
     // ensureModel() resolves modelName against models.manifest.json and verifies the
     // sha256 pinned there; it never reads downloadUrl. So the addon leg can only run
-    // blobs the manifest pins, and a generated adhoc-* name never is one. Fail with
-    // that, rather than letting resolveModelEntry report a missing manifest entry as
-    // if the manifest were at fault.
+    // blobs the manifest pins, and a generated adhoc-* name never is one. Say that when
+    // the name is genuinely absent, rather than reporting every manifest problem as a
+    // missing entry: resolveModelEntry also throws for an entry with no URL, no sha256
+    // or no byte-size pin, and those want the reader in models.manifest.json, not here.
     try {
       resolveModelEntry(plan.modelName)
-    } catch (_) {
+    } catch (err) {
+      const manifest = loadManifest()
+      if (manifest.models[plan.modelName] != null) throw err
       throw new Error(
         `${plan.modelName}: the addon leg runs only blobs pinned in models.manifest.json, so a bare ` +
         '<llm-url>|<mmproj-url> pair cannot run on it. Use a catalog name, or a json: spec whose ' +
-        'modelName matches a manifest key. CLI-only dispatches fetch the URL directly and are unaffected.'
+        'modelName matches a manifest key. CLI-only dispatches fetch the URL directly and are unaffected.',
+        { cause: err }
       )
     }
     return ensureModel({ modelName: plan.modelName })

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -87,41 +87,42 @@ function parsePair (token) {
 // only of dots, and `..` is a path segment that walks up one level.
 const MODEL_NAME_RE = /^(?!\.+$)[A-Za-z0-9._-]+$/
 
-// cliArgs exists for ONE purpose: per-model image preprocessing that the GGUF cannot
-// declare, e.g. VisionPsy Flash's --image-no-upscale. So allow exactly that family and
-// reject every other flag, rather than blocklisting the ones the harness sets.
+// cliArgs and addonConfig exist for ONE purpose: per-model image preprocessing that the
+// GGUF cannot declare, e.g. VisionPsy Flash's --image-no-upscale. Allow exactly that
+// family and reject every other flag, rather than blocklisting the ones the harness sets.
+// A blocklist cannot be made safe here, because llama.cpp gives most options several
+// spellings (common/arg.cpp: -n / --predict / --n-predict, -ngl / --gpu-layers /
+// --n-gpu-layers) and extra args are appended AFTER buildCliArgs' fixed flags, so a late
+// alias wins and a fabric bump can add one without touching this file.
 //
-// A blocklist cannot be made safe here. llama.cpp gives most options several spellings
-// (common/arg.cpp: {"-n","--predict","--n-predict"}, {"-s","--seed"},
-// {"--temp","--temperature"}, {"-mm","--mmproj"}, {"-ngl","--gpu-layers",
-// "--n-gpu-layers"}), extraArgs are appended AFTER buildCliArgs' fixed flags so a late
-// alias wins, and a fabric bump can add another alias without touching this file. An
-// allowlist cannot rot that way: a new spelling of --seed is still not on it.
-//
-// These are single-spelling in arg.cpp (:2418 :2425 :2452 :2463) and none of them is set
-// by buildCliArgs. Adding to this list is a deliberate act; do it when a model genuinely
-// needs a new preprocessing knob, and only once ALLOWED_ADDON_KEYS has the twin. A flag
-// with no addon twin cannot be set on both legs, so a spec using it would put the two
-// legs on different preprocessing under one model label. --image-max-tiles is the case in
-// point: arg.cpp takes it, the addon has no handler, so it stays off both lists.
-const ALLOWED_CLI_FLAGS = new Set([
-  '--image-no-upscale', '--image-tile-mode',
-  '--image-max-tokens', '--image-min-tokens'
+// One descriptor per option, so the CLI and addon sides cannot drift apart: both
+// allowlists and the twin lookup below are derived from it. `addon: null` means the
+// option has no addon handler and so cannot be set on both legs, which is why
+// --image-max-tiles is absent entirely: arg.cpp takes it, the addon does not.
+// mmproj-use-gpu is addon-only in the other direction. It picks the projector backend,
+// which `device` does not control, and on Android the addon auto-defaults it per GPU
+// class (LlamaModel.cpp: GPU for Adreno 800+, CPU for Mali and anything undetected), so
+// validating the projector on a Mali GPU is impossible without overriding it.
+const MODEL_OPTIONS = Object.freeze([
+  { cli: '--image-no-upscale', addon: 'image-no-upscale' },
+  { cli: '--image-tile-mode', addon: 'image-tile-mode' },
+  { cli: '--image-max-tokens', addon: 'image-max-tokens' },
+  { cli: '--image-min-tokens', addon: 'image-min-tokens' },
+  { cli: null, addon: 'mmproj-use-gpu' }
 ])
 
-// The addon twin. LOAD_CONFIG_HANDLERS in the addon accepts both spellings of each key,
-// so both are listed. reasoning-budget is deliberately absent: the harness pins it to 0
-// for every leg, so a spec that set it would be changing the comparison, not the model.
-// mmproj-use-gpu is here rather than treated as a device setting: `device` picks the
-// backend for the LLM layers, this picks it for the projector only, and on Android the
-// addon auto-defaults it per GPU class (LlamaModel.cpp: GPU for Adreno 800+, CPU for
-// Mali and anything undetected). Validating the projector on a Mali GPU is therefore
-// impossible without overriding it, so a dispatch has to be able to set it.
-const ALLOWED_ADDON_KEYS = new Set([
-  'image-no-upscale', 'image_no_upscale', 'image-tile-mode', 'image_tile_mode',
-  'image-max-tokens', 'image_max_tokens', 'image-min-tokens', 'image_min_tokens',
-  'mmproj-use-gpu', 'mmproj_use_gpu'
-])
+// The addon accepts either spelling of each key (LOAD_CONFIG_HANDLERS), so list both.
+// reasoning-budget is deliberately absent everywhere: the harness pins it to 0 on every
+// leg, so a spec setting it would change the comparison, not the model.
+const addonSpellings = (key) => [key, key.replace(/-/g, '_')]
+
+const ALLOWED_CLI_FLAGS = new Set(MODEL_OPTIONS.filter(o => o.cli).map(o => o.cli))
+const ALLOWED_ADDON_KEYS = new Set(MODEL_OPTIONS.filter(o => o.addon).flatMap(o => addonSpellings(o.addon)))
+
+// Canonical CLI flag -> addon key, and back. Both sides canonicalise before lookup, so
+// --image_no_upscale and image_no_upscale land on the same option.
+const CLI_TO_ADDON = new Map(MODEL_OPTIONS.filter(o => o.cli && o.addon).map(o => [o.cli, o.addon]))
+const ADDON_TO_CLI = new Map(MODEL_OPTIONS.filter(o => o.cli && o.addon).map(o => [o.addon, o.cli]))
 
 // llama.cpp rewrites `_` to `-` on any `--` argument before it looks the option up
 // (common/arg.cpp, both parse loops), so `--image_no_upscale` reaches the same option
@@ -158,6 +159,47 @@ function assertNoEqualsForm (args, i, label) {
   const bad = args.filter(a => a.includes('='))
   if (bad.length) {
     throw new Error(`json model #${i} ('${label || '?'}'): cliArgs must use the split form, llama.cpp does not accept --flag=value; write ['--image-no-upscale', 'on'] instead of ${bad.map(a => JSON.stringify(a)).join(', ')}`)
+  }
+}
+
+// Pair a cliArgs array down to {canonical flag -> value}. A flag with no following value,
+// or followed by another flag, is a valueless switch and pairs to ''.
+function cliArgsToMap (args) {
+  const out = new Map()
+  for (let n = 0; n < args.length; n++) {
+    if (!isFlagToken(args[n])) continue
+    const next = args[n + 1]
+    out.set(canonicalCliFlag(args[n]), next != null && !isFlagToken(next) ? next : '')
+  }
+  return out
+}
+
+// An option set on one leg only silently compares different preprocessing under one model
+// label, which is the failure the pairing exists to prevent. So a spec that sets an option
+// having a twin must set both sides to the same value. Options with no twin, currently
+// mmproj-use-gpu, are exempt: there is nothing to match them against.
+function assertTwinsMatch (spec, i) {
+  const label = spec.label || '?'
+  const cli = cliArgsToMap(spec.cliArgs || [])
+  const addon = new Map()
+  for (const [k, v] of Object.entries(spec.addonConfig || {})) {
+    addon.set(k.replace(/_/g, '-'), String(v))
+  }
+  const problems = []
+  for (const [flag, value] of cli) {
+    const twin = CLI_TO_ADDON.get(flag)
+    if (!twin) continue
+    if (!addon.has(twin)) problems.push(`${flag} is set for the CLI legs but addonConfig has no '${twin}'`)
+    else if (addon.get(twin) !== value) problems.push(`${flag} is '${value}' but addonConfig '${twin}' is '${addon.get(twin)}'`)
+  }
+  for (const [key, value] of addon) {
+    const twin = ADDON_TO_CLI.get(key)
+    if (!twin) continue
+    if (!cli.has(twin)) problems.push(`addonConfig '${key}' is set but cliArgs has no ${twin}`)
+    else if (cli.get(twin) !== value) problems.push(`addonConfig '${key}' is '${value}' but ${twin} is '${cli.get(twin)}'`)
+  }
+  if (problems.length) {
+    throw new Error(`json model #${i} ('${label}'): cliArgs and addonConfig must set the same preprocessing on both legs, otherwise the report compares different settings under one label; ${problems.join('; ')}`)
   }
 }
 
@@ -220,6 +262,7 @@ function normalizeSpec (spec, i) {
       throw new Error(`json model #${i} ('${spec.label || '?'}'): addonConfig may only carry per-model image preprocessing keys (${[...ALLOWED_ADDON_KEYS].join(', ')}); rejected ${bad.join(', ')}`)
     }
   }
+  assertTwinsMatch(spec, i)
   if (!spec.label) spec.label = `json-model-${i}`
   if (!spec.name) spec.name = spec.label
   if (!spec.ctx_size) spec.ctx_size = '4096'
@@ -255,4 +298,6 @@ function parseModels (raw, catalog, fallback) {
   return specs
 }
 
-module.exports = { parseModels, parsePair, blobFromUrl }
+// assertTwinsMatch is exported so a test can hold the committed catalog to the same rule
+// as a json: spec; normalizeSpec only runs on the latter.
+module.exports = { parseModels, parsePair, blobFromUrl, assertTwinsMatch, MODEL_OPTIONS }

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -133,6 +133,18 @@ function isFlagToken (a) {
   return a.startsWith('-') && !/^-\d/.test(a)
 }
 
+// One array element must stay one CLI token, because resolve-cli-model.cjs joins the array
+// with a space into the env file and cli-fixture-runner.cjs splits it back on whitespace.
+// An element carrying a space would therefore pass the allowlist as a single token and then
+// become two, and since extra args are appended after the fixed ones it could override a
+// benchmark-controlled flag such as --ctx-size.
+function assertNoWhitespace (args, i, label) {
+  const bad = args.filter(a => /\s/.test(a))
+  if (bad.length) {
+    throw new Error(`json model #${i} ('${label || '?'}'): cliArgs elements must not contain whitespace, one element is one argument; rejected ${bad.map(a => JSON.stringify(a)).join(', ')}`)
+  }
+}
+
 // Every URL the workflow hands to curl must be https. curl reads a leading dash as an
 // option however the shell quotes it, so a value like `--config=/tmp/curlrc` would be
 // obeyed rather than fetched; requiring the https:// prefix rejects that by construction.
@@ -175,6 +187,7 @@ function normalizeSpec (spec, i) {
     if (!Array.isArray(spec.cliArgs) || spec.cliArgs.some(a => typeof a !== 'string')) {
       throw new Error(`json model #${i} ('${spec.label || '?'}'): cliArgs must be an array of strings`)
     }
+    assertNoWhitespace(spec.cliArgs, i, spec.label)
     const bad = spec.cliArgs.filter(a => isFlagToken(a) && !ALLOWED_CLI_FLAGS.has(canonicalCliFlag(a)))
     if (bad.length) {
       throw new Error(`json model #${i} ('${spec.label || '?'}'): cliArgs may only carry per-model image preprocessing flags (${[...ALLOWED_CLI_FLAGS].join(', ')}); rejected ${bad.join(', ')}`)

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -82,8 +82,10 @@ function parsePair (token) {
 
 // Bare filename only: modelName becomes a path segment under $MODEL_DIR (see
 // resolve-cli-model.cjs / the benchmark-vlm-model-comparison.yml fetch_blob step), so a
-// caller-supplied value must not be able to escape that directory.
-const MODEL_NAME_RE = /^[A-Za-z0-9._-]+$/
+// caller-supplied value must not be able to escape that directory. The leading (?!\.+$)
+// is what closes that: the character class has no slash, but it does allow a name made
+// only of dots, and `..` is a path segment that walks up one level.
+const MODEL_NAME_RE = /^(?!\.+$)[A-Za-z0-9._-]+$/
 
 // cliArgs exists for ONE purpose: per-model image preprocessing that the GGUF cannot
 // declare, e.g. VisionPsy Flash's --image-no-upscale. So allow exactly that family and

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -87,22 +87,15 @@ function parsePair (token) {
 // only of dots, and `..` is a path segment that walks up one level.
 const MODEL_NAME_RE = /^(?!\.+$)[A-Za-z0-9._-]+$/
 
-// cliArgs and addonConfig exist for ONE purpose: per-model image preprocessing that the
-// GGUF cannot declare, e.g. VisionPsy Flash's --image-no-upscale. Allow exactly that
-// family and reject every other flag, rather than blocklisting the ones the harness sets.
-// A blocklist cannot be made safe here, because llama.cpp gives most options several
-// spellings (common/arg.cpp: -n / --predict / --n-predict, -ngl / --gpu-layers /
-// --n-gpu-layers) and extra args are appended AFTER buildCliArgs' fixed flags, so a late
-// alias wins and a fabric bump can add one without touching this file.
+// Per-model image preprocessing the GGUF cannot declare, e.g. VisionPsy Flash's
+// --image-no-upscale. An allowlist, not a blocklist: llama.cpp gives most options several
+// spellings and extra args are appended after buildCliArgs' fixed ones, so a late alias
+// would win and a fabric bump could add one without touching this file.
 //
-// One descriptor per option, so the CLI and addon sides cannot drift apart: both
-// allowlists and the twin lookup below are derived from it. `addon: null` means the
-// option has no addon handler and so cannot be set on both legs, which is why
-// --image-max-tiles is absent entirely: arg.cpp takes it, the addon does not.
-// mmproj-use-gpu is addon-only in the other direction. It picks the projector backend,
-// which `device` does not control, and on Android the addon auto-defaults it per GPU
-// class (LlamaModel.cpp: GPU for Adreno 800+, CPU for Mali and anything undetected), so
-// validating the projector on a Mali GPU is impossible without overriding it.
+// One entry per option, so the two sides cannot drift apart: both allowlists and the twin
+// lookup are derived from here. A null side means the option exists on one leg only and so
+// can never be paired, which is why --image-max-tiles is absent entirely (arg.cpp takes it,
+// the addon has no handler) and why mmproj-use-gpu is addon-only. See CONTRACT.md section 3.
 const MODEL_OPTIONS = Object.freeze([
   { cli: '--image-no-upscale', addon: 'image-no-upscale' },
   { cli: '--image-tile-mode', addon: 'image-tile-mode' },

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -80,6 +80,70 @@ function parsePair (token) {
   return { label, name: label, ctx_size: ctx, llm, mmproj }
 }
 
+// Bare filename only: modelName becomes a path segment under $MODEL_DIR (see
+// resolve-cli-model.cjs / the benchmark-vlm-model-comparison.yml fetch_blob step), so a
+// caller-supplied value must not be able to escape that directory.
+const MODEL_NAME_RE = /^[A-Za-z0-9._-]+$/
+
+// cliArgs exists for ONE purpose: per-model image preprocessing that the GGUF cannot
+// declare, e.g. VisionPsy Flash's --image-no-upscale. So allow exactly that family and
+// reject every other flag, rather than blocklisting the ones the harness sets.
+//
+// A blocklist cannot be made safe here. llama.cpp gives most options several spellings
+// (common/arg.cpp: {"-n","--predict","--n-predict"}, {"-s","--seed"},
+// {"--temp","--temperature"}, {"-mm","--mmproj"}, {"-ngl","--gpu-layers",
+// "--n-gpu-layers"}), extraArgs are appended AFTER buildCliArgs' fixed flags so a late
+// alias wins, and a fabric bump can add another alias without touching this file. An
+// allowlist cannot rot that way: a new spelling of --seed is still not on it.
+//
+// These five are single-spelling in arg.cpp (:2418 :2425 :2432 :2452 :2463) and none
+// of them is set by buildCliArgs. Adding to this list is a deliberate act; do it when a
+// model genuinely needs a new preprocessing knob.
+const ALLOWED_CLI_FLAGS = new Set([
+  '--image-no-upscale', '--image-tile-mode', '--image-max-tiles',
+  '--image-max-tokens', '--image-min-tokens'
+])
+
+// The addon twin. LOAD_CONFIG_HANDLERS in the addon accepts both spellings of each key,
+// so both are listed. reasoning-budget is deliberately absent: the harness pins it to 0
+// for every leg, so a spec that set it would be changing the comparison, not the model.
+// mmproj-use-gpu is here rather than treated as a device setting: `device` picks the
+// backend for the LLM layers, this picks it for the projector only, and on Android the
+// addon auto-defaults it per GPU class (LlamaModel.cpp: GPU for Adreno 800+, CPU for
+// Mali and anything undetected). Validating the projector on a Mali GPU is therefore
+// impossible without overriding it, so a dispatch has to be able to set it.
+const ALLOWED_ADDON_KEYS = new Set([
+  'image-no-upscale', 'image_no_upscale', 'image-tile-mode', 'image_tile_mode',
+  'image-max-tokens', 'image_max_tokens', 'image-min-tokens', 'image_min_tokens',
+  'mmproj-use-gpu', 'mmproj_use_gpu'
+])
+
+// llama.cpp rewrites `_` to `-` on any `--` argument before it looks the option up
+// (common/arg.cpp, both parse loops), so `--image_no_upscale` reaches the same option
+// as `--image-no-upscale`. Match that, and split `--flag=value` so the flag is compared
+// on its own.
+function canonicalCliFlag (a) {
+  const head = a.split('=')[0]
+  return head.startsWith('--') ? head.replace(/_/g, '-') : head
+}
+
+// A token is a flag if it starts with `-` and is not a negative number, since values
+// like `-1` are legitimate arguments to the flag before them.
+function isFlagToken (a) {
+  return a.startsWith('-') && !/^-\d/.test(a)
+}
+
+// Every URL the workflow hands to curl must be https. curl reads a leading dash as an
+// option however the shell quotes it, so a value like `--config=/tmp/curlrc` would be
+// obeyed rather than fetched; requiring the https:// prefix rejects that by construction.
+const HTTPS_RE = /^https:\/\/[^\s]+$/
+
+function assertHttpsUrl (value, what, i, label) {
+  if (!HTTPS_RE.test(String(value))) {
+    throw new Error(`json model #${i} ('${label || '?'}'): ${what} must be an https URL (got '${String(value).slice(0, 60)}')`)
+  }
+}
+
 // json: form — validate the minimum the harness needs; registry-type sources
 // are accepted here (desktop-only; the mobile app has no registry client).
 function normalizeSpec (spec, i) {
@@ -89,11 +153,42 @@ function normalizeSpec (spec, i) {
     if (!blob || (!blob.source && !blob.downloadUrl)) {
       throw new Error(`json model #${i} ('${spec.label || '?'}'): missing ${role}.source`)
     }
+    if (blob.downloadUrl) {
+      assertHttpsUrl(blob.downloadUrl, `${role}.downloadUrl`, i, spec.label)
+    }
+    // resolveBlob() turns a url/s3 source into exactly this downloadUrl, and
+    // resolve-cli-model.cjs emits it into the env file the workflow curls, so it needs
+    // the same check. `hf` is built from repo/sha/file and `registry` never reaches curl.
+    const src = blob.source || {}
+    if (src.type === 'url' || src.type === 's3') {
+      assertHttpsUrl(src.url, `${role}.source.url`, i, spec.label)
+    }
     if (!blob.modelName) {
       const ident = JSON.stringify(blob.source || blob.downloadUrl)
       blob.modelName = `adhoc-${hash8(ident)}-${role}.gguf`
+    } else if (!MODEL_NAME_RE.test(blob.modelName)) {
+      throw new Error(`json model #${i} ('${spec.label || '?'}'): ${role}.modelName must be a bare filename (got '${String(blob.modelName).slice(0, 60)}')`)
     }
     if (!blob.origin) blob.origin = blob.modelName
+  }
+  if (spec.cliArgs != null) {
+    if (!Array.isArray(spec.cliArgs) || spec.cliArgs.some(a => typeof a !== 'string')) {
+      throw new Error(`json model #${i} ('${spec.label || '?'}'): cliArgs must be an array of strings`)
+    }
+    const bad = spec.cliArgs.filter(a => isFlagToken(a) && !ALLOWED_CLI_FLAGS.has(canonicalCliFlag(a)))
+    if (bad.length) {
+      throw new Error(`json model #${i} ('${spec.label || '?'}'): cliArgs may only carry per-model image preprocessing flags (${[...ALLOWED_CLI_FLAGS].join(', ')}); rejected ${bad.join(', ')}`)
+    }
+  }
+  if (spec.addonConfig != null) {
+    const cfg = spec.addonConfig
+    if (typeof cfg !== 'object' || Array.isArray(cfg) || Object.values(cfg).some(v => typeof v !== 'string')) {
+      throw new Error(`json model #${i} ('${spec.label || '?'}'): addonConfig must be an object of string values`)
+    }
+    const bad = Object.keys(cfg).filter(k => !ALLOWED_ADDON_KEYS.has(k))
+    if (bad.length) {
+      throw new Error(`json model #${i} ('${spec.label || '?'}'): addonConfig may only carry per-model image preprocessing keys (${[...ALLOWED_ADDON_KEYS].join(', ')}); rejected ${bad.join(', ')}`)
+    }
   }
   if (!spec.label) spec.label = `json-model-${i}`
   if (!spec.name) spec.name = spec.label

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -298,6 +298,25 @@ function parseModels (raw, catalog, fallback) {
   return specs
 }
 
+// One canonical string for the per-model preprocessing a leg actually applied, so the report
+// can compare legs that were configured through different mechanisms. The addon leg passes
+// its addonConfig, the CLI legs the argv they were handed, and both come out as the same
+// sorted `key=value` form keyed on the addon spelling. Empty means base preprocessing, which
+// is the honest answer for an upstream-cli leg: cliArgs are fabric-fork flags and never reach
+// it, so it runs the model without them even when the addon leg does not.
+function preprocLabel ({ cliArgs, addonConfig } = {}) {
+  const applied = new Map()
+  for (const [k, v] of Object.entries(addonConfig || {})) applied.set(k.replace(/_/g, '-'), String(v))
+  for (const [flag, value] of cliArgsToMap(cliArgs || [])) {
+    const key = CLI_TO_ADDON.get(flag) || flag
+    if (!applied.has(key)) applied.set(key, value)
+  }
+  return [...applied.entries()]
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .map(([k, v]) => (v === '' ? k : `${k}=${v}`))
+    .join(' ')
+}
+
 // assertTwinsMatch is exported so a test can hold the committed catalog to the same rule
 // as a json: spec; normalizeSpec only runs on the latter.
-module.exports = { parseModels, parsePair, blobFromUrl, assertTwinsMatch, MODEL_OPTIONS }
+module.exports = { parseModels, parsePair, blobFromUrl, assertTwinsMatch, preprocLabel, MODEL_OPTIONS }

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/models.cjs
@@ -98,11 +98,14 @@ const MODEL_NAME_RE = /^(?!\.+$)[A-Za-z0-9._-]+$/
 // alias wins, and a fabric bump can add another alias without touching this file. An
 // allowlist cannot rot that way: a new spelling of --seed is still not on it.
 //
-// These five are single-spelling in arg.cpp (:2418 :2425 :2432 :2452 :2463) and none
-// of them is set by buildCliArgs. Adding to this list is a deliberate act; do it when a
-// model genuinely needs a new preprocessing knob.
+// These are single-spelling in arg.cpp (:2418 :2425 :2452 :2463) and none of them is set
+// by buildCliArgs. Adding to this list is a deliberate act; do it when a model genuinely
+// needs a new preprocessing knob, and only once ALLOWED_ADDON_KEYS has the twin. A flag
+// with no addon twin cannot be set on both legs, so a spec using it would put the two
+// legs on different preprocessing under one model label. --image-max-tiles is the case in
+// point: arg.cpp takes it, the addon has no handler, so it stays off both lists.
 const ALLOWED_CLI_FLAGS = new Set([
-  '--image-no-upscale', '--image-tile-mode', '--image-max-tiles',
+  '--image-no-upscale', '--image-tile-mode',
   '--image-max-tokens', '--image-min-tokens'
 ])
 
@@ -122,17 +125,17 @@ const ALLOWED_ADDON_KEYS = new Set([
 
 // llama.cpp rewrites `_` to `-` on any `--` argument before it looks the option up
 // (common/arg.cpp, both parse loops), so `--image_no_upscale` reaches the same option
-// as `--image-no-upscale`. Match that, and split `--flag=value` so the flag is compared
-// on its own.
+// as `--image-no-upscale`. Match that.
 function canonicalCliFlag (a) {
-  const head = a.split('=')[0]
-  return head.startsWith('--') ? head.replace(/_/g, '-') : head
+  return a.startsWith('--') ? a.replace(/_/g, '-') : a
 }
 
 // A token is a flag if it starts with `-` and is not a negative number, since values
-// like `-1` are legitimate arguments to the flag before them.
+// like `-1` are legitimate arguments to the flag before them. Anchored to a complete
+// number so a token such as `-1--ctx-size` is still treated as a flag and checked against
+// the allowlist rather than waved through as a value.
 function isFlagToken (a) {
-  return a.startsWith('-') && !/^-\d/.test(a)
+  return a.startsWith('-') && !/^-\d+(\.\d+)?$/.test(a)
 }
 
 // One array element must stay one CLI token, because resolve-cli-model.cjs joins the array
@@ -144,6 +147,17 @@ function assertNoWhitespace (args, i, label) {
   const bad = args.filter(a => /\s/.test(a))
   if (bad.length) {
     throw new Error(`json model #${i} ('${label || '?'}'): cliArgs elements must not contain whitespace, one element is one argument; rejected ${bad.map(a => JSON.stringify(a)).join(', ')}`)
+  }
+}
+
+// arg.cpp looks the whole argv token up in arg_to_options and never splits on `=`, so
+// `--image-no-upscale=on` is an unknown argument to it and aborts the run. The workflow
+// swallows that as a warning, which shows up as an engine leg with no rows rather than an
+// error, so reject the form here where the message can say why.
+function assertNoEqualsForm (args, i, label) {
+  const bad = args.filter(a => a.includes('='))
+  if (bad.length) {
+    throw new Error(`json model #${i} ('${label || '?'}'): cliArgs must use the split form, llama.cpp does not accept --flag=value; write ['--image-no-upscale', 'on'] instead of ${bad.map(a => JSON.stringify(a)).join(', ')}`)
   }
 }
 
@@ -190,6 +204,7 @@ function normalizeSpec (spec, i) {
       throw new Error(`json model #${i} ('${spec.label || '?'}'): cliArgs must be an array of strings`)
     }
     assertNoWhitespace(spec.cliArgs, i, spec.label)
+    assertNoEqualsForm(spec.cliArgs, i, spec.label)
     const bad = spec.cliArgs.filter(a => isFlagToken(a) && !ALLOWED_CLI_FLAGS.has(canonicalCliFlag(a)))
     if (bad.length) {
       throw new Error(`json model #${i} ('${spec.label || '?'}'): cliArgs may only carry per-model image preprocessing flags (${[...ALLOWED_CLI_FLAGS].join(', ')}); rejected ${bad.join(', ')}`)
@@ -226,7 +241,9 @@ function parseModels (raw, catalog, fallback) {
     return arr.map(normalizeSpec)
   }
   const specs = raw.split(',').map(t => t.trim()).filter(Boolean).map(t => {
-    if (catalog && catalog[t]) return catalog[t]
+    // Own-property check, so a name like `constructor` or `toString` falls through to the
+    // unknown-model error below instead of resolving to an Object.prototype member.
+    if (catalog && Object.prototype.hasOwnProperty.call(catalog, t)) return catalog[t]
     if (t.includes('|')) return parsePair(t)
     throw new Error(`unknown model '${t}' — not a catalog name (${Object.keys(catalog || {}).join(', ')}) and not an <llm-url>|<mmproj-url> pair`)
   })

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
@@ -1,16 +1,13 @@
 'use strict'
-// Resolve the several-sources model to shell variables for the workflow's native-CLI
-// step. Same resolution as harness.cjs runAll(): the QVAC_VLM_MODELS launch param
-// (first token) if set, else config.sourcesModel. The CLI legs need the on-disk blob
-// names (what the addon leg downloads, `modelName`), the download URLs (so a CLI-only
-// comparison can fetch them with no addon leg), and the provenance strings the report
-// prints per source.
+// Resolve the several-sources model to shell variables for the workflow's native-CLI step,
+// the same way harness.cjs runAll() does, so both legs read the same two files.
 //
 // Usage: node resolve-cli-model.cjs > "$RUNNER_TEMP/cli-model.env" && . "$RUNNER_TEMP/cli-model.env"
-// Write it outside the workspace: a URL here can be a presigned link, which is a bearer
+// Outside the workspace, because a URL here can be a presigned link, which is a bearer
 // credential, and a self-hosted runner's workspace outlives the job.
-// URL is empty for registry-type sources (P2P, addon-only), and the caller must
-// error out if the blob is not already on disk.
+//
+// A registry source emits an empty URL: those are addon-only, so the caller has to find the
+// blob on disk or fail.
 
 const { parseModels } = require('./models.cjs')
 const { serializeCliArgs } = require('./cli-args.cjs')

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
@@ -1,0 +1,69 @@
+'use strict'
+// Resolve the several-sources model to shell variables for the workflow's native-CLI
+// step. Same resolution as harness.cjs runAll(): the QVAC_VLM_MODELS launch param
+// (first token) if set, else config.sourcesModel. The CLI legs need the on-disk blob
+// names (what the addon leg downloads, `modelName`), the download URLs (so a CLI-only
+// comparison can fetch them with no addon leg), and the provenance strings the report
+// prints per source.
+//
+// Usage: node resolve-cli-model.cjs > cli-model.env && . ./cli-model.env
+// URL is empty for registry-type sources (P2P, addon-only), and the caller must
+// error out if the blob is not already on disk.
+
+const { parseModels } = require('./models.cjs')
+const config = require('./config.cjs')
+
+const hfUrl = (s) => `https://huggingface.co/${s.repo}/resolve/${s.sha}/${s.file}`
+
+// The workflow curls whatever this emits. Empty is fine and handled there (registry
+// sources have no URL and need an addon leg), but anything non-empty must be https:
+// curl reads a leading dash as an option no matter how the shell quotes it, so a value
+// like `--config=/tmp/curlrc` would be obeyed instead of fetched. models.cjs rejects
+// these at parse time too; this is the last gate before the value leaves the process.
+function checkedUrl (url, what) {
+  if (!url) return ''
+  if (!/^https:\/\/[^\s]+$/.test(url)) {
+    throw new Error(`${what}: refusing to emit a non-https URL ('${String(url).slice(0, 60)}')`)
+  }
+  return url
+}
+
+function blobUrl (blob) {
+  if (blob.downloadUrl) return checkedUrl(blob.downloadUrl, 'downloadUrl')
+  const s = blob.source || {}
+  if (s.type === 'hf') return checkedUrl(hfUrl(s), 'hf source')
+  if (s.type === 'url' || s.type === 's3') return checkedUrl(s.url || '', `${s.type} source`)
+  return ''
+}
+
+// Report Source column, same mapping as harness.cjs sourceType().
+function sourceKind (blob) {
+  if (blob.registry) return 'Registry'
+  const t = (blob.source && blob.source.type) || ''
+  return ({ hf: 'HF', s3: 'S3', url: 'URL' })[t] || (t || '?')
+}
+
+// Single-quote for `.`-sourcing. A literal quote is escaped the shell way rather than
+// stripped, so an origin or label carrying an apostrophe round-trips instead of coming
+// out silently altered.
+const sh = (name, value) => `${name}='${String(value == null ? '' : value).replace(/'/g, "'\\''")}'`
+
+const spec = parseModels(process.env.QVAC_VLM_MODELS, config.catalog, [config.sourcesModel])[0]
+
+console.log([
+  sh('LLM_NAME', spec.llm.modelName),
+  sh('LLM_URL', blobUrl(spec.llm)),
+  sh('MMPROJ_NAME', spec.mmproj.modelName),
+  sh('MMPROJ_URL', blobUrl(spec.mmproj)),
+  sh('MAIN_ORIGIN', spec.llm.origin || spec.llm.modelName),
+  sh('MMPROJ_ORIGIN', spec.mmproj.origin || spec.mmproj.modelName),
+  sh('MODEL_LABEL', spec.label),
+  // The addon leg runs at spec.ctx_size; without this the CLI legs silently stayed at
+  // their own default and the two engines were compared under different contexts.
+  sh('CTX_SIZE', spec.ctx_size),
+  sh('MAIN_SOURCE', sourceKind(spec.llm)),
+  sh('MMPROJ_SOURCE', sourceKind(spec.mmproj)),
+  // Model-specific flags for the fabric CLI only: these are fork additions, so passing
+  // them to upstream-cli would abort it on an unknown argument.
+  sh('CLI_EXTRA_ARGS', (spec.cliArgs || []).join(' '))
+].join('\n'))

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
@@ -6,7 +6,9 @@
 // comparison can fetch them with no addon leg), and the provenance strings the report
 // prints per source.
 //
-// Usage: node resolve-cli-model.cjs > cli-model.env && . ./cli-model.env
+// Usage: node resolve-cli-model.cjs > "$RUNNER_TEMP/cli-model.env" && . "$RUNNER_TEMP/cli-model.env"
+// Write it outside the workspace: a URL here can be a presigned link, which is a bearer
+// credential, and a self-hosted runner's workspace outlives the job.
 // URL is empty for registry-type sources (P2P, addon-only), and the caller must
 // error out if the blob is not already on disk.
 
@@ -14,7 +16,23 @@ const { parseModels } = require('./models.cjs')
 const { serializeCliArgs } = require('./cli-args.cjs')
 const config = require('./config.cjs')
 
-const hfUrl = (s) => `https://huggingface.co/${s.repo}/resolve/${s.sha}/${s.file}`
+// A json: spec supplies repo, sha and file, and this URL is the one the workflow sends the
+// HF token to. Constrain each part to the characters a real HF path uses so a spec cannot
+// steer the authenticated request off the resolve path it is meant to hit.
+const HF_PART_RE = /^[\w.-]+$/
+const HF_REPO_RE = /^[\w.-]+\/[\w.-]+$/
+
+function hfUrl (s) {
+  if (!HF_REPO_RE.test(String(s.repo || ''))) {
+    throw new Error(`hf source: repo must be '<owner>/<name>' (got '${String(s.repo).slice(0, 60)}')`)
+  }
+  for (const part of ['sha', 'file']) {
+    if (!HF_PART_RE.test(String(s[part] || ''))) {
+      throw new Error(`hf source: ${part} must be a bare path segment (got '${String(s[part]).slice(0, 60)}')`)
+    }
+  }
+  return `https://huggingface.co/${s.repo}/resolve/${s.sha}/${s.file}`
+}
 
 // The workflow curls whatever this emits. Empty is fine and handled there (registry
 // sources have no URL and need an addon leg), but anything non-empty must be https:
@@ -37,11 +55,25 @@ function blobUrl (blob) {
   return ''
 }
 
+// sha256 for the workflow to check a fetched blob against. The addon leg gets this for
+// free, since ensureModel() verifies the manifest pin, but a CLI-only dispatch fetches the
+// URL itself and had nothing to compare against. Prefer a spec's own sha256 so a json: blob
+// outside the manifest can still be pinned; empty means unverifiable and the caller warns.
+// The manifest is required directly rather than through test/integration/utils, which is a
+// bare-runtime module and cannot load under plain node.
+const manifest = require('../../test/integration/models.manifest.json')
+
+function blobSha256 (blob) {
+  if (blob.sha256) return String(blob.sha256)
+  const entry = manifest.models[blob.modelName]
+  return (entry && entry.sha256) || ''
+}
+
 // Report Source column, same mapping as harness.cjs sourceType().
 function sourceKind (blob) {
   if (blob.registry) return 'Registry'
   const t = (blob.source && blob.source.type) || ''
-  return ({ hf: 'HF', s3: 'S3', url: 'URL' })[t] || (t || '?')
+  return ({ hf: 'HF', s3: 'S3', url: 'URL' })[t] || (t || '—')
 }
 
 // Single-quote for `.`-sourcing. A literal quote is escaped the shell way rather than
@@ -54,8 +86,10 @@ const spec = parseModels(process.env.QVAC_VLM_MODELS, config.catalog, [config.so
 console.log([
   sh('LLM_NAME', spec.llm.modelName),
   sh('LLM_URL', blobUrl(spec.llm)),
+  sh('LLM_SHA256', blobSha256(spec.llm)),
   sh('MMPROJ_NAME', spec.mmproj.modelName),
   sh('MMPROJ_URL', blobUrl(spec.mmproj)),
+  sh('MMPROJ_SHA256', blobSha256(spec.mmproj)),
   sh('MAIN_ORIGIN', spec.llm.origin || spec.llm.modelName),
   sh('MMPROJ_ORIGIN', spec.mmproj.origin || spec.mmproj.modelName),
   sh('MODEL_LABEL', spec.label),

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
@@ -11,6 +11,7 @@
 // error out if the blob is not already on disk.
 
 const { parseModels } = require('./models.cjs')
+const { serializeCliArgs } = require('./cli-args.cjs')
 const config = require('./config.cjs')
 
 const hfUrl = (s) => `https://huggingface.co/${s.repo}/resolve/${s.sha}/${s.file}`
@@ -65,5 +66,5 @@ console.log([
   sh('MMPROJ_SOURCE', sourceKind(spec.mmproj)),
   // Model-specific flags for the fabric CLI only: these are fork additions, so passing
   // them to upstream-cli would abort it on an unknown argument.
-  sh('CLI_EXTRA_ARGS', (spec.cliArgs || []).join(' '))
+  sh('CLI_EXTRA_ARGS', serializeCliArgs(spec.cliArgs))
 ].join('\n'))

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/resolve-cli-model.cjs
@@ -19,18 +19,30 @@ const config = require('./config.cjs')
 // A json: spec supplies repo, sha and file, and this URL is the one the workflow sends the
 // HF token to. Constrain each part to the characters a real HF path uses so a spec cannot
 // steer the authenticated request off the resolve path it is meant to hit.
-const HF_PART_RE = /^[\w.-]+$/
+//
+// `file` is a path, not a single segment: HF repos nest, and the pair form accepts URLs
+// like .../resolve/<sha>/tinyllamas/stories260K.gguf. So allow `/` between segments while
+// rejecting anything that could climb or escape: an empty segment, `.`, or `..`.
+const HF_SEGMENT_RE = /^[\w.-]+$/
 const HF_REPO_RE = /^[\w.-]+\/[\w.-]+$/
+
+function checkedHfPath (value, what) {
+  const segments = String(value == null ? '' : value).split('/')
+  if (!segments.length || segments.some(seg => seg === '' || seg === '.' || seg === '..' || !HF_SEGMENT_RE.test(seg))) {
+    throw new Error(`hf source: ${what} must be a path of plain segments with no '.' or '..' (got '${String(value).slice(0, 60)}')`)
+  }
+  return value
+}
 
 function hfUrl (s) {
   if (!HF_REPO_RE.test(String(s.repo || ''))) {
     throw new Error(`hf source: repo must be '<owner>/<name>' (got '${String(s.repo).slice(0, 60)}')`)
   }
-  for (const part of ['sha', 'file']) {
-    if (!HF_PART_RE.test(String(s[part] || ''))) {
-      throw new Error(`hf source: ${part} must be a bare path segment (got '${String(s[part]).slice(0, 60)}')`)
-    }
+  // A commit sha is always one segment; only `file` may nest.
+  if (!HF_SEGMENT_RE.test(String(s.sha || ''))) {
+    throw new Error(`hf source: sha must be a bare path segment (got '${String(s.sha).slice(0, 60)}')`)
   }
+  checkedHfPath(s.file, 'file')
   return `https://huggingface.co/${s.repo}/resolve/${s.sha}/${s.file}`
 }
 

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/stdout-parser.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/stdout-parser.js
@@ -12,6 +12,12 @@
 // the actual encoder workload. visionEncodeSliceCount surfaces the
 // tile count so it shows up in the report alongside the summed time.
 const VISION_ENCODE_REGEX = /image (?:slice )?encoded in\s+(\d+(?:\.\d+)?)\s*ms/gi
+// The line above comes from mtmd_helper_eval_chunks (mtmd-helper.cpp). llama-mtmd-cli
+// does NOT call that helper, it runs its own encode loop and logs the two lines below
+// instead, so CLI legs reported no encode time at all. Chunk count comes from the
+// n_chunks field because one batch can carry several slices.
+const VISION_ENCODE_BATCH_REGEX = /mtmd batch encoding done in\s+(\d+(?:\.\d+)?)\s*ms/gi
+const VISION_ENCODE_CHUNKS_REGEX = /encoding mtmd batch,\s*n_chunks\s*=\s*(\d+)/gi
 // Pulled verbatim from Ian's Metal plan §5.7 — same llama.cpp output
 // shape on every platform.
 // Prompt eval must be matched BEFORE decode eval since "prompt eval time"
@@ -30,6 +36,16 @@ function parseStdoutMetrics (text) {
   if (visMatches.length) {
     out.visionEncodeMs = visMatches.reduce((sum, m) => sum + Number(m[1]), 0)
     out.visionEncodeSliceCount = visMatches.length
+  } else {
+    // Fall back to the CLI's own encode loop. Same ViT work, different log line.
+    const batches = [...text.matchAll(VISION_ENCODE_BATCH_REGEX)]
+    if (batches.length) {
+      out.visionEncodeMs = batches.reduce((sum, m) => sum + Number(m[1]), 0)
+      const chunks = [...text.matchAll(VISION_ENCODE_CHUNKS_REGEX)]
+      out.visionEncodeSliceCount = chunks.length
+        ? chunks.reduce((sum, m) => sum + Number(m[1]), 0)
+        : batches.length
+    }
   }
 
   const prompt = text.match(PROMPT_EVAL_REGEX)

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -30,7 +30,7 @@
     "verify:benchmark-shards": "node scripts/generate-benchmark-shards.js --check",
     "test:integration:generate": "npm run generate:benchmark-shards && brittle -r test/integration/all.js test/integration/*.test.js && npm run test:mobile:generate",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
-    "test:prestage": "node --test scripts/__tests__/*.test.js ../../.github/actions/cache-models/warm-models.test.mjs",
+    "test:prestage": "node --test scripts/__tests__/*.test.js benchmarks/vlm-benchmark/__tests__/*.test.js ../../.github/actions/cache-models/warm-models.test.mjs",
     "test:unit": "npm run build:ts && npm run test:unit:generate && bare test/unit/all.js --exit && npm run test:prestage",
     "test:cpp:build": "bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test",
     "test:cpp:models": "node scripts/download-unit-test-models.js",

--- a/packages/llm-llamacpp/test/integration/models.manifest.json
+++ b/packages/llm-llamacpp/test/integration/models.manifest.json
@@ -272,12 +272,28 @@
       "sha256": "ddc1be0331c403269b5eced1806c1a3f4a952f0d70b44e58da83bc846b5c8c5c",
       "bytes": 49564032
     },
+    "visionpsy-nano-460m-q4_0.gguf": {
+      "urls": [
+        "https://huggingface.co/qvac/VisionPsy-Nano-460M-GGUFs/resolve/4138c5bd6e026d67cebf2dbd2d81c6229c14cdc1/visionpsy-nano-460m-q4_0.gguf"
+      ],
+      "sha256": "803b0c846f63231fede7b98686e4ae837dd1b3a315c714482656e44ed8fa9598",
+      "bytes": 255764960,
+      "warm": false
+    },
     "visionpsy-nano-460m-q8_0.gguf": {
       "urls": [
         "https://huggingface.co/qvac/VisionPsy-Nano-460M-GGUFs/resolve/4138c5bd6e026d67cebf2dbd2d81c6229c14cdc1/visionpsy-nano-460m-q8_0.gguf"
       ],
       "sha256": "fc70a6c6eed7d2f82ed48cbd52cc7118b249eff8b91112ef9cbfca6813a1eefa",
       "bytes": 436676000,
+      "warm": false
+    },
+    "visionpsy-nano-460m-iq3_m-imat.gguf": {
+      "urls": [
+        "https://huggingface.co/qvac/VisionPsy-Nano-460M-GGUFs/resolve/4138c5bd6e026d67cebf2dbd2d81c6229c14cdc1/visionpsy-nano-460m-iq3_m-imat.gguf"
+      ],
+      "sha256": "9bafc829a0ca476da6e64c0ebd042b977d9f9049a5b5eab99fff10f0c47b028f",
+      "bytes": 251541312,
       "warm": false
     },
     "mmproj-visionpsy-nano-460m-q8.gguf": {
@@ -288,12 +304,28 @@
       "bytes": 108782144,
       "warm": false
     },
+    "visionpsy-nano-460m-flash-q4_0.gguf": {
+      "urls": [
+        "https://huggingface.co/qvac/VisionPsy-Nano-460M-Flash-GGUFs/resolve/a24fb9cdd1119406b15ff60b06a51f8438a931c1/visionpsy-nano-460m-flash-q4_0.gguf"
+      ],
+      "sha256": "21cf98677aead737689a30a6c3d61b989628d4fda36d192ff7c88fcff87eab20",
+      "bytes": 255764960,
+      "warm": false
+    },
     "visionpsy-nano-460m-flash-q8_0.gguf": {
       "urls": [
         "https://huggingface.co/qvac/VisionPsy-Nano-460M-Flash-GGUFs/resolve/a24fb9cdd1119406b15ff60b06a51f8438a931c1/visionpsy-nano-460m-flash-q8_0.gguf"
       ],
       "sha256": "66d84c0f552c96ec6734d8cef7f0a3192f4f2df2cd781a193339df194f501a12",
       "bytes": 436676000,
+      "warm": false
+    },
+    "visionpsy-nano-460m-flash-iq3_m-imat.gguf": {
+      "urls": [
+        "https://huggingface.co/qvac/VisionPsy-Nano-460M-Flash-GGUFs/resolve/a24fb9cdd1119406b15ff60b06a51f8438a931c1/visionpsy-nano-460m-flash-iq3_m-imat.gguf"
+      ],
+      "sha256": "126d3db15c14d125beac9dffb6eb7fe61c58bc1aa7dd4670396e676d3db2b3f4",
+      "bytes": 251541312,
       "warm": false
     },
     "mmproj-visionpsy-nano-460m-flash-q8.gguf": {

--- a/packages/llm-llamacpp/test/integration/models.manifest.json
+++ b/packages/llm-llamacpp/test/integration/models.manifest.json
@@ -123,6 +123,14 @@
       "sha256": "56e4c6cfe73b0c82e3e82bc518d7591997e61d81f723fc41a586f4fa69ea2453",
       "bytes": 204987232
     },
+    "mmproj-Qwen3.5-0.8B-Q8_0.gguf": {
+      "urls": [
+        "https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF/resolve/9d48fdbc0d8f133716da87ec1d904e5d2c7175a6/Qwen3.5-0.8B.mmproj-Q8_0.gguf"
+      ],
+      "sha256": "5a6b15da0f483b9e320a5b86b787ad1831953dfaa706e2c5d91de830ea70d784",
+      "bytes": 115923680,
+      "warm": false
+    },
     "mmproj-Qwen3.5-2B-F16.gguf": {
       "urls": [
         "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/mmproj-F16.gguf"
@@ -215,6 +223,14 @@
       ],
       "sha256": "3397f2e15859d268dc91782e92e70c485c7780448d57d622d145374390168f71",
       "bytes": 985653760
+    },
+    "mmproj-gemma-4-E2B-it-Q8_0.gguf": {
+      "urls": [
+        "https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF/resolve/a1dac71d3ab220618f5a7573a52acdc4baf3ae3b/mmproj-gemma-4-E2B-it-Q8_0.gguf"
+      ],
+      "sha256": "8a82e0fd831bb7cb5c8898b86393eb14042986b950a60e1034bf21d061aac8a8",
+      "bytes": 557367776,
+      "warm": false
     },
     "SmolVLM2-500M-Video-Instruct-Q8_0.gguf": {
       "urls": [
@@ -334,22 +350,6 @@
       ],
       "sha256": "bbb0691873a4e638f6928898b3c3be9a4730bd4ced301197726a4fcb549695d0",
       "bytes": 108782144,
-      "warm": false
-    },
-    "mmproj-Qwen3.5-0.8B-Q8_0.gguf": {
-      "urls": [
-        "https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF/resolve/9d48fdbc0d8f133716da87ec1d904e5d2c7175a6/Qwen3.5-0.8B.mmproj-Q8_0.gguf"
-      ],
-      "sha256": "5a6b15da0f483b9e320a5b86b787ad1831953dfaa706e2c5d91de830ea70d784",
-      "bytes": 115923680,
-      "warm": false
-    },
-    "mmproj-gemma-4-E2B-it-Q8_0.gguf": {
-      "urls": [
-        "https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF/resolve/a1dac71d3ab220618f5a7573a52acdc4baf3ae3b/mmproj-gemma-4-E2B-it-Q8_0.gguf"
-      ],
-      "sha256": "8a82e0fd831bb7cb5c8898b86393eb14042986b950a60e1034bf21d061aac8a8",
-      "bytes": 557367776,
       "warm": false
     }
   }

--- a/packages/llm-llamacpp/test/integration/models.manifest.json
+++ b/packages/llm-llamacpp/test/integration/models.manifest.json
@@ -335,6 +335,22 @@
       "sha256": "bbb0691873a4e638f6928898b3c3be9a4730bd4ced301197726a4fcb549695d0",
       "bytes": 108782144,
       "warm": false
+    },
+    "mmproj-Qwen3.5-0.8B-Q8_0.gguf": {
+      "urls": [
+        "https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF/resolve/9d48fdbc0d8f133716da87ec1d904e5d2c7175a6/Qwen3.5-0.8B.mmproj-Q8_0.gguf"
+      ],
+      "sha256": "5a6b15da0f483b9e320a5b86b787ad1831953dfaa706e2c5d91de830ea70d784",
+      "bytes": 115923680,
+      "warm": false
+    },
+    "mmproj-gemma-4-E2B-it-Q8_0.gguf": {
+      "urls": [
+        "https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF/resolve/a1dac71d3ab220618f5a7573a52acdc4baf3ae3b/mmproj-gemma-4-E2B-it-Q8_0.gguf"
+      ],
+      "sha256": "8a82e0fd831bb7cb5c8898b86393eb14042986b950a60e1034bf21d061aac8a8",
+      "bytes": 557367776,
+      "warm": false
     }
   }
 }

--- a/packages/llm-llamacpp/test/integration/models.manifest.json
+++ b/packages/llm-llamacpp/test/integration/models.manifest.json
@@ -128,8 +128,7 @@
         "https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF/resolve/9d48fdbc0d8f133716da87ec1d904e5d2c7175a6/Qwen3.5-0.8B.mmproj-Q8_0.gguf"
       ],
       "sha256": "5a6b15da0f483b9e320a5b86b787ad1831953dfaa706e2c5d91de830ea70d784",
-      "bytes": 115923680,
-      "warm": false
+      "bytes": 115923680
     },
     "mmproj-Qwen3.5-2B-F16.gguf": {
       "urls": [


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The VLM benchmark cannot run VisionPsy Nano. Neither checkpoint is in the catalog.
- The comparison would not be fair even with them: the CLI legs load hardcoded qwen filenames at a hardcoded context size, and a CLI-only dispatch is forced through an addon leg that cannot load a model on a fabric branch.

## 📝 How does it solve it?

- `config.cjs` gains seven catalog entries, three quants per checkpoint plus one Flash entry that forces the projector onto the GPU. That last one exists to reach Mali Vulkan for the vision encoder, which the addon's auto-default sends to CPU, so no other entry can measure it.
- The qwen blob names lose their `reg-` prefix and become the manifest keys `Qwen3.5-0.8B-Q8_0.gguf`, `mmproj-Qwen3.5-0.8B-F16.gguf` and `mmproj-Qwen3.5-0.8B-Q8_0.gguf`. `models.manifest.json` carries no `reg-qwen` key at all, so the names the CLI step used were never the ones the addon leg verifies against.
- `resolve-cli-model.cjs` resolves a spec to the blob the CLI legs load, so an addon leg and a CLI leg run the same bytes at the same `ctx_size`. `cli-fixture-runner.cjs` takes the names, origins, label and `ctx_size` as arguments instead of the hardcoded qwen values, which had mislabelled every several-sources run of anything else. It also restores `rss_mb`, which was being dropped so the report's peak-RSS row was empty for every CLI leg, and emits per-row vision encode time and slice count. `rss_mb` comes from the `/usr/bin/time -v` wrapper, so a CLI leg reports it on linux only.
- Per-model image preprocessing that the GGUF cannot declare, such as VisionPsy Flash's `--image-no-upscale`, travels as `cliArgs` for the native CLIs and `addonConfig` for the addon. Both come off one `MODEL_OPTIONS` descriptor in `models.cjs`, so the two allowlists cannot drift apart, and an option with a twin must be set on both legs with the same value or the spec is rejected at parse time. Without that check a leg silently runs base preprocessing under the same model label as one that applied the flag.
- `[VLMMETA]` carries `preproc`, the preprocessing each leg actually applied, in one canonical form for both mechanisms. The report shows it per leg and says so when the legs of one model disagree. `upstream-cli` is the honest case: `cliArgs` are fabric-fork flags, so it never receives them.
- `benchmark-vlm-model-comparison.yml` stops defaulting a CLI-only dispatch to the published addon. That default forced an addon leg into every comparison, and for a model the published prebuild cannot load it failed before the CLI step ran. A CLI-only run now fetches the two blobs itself, both at once, and checks each against its sha256 pin, taken from `models.manifest.json` or from a `sha256` field on a `json:` blob. A blob with neither fails the leg, since an unverified GGUF's own chat template reaches `--chat-template`; the new `allow_unverified_models` input overrides that. A blob failing the check is discarded and fetched once more, so a truncated file left by a cancelled run recovers instead of failing every rerun.
- `HF_TOKEN` is attached only to a `https://huggingface.co/` URL, so a `json:` spec pointing elsewhere cannot carry the secret with it. The token resolves the redirect hop without `-L` and the CDN target is fetched unauthenticated, because curl sends a `-H` header on every hop; the inline path uses `--max-redirs 0` so an unexpected redirect fails loudly rather than being saved and failing later at the sha check. The resolved URLs stay out of the log, and the env file holding them is written under `RUNNER_TEMP` and removed after use, because a presigned link holds its signature in the query string and a self-hosted runner's workspace outlives the job.
- Registry sources stay addon-only. The addon leg leaves those blobs in `benchmarks/model`, not the CLI step's model dir, so the CLI step looks there before calling a blob missing, and says so plainly instead of pointing at a remedy that cannot work.
- `harness.cjs` rejects a blob the manifest does not pin with a message saying so, since the addon leg verifies against `models.manifest.json` and never reads the supplied URL, and it reports the manifest URL as provenance so the marker names the bytes that actually ran. That message is used only when the name is really absent, so an entry missing a sha256 or byte-size pin still reports its own problem.
- `stdout-parser.js` and `aggregate.js` read vision-encode timing and score the new rows. `CONTRACT.md` documents the CLI-only dispatch, the new arguments, the twin rule and the `preproc` field.
- Three older spots in the same workflow passed a dispatch input into code instead of data. `matrix_preset` went into the source of six `node -e` scripts, the Aggregate step put `matrix_mode` and `matrix_preset` straight into a `run:` script, and the context step wrote `ref` to `GITHUB_OUTPUT` as a plain `key=value` line. The first two go through `env` now; `ref` is rejected outright if it carries whitespace, which a git ref cannot, and the output delimiter is randomised per run.
- `package.json` registers the new `__tests__` in `test:prestage`, which `on-pr-llm-llamacpp.yml` reaches through the `run-lint-and-unit-tests` action, so they run on every PR. The manifest gains the VisionPsy blobs the catalog points at; without them the catalog resolves to keys that do not exist. `mmproj-Qwen3.5-0.8B-Q8_0.gguf` is warmed because it is part of the default pair, so every default run was re-downloading it.
- No native code, so this does not depend on fabric. The catalog references `--image-no-upscale`, but only as data passed through to the CLI, so it builds and unit-tests without the addon change. The addon leg can run these checkpoints already: the projector arrived in `qvac-fabric` 10069.1.0 and `vcpkg.json` pins `>= 10069.1.1`, and the addon accepts `image-no-upscale` since #3725. So two-models works, not only several-sources against a fabric branch.

## 🧪 How was it tested?

- `__tests__/` covers the `cliArgs` round trip through the env file and back to an argv array, the flag allowlist, the twin rule including every committed catalog entry, the `modelName` check, hf URL construction with nested and traversing paths, the log parsers and the scoring. 58 test cases, all passing locally and in `sanity-checks (llm-llamacpp)`.
- The warmup case asserts the measured row count, so dropping the block 0 filter fails it. The `preproc` cases assert both the per-leg column and the mismatch callout, and that an older log without the field raises nothing.
- Three dispatches on this head, smoke on linux-cpu, all green: CLI-only several-sources on `fabric@v10069.1.0` with `visionpsy-flash-q4` ([run](https://github.com/tetherto/qvac/actions/runs/32493698755)), mixed addon and CLI ([run](https://github.com/tetherto/qvac/actions/runs/32493719403)), and default two-models ([run](https://github.com/tetherto/qvac/actions/runs/32493731437)). The first fetched both blobs in parallel, verified both sha256 pins against live downloads, passed `--image-no-upscale on` to the fabric CLI and reported `image-no-upscale=on` in the new preprocessing column.
- The shell paths a dispatch cannot reach were exercised locally: the ref guard against the newline-injection payload, `sha256sum` and `shasum` agreement, the discard-and-refetch-once flow, and `adopt_addon_blob`, which only a registry source hits. Every `run:` block in the workflow parses under `bash -n`.
- `run-desktop.cjs --selfcheck`, `validate-mobile-manifest.js`, prettier and lunte all pass, and every catalog blob resolves to a pinned manifest entry.
