### PR TITLE
chore: release @qvac/tts-ggml 0.7.0

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-08-14
 
 ### Added
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary
- Bump `@qvac/tts-ggml` from 0.6.2 to 0.7.0.
- Promote the accumulated CosyVoice3 0.5B and Audio8 0.6B changelog into the release, expanding multilingual TTS and zero-shot voice cloning coverage.
- Ship the existing desktop and mobile CPU/GPU support, including faster-than-real-time Audio8 voice cloning on iOS Metal.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:node`
- [x] `git diff --check` and JSON manifest validation
- [x] Confirm `vcpkg.json` and `vcpkg-configuration.json` remain aligned with the released engine pins