### PR TITLE
fix: build classification-ggml against addon-cpp 1.3.3

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-08-18
+
+### Fixed
+
+- The addon now actually builds against the `qvac-lib-inference-addon-cpp` `1.3.3`
+  its manifest already asked for, rather than `1.2.4`. `vcpkg.json` carried both a
+  `"version>=": "1.3.3"` constraint and an `overrides` entry pinning the same port
+  to `1.2.4`, and a vcpkg override wins over a constraint — so this was the only one
+  of the shared runtime's twelve consumers not resolving 1.3.3, and 0.17.0's note
+  about aligning that floor did not describe what was built here. The pin was added
+  in 0.16.0 for a narrower reason: the registry-baseline bump that made
+  `abseil 20260526.0` available to the new fuzz feature would have carried the header
+  library from 1.2.4 to 1.3.2 as a side effect, and 1.3.2 was unvalidated for this
+  package at the time. That reason is spent — 1.3.3 is both what the constraint
+  requires and the registry baseline's default version for the port, so dropping the
+  override resolves exactly that version rather than leaving resolution to drift.
+
+  No public API change. `runJob()` keeps returning a Boolean admission result on the
+  untagged single-job path this addon uses, and `ClassificationModel` implements
+  plain `IModel`, so none of 1.3.0's job-scheduling interfaces apply to it. What the
+  addon does pick up is teardown and cancellation hardening in the shared runtime:
+  `AddonCpp` destroys its scheduler before stopping the output callback, so teardown
+  terminal events are still delivered; `destroyInstance` destroys the instance
+  outside the instance-registry mutex, so an output callback that re-enters a binding
+  during teardown cannot deadlock (both 1.3.0); `JsAsyncTask` defers environment
+  teardown until queued completions finish (1.3.2), releases its work captures on the
+  JavaScript loop before settling its promise, and no longer retains the model at all
+  for a `cancel()` with no live jobs (both 1.3.3) — the path `unload()` takes here.
+
 ## [0.19.0] - 2026-08-18
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {

--- a/packages/classification-ggml/vcpkg.json
+++ b/packages/classification-ggml/vcpkg.json
@@ -45,12 +45,5 @@
         "gtest"
       ]
     }
