### PR TITLE
QVAC-23669 infra: resolve @qvac/inference from the in-repo build in the SDK consumer check

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -235,6 +235,20 @@ jobs:
             test -n "$tarball" || { echo "::error::No SDK tarball found after pack"; exit 1; }
             tarball_abs="$(pwd)/$tarball"
 
+            # Pack the in-repo @qvac/inference so each consumer below redirects
+            # the SDK's transitive @qvac/inference to it via an npm `overrides`
+            # entry — sdk and inference ship lockstep, so the consumer resolves
+            # the engine at this commit rather than a published release.
+            inference_tgz=""
+            if [ -n "$(jq -r '.dependencies["@qvac/inference"] // empty' package.json)" ]; then
+              echo "::group::Pack in-repo @qvac/inference for consumer install"
+              ( cd "$WS/packages/inference" && bun install && bun pm pack --destination dist/ )
+              inference_tgz=$(ls "$WS"/packages/inference/dist/qvac-inference-*.tgz | head -n1)
+              test -n "$inference_tgz" || { echo "::error::No @qvac/inference tarball found after pack"; exit 1; }
+              echo "::notice::Consumer installs override @qvac/inference -> $inference_tgz"
+              echo "::endgroup::"
+            fi
+
             check_consumer() {
               local consumer="$1" label="$2"
               cd "$consumer"
@@ -270,6 +284,7 @@ jobs:
             npm init -y > /dev/null
             npm pkg set type=module > /dev/null
             if [ -f "$npmrc_src" ]; then cp "$npmrc_src" .npmrc; fi
+            if [ -n "$inference_tgz" ]; then npm pkg set "overrides.@qvac/inference=file:$inference_tgz"; fi
             npm install --no-fund --no-audit --ignore-scripts --loglevel=info "$tarball_abs" 2>&1 | tee install.log
             check_consumer "$consumer_default" "default"
 
@@ -279,6 +294,7 @@ jobs:
             npm init -y > /dev/null
             npm pkg set type=module > /dev/null
             if [ -f "$npmrc_src" ]; then cp "$npmrc_src" .npmrc; fi
+            if [ -n "$inference_tgz" ]; then npm pkg set "overrides.@qvac/inference=file:$inference_tgz"; fi
             npm install --no-fund --no-audit --ignore-scripts --omit=optional --loglevel=info "$tarball_abs" 2>&1 | tee install.log
             check_consumer "$consumer_lean" "lean (--omit=optional)"
           )


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The SDK pod's consumer-install check resolves `@qvac/inference` from the registry. Once the SDK adopts the engine, a PR that uses a not-yet-published inference API fails the check against the stale published artifact — even though sdk and inference ship lockstep at one version.

## 📝 How does it solve it?

- In `consumer_install_check`, when the SDK declares `@qvac/inference`, pack the in-repo engine and add an npm `overrides` entry in each consumer so the SDK's transitive `@qvac/inference` resolves to that tarball. The packed SDK tarball is untouched.
- No-op when the SDK declares no `@qvac/inference` (main today), so it lands inert and activates automatically once the SDK adopts the engine.

## 🧪 How was it tested?

- Offline: an `overrides` entry redirects a transitive `@qvac/inference` to a local tarball (single copy, resolves `/surface` from the tgz, no registry hit).
- Real CI, base carrying this change: the consumer legs pack the in-repo inference and import `@qvac/sdk` cleanly (504 exports, both default and `--omit=optional`) — the same assertion that fails against the published engine's missing `/surface` export. `All SDK pod checks passed.`
