### PR TITLE
chore[skiplog]: bump gh-action-pypi-publish to v1.14.2 for Metadata 2.5

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -935,7 +935,7 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # Create GitHub release only for actual releases (after NPM publish).
   # Require all lockstep npm publishes before tagging sdk-v*.


### PR DESCRIPTION
## Summary
- Bump `pypa/gh-action-pypi-publish` from v1.13.0 → v1.14.2 (Twine 7) so PyPI upload accepts hatchling Metadata-Version 2.5.
- Unblocks `tetherto-qvac-sdk@0.17.1` publish after run 31717786691 failed on `InvalidDistribution: '2.5' is not a valid metadata version`.

## Test plan
- [ ] Merge to `release-sdk-0.17.1`
- [ ] `gh workflow run publish-sdk.yml --repo tetherto/qvac --ref release-sdk-0.17.1 -f publish_pypi_only=true`
- [ ] `qvac-internal-release` approves `pypi` environment
- [ ] Confirm https://pypi.org/project/tetherto-qvac-sdk/0.17.1/
