### PR TITLE
test[mod]: preflight Audio8 speech-cpp Vulkan fix

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -121,6 +121,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Audio8 Vulkan synthesis crash with quantized models.** Requires
+  `speech-cpp` >= `2026-08-12#1`, whose TTS feature keeps Metal-specific F32
+  output precision scoped to Metal so Vulkan selects a valid matrix
+  multiplication pipeline.
 - **Public TypeScript and CommonJS API.** Audio chunks are now declared as
   their runtime `Int16Array` type, enhancer backend fields are included in
   `RuntimeStats`, invalid reload sample rates are rejected, and the package

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,8 +1,8 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "5ee5160b1c757f28872be8f2e744447bdf61a272",
-    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
+    "baseline": "cea835243938cc669972923c307b81157a812804",
+    "repository": "https://github.com/Zbig9000/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "3689b2615f2eeec32ff1af840eb4ae1184ffa516",
+    "baseline": "5ee5160b1c757f28872be8f2e744447bdf61a272",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,6 +10,7 @@
     },
     {
       "name": "speech-cpp",
+      "version>=": "2026-08-12#1",
       "default-features": false,
       "features": [
         "tts",
@@ -19,6 +20,7 @@
     },
     {
       "name": "speech-cpp",
+      "version>=": "2026-08-12#1",
       "default-features": false,
       "features": [
         "tts",
@@ -29,6 +31,7 @@
     },
     {
       "name": "speech-cpp",
+      "version>=": "2026-08-12#1",
       "default-features": false,
       "features": [
         "tts",
@@ -49,6 +52,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
+          "version>=": "2026-08-12#1",
           "default-features": false,
           "features": [
             "vulkan"

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-12#1",
+      "version>=": "2026-08-13#1",
       "default-features": false,
       "features": [
         "tts",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-12#1",
+      "version>=": "2026-08-13#1",
       "default-features": false,
       "features": [
         "tts",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-12#1",
+      "version>=": "2026-08-13#1",
       "default-features": false,
       "features": [
         "tts",
@@ -52,7 +52,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-12#1",
+          "version>=": "2026-08-13#1",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## Summary
- test the Audio8 Vulkan fix through the current `speech-cpp[tts]` dependency path
- temporarily pin the registry baseline to the unmerged [speech-cpp release](https://github.com/tetherto/qvac-registry-vcpkg/pull/315)
- require `speech-cpp@2026-08-12#1` and run the full desktop TTS integration matrix

This is a temporary preflight PR. The registry baseline change will not be included in the final consumer PR.

## Test plan
- [ ] Linux x64 Vulkan Audio8 text-only synthesis and voice cloning
- [ ] Windows x64 Vulkan Audio8 text-only synthesis and voice cloning
- [ ] macOS ARM64 Metal Audio8 integration coverage
- [ ] desktop CPU Audio8 integration coverage