### PR TITLE
fix[mod]: consume Audio8 Vulkan fix via speech-cpp

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -121,6 +121,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Audio8 Vulkan synthesis crash with quantized models.** Requires
+  `speech-cpp` >= `2026-08-12#1`, whose TTS feature keeps Metal-specific F32
+  output precision scoped to Metal so Vulkan selects a valid matrix
+  multiplication pipeline.
 - **Public TypeScript and CommonJS API.** Audio chunks are now declared as
   their runtime `Int16Array` type, enhancer backend fields are included in
   `RuntimeStats`, invalid reload sample rates are rejected, and the package

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,6 +10,7 @@
     },
     {
       "name": "speech-cpp",
+      "version>=": "2026-08-12#1",
       "default-features": false,
       "features": [
         "tts",
@@ -19,6 +20,7 @@
     },
     {
       "name": "speech-cpp",
+      "version>=": "2026-08-12#1",
       "default-features": false,
       "features": [
         "tts",
@@ -29,6 +31,7 @@
     },
     {
       "name": "speech-cpp",
+      "version>=": "2026-08-12#1",
       "default-features": false,
       "features": [
         "tts",
@@ -49,6 +52,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
+          "version>=": "2026-08-12#1",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## Summary
- require the official `speech-cpp@2026-08-12#1` umbrella release from [qvac-registry-vcpkg#315](https://github.com/tetherto/qvac-registry-vcpkg/pull/315)
- deliver the merged [native Audio8 Vulkan fix](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/148) through the dependency path used by `@qvac/tts-ggml`
- document the quantized Vulkan synthesis crash fix without changing the package registry baseline

## Test plan
- [x] resolve and build `speech-cpp[tts,vulkan]@2026-08-12#1` from the official registry with the existing baseline
- [x] build and install the Linux x64 `tts-ggml` addon
- [x] run package lint and unit tests
- [x] run the full desktop prebuild and integration matrix, including Audio8 Vulkan on Linux/Windows and Metal on macOS

## Verification
- [Desktop workflow](https://github.com/tetherto/qvac/actions/runs/31805061015): passed on all seven desktop runners