### PR TITLE
QVAC-22534 chore: bump diffusion-cpp to 0.20.0 for LTX Ingredients

### DIFF
--- a/packages/diffusion-cpp/CHANGELOG.md
+++ b/packages/diffusion-cpp/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [0.20.0] - 2026-08-14
+
+This release adds production LTX-2.3 Ingredients IC-LoRA video generation
+with reference-sheet conditioning and validated controls across the JavaScript
+and native addon surfaces.
+
+### Added
+
+#### LTX Ingredients reference-guided video
+
+- LTX video requests accept IC-LoRA adapters, runtime `lora_strength`, and
+  `reference_images`, with validation that rejects unsupported combinations.
+- LTX-2 scheduling is selected by default for LTX models and can be requested
+  explicitly; `stg_scale` and `stg_block` expose skip-layer guidance controls.
+- The `generate:ltx-coffee` example and pinned download workflow provide a
+  reproducible reference-conditioned Ingredients showcase.
+
+### Changed
+
+- `vae_auto_cpu_fallback` and its memory-ratio control expose automatic VAE
+  capacity fallback, while the dependency stack selects exact-stateful VAE
+  behavior for Vulkan.
+- `stable-diffusion-cpp` now resolves at `2026-07-03#7` from the
+  `tetherto/qvac-registry-vcpkg` registry. The package uses registry-backed
+  `stable-diffusion-cpp` and `ggml` dependencies without local overlays.
+- TypeScript declarations and generated bindings, JavaScript and C++ unit
+  tests, addon tests, and registry-backed native builds validate the new
+  request surface and dependency path.
+
+### Pull Requests
+
+- [#3551](https://github.com/tetherto/qvac/pull/3551) - QVAC-22534
+  Feature/ltx lora
+
 ## [0.19.0] - 2026-08-12
 
 This release adds ABot-World: a causal, interactive world model

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## What problem does this PR solve?

- The LTX Ingredients IC-LoRA and registry-backed dependency work from #3551 is on `main`, while `@qvac/diffusion-cpp` remains at `0.19.0`.
- The package changelog does not yet describe the new reference-guided LTX surface and dependency behavior for a release.

## How does it solve it?

- Bumps `@qvac/diffusion-cpp` to `0.20.0`, following the minor-version convention for a new public model workflow and controls.
- Adds a concise `0.20.0` changelog entry for LTX Ingredients IC-LoRA/reference inputs, LTX-2 and STG controls, VAE capacity fallback and Vulkan exact-stateful behavior, registry-backed dependencies without local overlays, and the validation completed in #3551.
- Changes release metadata only: `packages/diffusion-cpp/package.json` and `packages/diffusion-cpp/CHANGELOG.md`.

## Test plan

- [x] Parse `package.json` and verify version `0.20.0` matches a non-empty changelog entry.
- [x] Check the new changelog entry and package JSON with Prettier.
- [x] Run `git diff --check`.
- [x] Verify the branch differs from `main` in exactly the two release metadata files.
- [x] Verify the commit SSH signature against the requested signing key.

No native build or long-running model tests were run because this PR changes release metadata only.