### PR TITLE
fix[notask]: complete PAT_TOKEN retirement (4 residual refs)

### DIFF
--- a/.github/workflows/benchmark-asr-ggml.yml
+++ b/.github/workflows/benchmark-asr-ggml.yml
@@ -1058,7 +1058,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repository || github.repository }}
           ref: ${{ github.event.inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download benchmark results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/benchmark-translation-nmtcpp.yml
+++ b/.github/workflows/benchmark-translation-nmtcpp.yml
@@ -490,7 +490,7 @@ jobs:
       - name: Configure git
         if: matrix.platform.source == 'prebuild'
         run: |
-          GIT_PAT="${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}"
+          GIT_PAT="${{ secrets.GITHUB_TOKEN }}"
           git config --global --add url."https://${GIT_PAT}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           git config --global --add url."https://${GIT_PAT}:x-oauth-basic@github.com/".insteadOf "git@github.com:"
           git config --global --add url."https://${GIT_PAT}:x-oauth-basic@github.com/".insteadOf "ssh://git@github.com/"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -350,6 +350,10 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # The scoped-registry step below writes an @tetherto GPR authToken into
+      # .npmrc/bunfig. GITHUB_TOKEN is bounded by this block (PAT_TOKEN was not),
+      # so declare the scope the config implies.
+      packages: read
     env:
       WORKDIR_INFERENCE: packages/inference
     steps:
@@ -358,7 +362,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
@@ -369,7 +373,7 @@ jobs:
         shell: bash
         working-directory: ${{ env.WORKDIR_INFERENCE }}
         env:
-          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+          GIT_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
           cat > .npmrc <<NPMRC

--- a/.github/workflows/reusable-summarize-audiogen-ggml-benchmarks.yml
+++ b/.github/workflows/reusable-summarize-audiogen-ggml-benchmarks.yml
@@ -23,16 +23,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      # This job only needs the repo to run the aggregator script, so fall back
-      # to the automatic token where PAT_TOKEN is not configured (forks). An
-      # empty `token:` is not a no-op — checkout fails with "Input required and
-      # not supplied".
+      # This job only needs a read-only checkout of the (public) repo to run the
+      # aggregator script, so the ambient GITHUB_TOKEN suffices. An empty `token:`
+      # is not a no-op — checkout fails with "Input required and not supplied" —
+      # so keep it set explicitly.
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       # No merge-multiple: same-platform runners emit identically named
       # rtf-benchmark-*.json files, so per-artifact subdirectories preserve all


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

#3807 retired the org-wide `PAT_TOKEN` and stated *"No secrets.PAT_TOKEN references remain, so the org secret can be deleted."* A post-merge grep of `main` shows that is **not** true — four workflow references survived the migration and still resolve `secrets.PAT_TOKEN`. Two have **no fallback**, so deleting the `PAT_TOKEN` org secret today would break them at runtime.

| File / job | Ref | Fallback | Impact if secret deleted |
|---|---|---|---|
| `publish-sdk.yml` → `build-inference` | `token:` + `GIT_PAT:` | ❌ | **Breaks the SDK publish path** (empty checkout token → "Input required and not supplied"; empty GPR auth) |
| `benchmark-asr-ggml.yml` → `summarize` | `token:` | ❌ | Breaks the benchmark summarize job (dispatch-only) |
| `benchmark-translation-nmtcpp.yml` | `secrets.PAT_TOKEN \|\| secrets.GITHUB_TOKEN` | ✅ | Degrades to GITHUB_TOKEN |
| `reusable-summarize-audiogen-ggml-benchmarks.yml` | `secrets.PAT_TOKEN \|\| github.token` | ✅ | Degrades to github.token (**file was never in #3807**) |

## 📝 How does it solve it?

- Switched all four to `GITHUB_TOKEN` / `github.token`. Every one of these checkouts targets the now-public `qvac`, so the ambient token suffices — these were overlooked lines, not deliberate retentions (their sibling jobs in the same files were already migrated by #3807).
- `publish-sdk.yml` `build-inference`: added `packages: read`. `GITHUB_TOKEN` is bounded by the `permissions:` block (`PAT_TOKEN` was not), and the job writes an `@tetherto` GPR authToken into `.npmrc`/`bunfig.toml` — this mirrors the scope-declaration fix made in #3807's commit 2 for `trigger-reusable-lib-inference`.
- Collapsed the two `|| <fallback>` expressions to the single token for consistency with the rest of the migration.

Scope check: value substitutions + one `permissions:` scope addition + comment updates. No `workflow_call` interface, action pin, or trigger changed.

## 🧪 How was it tested?

- `grep -rn "secrets\.PAT_TOKEN" .github` on the branch → **0 matches** (down from 4 on `main`). Remaining `PAT_TOKEN` hits are two historical comments and the `run-lint-and-unit-tests` composite's internal `pat-token` *input* (callers already pass `GITHUB_TOKEN`).
- `python3 -c "yaml.safe_load(...)"` on all four changed files → parses clean.
- Repo visibility confirmed via `gh api`: `qvac` and `qvac-registry-vcpkg` are public, so `GITHUB_TOKEN` can perform every checkout/registry read these jobs need.

Once this lands, no `secrets.PAT_TOKEN` reference remains in `.github` and the `PAT_TOKEN` org secret is safe to delete.

Follow-up (optional, out of scope): the `run-lint-and-unit-tests` composite still names its input `pat-token`; renaming it to something neutral would remove the last cosmetic `PAT_TOKEN` occurrences.