-  },
-  "overrides": [
-    {
-      "$comment": "Pinned so the registry-baseline bump that made abseil 20260526.0 available (needed by the fuzz feature) does not also drag this header library from 1.2.4 to 1.3.2. Drop the override to take the newer one deliberately.",
-      "name": "qvac-lib-inference-addon-cpp",
-      "version": "1.2.4"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`packages/classification-ggml/vcpkg.json` asks for `qvac-lib-inference-addon-cpp`
`"version>=": "1.3.3"` and then overrides the same port to `1.2.4`. A vcpkg
override wins over a constraint, so the constraint is dead text and the package
builds 1.2.4 — the only one of the shared runtime's twelve consumers not on
1.3.3. `packages/classification-ggml` is also the only package in the repo that
overrides this port at all (the other two `overrides` blocks, in `onnx` and
`translation-nmtcpp`, pin `flatbuffers` / `marian-dev`).

That makes the `[0.17.0]` changelog entry — "align `@qvac/infer-base` and
`qvac-lib-inference-addon-cpp` dependency floors with the shared addon runtime
validated across the live addon consumer set" — untrue of this package.

How it happened is an ordering accident. #3527 (0.16.0, Aug 4) added the fuzz
feature and, with it, the override: the registry-baseline bump needed to make
`abseil 20260526.0` available would otherwise have carried the header library
from 1.2.4 to the then-unvalidated 1.3.2, as the `$comment` records. #3567
(0.17.0, Aug 6) then raised the floor to 1.3.3 across every consumer and dropped
the temporary overlay ports, but left this override in place.

## 📝 How does it solve it?

Removes the `overrides` block, so the declared constraint is what resolves. The
resolution is deterministic rather than open-ended: at the registry baseline this
package pins (`1d658f603c`), the port's default version is already `1.3.3`, so
`>=1.3.3` lands exactly there. Nothing else in the manifest moves — both 1.2.4
and 1.3.3 declare the identical dependency set (`qvac-lint-cpp >= 1.4.5`), and
the baseline's default for `qvac-lint-cpp` is already 1.4.5, so the
clang-format/clang-tidy toolchain does not shift and no source reformatting is
implied.

No source change is needed for the 1.2.4 → 1.3.3 jump. Checked each break and
behaviour change addon-cpp 1.3.0–1.3.3 introduced against this package's code:

- **`OutputQueue::clear()` return type changed (1.3.0, breaking).**
  `addon/src/addon/AddonJs.hpp` includes `queue/OutputQueue.hpp` but never calls
  `clear()`.
- **`JobRunner` renamed to `SingleJobScheduler`, forwarding header removed
  (1.3.0, breaking).** No occurrence of `JobRunner` in the package.
- **`runJob` admission result.** This is what broke `vla-ggml` on 1.3.3, which
  read `AddonCpp::runJob`'s return as a `bool`. This addon calls
  `AddonJs::runJob`, whose signature is unchanged and which still returns
  Boolean `true`/`false` on the untagged single-job path, so `if (!accepted)` in
  `src/index.ts:249` keeps working.
- **New model interfaces.** `IModel` is unchanged apart from comments;
  `IModelMultiprocessor`, `IModelCancelById`, `IModelJobStats` and
  `IModelJobLifecycle` are additive, and `ClassificationModel` derives from
  `IModel` alone.
- **Constructors.** `AddonJs(env, callback, model)` gained a *defaulted* fourth
  scheduler parameter; `OutputCallBackJs(env, jsHandle, outputCb, handlers)` is
  byte-identical. Both call sites compile unchanged.
- **Fuzz targets.** `test/fuzz/preprocess_fuzz.cpp` includes only
  `inference-addon-cpp/Errors.hpp`, which is untouched between the two versions.

What the addon gains is teardown and cancellation hardening it currently misses:
`~AddonCpp` destroys its scheduler before stopping the output callback so
teardown terminal events are still delivered; `destroyInstance` destroys the
instance outside the instance-registry mutex so an output callback re-entering a
binding during teardown cannot deadlock (both 1.3.0); and `JsAsyncTask` defers
environment teardown until queued completions finish (1.3.2), releases its work
captures on the JS loop before settling its promise, and no longer retains the
model for a `cancel()` with no live jobs (both 1.3.3) — the path `unload()` takes
here. Aligning also removes the mixed-version surface in the desktop co-load
matrix, where this addon is loaded into one Bare process alongside addons built
against 1.3.3.

Ticket: attributed to QVAC-18397, the addon-cpp 1.3.3 adoption work whose sweep
(#3567) this completes for the one consumer it missed.

## 🧪 How was it tested?

CI run: https://github.com/tetherto/qvac/actions/runs/32181954968

**Not built or run locally — this is a static-analysis case and CI is the
verification.** The per-item reasoning is in the section above; the manifest was
confirmed to parse with `overrides` gone and both `fuzz` and `tests` features
intact.

Registry facts were read from `tetherto/qvac-registry-vcpkg` at the exact
baseline this package pins, not assumed:

- `versions/q-/qvac-lib-inference-addon-cpp.json` at `1d658f603c` lists 1.3.3 as
  the newest entry, and `ports/qvac-lib-inference-addon-cpp/vcpkg.json` at that
  ref is version 1.3.3 — the baseline default.
- The 1.3.3 portfile builds `tetherto/qvac` @ `8f1ccdb46`; its
  `packages/inference-addon-cpp/src` tree hash is identical to `main`'s, so the
  1.2.4-vs-1.3.3 header diff used for the analysis above is the real one
  (`c68ee33d5` → `main`).

Prebuild reuse cannot mask the change: `detect-native-changes` counts
`<pkg>/vcpkg.json` as a native change and folds it into `native_hash`
(`.github/actions/detect-native-changes/action.yml:117`), so prebuilds rebuild
from source rather than being reused from a 1.2.4 cache.

Labels `prebuilds`, `run-cpp-addon-tests`, `run-desktop-addon-tests` and
`run-mobile-addon-tests` are applied so the C++ unit tests, desktop integration
and on-device suites all run against the newly resolved version. The desktop
integration suite is a real end-to-end check here — the MobileNetV3 weights are
committed under `packages/classification-ggml/weights/`, so no model download is
involved.

## ⚠️ Breaking changes

None. No public API change, and no behavioural change on the admission path this
addon uses. Patch-bumped to `0.19.1` on those grounds; a reviewer who would
rather treat a resolved-native-dependency move as a minor should say so and I
will re-cut it as `0.20.0`.
