### PR TITLE
chore: release @qvac/audiogen-ggml 0.2.1

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] - 2026-08-14
 
 ### Breaking
 

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary
- bump `@qvac/audiogen-ggml` from 0.2.0 to 0.2.1
- publish the accumulated release notes under the 0.2.1 heading

## Test plan
- [x] Run `git diff --check`
- [x] Verify `package.json` and `CHANGELOG.md` agree on version 0.2.1
- [ ] Run `npm run test:package` (development dependencies are not installed; `tsc` is unavailable)