### PR TITLE
[notask] mod: fix qwen3.8 tags

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -8540,7 +8540,7 @@
     "quantization": "UD-Q4_K_XL",
     "params": "27B",
     "licenseId": "Apache-2.0",
-    "tags": ["generation", "instruct", "multimodal", "qwen3.8", "video-instruct"],
+    "tags": ["generation", "multimodal", "qwen3.8", "instruct", "video-instruct"],
     "notes": "Pair with the F16 mmproj entry for image and video input.",
     "link": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF"
   },
@@ -8551,7 +8551,7 @@
     "quantization": "UD-Q8_K_XL",
     "params": "27B",
     "licenseId": "Apache-2.0",
-    "tags": ["generation", "instruct", "multimodal", "qwen3.8", "video-instruct"],
+    "tags": ["generation", "multimodal", "qwen3.8", "instruct", "video-instruct"],
     "notes": "Pair with the F16 mmproj entry for image and video input.",
     "link": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF"
   },
@@ -8562,7 +8562,7 @@
     "quantization": "f16",
     "params": "27B",
     "licenseId": "Apache-2.0",
-    "tags": ["generation", "instruct", "multimodal", "qwen3.8", "video-instruct"],
+    "tags": ["generation", "multimodal", "qwen3.8", "instruct", "video-instruct"],
     "notes": "Required for image and video input.",
     "link": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF"
   }


### PR DESCRIPTION
## What problem does this PR solve?

- Models tags on new Qwen 3.8 models have incorrect order which resulted in bad model constant generation

## How does it solve it?

- Fixed tag ordering for Qwen 3.8 and its projetor

## Breaking changes

- None