### PR TITLE
chore: bump model-fit to inference-addon-cpp 1.3.3

### DIFF
--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -25,6 +25,11 @@
   short-lived isolated worklet, which is exactly the load/terminate cycle those
   fixes cover.
 
+### Pull Requests
+
+- [#3926](https://github.com/tetherto/qvac/pull/3926) - chore[notask]: bump
+  model-fit to inference-addon-cpp 1.3.3
+
 ## [0.2.1] - 2026-08-18
 
 Records a fix that was left out of `0.2.0`. It merged (#3890) before the

--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.3.0] - 2026-08-18
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor moves `1.2.1` -> `1.3.3`,
+  bringing this package onto the same shared-runtime floor every other addon
+  consumer already builds against. `model-fit` was the last one left behind.
+
+  No source change is needed here. The addon uses only the header-only JS
+  boundary (`inference-addon-cpp/Errors.hpp`, `JsInterface.hpp`, `JsUtils.hpp`)
+  and its binding is synchronous — it never constructs an `AddonCpp`, a
+  scheduler or an `OutputQueue` — so 1.3.0's two breaking changes (the
+  `JobRunner` -> `SingleJobScheduler` rename with the `JobRunner.hpp` forwarding
+  header removed, and `OutputQueue::clear()` returning job-tagged entries) reach
+  nothing this package compiles.
+
+  What the floor does pick up is the run of lifecycle fixes released between the
+  two versions: the `dlclose()` self-pin that makes `Worklet.terminate()` safe on
+  Android bionic (1.2.2), the `JsLogger` teardown and re-`setLogger` crash fixes
+  and their concurrent-env ownership hardening (1.2.3, 1.2.4), and the
+  `JsAsyncTask` teardown-thread and capture-release fixes (1.3.2, 1.3.3). The
+  first three matter to `model-fit` in particular: it is designed to run in a
+  short-lived isolated worklet, which is exactly the load/terminate cycle those
+  fixes cover.
+
 ## [0.2.1] - 2026-08-18
 
 Records a fix that was left out of `0.2.0`. It merged (#3890) before the

--- a/packages/model-fit/package.json
+++ b/packages/model-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/model-fit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Memory-fit preflight addon for QVAC — wraps llama.cpp's common_fit_params to project whether a GGUF model fits available device memory before loading it",
   "addon": true,
   "scripts": {

--- a/packages/model-fit/vcpkg.json
+++ b/packages/model-fit/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.2.1"
+      "version>=": "1.3.3"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## 🎯 Problem

`packages/model-fit` is the last addon consumer still pinned to the old
`qvac-lib-inference-addon-cpp` floor. Every other package that depends on the
shared runtime asks for `1.3.3`; `model-fit` asks for `1.2.1`, and its registry
baseline (`c57eec31bdc3`) only offers `1.1.2`, so nothing was pulling it forward.

There is no override and no comment explaining the pin — unlike
`classification-ggml`, which holds `1.2.4` deliberately and says so in its
manifest. `model-fit` simply never got bumped when the rest of the consumer set
moved in #3567.

Left alone, the package keeps building against a runtime that predates the
worklet lifecycle fixes, and the divergence grows every time the shared runtime
is released.

## 📝 How

Three files, all under `packages/model-fit`:

- `vcpkg.json` — `qvac-lib-inference-addon-cpp` floor `1.2.1` -> `1.3.3`.
- `package.json` — `0.2.1` -> `0.3.0`, matching how this repo versions a
  dependency-floor move (`@qvac/vla-ggml` 0.18.0/0.19.0/0.20.0, and this
  package's own 0.2.0 for the fabric bump).
- `CHANGELOG.md` — a `[0.3.0]` entry recording the move and why no source
  change accompanies it.

**No source change is needed, and that is the part worth checking.** 1.3.0
carried two breaking changes: `JobRunner` was renamed `SingleJobScheduler` and
its forwarding header removed, and `OutputQueue::clear()` now returns job-tagged
entries. Neither reaches this package. `model-fit` includes exactly three
headers from the runtime —

```
inference-addon-cpp/Errors.hpp
inference-addon-cpp/JsInterface.hpp
inference-addon-cpp/JsUtils.hpp
```

— and its binding (`addon/src/js-interface/binding.cpp`) is a synchronous
`paramsFit(config)` call. It never constructs an `AddonCpp`, never installs a
scheduler, never touches an output queue. `grep` for `JobRunner`,
`SingleJobScheduler` or `OutputQueue` across `addon/` returns nothing.

What the floor does pick up is the run of fixes between the two versions:

| Version | Fix |
|---|---|
| 1.2.2 | `dlclose()` self-pin — makes `Worklet.terminate()` safe on Android bionic |
| 1.2.3 | `JsLogger` teardown / re-`setLogger` crash after a soft reload |
| 1.2.4 | `JsLogger` concurrent-env ownership hardening |
| 1.3.2 | `JsAsyncTask` defers env teardown until queued completions finish |
| 1.3.3 | `JsAsyncTask` releases work captures on the JS loop before settling |

The first three are directly relevant: `model-fit` is designed to run in a
short-lived isolated worklet before handing a model to `@qvac/llm-llamacpp`, so
load/terminate cycling is its normal operating mode, not an edge case.

## 🧪 Tested

Full CI run: https://github.com/tetherto/qvac/actions/runs/32170739689

Built and tested locally on `linux-x64` in a clean worktree cut from
`origin/main`, on the same branch as the commits.

**Resolution.** `bare-make generate` picked up the intended versions, and the
git-trees match the registry entries:

```
qvac-lib-inference-addon-cpp:x64-linux@1.3.3  -- @7de84fa49a34
qvac-fabric[core,gpu-backends,llama]:x64-linux@10069.1.0 -- @bdb457fa20ca
```

This is the part the bump actually depends on: `model-fit`'s baseline
(`c57eec31bdc3`) only offers `1.1.2`, so the raised floor is what pulls `1.3.3`
in, and it resolves cleanly.

**Build.** `bare-make build` — clean, 0 warnings across all three translation
units, links `qvac__model-fit@0.bare`. `bare-make install` stages the
`linux-x64` prebuild. This is the direct evidence for the "no source change
needed" claim above: the addon compiles against 1.3.3 untouched.

**Unit tests.** `npm run test:unit` — 27/27 pass, 76/76 asserts, plus 2/2 in the
Node lane. Notably `fit process runner returns a real fit through the boundary`
passes, so the freshly built native binding was exercised end to end, not just
compiled.

**Lint and types.** `npm run lint` (prettier + lunte + eslint) and
`npm run test:types` (typecheck, consumer `.d.ts` check, generated-file drift
check) both clean.

Not covered locally: the integration suite and any non-`linux-x64` target. CI's
prebuild and addon-test stages are the authoritative check there and need the
routing labels to fire.

## ⚠️ Breaking

None. No public API, config key or result shape changes. The version bump is
minor rather than patch only to follow this repo's convention for a dependency
floor move; consumers see no behavioural difference beyond the upstream
lifecycle fixes listed above.
