### PR TITLE
QVAC-22800 fix: remove unsupported GPR inference source

### DIFF
--- a/.github/actions/sdk-e2e-prepare-inference/action.yml
+++ b/.github/actions/sdk-e2e-prepare-inference/action.yml
@@ -3,10 +3,10 @@ description: Apply the centrally resolved inference package to an SDK E2E checko
 
 inputs:
   source:
-    description: "Inference source: branch, gpr, npm, or manifest"
+    description: "Inference source: branch, npm, or manifest"
     required: true
   dependency-spec:
-    description: "Resolved package spec for gpr/npm; empty for branch/manifest"
+    description: "Resolved npm package spec; empty for branch/manifest"
     required: false
     default: ""
   artifact-name:

--- a/.github/actions/sdk-e2e-prepare-inference/prepare.mjs
+++ b/.github/actions/sdk-e2e-prepare-inference/prepare.mjs
@@ -5,9 +5,8 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 const INFERENCE_DEPENDENCY = "@qvac/inference";
-const GPR_PACKAGE = "@tetherto/inference-mono";
 const NPM_PACKAGE = "@qvac/inference";
-const SOURCES = new Set(["branch", "gpr", "npm", "manifest"]);
+const SOURCES = new Set(["branch", "npm", "manifest"]);
 
 function requireSource(source) {
   const normalized = String(source || "manifest")
@@ -15,7 +14,7 @@ function requireSource(source) {
     .toLowerCase();
   if (!SOURCES.has(normalized)) {
     throw new Error(
-      `Unsupported inference source "${source}". Expected branch, gpr, npm, or manifest.`,
+      `Unsupported inference source "${source}". Expected branch, npm, or manifest.`,
     );
   }
   return normalized;
@@ -64,7 +63,7 @@ export function resolvePublishedSource({
   resolvedVersion,
 }) {
   const normalized = requireSource(source);
-  if (normalized !== "gpr" && normalized !== "npm") {
+  if (normalized !== "npm") {
     throw new Error(`"${normalized}" is not a published inference source.`);
   }
   if (typeof resolvedVersion !== "string" || resolvedVersion.length === 0) {
@@ -73,14 +72,7 @@ export function resolvePublishedSource({
     );
   }
 
-  const request = requestedVersion || (normalized === "gpr" ? "dev" : "latest");
-  if (normalized === "gpr") {
-    return {
-      dependencySpec: `npm:${GPR_PACKAGE}@${resolvedVersion}`,
-      provenance: `gpr:${GPR_PACKAGE}@${resolvedVersion}`,
-      requestedVersion: request,
-    };
-  }
+  const request = requestedVersion || "latest";
   return {
     dependencySpec: resolvedVersion,
     provenance: `npm:${NPM_PACKAGE}@${resolvedVersion}`,
@@ -146,14 +138,9 @@ export function applyInferenceSource({
   return { dependencySpec: appliedSpec };
 }
 
-function resolveRegistryVersion(source, requestedVersion) {
-  const isGpr = source === "gpr";
-  const packageName = isGpr ? GPR_PACKAGE : NPM_PACKAGE;
-  const request = requestedVersion || (isGpr ? "dev" : "latest");
-  const args = ["view", `${packageName}@${request}`, "version", "--json"];
-  if (isGpr) {
-    args.push("--registry=https://npm.pkg.github.com/");
-  }
+function resolveRegistryVersion(requestedVersion) {
+  const request = requestedVersion || "latest";
+  const args = ["view", `${NPM_PACKAGE}@${request}`, "version", "--json"];
   const output = run("npm", args, { capture: true });
   return { request, version: exactVersion(output) };
 }
@@ -209,7 +196,6 @@ function resolveCommand() {
     };
   } else {
     const resolved = resolveRegistryVersion(
-      source,
       process.env.INFERENCE_VERSION || "",
     );
     result = resolvePublishedSource({

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -64,7 +64,7 @@ on:
         type: string
         default: manifest
       inference-dependency-spec:
-        description: "Resolved inference package spec for gpr/npm"
+        description: "Resolved inference package spec for npm"
         required: false
         type: string
         default: ""

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -63,7 +63,7 @@ on:
         type: string
         default: manifest
       inference-dependency-spec:
-        description: "Resolved inference package spec for gpr/npm"
+        description: "Resolved inference package spec for npm"
         required: false
         type: string
         default: ""

--- a/.github/workflows/test-node-sdk.yml
+++ b/.github/workflows/test-node-sdk.yml
@@ -50,7 +50,7 @@ on:
         type: string
         default: manifest
       inference-dependency-spec:
-        description: "Resolved inference package spec for gpr/npm"
+        description: "Resolved inference package spec for npm"
         required: false
         type: string
         default: ""

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -57,16 +57,15 @@ on:
         description: "Code ref to test (branch, tag, or SHA; blank = selected workflow branch)"
         type: string
       inference-source:
-        description: "Inference source (branch builds packages/inference; gpr/npm resolve a version; manifest keeps SDK package.json)"
+        description: "Inference source (branch builds packages/inference; npm resolves a version; manifest keeps SDK package.json)"
         type: choice
         options:
           - manifest
           - branch
-          - gpr
           - npm
         default: manifest
       inference-version:
-        description: "Inference version or dist-tag (gpr defaults to dev; npm defaults to latest)"
+        description: "npm inference version or dist-tag (blank defaults to latest)"
         type: string
       cache-models:
         description: "Reuse downloaded models for Desktop, Electron, and Snap"
@@ -151,11 +150,11 @@ on:
       test-version:
         type: string
       inference-source:
-        description: "Inference source: branch, gpr, npm, or manifest"
+        description: "Inference source: branch, npm, or manifest"
         type: string
         default: "manifest"
       inference-version:
-        description: "Inference version or dist-tag for gpr/npm"
+        description: "Inference version or dist-tag for npm"
         type: string
         default: ""
       cache-models:

--- a/packages/sdk/e2e/README.md
+++ b/packages/sdk/e2e/README.md
@@ -183,12 +183,10 @@ Non-obvious inputs:
   - `branch` builds and packs `packages/inference` from `test-version`. The resulting tarball is produced once
     and reused by desktop, Electron, Snap, Android, and iOS jobs, so SDK and inference changes from that ref are
     tested together.
-  - `gpr` resolves `@tetherto/inference-mono` from GitHub Packages. Set `inference-version` to an exact
-    prerelease or dist-tag; blank means `dev`.
   - `npm` resolves the public `@qvac/inference` package. Set `inference-version` to a version/range or dist-tag;
     blank means `latest`.
   - `manifest` preserves the dependency already declared in `packages/sdk/package.json`.
-- GPR/npm selectors are resolved to one immutable version before platform fan-out. The exact branch SHA/package
+- The npm selector is resolved to one immutable version before platform fan-out. The exact branch SHA/package
   version is shown in the workflow summary and PR test comments.
 - `suite` + `suite-custom` — pick `custom` to pass arbitrary comma-separated suite tags via `suite-custom`.
 - `desktop-platforms`, `electron-platforms`, and `snap-platforms` — advanced JSON runner overrides,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `inference-source: gpr` cannot authenticate under the current CI token policy and fails with `403 permission_denied: read_package` before E2E jobs start.
- Keeping the selector exposes a CI mode that cannot run successfully.

## 📝 How does it solve it?

- Removes GPR from workflow inputs and inference resolution logic.
- Keeps branch builds, npm versions/dist-tags, and manifest dependencies as supported sources.
- Updates reusable workflow descriptions and SDK E2E documentation.

## 🧪 How was it tested?

- Confirmed the GPR failure in [run 32131172062](https://github.com/tetherto/qvac/actions/runs/32131172062).
- Verified npm resolution remains supported and GPR is rejected.
- `actionlint` passes for all changed SDK E2E workflows.
- Repo policy tests pass: 83/83.
- `node --check` and targeted Prettier checks pass.