### PR TITLE
QVAC-23426 chore[skiplog]: bump gh-action-pypi-publish to v1.14.2 for Metadata 2.5

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -935,7 +935,7 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   # Create GitHub release only for actual releases (after NPM publish).
   # Require all lockstep npm publishes before tagging sdk-v*.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.17.1
 
-QVAC SDK 0.17.1 is a patch cut focused on Python packaging and release lockstep. It ships self-contained per-platform `tetherto-qvac-sdk` wheels on the GitHub release, keeps thin wheels on PyPI, makes the embedded Python examples runnable without shared helpers, and publishes `@qvac/inference` together with `@qvac/sdk`, `@qvac/bare-sdk`, and `tetherto-qvac-sdk` at the same version. It also fixes Windows fat-wheel builds and a dropped `bare-rpc` stream teardown.
+QVAC SDK 0.17.1 is a patch cut, focused on Python packaging and release lockstep. It ships self-contained per-platform `tetherto-qvac-sdk` wheels on the GitHub release, keeps thin wheels on PyPI, makes the embedded Python examples runnable without shared helpers, and publishes `@qvac/inference` together with `@qvac/sdk`, `@qvac/bare-sdk`, and `tetherto-qvac-sdk` at the same version. It also fixes Windows fat-wheel builds and a dropped `bare-rpc` stream teardown.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Bump `pypa/gh-action-pypi-publish` from v1.13.0 → v1.14.2 (Twine 7) so PyPI upload accepts hatchling Metadata-Version 2.5.
- Unblocks `tetherto-qvac-sdk@0.17.1` after run 31717786691 (`InvalidDistribution: '2.5' is not a valid metadata version`).