### PR TITLE
fix[mod]: consume Audio8 Vulkan regression fix

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -121,6 +121,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Audio8 Vulkan synthesis crash with quantized models.** Bumps `tts-cpp` to
+  `2026-08-12#2`, which keeps Metal-specific F32 output precision scoped to
+  Metal so Vulkan selects a valid matrix multiplication pipeline.
 - **Public TypeScript and CommonJS API.** Audio chunks are now declared as
   their runtime `Int16Array` type, enhancer backend fields are included in
   `RuntimeStats`, invalid reload sample rates are rejected, and the package

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-08-12#1"
+      "version>=": "2026-08-12#2"
     }
   ],
   "features": {


### PR DESCRIPTION
## Summary
- require `tts-cpp@2026-08-12#2` in `@qvac/tts-ggml`
- deliver the merged [native Audio8 Vulkan fix](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/148) to QVAC consumers
- document the quantized Vulkan synthesis crash fix

Depends on [qvac-registry-vcpkg#314](https://github.com/tetherto/qvac-registry-vcpkg/pull/314).

## Test plan
- [x] validate the updated vcpkg manifest and patch formatting
- [x] Linux native Audio8 CPU/Vulkan LM, codec, engine, and Q8 CLI regression tests
- [x] macOS ARM64 native Audio8 Metal LM, codec, and engine tests
- [ ] QVAC build and Audio8 integration CI after the registry release merges