### PR TITLE
QVAC-23075 feat[api]: bump qvac-fabric to 10069.1.0 across consumers

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.33.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.32.0] - 2026-08-10
 
 ### Changed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/embed-llamacpp/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10069.0.0"
+      "version>=": "10069.1.0"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/fabric/CHANGELOG.md
+++ b/packages/fabric/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.4.0] - 2026-08-10
 
 ### Changed

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/fabric",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shared bare addon hosting the qvac-fabric (forked llama.cpp + ggml) runtime for QVAC inference addons",
   "addon": true,
   "engines": {

--- a/packages/fabric/vcpkg.json
+++ b/packages/fabric/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10069.0.0"
+      "version>=": "10069.1.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.44.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.43.0] - 2026-08-14
 
 This release removes the Qwen3-only dynamic tools feature behind

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/llm-llamacpp/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg.json
@@ -9,7 +9,7 @@
     "concurrentqueue",
     {
       "name": "qvac-fabric",
-      "version>=": "10069.0.0"
+      "version>=": "10069.1.0"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.1.0] - 2026-08-12
 
 ### Added

--- a/packages/model-fit/package.json
+++ b/packages/model-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/model-fit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Memory-fit preflight addon for QVAC — wraps llama.cpp's common_fit_params to project whether a GGUF model fits available device memory before loading it",
   "addon": true,
   "scripts": {

--- a/packages/model-fit/vcpkg.json
+++ b/packages/model-fit/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10069.0.0"
+      "version>=": "10069.1.0"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.16.0] - 2026-08-11
 
 ### Added

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR and DocTR pipelines on GGUF weights)",
   "addon": true,
   "engines": {

--- a/packages/ocr-ggml/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg.json
@@ -20,7 +20,7 @@
     {
       "name": "qvac-fabric",
       "default-features": false,
-      "version>=": "10069.0.0",
+      "version>=": "10069.1.0",
       "features": [
         "gpu-backends"
       ]

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.8.0] - 2026-08-13
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg.json
@@ -16,7 +16,7 @@
     "ssplit",
     {
       "name": "qvac-fabric",
-      "version>=": "10069.0.0",
+      "version>=": "10069.1.0",
       "default-features": false,
       "features": [
         "gpu-backends"

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.20.0] - 2026-08-17
+
+### Changed
+
+- `qvac-fabric` dependency bumped `10069.0.0` -> `10069.1.0` (VisionPsy Nano
+  support and its Flash preprocessing rule; no API change for this package).
+
 ## [0.19.0] - 2026-08-10
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/vcpkg.json
+++ b/packages/vla-ggml/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10069.0.0",
+      "version>=": "10069.1.0",
       "features": [
         "hip-backend"
       ]


### PR DESCRIPTION
## 🎯 Problem

`qvac-fabric` 10069.1.0 adds VisionPsy Nano support and its Flash preprocessing rule
([tetherto/qvac-fabric-llm.cpp#205](https://github.com/tetherto/qvac-fabric-llm.cpp/pull/205)).
All 7 fabric consumers are still pinned to a `version>=` floor of `10069.0.0`, so none of them can
resolve the new fabric.

## 📝 How

One bundled PR carrying the whole consumer-side rollout for all 7 fabric consumers:

- `vcpkg.json` — `qvac-fabric` `version>=` floor `10069.0.0` → `10069.1.0`
- `package.json` — version bump (all 7 are pre-1.0, so all take the minor path)
- `CHANGELOG.md` — dated `## [<version>]` entry recording the fabric bump

| Package | Version |
|---|---|
| `@qvac/embed-llamacpp` | 0.32.0 → 0.33.0 |
| `@qvac/fabric` | 0.4.0 → 0.5.0 |
| `@qvac/llm-llamacpp` | 0.43.0 → 0.44.0 |
| `@qvac/model-fit` | 0.1.0 → 0.2.0 |
| `@qvac/ocr-ggml` | 0.16.0 → 0.17.0 |
| `@qvac/translation-nmtcpp` | 0.8.0 → 0.9.0 |
| `@qvac/vla-ggml` | 0.19.0 → 0.20.0 |

No C++ or JS source changes — the fabric bump is API-neutral for every consumer. No
`default-registry.baseline` changes.

**Depends on** the registry publish: https://github.com/tetherto/qvac-registry-vcpkg/pull/317

CI will fail until #317 merges, because `version>=: 10069.1.0` cannot resolve before then. Expected
— CI needs a retrigger once the registry PR lands.

## 🧪 Tested

- Fabric tag `v10069.1.0` created at `50713f4dfc54b1fe09826a343527e83d90f5df62`, the head of the
  `temp-10069` release branch (the merge commit of #205).
- Release archive SHA512 computed and cross-checked with both `vcpkg hash` and `sha512sum`.
- The registry port built from the new tag against a clean, isolated vcpkg install root
  (`x64-linux`, `[core,gpu-backends,llama]`): archive downloaded, SHA512 accepted, build and install
  succeeded.
- Phase A overlay-validated all 7 consumers against the fabric branch before the tag was cut; that
  overlay has since been reverted from PR #3725.
- Branch cut fresh from `origin/main`; verified no `vcpkg-overlays/ports/qvac-fabric` subtree, no
  `overlay-ports` key anywhere in the repo, and no `vcpkg-configuration.json` drift.

## ⚠️ Breaking

None. No addon API changes in any of the 7 packages — each changelog entry records the dependency
bump only.
