### PR TITLE
chore[notask]: bump tts-ggml to 0.7.2

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.2] - 2026-08-18
+
+### Fixed
+
+- **Consumer installs dedupe hyperdb again.** `@qvac/registry-client` (a
+  runtime dependency since 0.7.0, powering `download-models:registry`) is
+  bumped from `^0.4.0` to `^0.6.1` so its transitive `hyperdb` rides the
+  v6 line shared by the rest of the @qvac ecosystem. 0.7.0/0.7.1 installs
+  resolved two hyperdb copies (4.x + 6.x), violating the SDK pod check
+  single-copy invariant for shared P2P packages. The `QVACRegistryClient`
+  surface the download script uses is unchanged.
 
 ### Added
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/tts-ggml` 0.7.0/0.7.1 ship `@qvac/registry-client@^0.4.0` as a runtime dependency, whose transitive `hyperdb@4.x` breaks the SDK pod check's single-copy invariant in consumer installs (`hyperdb resolved to 2 copies`). The fix (#3898, bump to `^0.6.1`) is merged on `main` but unreleased, so the SDK CosyVoice3/Audio8 PRs (#3857 / #3858) stay red.

## 📝 How does it solve it?

- Bumps `packages/tts-ggml` to **0.7.2** (`package.json` + CHANGELOG), following the release-from-main flow used for 0.7.0 (#3877) and 0.7.1 (#3901).
- Retitles the CHANGELOG `[Unreleased]` section — CosyVoice3 zero-shot / cross-lingual voice cloning (#3872) — to 0.7.2, and records the #3898 registry-client fix under **Fixed**.

## 🧪 How was it tested?

- `node --test scripts/__tests__/package-contract.test.js` — 4/4 pass.
- After 0.7.2 publishes, the SDK PRs' `^0.7.0` range resolves it automatically; re-running `sdk-pod-checks` on #3857 / #3858 is the end-to-end proof.