### PR TITLE
infra[notask]: raise branch-cleanup max_deletions_per_run to 200

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -16,7 +16,7 @@ on:
       max_deletions_per_run:
         description: "Max branches to delete in a single run"
         type: number
-        default: 50
+        default: 200
 
 permissions:
   contents: read
@@ -46,4 +46,4 @@ jobs:
       # Raised above the reusable default (10) so the weekly run keeps pace with this
       # monorepo's branch churn instead of accumulating a backlog; a manual dispatch
       # can override for a one-off larger drain.
-      max_deletions_per_run: ${{ github.event_name == 'workflow_dispatch' && inputs.max_deletions_per_run || 50 }}
+      max_deletions_per_run: ${{ github.event_name == 'workflow_dispatch' && inputs.max_deletions_per_run || 200 }}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The weekly `branch-cleanup` scheduled run is throttled at **50 deletions per run**, but stale branches accumulate faster than that, so a backlog builds up instead of draining.

- The 2026-08-17 scheduled run ([run 32009753896](https://github.com/tetherto/qvac/actions/runs/32009753896)) computed **223 deletion candidates**, deleted only 50, and left **173 branches already past their grace period pending** (tracking issue [#3230](https://github.com/tetherto/qvac/issues/3230)).

## 📝 How does it solve it?

- Raises `max_deletions_per_run` from **50 → 200** in `.github/workflows/branch-cleanup.yml`, for both the scheduled fallback and the `workflow_dispatch` input default, so the weekly run keeps pace with the monorepo's branch churn and can clear the existing backlog in a single pass.

- No change to retention thresholds or the ~7-day grace ledger: branches are still flagged on the tracking issue and only deleted after the grace window. This only lifts the per-run throttle.

## 🧪 How was it tested?

- `git diff` confirmed exactly two lines changed (the `workflow_dispatch` default and the scheduled `|| 50` fallback), with no stray `50` left in the file.
- Change is a numeric default only — no structural change to jobs, `permissions:`, or the reusable workflow contract.
- Post-merge validation: next scheduled run (or a manual `workflow_dispatch` with `dry_run: true`) should report up to 200 deletions.