### PR TITLE
feat[audiogen-ggml]: add MiniMax-Music3 desktop CPU support

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add desktop CPU support for MiniMax-Music3 through local LM and synthesis
+  GGUF files, with engine-specific validation, progress, cancellation, runtime
+  statistics, and a skippable model-backed integration regression.
+
 ## [0.2.3] - 2026-08-18
 
 ### Changed

--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -87,6 +87,15 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/acestep/AcestepModel.cpp
 )
 
+if(NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  target_sources(
+    ${audiogen-ggml}
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/addon/src/model-interface/minimax/MinimaxModel.cpp
+  )
+  target_compile_definitions(${audiogen-ggml} PRIVATE AUDIOGEN_HAS_MINIMAX=1)
+endif()
+
 target_include_directories(
   ${audiogen-ggml}
   PRIVATE

--- a/packages/audiogen-ggml/NOTICE
+++ b/packages/audiogen-ggml/NOTICE
@@ -66,6 +66,14 @@ C++ Dependencies
   audiogen-cpp
     https://github.com/tetherto/qvac-ext-lib-whisper.cpp
 
+--- minimax-music3-community-license ---
+
+  MiniMax-Music3 model weights
+    https://huggingface.co/MiniMaxAI/MiniMax-Music3
+
+  Model weights are governed by the MiniMax-Music3 Community License.
+  Distribute the upstream license text with converted model files.
+
 --- Unknown ---
 
   qvac-lint-cpp

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -1,11 +1,10 @@
 # @qvac/audiogen-ggml
 
-Generate **music from a text description** — fully native, on CPU or GPU. You
-give it a prompt like _"lo-fi hip hop, mellow piano, rainy night"_ (optionally
-with lyrics to sing and musical hints like BPM or key), and it returns stereo
-48 kHz audio. It's the ggml-backed qvac addon around the
-[ACE-Step 1.5](https://github.com/ace-step/ACE-Step-1.5) model, same shape as
-`@qvac/tts-ggml`.
+Generate **music from a text description** with
+[ACE-Step 1.5](https://github.com/ace-step/ACE-Step-1.5) or
+[MiniMax-Music3](https://huggingface.co/MiniMaxAI/MiniMax-Music3). ACE-Step
+supports CPU and GPU generation across desktop and mobile. MiniMax-Music3 runs
+on desktop CPUs and returns stereo 44.1 kHz audio.
 
 ## How it works
 
@@ -39,6 +38,7 @@ npm install @qvac/audiogen-ggml
 Published prebuilds cover Linux x64/arm64, macOS x64/arm64, Windows x64,
 Android arm64, and iOS arm64. You also need the model GGUFs on disk (see
 [Models](#models)); point the addon at the folder that holds them.
+MiniMax-Music3 is available only in the Linux, macOS, and Windows prebuilds.
 
 To build the native addon from source in a repository checkout:
 
@@ -53,6 +53,36 @@ npm run build
 > Building with `@qvac/sdk`? Use the SDK's
 > [`audioGen()` music generation guide](../../docs/website/content/docs/ai-capabilities/music-generation.mdx)
 > for registry-hosted models, progress streaming, and targeted cancellation.
+
+### MiniMax-Music3 on desktop
+
+MiniMax-Music3 needs an LM GGUF and a synthesis GGUF. Pass their directory or
+both explicit paths:
+
+```js
+const { AudioGen, ENGINE_MINIMAX } = require('@qvac/audiogen-ggml')
+
+const gen = new AudioGen({
+  engine: ENGINE_MINIMAX,
+  files: { modelDir: '/path/to/minimax-music3' },
+  config: { threads: 8 }
+})
+
+await gen.load()
+const response = await gen.run('warm cinematic piano with gentle strings', {
+  lyrics: '[Instrumental]',
+  duration: 12,
+  seed: 7,
+  inferenceSteps: 8,
+  cfgScale: 1.7
+})
+```
+
+`duration` is converted to the model's 25 semantic frames per second. Use
+`maxFrames` instead for direct control. MiniMax-Music3 rejects ACE-Step-only
+controls such as BPM, DiT shift, frozen semantic codes, cover audio, and GPU
+offloading. See
+[`examples/generate-music-minimax.js`](examples/generate-music-minimax.js).
 
 ### 1. Simplest case — an instrumental
 
@@ -239,7 +269,10 @@ runnable end-to-end script (`npm run example`).
 
 ## Options
 
-**Constructor** (`new AudioGen({ files, config, logger })`):
+**Constructor** (`new AudioGen({ engine, files, config, logger })`):
+
+`engine` is `acestep` by default. It is inferred as `minimax` when
+`files.synthModel` is present.
 
 `files` — model paths:
 
@@ -248,6 +281,7 @@ runnable end-to-end script (`npm run example`).
 | `modelDir` | Folder holding the GGUFs (stages auto-classified by name). |
 | `ditVariant` | Which DiT to load from `modelDir`: `turbo-q4` \| `turbo-q8` \| `sft`. |
 | `textEncModel` / `lmModel` / `ditModel` / `vaeModel` | Explicit per-stage paths (override `modelDir`). |
+| `lmModel` / `synthModel` | Explicit MiniMax-Music3 pair (override `modelDir`). |
 
 `config` — runtime knobs:
 
@@ -255,6 +289,7 @@ runnable end-to-end script (`npm run example`).
 |--------|---------|
 | `useGPU` | Run on GPU (Metal / Vulkan, including Android Mali); falls back to CPU. |
 | `inferenceSteps` / `shift` | Advanced; leave unset to auto-tune per DiT. |
+| `cfgScale` | Default MiniMax flow guidance scale; `0` uses the model default. |
 | `nGpuLayers` | GPU layers to offload when `useGPU` is set (99 = all). |
 | `threads` | CPU thread count (0 / unset = hardware default). |
 | `backendsDir` | Advanced; override the prebuilds root scanned for dlopen'd ggml backend modules. Defaults to `<addon>/prebuilds` (correct for the shipped package). Needed on arm64, where the CPU backend is a set of per-microarch module `.so`s. |
@@ -272,6 +307,8 @@ wrapped by a level-gated `QvacLogger`.
 | `keyscale` | Key and scale, such as `C minor`. |
 | `timesignature` | Time signature, such as `4/4`. |
 | `duration` | Target length in seconds; omit to let the LM decide. |
+| `maxFrames` | MiniMax semantic-frame cap; cannot be combined with `duration`. |
+| `inferenceSteps` / `cfgScale` | Per-run MiniMax flow controls. |
 | `seed` | RNG seed for reproducible generation. |
 | `lmTemperature` / `lmTopP` / `lmTopK` / `lmCfgScale` | LM sampling controls. |
 | `lmPhase1` | Allow the LM to infer missing metadata before generating semantic codes. |
@@ -284,6 +321,16 @@ wrapped by a level-gated `QvacLogger`.
 | `coverNoiseStrength` | Initial source/noise blend from `0` to `1`. |
 
 ## Models
+
+### MiniMax-Music3
+
+MiniMax-Music3 uses two GGUF files: `mm3-lm-<quant>.gguf` and
+`mm3-synth-<quant>.gguf`. This package does not publish or download those
+weights yet. Supply local converted files through `modelDir` or explicit
+`lmModel` and `synthModel` paths. The model weights are governed by the
+MiniMax-Music3 Community License.
+
+### ACE-Step
 
 Four stages. Three are fixed; only the DiT changes, so you pick it with
 `ditVariant`.
@@ -347,17 +394,15 @@ model-directory, and DiT-variant variables.
 
 ## Internals
 
-```
-index.js ─► binding (BARE_MODULE) ─► AcestepModel ─► tts_cpp::acestep::Engine
-                                                          │
-                          text-enc ─► LM ─► DiT ─► VAE   (ggml graphs)
-```
+`index.js` selects `AcestepModel` or `MinimaxModel`, then the native binding
+dispatches to the corresponding `audiogen-cpp` engine.
 
 - `addon/src/js-interface/binding.cpp` — `BARE_MODULE` exports.
 - `addon/src/addon/AddonJs.hpp` — `createInstance` / `activate` / `runJob`.
 - `addon/src/model-interface/acestep/` — `AcestepModel`, wrapping the engine.
-- Built with `cmake-bare` + `cmake-vcpkg`; `vcpkg.json` depends on `audiogen-cpp`
-  (the C++ engine, on our ggml-speech fork).
+- `addon/src/model-interface/minimax/` — desktop-only `MinimaxModel`.
+- Built with `cmake-bare` + `cmake-vcpkg`; `vcpkg.json` depends on the
+  `speech-cpp[audiogen]` port.
 
 ## Benchmarking
 
@@ -401,4 +446,5 @@ version bump.
 
 ## License
 
-Apache-2.0. Model weights belong to ACE Studio and StepFun.
+Apache-2.0. ACE-Step model weights belong to ACE Studio and StepFun.
+MiniMax-Music3 weights are governed by the MiniMax-Music3 Community License.

--- a/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/audiogen-ggml/addon/src/addon/AddonJs.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <any>
+#include <cmath>
 #include <cstdint>
+#include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <span>
@@ -20,13 +23,79 @@
 #include <js.h>
 
 #include "js-interface/JSAdapter.hpp"
+#include "model-interface/AudioGenProgress.hpp"
 #include "model-interface/acestep/AcestepModel.hpp"
+#ifdef AUDIOGEN_HAS_MINIMAX
+#include "model-interface/minimax/MinimaxModel.hpp"
+#endif
 
 namespace qvac::audiogenggml::addon_js {
 
 namespace js = qvac_lib_inference_addon_cpp::js;
 
 using acestep::AcestepModel;
+#ifdef AUDIOGEN_HAS_MINIMAX
+using minimax::MinimaxModel;
+#endif
+
+inline constexpr double kMaximumSafeInteger = 9007199254740991.0;
+inline constexpr int kMaximumMinimaxInferenceSteps = 1000;
+
+inline std::optional<double> readOptionalNumber(
+    js::Object object, js_env_t* env, const char* name) {
+  js_value_t* raw = object.getProperty(env, name);
+  if (js::is<js::Undefined>(env, raw) || js::is<js::Null>(env, raw)) {
+    return std::nullopt;
+  }
+  if (!js::is<js::Number>(env, raw)) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        std::string(name) + " must be a number");
+  }
+  return js::Number::fromValue(raw).as<double>(env);
+}
+
+inline int64_t checkedSafeInteger(double value, const char* name) {
+  if (!std::isfinite(value) || std::trunc(value) != value ||
+      std::fabs(value) > kMaximumSafeInteger) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        std::string(name) + " must be a safe integer");
+  }
+  return static_cast<int64_t>(value);
+}
+
+inline int64_t checkedPositiveSafeInteger(double value, const char* name) {
+  const int64_t integer = checkedSafeInteger(value, name);
+  if (integer <= 0) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        std::string(name) + " must be greater than zero");
+  }
+  return integer;
+}
+
+inline int checkedMinimaxInferenceSteps(double value) {
+  const int64_t integer = checkedSafeInteger(value, "inferenceSteps");
+  if (integer < 0 || integer > kMaximumMinimaxInferenceSteps) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        "inferenceSteps must be between 0 and 1000");
+  }
+  return static_cast<int>(integer);
+}
+
+inline float checkedMinimaxCfgScale(double value) {
+  const double maximum = std::numeric_limits<float>::max();
+  const double minimum = std::numeric_limits<float>::denorm_min();
+  if (!std::isfinite(value) || value < 0.0 || value > maximum ||
+      (value > 0.0 && value < minimum)) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        "cfgScale must be 0 or a positive float32 value");
+  }
+  return static_cast<float>(value);
+}
 
 inline std::vector<int>
 copyAudioCodes(js_env_t* env, js::TypedArray<int32_t> array) {
@@ -62,19 +131,15 @@ copyFloat32Pcm(js_env_t* env, js::TypedArray<float> array, const char* name) {
   return {data, data + len};
 }
 
-// Emits the generated track as interleaved stereo Int16 + sample rate, mirror
-// of ttsggml::JsAudioOutputHandler. The rate/channels are sourced from the model
-// (which reads them from the engine's decode result) rather than hardcoded, so
-// the values reported alongside the PCM always match the runtime stats. PCM is
-// emitted once, after generate() completes, so the model already holds the real
-// engine values by the time this runs.
 struct JsAudioOutputHandler
     : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
           std::vector<int16_t>> {
-  explicit JsAudioOutputHandler(const AcestepModel* model)
+  JsAudioOutputHandler(
+      std::function<int()> sampleRate, std::function<int()> channels)
       : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
             std::vector<int16_t>>(
-            [this, model](
+            [this, sampleRate = std::move(sampleRate),
+             channels = std::move(channels)](
                 const std::vector<int16_t>& data) -> js_value_t* {
               auto result = js::Object::create(this->env_);
               std::span<const int16_t> outputSpan(data.data(), data.size());
@@ -83,24 +148,21 @@ struct JsAudioOutputHandler
               result.setProperty(this->env_, "outputArray", typedArray);
               result.setProperty(
                   this->env_, "sampleRate",
-                  js::Number::create(this->env_, model->sampleRate()));
+                  js::Number::create(this->env_, sampleRate()));
               result.setProperty(
                   this->env_, "channels",
-                  js::Number::create(this->env_, model->channels()));
+                  js::Number::create(this->env_, channels()));
               return result;
             }) {}
 };
 
-// Emits a mid-generation progress tick as { progressStage, progressStep,
-// progressTotal }. The JS side (plugin sink) distinguishes it from PCM/stats by
-// the presence of `progressTotal`.
 struct JsProgressOutputHandler
     : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
-          acestep::AcestepProgress> {
+          AudioGenProgress> {
   JsProgressOutputHandler()
       : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
-            acestep::AcestepProgress>(
-            [this](const acestep::AcestepProgress& p) -> js_value_t* {
+            AudioGenProgress>(
+            [this](const AudioGenProgress& p) -> js_value_t* {
               auto result = js::Object::create(this->env_);
               result.setProperty(
                   this->env_, "progressStage",
@@ -123,25 +185,55 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   auto configurationParams = args.getJsObject(1, "configurationParams");
 
   JSAdapter adapter;
-  auto cfg = adapter.buildAcestepConfig(configurationParams, env);
+  const EngineType engineType = adapter.readEngineType(configurationParams, env);
+  unique_ptr<model::IModel> model;
+  function<int()> sampleRate;
+  function<int()> channels;
+  function<void(function<void(const AudioGenProgress&)>)> setProgressSink;
 
-  auto model = make_unique<AcestepModel>(std::move(cfg));
-  AcestepModel* modelPtr = model.get();
+  if (engineType == EngineType::Minimax) {
+#ifdef AUDIOGEN_HAS_MINIMAX
+    auto minimaxModel =
+        make_unique<MinimaxModel>(
+            adapter.buildMinimaxConfig(configurationParams, env));
+    MinimaxModel* modelPtr = minimaxModel.get();
+    sampleRate = [modelPtr]() { return modelPtr->sampleRate(); };
+    channels = [modelPtr]() { return modelPtr->channels(); };
+    setProgressSink = [modelPtr](
+                          function<void(const AudioGenProgress&)> sink) {
+      modelPtr->setProgressSink(std::move(sink));
+    };
+    model = std::move(minimaxModel);
+#else
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        "MiniMax-Music3 is available on desktop builds only");
+#endif
+  } else {
+    auto acestepModel =
+        make_unique<AcestepModel>(
+            adapter.buildAcestepConfig(configurationParams, env));
+    AcestepModel* modelPtr = acestepModel.get();
+    sampleRate = [modelPtr]() { return modelPtr->sampleRate(); };
+    channels = [modelPtr]() { return modelPtr->channels(); };
+    setProgressSink = [modelPtr](
+                          function<void(const AudioGenProgress&)> sink) {
+      modelPtr->setProgressSink(std::move(sink));
+    };
+    model = std::move(acestepModel);
+  }
 
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
-  outHandlers.add(make_shared<JsAudioOutputHandler>(modelPtr));
+  outHandlers.add(make_shared<JsAudioOutputHandler>(
+      std::move(sampleRate), std::move(channels)));
   outHandlers.add(make_shared<JsProgressOutputHandler>());
   unique_ptr<OutputCallBackInterface> callback = make_unique<OutputCallBackJs>(
       env, args.get(0, "jsHandle"), args.getFunction(2, "outputCallback"),
       std::move(outHandlers));
 
   auto addon = make_unique<AddonJs>(env, std::move(callback), std::move(model));
-
-  // Route per-step engine progress into the output queue so it reaches JS via
-  // the same output callback as PCM/stats. The model runs on the job worker
-  // thread; OutputQueue::queueResult is thread-safe (locks + uv_async_send).
   auto outputQueue = addon->addonCpp->outputQueue;
-  modelPtr->setProgressSink([outputQueue](const acestep::AcestepProgress& p) {
+  setProgressSink([outputQueue](const AudioGenProgress& p) {
     outputQueue->queueResult(std::any(p));
   });
 
@@ -162,9 +254,6 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
         "Unknown input type: " + type);
   }
 
-  // The caption is the primary text input. Generation metadata, LM sampler
-  // controls and optional frozen semantic codes are per-call overrides on the
-  // same job object the framework hands us at arg index 1.
   auto jobObj = args.getJsObject(1, "inputObj");
   auto optStr = [&](const char* key) -> std::optional<std::string> {
     return jobObj.getOptionalPropertyAs<js::String, std::string>(env, key);
@@ -189,6 +278,27 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
     }
     return std::nullopt;
   };
+
+#ifdef AUDIOGEN_HAS_MINIMAX
+  if (dynamic_cast<MinimaxModel*>(&instance.addonCpp->model.get())) {
+    MinimaxModel::AnyInput modelInput;
+    modelInput.caption = js::String(env, jsInput).as<std::string>(env);
+    if (auto value = optStr("lyrics")) modelInput.lyrics = *value;
+    if (auto value = readOptionalNumber(jobObj, env, "seed")) {
+      modelInput.seed = checkedSafeInteger(*value, "seed");
+    }
+    if (auto value = readOptionalNumber(jobObj, env, "maxFrames")) {
+      modelInput.maxFrames = checkedPositiveSafeInteger(*value, "maxFrames");
+    }
+    if (auto value = readOptionalNumber(jobObj, env, "inferenceSteps")) {
+      modelInput.inferenceSteps = checkedMinimaxInferenceSteps(*value);
+    }
+    if (auto value = readOptionalNumber(jobObj, env, "cfgScale")) {
+      modelInput.cfgScale = checkedMinimaxCfgScale(*value);
+    }
+    return instance.runJob(std::any(std::move(modelInput)));
+  }
+#endif
 
   AcestepModel::AnyInput modelInput;
   modelInput.caption = js::String(env, jsInput).as<std::string>(env);
@@ -256,19 +366,44 @@ inline js_value_t* reload(js_env_t* env, js_callback_info_t* info) try {
   AddonJs& instance = JsInterface::getInstance(env, args.get(0, "instance"));
   auto configurationParams = args.getJsObject(1, "configurationParams");
   JSAdapter adapter;
-  auto newCfg = adapter.buildAcestepConfig(configurationParams, env);
+  const EngineType engineType = adapter.readEngineType(configurationParams, env);
 
+  if (engineType == EngineType::Minimax) {
+#ifdef AUDIOGEN_HAS_MINIMAX
+    auto newConfig = adapter.buildMinimaxConfig(configurationParams, env);
+    return js::JsAsyncTask::run(
+        env,
+        [addonCpp = instance.addonCpp,
+         newConfig = std::move(newConfig)]() mutable {
+          auto* model =
+              dynamic_cast<MinimaxModel*>(&addonCpp->model.get());
+          if (model == nullptr) {
+            throw qvac_errors::StatusError(
+                qvac_errors::general_error::InvalidArgument,
+                "reload cannot change the audiogen engine type");
+          }
+          model->reload(std::move(newConfig));
+        });
+#else
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        "MiniMax-Music3 is available on desktop builds only");
+#endif
+  }
+
+  auto newConfig = adapter.buildAcestepConfig(configurationParams, env);
   return js::JsAsyncTask::run(
       env,
-      [addonCpp = instance.addonCpp, newCfg = std::move(newCfg)]() mutable {
-        auto* m = dynamic_cast<AcestepModel*>(&addonCpp->model.get());
-        if (m == nullptr) {
+      [addonCpp = instance.addonCpp,
+       newConfig = std::move(newConfig)]() mutable {
+        auto* model = dynamic_cast<AcestepModel*>(&addonCpp->model.get());
+        if (model == nullptr) {
           throw qvac_errors::StatusError(
-              qvac_errors::general_error::InternalError,
-              "reload: model is not an AcestepModel");
+              qvac_errors::general_error::InvalidArgument,
+              "reload cannot change the audiogen engine type");
         }
-        m->setConfig(std::move(newCfg));
-        m->reload();
+        model->setConfig(std::move(newConfig));
+        model->reload();
       });
 }
 JSCATCH

--- a/packages/audiogen-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/audiogen-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -94,6 +94,21 @@ bool readRequiredBool(js::Object obj, js_env_t* env, const char* key) {
 
 }  // namespace
 
+EngineType JSAdapter::readEngineType(
+    js::Object configurationParams, js_env_t* env) {
+  const std::string engineType =
+      readOptionalString(configurationParams, env, "engineType");
+  if (engineType.empty() || engineType == "acestep") {
+    return EngineType::Acestep;
+  }
+  if (engineType == "minimax") {
+    return EngineType::Minimax;
+  }
+  throw qvac_errors::StatusError(
+      general_error::InvalidArgument,
+      "engineType must be 'acestep' or 'minimax' (got '" + engineType + "')");
+}
+
 acestep::AcestepConfig JSAdapter::buildAcestepConfig(
     js::Object configurationParams, js_env_t* env) {
   acestep::AcestepConfig cfg;
@@ -112,6 +127,20 @@ acestep::AcestepConfig JSAdapter::buildAcestepConfig(
   // (see AcestepConfig::backendsDir). Empty when the host omits it; the addon
   // then relies on ggml's built-in search path.
   cfg.backendsDir = readOptionalString(configurationParams, env, "backendsDir");
+  return cfg;
+}
+
+minimax::MinimaxConfig JSAdapter::buildMinimaxConfig(
+    js::Object configurationParams, js_env_t* env) {
+  minimax::MinimaxConfig cfg;
+  cfg.modelDir = readOptionalString(configurationParams, env, "modelDir");
+  cfg.lmModelPath =
+      readOptionalString(configurationParams, env, "lmModelPath");
+  cfg.synthModelPath =
+      readOptionalString(configurationParams, env, "synthModelPath");
+  cfg.threads = readRequiredInt(configurationParams, env, "threads");
+  cfg.backendsDir =
+      readOptionalString(configurationParams, env, "backendsDir");
   return cfg;
 }
 

--- a/packages/audiogen-ggml/addon/src/js-interface/JSAdapter.hpp
+++ b/packages/audiogen-ggml/addon/src/js-interface/JSAdapter.hpp
@@ -4,14 +4,21 @@
 #include <inference-addon-cpp/JsUtils.hpp>
 
 #include "model-interface/acestep/AcestepConfig.hpp"
+#include "model-interface/minimax/MinimaxConfig.hpp"
 
 namespace qvac::audiogenggml {
 
-// Translates the JS `configuration` object into the C++ AcestepConfig.
-// Mirrors ttsggml::JSAdapter (flat keys, read via inference-addon-cpp JsUtils).
+enum class EngineType { Acestep, Minimax };
+
 class JSAdapter {
 public:
+  EngineType readEngineType(
+      qvac_lib_inference_addon_cpp::js::Object configurationParams,
+      js_env_t* env);
   acestep::AcestepConfig buildAcestepConfig(
+      qvac_lib_inference_addon_cpp::js::Object configurationParams,
+      js_env_t* env);
+  minimax::MinimaxConfig buildMinimaxConfig(
       qvac_lib_inference_addon_cpp::js::Object configurationParams,
       js_env_t* env);
 };

--- a/packages/audiogen-ggml/addon/src/model-interface/AudioGenProgress.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/AudioGenProgress.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace qvac::audiogenggml {
+
+struct AudioGenProgress {
+  std::string stage;
+  int64_t step = 0;
+  int64_t total = 0;
+};
+
+}

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
@@ -183,7 +183,7 @@ AcestepModel::Output AcestepModel::generate(const AnyInput& in) {
   params.shift = cfg_.shift;
 
   auto progress = [this](const std::string& stage, int step, int total) -> bool {
-    if (progressSink_) progressSink_(AcestepProgress{stage, step, total});
+    if (progressSink_) progressSink_(AudioGenProgress{stage, step, total});
     return !cancelRequested_.load();
   };
 

--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.hpp
@@ -12,6 +12,7 @@
 #include "inference-addon-cpp/ModelInterfaces.hpp"
 #include "inference-addon-cpp/RuntimeStats.hpp"
 
+#include "model-interface/AudioGenProgress.hpp"
 #include "model-interface/acestep/AcestepConfig.hpp"
 
 namespace tts_cpp::acestep {
@@ -19,16 +20,6 @@ class Engine;
 }
 
 namespace qvac::audiogenggml::acestep {
-
-// One progress tick surfaced mid-generation. `stage` is "lm" | "dit" | "vae";
-// `step`/`total` count within that stage (the DiT stage streams every Euler
-// step, which is the bulk of the work). Emitted through the same output queue
-// as PCM so the JS side receives it via the output callback.
-struct AcestepProgress {
-  std::string stage;
-  int         step  = 0;
-  int         total = 0;
-};
 
 // Music-generation model interface for the audiogen-ggml addon. Wraps
 // tts_cpp::acestep::Engine (text-enc + LM + DiT + VAE) behind the
@@ -97,7 +88,7 @@ public:
 
   // Install a sink for mid-generation progress ticks. Set once at construction
   // (before any job runs), invoked on the job worker thread during generate().
-  void setProgressSink(std::function<void(const AcestepProgress&)> sink) {
+  void setProgressSink(std::function<void(const AudioGenProgress&)> sink) {
     progressSink_ = std::move(sink);
   }
 
@@ -118,7 +109,7 @@ private:
   mutable std::atomic_bool cancelRequested_{false};
   std::atomic_bool jobInProgress_{false};
 
-  std::function<void(const AcestepProgress&)> progressSink_;
+  std::function<void(const AudioGenProgress&)> progressSink_;
 
   double totalTime_ = 0.0;
   double audioDurationMs_ = 0.0;

--- a/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxConfig.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxConfig.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace qvac::audiogenggml::minimax {
+
+struct MinimaxConfig {
+  std::string modelDir;
+  std::string lmModelPath;
+  std::string synthModelPath;
+  int threads = 0;
+  std::string backendsDir;
+};
+
+}

--- a/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxModel.cpp
@@ -1,0 +1,199 @@
+#include "model-interface/minimax/MinimaxModel.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <stdexcept>
+#include <utility>
+
+#include "audiogen-cpp/minimax/engine.h"
+
+namespace qvac::audiogenggml::minimax {
+
+namespace {
+
+constexpr float kInt16Scale = 32767.0F;
+constexpr float kInt16Minimum = -32768.0F;
+constexpr float kTargetPeak = 0.9F;
+constexpr float kMinimumNormalizationPeak = 1e-3F;
+constexpr int64_t kBackendDeviceCpu = 0;
+constexpr int64_t kBackendIdCpu = 0;
+constexpr int kStereoChannels = 2;
+constexpr double kMillisecondsPerSecond = 1000.0;
+
+int16_t f32ToI16(float sample) {
+  float value = sample * kInt16Scale;
+  value = std::fmin(value, kInt16Scale);
+  value = std::fmax(value, kInt16Minimum);
+  return static_cast<int16_t>(std::lrint(value));
+}
+
+float peakAmplitude(const std::vector<float>& pcm) {
+  float peak = 0.0F;
+  for (const float sample : pcm) {
+    if (!std::isfinite(sample)) {
+      throw std::runtime_error("MinimaxModel: engine returned non-finite PCM");
+    }
+    peak = std::fmax(peak, std::fabs(sample));
+  }
+  return peak;
+}
+
+float normalizationGain(const std::vector<float>& pcm) {
+  const float peak = peakAmplitude(pcm);
+  return peak > kMinimumNormalizationPeak ? kTargetPeak / peak : 1.0F;
+}
+
+MinimaxModel::Output convertPcm(const std::vector<float>& pcm) {
+  const float gain = normalizationGain(pcm);
+  MinimaxModel::Output output;
+  output.reserve(pcm.size());
+  for (const float sample : pcm) {
+    output.push_back(f32ToI16(sample * gain));
+  }
+  return output;
+}
+
+std::string resolveBackendsDir(const std::string& root) {
+  if (root.empty()) return {};
+  std::filesystem::path path(root);
+#ifdef BACKENDS_SUBDIR
+  path = (path / std::filesystem::path(BACKENDS_SUBDIR)).lexically_normal();
+#endif
+  return path.string();
+}
+
+}
+
+MinimaxModel::MinimaxModel(MinimaxConfig config) : config_(std::move(config)) {
+  validateConfig(config_);
+}
+
+MinimaxModel::~MinimaxModel() noexcept {
+  try {
+    std::lock_guard operationLock(operationMutex_);
+    std::lock_guard lock(engineMutex_);
+    unloadLocked();
+  } catch (...) {
+  }
+}
+
+void MinimaxModel::validateConfig(const MinimaxConfig& config) {
+  const bool hasDirectory = !config.modelDir.empty();
+  const bool hasPair =
+      !config.lmModelPath.empty() && !config.synthModelPath.empty();
+  if (!hasDirectory && !hasPair) {
+    throw std::invalid_argument(
+        "MinimaxModel: set `modelDir` or both MiniMax GGUF paths (lm/synth)");
+  }
+}
+
+void MinimaxModel::load() {
+  std::lock_guard operationLock(operationMutex_);
+  std::lock_guard lock(engineMutex_);
+  loadLocked();
+}
+
+void MinimaxModel::loadLocked() {
+  if (engine_) return;
+  tts_cpp::minimax::EngineOptions options;
+  options.model_dir = config_.modelDir;
+  options.lm_model_path = config_.lmModelPath;
+  options.synth_model_path = config_.synthModelPath;
+  options.n_threads = config_.threads;
+  options.backends_dir = resolveBackendsDir(config_.backendsDir);
+  engine_ = tts_cpp::minimax::Engine::create(options);
+  if (!engine_) {
+    throw std::runtime_error("MinimaxModel: failed to create MiniMax engine");
+  }
+  sampleRate_ = engine_->sample_rate();
+  channels_ = kStereoChannels;
+}
+
+void MinimaxModel::unload() {
+  std::lock_guard operationLock(operationMutex_);
+  std::lock_guard lock(engineMutex_);
+  unloadLocked();
+}
+
+void MinimaxModel::unloadLocked() {
+  engine_.reset();
+}
+
+void MinimaxModel::reload(MinimaxConfig config) {
+  validateConfig(config);
+  std::lock_guard operationLock(operationMutex_);
+  std::lock_guard lock(engineMutex_);
+  unloadLocked();
+  config_ = std::move(config);
+  loadLocked();
+}
+
+void MinimaxModel::cancel() const {
+  cancelRequested_.store(true);
+  std::lock_guard lock(engineMutex_);
+  if (engine_) engine_->cancel();
+}
+
+std::any MinimaxModel::process(const std::any& input) {
+  return std::any(generate(std::any_cast<const AnyInput&>(input)));
+}
+
+MinimaxModel::Output MinimaxModel::generate(const AnyInput& input) {
+  std::lock_guard operationLock(operationMutex_);
+  cancelRequested_.store(false);
+  const auto start = std::chrono::steady_clock::now();
+  std::shared_ptr<tts_cpp::minimax::Engine> engine;
+  {
+    std::lock_guard lock(engineMutex_);
+    if (!engine_) loadLocked();
+    engine = engine_;
+  }
+
+  tts_cpp::minimax::GenerateParams params;
+  params.caption = input.caption;
+  params.lyrics = input.lyrics;
+  params.max_frames = input.maxFrames;
+  params.seed = input.seed;
+  params.inference_steps = input.inferenceSteps;
+  params.cfg_scale = input.cfgScale;
+
+  auto progress =
+      [this](const std::string& stage, int64_t step, int64_t total) -> bool {
+    if (progressSink_) progressSink_(AudioGenProgress{stage, step, total});
+    return !cancelRequested_.load();
+  };
+  const auto result = engine->generate(params, progress);
+  if (cancelRequested_.load()) {
+    throw std::runtime_error("MiniMax generation cancelled");
+  }
+  Output pcm = convertPcm(result.pcm);
+  const auto finish = std::chrono::steady_clock::now();
+
+  totalTimeMs_ =
+      std::chrono::duration<double, std::milli>(finish - start).count();
+  totalSamples_ = static_cast<int64_t>(pcm.size());
+  sampleRate_ = result.sample_rate;
+  channels_ = result.channels;
+  audioDurationMs_ =
+      sampleRate_ > 0 && channels_ > 0
+          ? static_cast<double>(totalSamples_) / channels_ / sampleRate_ *
+                kMillisecondsPerSecond
+          : 0.0;
+  realTimeFactor_ =
+      audioDurationMs_ > 0.0 ? totalTimeMs_ / audioDurationMs_ : 0.0;
+  return pcm;
+}
+
+qvac_lib_inference_addon_cpp::RuntimeStats MinimaxModel::runtimeStats() const {
+  qvac_lib_inference_addon_cpp::RuntimeStats stats;
+  stats.emplace_back("totalTimeMs", totalTimeMs_);
+  stats.emplace_back("realTimeFactor", realTimeFactor_);
+  stats.emplace_back("audioDurationMs", audioDurationMs_);
+  stats.emplace_back("backendDevice", kBackendDeviceCpu);
+  stats.emplace_back("backendId", kBackendIdCpu);
+  return stats;
+}
+
+}

--- a/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxModel.hpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxModel.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <any>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "inference-addon-cpp/ModelInterfaces.hpp"
+#include "inference-addon-cpp/RuntimeStats.hpp"
+
+#include "model-interface/AudioGenProgress.hpp"
+#include "model-interface/minimax/MinimaxConfig.hpp"
+
+namespace tts_cpp::minimax {
+class Engine;
+}
+
+namespace qvac::audiogenggml::minimax {
+
+inline constexpr int64_t kDefaultMaxFrames = 300;
+
+class MinimaxModel
+    : public qvac_lib_inference_addon_cpp::model::IModel,
+      public qvac_lib_inference_addon_cpp::model::IModelCancel,
+      public qvac_lib_inference_addon_cpp::model::IModelAsyncLoad {
+public:
+  using Output = std::vector<int16_t>;
+
+  struct AnyInput {
+    std::string caption;
+    std::string lyrics = "[Instrumental]";
+    int64_t maxFrames = kDefaultMaxFrames;
+    int64_t seed = -1;
+    int inferenceSteps = 0;
+    float cfgScale = 0.0F;
+  };
+
+  explicit MinimaxModel(MinimaxConfig config);
+  ~MinimaxModel() noexcept override;
+
+  std::string getName() const override { return "MinimaxModel"; }
+  std::any process(const std::any& input) override;
+  qvac_lib_inference_addon_cpp::RuntimeStats runtimeStats() const override;
+
+  void cancel() const override;
+  void load();
+  void unload();
+  void reload(MinimaxConfig config);
+  void waitForLoadInitialization() override { load(); }
+  void setWeightsForFile(
+      const std::string&,
+      std::unique_ptr<std::basic_streambuf<char>>&&) override {}
+
+  void setProgressSink(std::function<void(const AudioGenProgress&)> sink) {
+    progressSink_ = std::move(sink);
+  }
+
+  int sampleRate() const { return sampleRate_; }
+  int channels() const { return channels_; }
+
+private:
+  Output generate(const AnyInput& input);
+  static void validateConfig(const MinimaxConfig& config);
+  void loadLocked();
+  void unloadLocked();
+
+  MinimaxConfig config_;
+  std::mutex operationMutex_;
+  mutable std::mutex engineMutex_;
+  std::shared_ptr<tts_cpp::minimax::Engine> engine_;
+  mutable std::atomic_bool cancelRequested_{false};
+  std::function<void(const AudioGenProgress&)> progressSink_;
+  double totalTimeMs_ = 0.0;
+  double audioDurationMs_ = 0.0;
+  int64_t totalSamples_ = 0;
+  double realTimeFactor_ = 0.0;
+  int sampleRate_ = 0;
+  int channels_ = 0;
+};
+
+}

--- a/packages/audiogen-ggml/audiogen.d.ts
+++ b/packages/audiogen-ggml/audiogen.d.ts
@@ -1,14 +1,9 @@
-/**
- * Flat native configuration object, read 1:1 by the C++ JSAdapter
- * (buildAcestepConfig). Either `modelDir` (auto-classify the four GGUFs) or the
- * explicit per-stage paths are set. The numeric/bool fields are REQUIRED by the
- * native side (it carries no defaults); the high-level class fills them in.
- */
 export interface AudioGenConfigurationParams {
     engineType?: string;
     modelDir?: string;
     textEncModelPath?: string;
     lmModelPath?: string;
+    synthModelPath?: string;
     ditModelPath?: string;
     vaeModelPath?: string;
     inferenceSteps?: number;
@@ -48,6 +43,9 @@ export interface AudioGenJobData {
     taskType?: string;
     audioCoverStrength?: number;
     coverNoiseStrength?: number;
+    maxFrames?: number;
+    inferenceSteps?: number;
+    cfgScale?: number;
 }
 /** Native output event: (handle, event, data, error). */
 export type AudioGenOutputCallback = (handle: unknown, event: unknown, data: unknown, error: unknown) => void;

--- a/packages/audiogen-ggml/audiogen.js
+++ b/packages/audiogen-ggml/audiogen.js
@@ -1,7 +1,4 @@
 "use strict";
-// Thin JS <-> C++ boundary for the ACE-Step music addon, mirroring
-// tts-ggml/src/tts.ts. `AudioGenInterface` owns the native handle and forwards
-// createInstance / activate / runJob / cancel / destroyInstance to the binding.
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AudioGenInterface = void 0;
 /** An interface between the Bare addon in C++ and the JS runtime. */

--- a/packages/audiogen-ggml/examples/generate-music-minimax.js
+++ b/packages/audiogen-ggml/examples/generate-music-minimax.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const fs = require('bare-fs')
+const process = require('bare-process')
+const { AudioGen, ENGINE_MINIMAX } = require('..')
+
+const DEFAULT_CAPTION = 'Warm cinematic piano with gentle strings'
+const DEFAULT_OUTPUT = 'minimax-music3-output.wav'
+
+function requiredModelDir() {
+  const modelDir = process.env.AUDIOGEN_TEST_MINIMAX_MODELS_DIR
+  if (!modelDir) throw new Error('AUDIOGEN_TEST_MINIMAX_MODELS_DIR is required')
+  return modelDir
+}
+
+function numberFromEnv(name) {
+  const value = process.env[name]
+  return value ? Number(value) : undefined
+}
+
+function pcmBytes(outputArray) {
+  return Buffer.from(
+    outputArray.buffer.slice(
+      outputArray.byteOffset,
+      outputArray.byteOffset + outputArray.byteLength
+    )
+  )
+}
+
+async function collectOutput(response) {
+  const chunks = []
+  let sampleRate = 0
+  let channels = 0
+  for await (const item of response.iterate()) {
+    if (item.progress) {
+      console.log(`${item.progress.stage}: ${item.progress.step}/${item.progress.total}`)
+    } else if (item.outputArray) {
+      chunks.push(pcmBytes(item.outputArray))
+      sampleRate = item.sampleRate
+      channels = item.channels
+    }
+  }
+  const stats = await response.await()
+  return { pcm: Buffer.concat(chunks), sampleRate, channels, stats }
+}
+
+async function main() {
+  const generator = new AudioGen({
+    engine: ENGINE_MINIMAX,
+    files: { modelDir: requiredModelDir() },
+    config: { threads: numberFromEnv('AUDIOGEN_THREADS') }
+  })
+  try {
+    await generator.load()
+    const response = await generator.run(process.argv[2] || DEFAULT_CAPTION, {
+      lyrics: process.env.AUDIOGEN_LYRICS || '[Instrumental]',
+      duration: numberFromEnv('AUDIOGEN_DUR'),
+      seed: numberFromEnv('AUDIOGEN_SEED'),
+      inferenceSteps: numberFromEnv('AUDIOGEN_STEPS'),
+      cfgScale: numberFromEnv('AUDIOGEN_CFG_SCALE')
+    })
+    const result = await collectOutput(response)
+    const wav = AudioGen.encode(result.pcm, 'wav', {
+      sampleRate: result.sampleRate,
+      channels: result.channels
+    })
+    const outputPath = process.env.AUDIOGEN_OUT || DEFAULT_OUTPUT
+    fs.writeFileSync(outputPath, wav.data)
+    console.log(`WAV written to ${outputPath}`)
+    console.log(JSON.stringify(result.stats))
+  } finally {
+    await generator.destroy()
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/audiogen-ggml/index.d.ts
+++ b/packages/audiogen-ggml/index.d.ts
@@ -4,7 +4,11 @@ import { AudioGenInterface } from './audiogen';
 import { type DitVariant } from './models';
 import { type EncodeOptions, type EncodedAudio, type OutputFormat } from './lib/audio-format';
 export declare const ENGINE_ACESTEP = "acestep";
-/** Model file paths for the four ACE-Step stages. */
+export declare const ENGINE_MINIMAX = "minimax";
+export declare const MINIMAX_FRAMES_PER_SECOND = 25;
+export declare const MINIMAX_DEFAULT_MAX_FRAMES = 300;
+export type AudioGenEngine = typeof ENGINE_ACESTEP | typeof ENGINE_MINIMAX;
+/** Model file paths for ACE-Step or MiniMax-Music3. */
 export interface AudioGenFiles {
     /** Directory holding the four ACE-Step GGUFs (engine auto-classifies them). */
     modelDir?: string;
@@ -12,6 +16,8 @@ export interface AudioGenFiles {
     textEncModel?: string;
     /** Explicit LM GGUF path. */
     lmModel?: string;
+    /** Explicit MiniMax synthesis GGUF path. */
+    synthModel?: string;
     /** Explicit DiT GGUF path (wins over `ditVariant`). */
     ditModel?: string;
     /** Selects the DiT GGUF from `modelDir` when `ditModel` is not given. */
@@ -23,6 +29,8 @@ export interface AudioGenFiles {
 export interface AudioGenRuntimeConfig {
     /** 0 = engine auto-picks per DiT architecture (turbo 8 / sft 50). */
     inferenceSteps?: number;
+    /** MiniMax flow classifier-free guidance scale; 0 uses the model default. */
+    cfgScale?: number;
     /** 0 = engine auto-picks per DiT architecture (turbo 3.0 / sft 1.0). */
     shift?: number;
     useGPU?: boolean;
@@ -39,7 +47,9 @@ export interface AudioGenRuntimeConfig {
     backendsDir?: string;
 }
 export interface AudioGenOptions {
-    /** Model file paths for the four stages. */
+    /** Music engine. Inferred as MiniMax when `synthModel` is present. */
+    engine?: AudioGenEngine;
+    /** Local GGUF paths for the selected engine. */
     files?: AudioGenFiles;
     /** Runtime knobs (steps, shift, GPU, threads). */
     config?: AudioGenRuntimeConfig;
@@ -56,8 +66,14 @@ export interface GenerateOptions {
     keyscale?: string;
     /** Time signature, e.g. "4/4". */
     timesignature?: string;
-    /** Target length in seconds; undefined lets the LM decide the full length. */
+    /** Target length in seconds; MiniMax converts it to 25 semantic frames per second. */
     duration?: number;
+    /** MiniMax semantic-frame cap. Cannot be combined with `duration`. */
+    maxFrames?: number;
+    /** MiniMax flow steps for this generation; 0 uses the model default. */
+    inferenceSteps?: number;
+    /** MiniMax flow classifier-free guidance scale for this generation. */
+    cfgScale?: number;
     /** LM sampling temperature (ACE-Step default: 0.85). */
     lmTemperature?: number;
     /** LM nucleus-sampling probability (ACE-Step default: 0.9). */
@@ -103,7 +119,7 @@ export interface GenerateOptions {
      */
     coverNoiseStrength?: number;
 }
-/** A per-step progress tick from the engine (stage = "lm" | "dit" | "vae"). */
+/** A per-step progress tick from the selected engine. */
 export interface AudiogenProgress {
     stage: string;
     step: number;
@@ -123,7 +139,7 @@ export interface AudiogenProgressChunk {
 export type AudiogenOutputChunk = AudiogenPcmChunk | AudiogenProgressChunk;
 /**
  * Terminal run stats, resolved by `QvacResponse.await()`. These mirror exactly
- * what the native `AcestepModel::runtimeStats()` emits — `totalTimeMs`,
+ * what the native model emits — `totalTimeMs`,
  * `realTimeFactor`, `audioDurationMs` and the resolved backend. Sample rate and
  * channel count are NOT here: they ride on each PCM chunk instead (see
  * `AudiogenPcmChunk`).
@@ -141,27 +157,28 @@ export interface AudiogenStats {
     /** 0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other. */
     backendId?: number;
 }
-/**
- * GGML-backed music generation via the ACE-Step engine. Owns a persistent
- * native engine: the four model stages are loaded once by `load()` and reused
- * by every `run()`.
- */
+export declare function detectEngineType(files?: AudioGenFiles, explicitEngine?: string): AudioGenEngine;
 export declare class AudioGen {
     static readonly inferenceManagerConfig: {
         noAdditionalDownload: boolean;
     };
     static readonly ENGINE_ACESTEP = "acestep";
+    static readonly ENGINE_MINIMAX = "minimax";
     addon: AudioGenInterface | null;
     private readonly _job;
     private readonly _runExclusive;
     private readonly _configuration;
     private readonly _logger;
+    private readonly _engineType;
+    private readonly _defaultInferenceSteps;
+    private readonly _defaultCfgScale;
     private _lifecycleRevision;
     private _destroyed;
     private _cancelPromise;
     private _cancellingResponse;
+    private _cancelTerminalResolve;
     constructor(options?: AudioGenOptions);
-    /** Create the native engine and load every stage GGUF. Idempotent. */
+    /** Create the native engine and load its GGUF files. Idempotent. */
     load(): Promise<void>;
     private _load;
     /**
@@ -171,6 +188,8 @@ export declare class AudioGen {
     run(caption: string, opts?: GenerateOptions): Promise<QvacResponse<AudiogenOutputChunk>>;
     private _admitAndWait;
     private _createJobData;
+    private _createMinimaxJobData;
+    private _createAcestepJobData;
     cancel(): Promise<void>;
     private _cancelActiveResponse;
     unload(): Promise<void>;

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -11,17 +11,28 @@
 // streams the engine's output (progress ticks + one interleaved-Int16 PCM
 // chunk) and resolves with the run stats.
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.QvacErrorAudioGen = exports.ERR_CODES = exports.ERR_CODE_RANGE = exports.OUTPUT_FORMATS = exports.pcmToWav = exports.encodePcm = exports.allRegistryPaths = exports.resolveDitModelPath = exports.modelSources = exports.modelManifest = exports.modelFilenames = exports.registryPath = exports.ditFilename = exports.ditVariants = exports.DEFAULT_DIT_VARIANT = exports.DIT_VARIANTS = exports.FIXED_MODELS = exports.REGISTRY_PREFIX = exports.REGISTRY_SOURCE = exports.AudioGen = exports.ENGINE_ACESTEP = void 0;
+exports.QvacErrorAudioGen = exports.ERR_CODES = exports.ERR_CODE_RANGE = exports.OUTPUT_FORMATS = exports.pcmToWav = exports.encodePcm = exports.allRegistryPaths = exports.resolveDitModelPath = exports.modelSources = exports.modelManifest = exports.modelFilenames = exports.registryPath = exports.ditFilename = exports.ditVariants = exports.DEFAULT_DIT_VARIANT = exports.DIT_VARIANTS = exports.FIXED_MODELS = exports.REGISTRY_PREFIX = exports.REGISTRY_SOURCE = exports.AudioGen = exports.MINIMAX_DEFAULT_MAX_FRAMES = exports.MINIMAX_FRAMES_PER_SECOND = exports.ENGINE_MINIMAX = exports.ENGINE_ACESTEP = void 0;
+exports.detectEngineType = detectEngineType;
 const infer_base_1 = require("@qvac/infer-base");
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- @qvac/logging exposes a CommonJS export-assignment shape.
 const QvacLogger = require("@qvac/logging");
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- bare-path is a CommonJS module.
 const path = require("bare-path");
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- bare-os is a CommonJS module.
+const os = require("bare-os");
 const audiogen_1 = require("./audiogen");
 const models_1 = require("./models");
 const audio_format_1 = require("./lib/audio-format");
 const error_1 = require("./error");
 exports.ENGINE_ACESTEP = 'acestep';
+exports.ENGINE_MINIMAX = 'minimax';
+exports.MINIMAX_FRAMES_PER_SECOND = 25;
+exports.MINIMAX_DEFAULT_MAX_FRAMES = 300;
+const MINIMAX_MIN_FRAMES = 1;
+const MINIMAX_MAX_INFERENCE_STEPS = 1000;
+const INT32_MAX = 2147483647;
+const FLOAT32_MAX = 3.4028234663852886e38;
+const FLOAT32_MIN_POSITIVE = 1.401298464324817e-45;
 function asNativeData(data) {
     if (typeof data !== 'object' || data === null)
         return null;
@@ -44,6 +55,36 @@ function requireFiniteNumber(value, name, integer = false) {
 }
 function optionalFiniteNumber(value, name, integer = false) {
     return value === undefined ? undefined : requireFiniteNumber(value, name, integer);
+}
+function requireSafeInteger(value, name) {
+    requireFiniteNumber(value, name, true);
+    if (!Number.isSafeInteger(value)) {
+        throw invalidInput(`${name} must be a safe integer, got ${value}`);
+    }
+    return value;
+}
+function requireMinimaxInferenceSteps(value) {
+    const steps = requireSafeInteger(value, 'inferenceSteps');
+    if (steps < 0 || steps > MINIMAX_MAX_INFERENCE_STEPS) {
+        throw invalidInput(`inferenceSteps must be between 0 and ${MINIMAX_MAX_INFERENCE_STEPS}`);
+    }
+    return steps;
+}
+function requireNonNegativeInt32(value, name) {
+    const integer = requireSafeInteger(value, name);
+    if (integer < 0 || integer > INT32_MAX) {
+        throw invalidInput(`${name} must be between 0 and ${INT32_MAX}`);
+    }
+    return integer;
+}
+function requireMinimaxCfgScale(value) {
+    const scale = requireFiniteNumber(value, 'cfgScale');
+    if (scale < 0 ||
+        scale > FLOAT32_MAX ||
+        (scale > 0 && scale < FLOAT32_MIN_POSITIVE)) {
+        throw invalidInput('cfgScale must be 0 or a positive float32 value');
+    }
+    return scale;
 }
 const GENERATE_TASK_TYPES = new Set(['text2music', 'cover', 'cover-nofsq']);
 function optionalTaskType(value) {
@@ -82,60 +123,183 @@ function invalidInput(message) {
 function errorMessage(error) {
     return error instanceof Error ? error.message : String(error);
 }
-/**
- * GGML-backed music generation via the ACE-Step engine. Owns a persistent
- * native engine: the four model stages are loaded once by `load()` and reused
- * by every `run()`.
- */
+const ACESTEP_FILE_KEYS = [
+    'textEncModel',
+    'ditModel',
+    'ditVariant',
+    'vaeModel'
+];
+const ACESTEP_GENERATE_KEYS = [
+    'vocalLanguage',
+    'bpm',
+    'keyscale',
+    'timesignature',
+    'lmTemperature',
+    'lmTopP',
+    'lmTopK',
+    'lmCfgScale',
+    'lmPhase1',
+    'dcwEnabled',
+    'dcwScaler',
+    'dcwHighScaler',
+    'audioCodes',
+    'referenceAudio',
+    'sourceAudio',
+    'taskType',
+    'audioCoverStrength',
+    'coverNoiseStrength'
+];
+function hasAnyFile(files, keys) {
+    return keys.some((key) => files[key] !== undefined);
+}
+function detectEngineType(files = {}, explicitEngine) {
+    if (explicitEngine !== undefined &&
+        explicitEngine !== exports.ENGINE_ACESTEP &&
+        explicitEngine !== exports.ENGINE_MINIMAX) {
+        throw invalidInput(`engine must be '${exports.ENGINE_ACESTEP}' or '${exports.ENGINE_MINIMAX}'`);
+    }
+    if (explicitEngine !== undefined)
+        return explicitEngine;
+    if (files.synthModel !== undefined)
+        return exports.ENGINE_MINIMAX;
+    return exports.ENGINE_ACESTEP;
+}
+function validateMinimaxFiles(files) {
+    if (hasAnyFile(files, ACESTEP_FILE_KEYS)) {
+        throw invalidInput('MiniMax does not accept ACE-Step text encoder, DiT, or VAE files');
+    }
+    const hasDirectory = typeof files.modelDir === 'string' && files.modelDir.length > 0;
+    const hasPair = typeof files.lmModel === 'string' &&
+        files.lmModel.length > 0 &&
+        typeof files.synthModel === 'string' &&
+        files.synthModel.length > 0;
+    if (!hasDirectory && !hasPair) {
+        throw invalidInput('MiniMax requires modelDir or both lmModel and synthModel');
+    }
+}
+function validateAcestepOptions(files, config) {
+    if (files.synthModel !== undefined) {
+        throw invalidInput('ACE-Step does not accept synthModel');
+    }
+    if (config.cfgScale !== undefined) {
+        throw invalidInput('ACE-Step does not accept cfgScale');
+    }
+}
+function validateMinimaxConfig(config) {
+    if (config.useGPU !== undefined && typeof config.useGPU !== 'boolean') {
+        throw invalidInput('useGPU must be a boolean');
+    }
+    if (config.useGPU === true) {
+        throw invalidInput('MiniMax-Music3 supports CPU inference only');
+    }
+    if (config.shift !== undefined || config.nGpuLayers !== undefined) {
+        throw invalidInput('MiniMax does not accept shift or nGpuLayers');
+    }
+}
+function assertNoAcestepGenerateOptions(options) {
+    for (const key of ACESTEP_GENERATE_KEYS) {
+        if (options[key] !== undefined) {
+            throw invalidInput(`MiniMax does not accept ${key}`);
+        }
+    }
+}
+function assertNoMinimaxGenerateOptions(options) {
+    if (options.maxFrames !== undefined ||
+        options.inferenceSteps !== undefined ||
+        options.cfgScale !== undefined) {
+        throw invalidInput('ACE-Step does not accept maxFrames, inferenceSteps, or cfgScale per run');
+    }
+}
+function resolveMinimaxMaxFrames(options) {
+    if (options.maxFrames !== undefined && options.duration !== undefined) {
+        throw invalidInput('MiniMax accepts either maxFrames or duration, not both');
+    }
+    if (options.maxFrames !== undefined) {
+        const frames = requireSafeInteger(options.maxFrames, 'maxFrames');
+        if (frames < MINIMAX_MIN_FRAMES)
+            throw invalidInput('maxFrames must be at least 1');
+        return frames;
+    }
+    if (options.duration !== undefined) {
+        const duration = requireFiniteNumber(options.duration, 'duration');
+        if (duration <= 0)
+            throw invalidInput('duration must be greater than 0');
+        const frames = Math.max(MINIMAX_MIN_FRAMES, Math.round(duration * exports.MINIMAX_FRAMES_PER_SECOND));
+        return requireSafeInteger(frames, 'duration-derived maxFrames');
+    }
+    return exports.MINIMAX_DEFAULT_MAX_FRAMES;
+}
+function isMobilePlatform() {
+    const platform = os.platform();
+    return platform === 'android' || platform === 'ios';
+}
 class AudioGen {
     static inferenceManagerConfig = {
         noAdditionalDownload: true
     };
     static ENGINE_ACESTEP = exports.ENGINE_ACESTEP;
+    static ENGINE_MINIMAX = exports.ENGINE_MINIMAX;
     addon;
     _job;
     _runExclusive;
     _configuration;
     _logger;
+    _engineType;
+    _defaultInferenceSteps;
+    _defaultCfgScale;
     _lifecycleRevision;
     _destroyed;
     _cancelPromise;
     _cancellingResponse;
+    _cancelTerminalResolve;
     constructor(options = {}) {
         this._logger = new QvacLogger(options.logger);
         const files = options.files ?? {};
         const config = options.config ?? {};
-        // DiT selection: an explicit `ditModel` path always wins; otherwise a
-        // `ditVariant` enum picks which DiT GGUF to load from `modelDir` (the three
-        // other stages are fixed, so the variant is the only real choice).
-        const ditModelPath = (0, models_1.resolveDitModelPath)({
-            modelDir: files.modelDir,
-            ditModel: files.ditModel,
-            ditVariant: files.ditVariant
-        });
-        // The native side carries NO defaults: it requires every numeric/bool field
-        // and throws if one is missing. JS is the single place that decides defaults.
-        // 0 for inferenceSteps/shift/threads means "auto"; nGpuLayers 99 = all layers
-        // (only applied by the engine when useGPU is true).
-        const useGpu = config.useGPU ?? false;
-        this._configuration = {
-            engineType: exports.ENGINE_ACESTEP,
-            modelDir: files.modelDir,
-            textEncModelPath: files.textEncModel,
-            lmModelPath: files.lmModel,
-            ditModelPath,
-            vaeModelPath: files.vaeModel,
-            inferenceSteps: requireFiniteNumber(config.inferenceSteps ?? 0, 'inferenceSteps', true),
-            shift: requireFiniteNumber(config.shift ?? 0, 'shift'),
-            useGPU: useGpu,
-            nGpuLayers: requireFiniteNumber(config.nGpuLayers ?? 99, 'nGpuLayers', true),
-            threads: requireFiniteNumber(config.threads ?? 0, 'threads', true),
-            // Where the native engine dlopens the ggml backend modules staged next to
-            // the `.bare`. Default to the package's own prebuilds dir; the C++ side
-            // appends the per-target BACKENDS_SUBDIR. Required on arm64 (per-microarch
-            // MODULE CPU backends); harmless on static desktop / Apple builds.
-            backendsDir: config.backendsDir ?? path.join(__dirname, 'prebuilds')
-        };
+        this._engineType = detectEngineType(files, options.engine);
+        const backendsDir = config.backendsDir ?? path.join(__dirname, 'prebuilds');
+        const threads = requireNonNegativeInt32(config.threads ?? 0, 'threads');
+        if (this._engineType === exports.ENGINE_MINIMAX) {
+            if (isMobilePlatform()) {
+                throw invalidInput('MiniMax-Music3 is available on desktop only');
+            }
+            validateMinimaxFiles(files);
+            validateMinimaxConfig(config);
+            this._defaultInferenceSteps = requireMinimaxInferenceSteps(config.inferenceSteps ?? 0);
+            this._defaultCfgScale = requireMinimaxCfgScale(config.cfgScale ?? 0);
+            this._configuration = {
+                engineType: exports.ENGINE_MINIMAX,
+                modelDir: files.modelDir,
+                lmModelPath: files.lmModel,
+                synthModelPath: files.synthModel,
+                threads,
+                backendsDir
+            };
+        }
+        else {
+            validateAcestepOptions(files, config);
+            this._defaultInferenceSteps = requireFiniteNumber(config.inferenceSteps ?? 0, 'inferenceSteps', true);
+            this._defaultCfgScale = 0;
+            const ditModelPath = (0, models_1.resolveDitModelPath)({
+                modelDir: files.modelDir,
+                ditModel: files.ditModel,
+                ditVariant: files.ditVariant
+            });
+            this._configuration = {
+                engineType: exports.ENGINE_ACESTEP,
+                modelDir: files.modelDir,
+                textEncModelPath: files.textEncModel,
+                lmModelPath: files.lmModel,
+                ditModelPath,
+                vaeModelPath: files.vaeModel,
+                inferenceSteps: this._defaultInferenceSteps,
+                shift: requireFiniteNumber(config.shift ?? 0, 'shift'),
+                useGPU: config.useGPU ?? false,
+                nGpuLayers: requireFiniteNumber(config.nGpuLayers ?? 99, 'nGpuLayers', true),
+                threads,
+                backendsDir
+            };
+        }
         this.addon = null;
         this._job = (0, infer_base_1.createJobHandler)({
             cancel: () => this.addon?.cancel() ?? Promise.resolve()
@@ -145,8 +309,9 @@ class AudioGen {
         this._destroyed = false;
         this._cancelPromise = null;
         this._cancellingResponse = null;
+        this._cancelTerminalResolve = null;
     }
-    /** Create the native engine and load every stage GGUF. Idempotent. */
+    /** Create the native engine and load its GGUF files. Idempotent. */
     async load() {
         const revision = this._lifecycleRevision;
         return this._runExclusive(() => this._load(revision));
@@ -157,7 +322,7 @@ class AudioGen {
         }
         if (this.addon)
             return;
-        this._logger.info('audiogen-ggml: loading ACE-Step engine');
+        this._logger.info(`audiogen-ggml: loading ${this._engineType} engine`);
         const addon = this._createAddon(this._configuration, this._addonOutputCallback.bind(this));
         this.addon = addon;
         // If activation fails, tear down the half-initialized native handle and
@@ -236,6 +401,29 @@ class AudioGen {
             throw invalidInput('caption must be a non-empty string');
         }
         this._logger.debug(`audiogen-ggml: run (caption ${caption.length} chars, lyrics=${opts.lyrics ? 'yes' : 'no'})`);
+        if (this._engineType === exports.ENGINE_MINIMAX) {
+            return this._createMinimaxJobData(caption, opts);
+        }
+        return this._createAcestepJobData(caption, opts);
+    }
+    _createMinimaxJobData(caption, opts) {
+        assertNoAcestepGenerateOptions(opts);
+        return {
+            type: 'text',
+            input: caption,
+            lyrics: opts.lyrics ?? '[Instrumental]',
+            seed: opts.seed === undefined ? undefined : requireSafeInteger(opts.seed, 'seed'),
+            maxFrames: resolveMinimaxMaxFrames(opts),
+            inferenceSteps: opts.inferenceSteps === undefined
+                ? this._defaultInferenceSteps
+                : requireMinimaxInferenceSteps(opts.inferenceSteps),
+            cfgScale: opts.cfgScale === undefined
+                ? this._defaultCfgScale
+                : requireMinimaxCfgScale(opts.cfgScale)
+        };
+    }
+    _createAcestepJobData(caption, opts) {
+        assertNoMinimaxGenerateOptions(opts);
         if (opts.lmPhase1 !== undefined && typeof opts.lmPhase1 !== 'boolean') {
             throw invalidInput('lmPhase1 must be a boolean');
         }
@@ -295,12 +483,17 @@ class AudioGen {
                 this._cancelPromise = null;
             if (this._cancellingResponse === response)
                 this._cancellingResponse = null;
+            this._cancelTerminalResolve = null;
         }
     }
     async _cancelActiveResponse(response) {
         this._cancellingResponse = response;
+        const terminal = new Promise((resolve) => {
+            this._cancelTerminalResolve = resolve;
+        });
         try {
             await (this.addon?.cancel() ?? Promise.resolve());
+            await terminal;
         }
         catch (error) {
             const failedError = this._failedCancelError(error);
@@ -375,8 +568,17 @@ class AudioGen {
         return new audiogen_1.AudioGenInterface(binding, configuration, outputCallback);
     }
     _addonOutputCallback(_handle, _event, data, error) {
-        if (this._cancellingResponse)
+        if (this._cancellingResponse) {
+            const cancelledData = asNativeData(data);
+            const terminalError = typeof error === 'string' && error.length > 0;
+            const terminalStats = cancelledData !== null &&
+                (typeof cancelledData.audioDurationMs === 'number' ||
+                    typeof cancelledData.totalTimeMs === 'number');
+            if (terminalError || terminalStats) {
+                this._cancelTerminalResolve?.();
+            }
             return;
+        }
         if (typeof error === 'string' && error.length > 0) {
             this._logger.error(`audiogen-ggml: engine error: ${error}`);
             this._job.fail(new error_1.QvacErrorAudioGen({

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -12,6 +12,7 @@
     "build:ts": "tsc -p tsconfig.build.json",
     "build:pack": "npm run build:ts && mkdir -p dist && npm pack --pack-destination dist",
     "example": "bare examples/generate-music.js \"Upbeat pop rock with driving electric guitars and a catchy hook\"",
+    "example:minimax": "bare examples/generate-music-minimax.js",
     "example:cover": "bare examples/generate-cover.js",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "check:generated": "node scripts/check-generated.mjs",
@@ -66,6 +67,7 @@
     "scripts/download-audiogen-ggml-models.js",
     "README.md",
     "CHANGELOG.md",
+    "NOTICE",
     "LICENSE"
   ],
   "license": "Apache-2.0",
@@ -81,6 +83,7 @@
     "audiogen",
     "music-generation",
     "acestep",
+    "minimax-music3",
     "ggml"
   ],
   "devDependencies": {

--- a/packages/audiogen-ggml/src/audiogen.ts
+++ b/packages/audiogen-ggml/src/audiogen.ts
@@ -1,18 +1,9 @@
-// Thin JS <-> C++ boundary for the ACE-Step music addon, mirroring
-// tts-ggml/src/tts.ts. `AudioGenInterface` owns the native handle and forwards
-// createInstance / activate / runJob / cancel / destroyInstance to the binding.
-
-/**
- * Flat native configuration object, read 1:1 by the C++ JSAdapter
- * (buildAcestepConfig). Either `modelDir` (auto-classify the four GGUFs) or the
- * explicit per-stage paths are set. The numeric/bool fields are REQUIRED by the
- * native side (it carries no defaults); the high-level class fills them in.
- */
 export interface AudioGenConfigurationParams {
   engineType?: string
   modelDir?: string
   textEncModelPath?: string
   lmModelPath?: string
+  synthModelPath?: string
   ditModelPath?: string
   vaeModelPath?: string
   inferenceSteps?: number
@@ -53,6 +44,9 @@ export interface AudioGenJobData {
   taskType?: string
   audioCoverStrength?: number
   coverNoiseStrength?: number
+  maxFrames?: number
+  inferenceSteps?: number
+  cfgScale?: number
 }
 
 /** Native output event: (handle, event, data, error). */

--- a/packages/audiogen-ggml/src/bare-modules.d.ts
+++ b/packages/audiogen-ggml/src/bare-modules.d.ts
@@ -2,3 +2,7 @@
 declare const __dirname: string
 declare function require(id: string): unknown
 declare const module: { exports: unknown }
+
+declare module 'bare-os' {
+  export function platform(): string
+}

--- a/packages/audiogen-ggml/src/index.ts
+++ b/packages/audiogen-ggml/src/index.ts
@@ -20,6 +20,8 @@ import {
 import QvacLogger = require('@qvac/logging')
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- bare-path is a CommonJS module.
 import path = require('bare-path')
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- bare-os is a CommonJS module.
+import os = require('bare-os')
 
 import {
   AudioGenInterface,
@@ -33,10 +35,20 @@ import { encodePcm, type EncodeOptions, type EncodedAudio, type OutputFormat } f
 import { ERR_CODES, QvacErrorAudioGen } from './error'
 
 export const ENGINE_ACESTEP = 'acestep'
+export const ENGINE_MINIMAX = 'minimax'
+export const MINIMAX_FRAMES_PER_SECOND = 25
+export const MINIMAX_DEFAULT_MAX_FRAMES = 300
+const MINIMAX_MIN_FRAMES = 1
+const MINIMAX_MAX_INFERENCE_STEPS = 1000
+const INT32_MAX = 2147483647
+const FLOAT32_MAX = 3.4028234663852886e38
+const FLOAT32_MIN_POSITIVE = 1.401298464324817e-45
+
+export type AudioGenEngine = typeof ENGINE_ACESTEP | typeof ENGINE_MINIMAX
 
 type RunExclusive = <T>(callback: () => Promise<T>) => Promise<T>
 
-/** Model file paths for the four ACE-Step stages. */
+/** Model file paths for ACE-Step or MiniMax-Music3. */
 export interface AudioGenFiles {
   /** Directory holding the four ACE-Step GGUFs (engine auto-classifies them). */
   modelDir?: string
@@ -44,6 +56,8 @@ export interface AudioGenFiles {
   textEncModel?: string
   /** Explicit LM GGUF path. */
   lmModel?: string
+  /** Explicit MiniMax synthesis GGUF path. */
+  synthModel?: string
   /** Explicit DiT GGUF path (wins over `ditVariant`). */
   ditModel?: string
   /** Selects the DiT GGUF from `modelDir` when `ditModel` is not given. */
@@ -56,6 +70,8 @@ export interface AudioGenFiles {
 export interface AudioGenRuntimeConfig {
   /** 0 = engine auto-picks per DiT architecture (turbo 8 / sft 50). */
   inferenceSteps?: number
+  /** MiniMax flow classifier-free guidance scale; 0 uses the model default. */
+  cfgScale?: number
   /** 0 = engine auto-picks per DiT architecture (turbo 3.0 / sft 1.0). */
   shift?: number
   useGPU?: boolean
@@ -73,7 +89,9 @@ export interface AudioGenRuntimeConfig {
 }
 
 export interface AudioGenOptions {
-  /** Model file paths for the four stages. */
+  /** Music engine. Inferred as MiniMax when `synthModel` is present. */
+  engine?: AudioGenEngine
+  /** Local GGUF paths for the selected engine. */
   files?: AudioGenFiles
   /** Runtime knobs (steps, shift, GPU, threads). */
   config?: AudioGenRuntimeConfig
@@ -91,8 +109,14 @@ export interface GenerateOptions {
   keyscale?: string
   /** Time signature, e.g. "4/4". */
   timesignature?: string
-  /** Target length in seconds; undefined lets the LM decide the full length. */
+  /** Target length in seconds; MiniMax converts it to 25 semantic frames per second. */
   duration?: number
+  /** MiniMax semantic-frame cap. Cannot be combined with `duration`. */
+  maxFrames?: number
+  /** MiniMax flow steps for this generation; 0 uses the model default. */
+  inferenceSteps?: number
+  /** MiniMax flow classifier-free guidance scale for this generation. */
+  cfgScale?: number
   /** LM sampling temperature (ACE-Step default: 0.85). */
   lmTemperature?: number
   /** LM nucleus-sampling probability (ACE-Step default: 0.9). */
@@ -139,7 +163,7 @@ export interface GenerateOptions {
   coverNoiseStrength?: number
 }
 
-/** A per-step progress tick from the engine (stage = "lm" | "dit" | "vae"). */
+/** A per-step progress tick from the selected engine. */
 export interface AudiogenProgress {
   stage: string
   step: number
@@ -163,7 +187,7 @@ export type AudiogenOutputChunk = AudiogenPcmChunk | AudiogenProgressChunk
 
 /**
  * Terminal run stats, resolved by `QvacResponse.await()`. These mirror exactly
- * what the native `AcestepModel::runtimeStats()` emits — `totalTimeMs`,
+ * what the native model emits — `totalTimeMs`,
  * `realTimeFactor`, `audioDurationMs` and the resolved backend. Sample rate and
  * channel count are NOT here: they ride on each PCM chunk instead (see
  * `AudiogenPcmChunk`).
@@ -227,6 +251,44 @@ function optionalFiniteNumber (
   return value === undefined ? undefined : requireFiniteNumber(value, name, integer)
 }
 
+function requireSafeInteger (value: number, name: string): number {
+  requireFiniteNumber(value, name, true)
+  if (!Number.isSafeInteger(value)) {
+    throw invalidInput(`${name} must be a safe integer, got ${value}`)
+  }
+  return value
+}
+
+function requireMinimaxInferenceSteps (value: number): number {
+  const steps = requireSafeInteger(value, 'inferenceSteps')
+  if (steps < 0 || steps > MINIMAX_MAX_INFERENCE_STEPS) {
+    throw invalidInput(
+      `inferenceSteps must be between 0 and ${MINIMAX_MAX_INFERENCE_STEPS}`
+    )
+  }
+  return steps
+}
+
+function requireNonNegativeInt32 (value: number, name: string): number {
+  const integer = requireSafeInteger(value, name)
+  if (integer < 0 || integer > INT32_MAX) {
+    throw invalidInput(`${name} must be between 0 and ${INT32_MAX}`)
+  }
+  return integer
+}
+
+function requireMinimaxCfgScale (value: number): number {
+  const scale = requireFiniteNumber(value, 'cfgScale')
+  if (
+    scale < 0 ||
+    scale > FLOAT32_MAX ||
+    (scale > 0 && scale < FLOAT32_MIN_POSITIVE)
+  ) {
+    throw invalidInput('cfgScale must be 0 or a positive float32 value')
+  }
+  return scale
+}
+
 const GENERATE_TASK_TYPES = new Set(['text2music', 'cover', 'cover-nofsq'])
 
 function optionalTaskType (value: string | undefined): string | undefined {
@@ -272,64 +334,212 @@ function errorMessage (error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-/**
- * GGML-backed music generation via the ACE-Step engine. Owns a persistent
- * native engine: the four model stages are loaded once by `load()` and reused
- * by every `run()`.
- */
+const ACESTEP_FILE_KEYS: Array<keyof AudioGenFiles> = [
+  'textEncModel',
+  'ditModel',
+  'ditVariant',
+  'vaeModel'
+]
+
+const ACESTEP_GENERATE_KEYS: Array<keyof GenerateOptions> = [
+  'vocalLanguage',
+  'bpm',
+  'keyscale',
+  'timesignature',
+  'lmTemperature',
+  'lmTopP',
+  'lmTopK',
+  'lmCfgScale',
+  'lmPhase1',
+  'dcwEnabled',
+  'dcwScaler',
+  'dcwHighScaler',
+  'audioCodes',
+  'referenceAudio',
+  'sourceAudio',
+  'taskType',
+  'audioCoverStrength',
+  'coverNoiseStrength'
+]
+
+function hasAnyFile (files: AudioGenFiles, keys: Array<keyof AudioGenFiles>): boolean {
+  return keys.some((key) => files[key] !== undefined)
+}
+
+export function detectEngineType (
+  files: AudioGenFiles = {},
+  explicitEngine?: string
+): AudioGenEngine {
+  if (
+    explicitEngine !== undefined &&
+    explicitEngine !== ENGINE_ACESTEP &&
+    explicitEngine !== ENGINE_MINIMAX
+  ) {
+    throw invalidInput(`engine must be '${ENGINE_ACESTEP}' or '${ENGINE_MINIMAX}'`)
+  }
+  if (explicitEngine !== undefined) return explicitEngine
+  if (files.synthModel !== undefined) return ENGINE_MINIMAX
+  return ENGINE_ACESTEP
+}
+
+function validateMinimaxFiles (files: AudioGenFiles): void {
+  if (hasAnyFile(files, ACESTEP_FILE_KEYS)) {
+    throw invalidInput('MiniMax does not accept ACE-Step text encoder, DiT, or VAE files')
+  }
+  const hasDirectory = typeof files.modelDir === 'string' && files.modelDir.length > 0
+  const hasPair =
+    typeof files.lmModel === 'string' &&
+    files.lmModel.length > 0 &&
+    typeof files.synthModel === 'string' &&
+    files.synthModel.length > 0
+  if (!hasDirectory && !hasPair) {
+    throw invalidInput('MiniMax requires modelDir or both lmModel and synthModel')
+  }
+}
+
+function validateAcestepOptions (
+  files: AudioGenFiles,
+  config: AudioGenRuntimeConfig
+): void {
+  if (files.synthModel !== undefined) {
+    throw invalidInput('ACE-Step does not accept synthModel')
+  }
+  if (config.cfgScale !== undefined) {
+    throw invalidInput('ACE-Step does not accept cfgScale')
+  }
+}
+
+function validateMinimaxConfig (config: AudioGenRuntimeConfig): void {
+  if (config.useGPU !== undefined && typeof config.useGPU !== 'boolean') {
+    throw invalidInput('useGPU must be a boolean')
+  }
+  if (config.useGPU === true) {
+    throw invalidInput('MiniMax-Music3 supports CPU inference only')
+  }
+  if (config.shift !== undefined || config.nGpuLayers !== undefined) {
+    throw invalidInput('MiniMax does not accept shift or nGpuLayers')
+  }
+}
+
+function assertNoAcestepGenerateOptions (options: GenerateOptions): void {
+  for (const key of ACESTEP_GENERATE_KEYS) {
+    if (options[key] !== undefined) {
+      throw invalidInput(`MiniMax does not accept ${key}`)
+    }
+  }
+}
+
+function assertNoMinimaxGenerateOptions (options: GenerateOptions): void {
+  if (
+    options.maxFrames !== undefined ||
+    options.inferenceSteps !== undefined ||
+    options.cfgScale !== undefined
+  ) {
+    throw invalidInput('ACE-Step does not accept maxFrames, inferenceSteps, or cfgScale per run')
+  }
+}
+
+function resolveMinimaxMaxFrames (options: GenerateOptions): number {
+  if (options.maxFrames !== undefined && options.duration !== undefined) {
+    throw invalidInput('MiniMax accepts either maxFrames or duration, not both')
+  }
+  if (options.maxFrames !== undefined) {
+    const frames = requireSafeInteger(options.maxFrames, 'maxFrames')
+    if (frames < MINIMAX_MIN_FRAMES) throw invalidInput('maxFrames must be at least 1')
+    return frames
+  }
+  if (options.duration !== undefined) {
+    const duration = requireFiniteNumber(options.duration, 'duration')
+    if (duration <= 0) throw invalidInput('duration must be greater than 0')
+    const frames = Math.max(
+      MINIMAX_MIN_FRAMES,
+      Math.round(duration * MINIMAX_FRAMES_PER_SECOND)
+    )
+    return requireSafeInteger(frames, 'duration-derived maxFrames')
+  }
+  return MINIMAX_DEFAULT_MAX_FRAMES
+}
+
+function isMobilePlatform (): boolean {
+  const platform = os.platform()
+  return platform === 'android' || platform === 'ios'
+}
+
 export class AudioGen {
   static readonly inferenceManagerConfig = {
     noAdditionalDownload: true
   }
 
   static readonly ENGINE_ACESTEP = ENGINE_ACESTEP
+  static readonly ENGINE_MINIMAX = ENGINE_MINIMAX
 
   addon: AudioGenInterface | null
   private readonly _job: JobHandler
   private readonly _runExclusive: RunExclusive
   private readonly _configuration: AudioGenConfigurationParams
   private readonly _logger: QvacLogger
+  private readonly _engineType: AudioGenEngine
+  private readonly _defaultInferenceSteps: number
+  private readonly _defaultCfgScale: number
   private _lifecycleRevision: number
   private _destroyed: boolean
   private _cancelPromise: Promise<void> | null
   private _cancellingResponse: QvacResponse<AudiogenOutputChunk> | null
+  private _cancelTerminalResolve: (() => void) | null
 
   constructor (options: AudioGenOptions = {}) {
     this._logger = new QvacLogger(options.logger)
     const files = options.files ?? {}
     const config = options.config ?? {}
+    this._engineType = detectEngineType(files, options.engine)
+    const backendsDir = config.backendsDir ?? path.join(__dirname, 'prebuilds')
+    const threads = requireNonNegativeInt32(config.threads ?? 0, 'threads')
 
-    // DiT selection: an explicit `ditModel` path always wins; otherwise a
-    // `ditVariant` enum picks which DiT GGUF to load from `modelDir` (the three
-    // other stages are fixed, so the variant is the only real choice).
-    const ditModelPath = resolveDitModelPath({
-      modelDir: files.modelDir,
-      ditModel: files.ditModel,
-      ditVariant: files.ditVariant
-    })
-
-    // The native side carries NO defaults: it requires every numeric/bool field
-    // and throws if one is missing. JS is the single place that decides defaults.
-    // 0 for inferenceSteps/shift/threads means "auto"; nGpuLayers 99 = all layers
-    // (only applied by the engine when useGPU is true).
-    const useGpu = config.useGPU ?? false
-    this._configuration = {
-      engineType: ENGINE_ACESTEP,
-      modelDir: files.modelDir,
-      textEncModelPath: files.textEncModel,
-      lmModelPath: files.lmModel,
-      ditModelPath,
-      vaeModelPath: files.vaeModel,
-      inferenceSteps: requireFiniteNumber(config.inferenceSteps ?? 0, 'inferenceSteps', true),
-      shift: requireFiniteNumber(config.shift ?? 0, 'shift'),
-      useGPU: useGpu,
-      nGpuLayers: requireFiniteNumber(config.nGpuLayers ?? 99, 'nGpuLayers', true),
-      threads: requireFiniteNumber(config.threads ?? 0, 'threads', true),
-      // Where the native engine dlopens the ggml backend modules staged next to
-      // the `.bare`. Default to the package's own prebuilds dir; the C++ side
-      // appends the per-target BACKENDS_SUBDIR. Required on arm64 (per-microarch
-      // MODULE CPU backends); harmless on static desktop / Apple builds.
-      backendsDir: config.backendsDir ?? path.join(__dirname, 'prebuilds')
+    if (this._engineType === ENGINE_MINIMAX) {
+      if (isMobilePlatform()) {
+        throw invalidInput('MiniMax-Music3 is available on desktop only')
+      }
+      validateMinimaxFiles(files)
+      validateMinimaxConfig(config)
+      this._defaultInferenceSteps = requireMinimaxInferenceSteps(
+        config.inferenceSteps ?? 0
+      )
+      this._defaultCfgScale = requireMinimaxCfgScale(config.cfgScale ?? 0)
+      this._configuration = {
+        engineType: ENGINE_MINIMAX,
+        modelDir: files.modelDir,
+        lmModelPath: files.lmModel,
+        synthModelPath: files.synthModel,
+        threads,
+        backendsDir
+      }
+    } else {
+      validateAcestepOptions(files, config)
+      this._defaultInferenceSteps = requireFiniteNumber(
+        config.inferenceSteps ?? 0,
+        'inferenceSteps',
+        true
+      )
+      this._defaultCfgScale = 0
+      const ditModelPath = resolveDitModelPath({
+        modelDir: files.modelDir,
+        ditModel: files.ditModel,
+        ditVariant: files.ditVariant
+      })
+      this._configuration = {
+        engineType: ENGINE_ACESTEP,
+        modelDir: files.modelDir,
+        textEncModelPath: files.textEncModel,
+        lmModelPath: files.lmModel,
+        ditModelPath,
+        vaeModelPath: files.vaeModel,
+        inferenceSteps: this._defaultInferenceSteps,
+        shift: requireFiniteNumber(config.shift ?? 0, 'shift'),
+        useGPU: config.useGPU ?? false,
+        nGpuLayers: requireFiniteNumber(config.nGpuLayers ?? 99, 'nGpuLayers', true),
+        threads,
+        backendsDir
+      }
     }
 
     this.addon = null
@@ -341,9 +551,10 @@ export class AudioGen {
     this._destroyed = false
     this._cancelPromise = null
     this._cancellingResponse = null
+    this._cancelTerminalResolve = null
   }
 
-  /** Create the native engine and load every stage GGUF. Idempotent. */
+  /** Create the native engine and load its GGUF files. Idempotent. */
   async load (): Promise<void> {
     const revision = this._lifecycleRevision
     return this._runExclusive(() => this._load(revision))
@@ -354,7 +565,7 @@ export class AudioGen {
       throw this._lifecycleError()
     }
     if (this.addon) return
-    this._logger.info('audiogen-ggml: loading ACE-Step engine')
+    this._logger.info(`audiogen-ggml: loading ${this._engineType} engine`)
     const addon = this._createAddon(
       this._configuration,
       this._addonOutputCallback.bind(this)
@@ -443,6 +654,39 @@ export class AudioGen {
     this._logger.debug(
       `audiogen-ggml: run (caption ${caption.length} chars, lyrics=${opts.lyrics ? 'yes' : 'no'})`
     )
+    if (this._engineType === ENGINE_MINIMAX) {
+      return this._createMinimaxJobData(caption, opts)
+    }
+    return this._createAcestepJobData(caption, opts)
+  }
+
+  private _createMinimaxJobData (
+    caption: string,
+    opts: GenerateOptions
+  ): AudioGenJobData {
+    assertNoAcestepGenerateOptions(opts)
+    return {
+      type: 'text',
+      input: caption,
+      lyrics: opts.lyrics ?? '[Instrumental]',
+      seed: opts.seed === undefined ? undefined : requireSafeInteger(opts.seed, 'seed'),
+      maxFrames: resolveMinimaxMaxFrames(opts),
+      inferenceSteps:
+        opts.inferenceSteps === undefined
+          ? this._defaultInferenceSteps
+          : requireMinimaxInferenceSteps(opts.inferenceSteps),
+      cfgScale:
+        opts.cfgScale === undefined
+          ? this._defaultCfgScale
+          : requireMinimaxCfgScale(opts.cfgScale)
+    }
+  }
+
+  private _createAcestepJobData (
+    caption: string,
+    opts: GenerateOptions
+  ): AudioGenJobData {
+    assertNoMinimaxGenerateOptions(opts)
     if (opts.lmPhase1 !== undefined && typeof opts.lmPhase1 !== 'boolean') {
       throw invalidInput('lmPhase1 must be a boolean')
     }
@@ -500,6 +744,7 @@ export class AudioGen {
     } finally {
       if (this._cancelPromise === cancellation) this._cancelPromise = null
       if (this._cancellingResponse === response) this._cancellingResponse = null
+      this._cancelTerminalResolve = null
     }
   }
 
@@ -507,8 +752,12 @@ export class AudioGen {
     response: QvacResponse<AudiogenOutputChunk>
   ): Promise<void> {
     this._cancellingResponse = response
+    const terminal = new Promise<void>((resolve) => {
+      this._cancelTerminalResolve = resolve
+    })
     try {
       await (this.addon?.cancel() ?? Promise.resolve())
+      await terminal
     } catch (error) {
       const failedError = this._failedCancelError(error)
       response.failed(failedError)
@@ -601,7 +850,18 @@ export class AudioGen {
     data: unknown,
     error: unknown
   ): void {
-    if (this._cancellingResponse) return
+    if (this._cancellingResponse) {
+      const cancelledData = asNativeData(data)
+      const terminalError = typeof error === 'string' && error.length > 0
+      const terminalStats =
+        cancelledData !== null &&
+        (typeof cancelledData.audioDurationMs === 'number' ||
+          typeof cancelledData.totalTimeMs === 'number')
+      if (terminalError || terminalStats) {
+        this._cancelTerminalResolve?.()
+      }
+      return
+    }
     if (typeof error === 'string' && error.length > 0) {
       this._logger.error(`audiogen-ggml: engine error: ${error}`)
       this._job.fail(

--- a/packages/audiogen-ggml/test/integration/minimax-input-safety.test.js
+++ b/packages/audiogen-ggml/test/integration/minimax-input-safety.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const test = require('brittle')
+const os = require('bare-os')
+const { AudioGenInterface } = require('../../audiogen.js')
+const binding = require('../../binding.js')
+
+const platform = os.platform()
+const shouldSkip = platform === 'android' || platform === 'ios'
+
+test(
+  'AudioGen native MiniMax bridge rejects unsafe numeric casts',
+  { skip: shouldSkip },
+  async (t) => {
+    const addon = new AudioGenInterface(
+      binding,
+      {
+        engineType: 'minimax',
+        modelDir: '/models/not-loaded',
+        threads: 0
+      },
+      () => {}
+    )
+    t.teardown(() => addon.destroyInstance())
+
+    await t.exception(
+      () =>
+        addon.runJob({
+          type: 'text',
+          input: 'test',
+          maxFrames: Number.MAX_VALUE
+        }),
+      /maxFrames must be a safe integer/
+    )
+    await t.exception(
+      () =>
+        addon.runJob({
+          type: 'text',
+          input: 'test',
+          inferenceSteps: 1001
+        }),
+      /inferenceSteps must be between 0 and 1000/
+    )
+    await t.exception(
+      () =>
+        addon.runJob({
+          type: 'text',
+          input: 'test',
+          cfgScale: Number.MAX_VALUE
+        }),
+      /cfgScale must be 0 or a positive float32 value/
+    )
+  }
+)

--- a/packages/audiogen-ggml/test/integration/minimax.test.js
+++ b/packages/audiogen-ggml/test/integration/minimax.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const test = require('brittle')
+const os = require('bare-os')
+const proc = require('bare-process')
+const { AudioGen, ENGINE_MINIMAX, ERR_CODES } = require('@qvac/audiogen-ggml')
+const { runAudioGen, INTEGRATION_TIMEOUT_MS } = require('../utils/runAudioGen')
+
+const modelDir = proc.env.AUDIOGEN_TEST_MINIMAX_MODELS_DIR
+const platform = os.platform()
+const shouldSkip = !modelDir || platform === 'android' || platform === 'ios'
+
+test(
+  'AudioGen (ggml): MiniMax-Music3 desktop CPU generation',
+  { timeout: INTEGRATION_TIMEOUT_MS, skip: shouldSkip },
+  async (t) => {
+    const gen = new AudioGen({
+      engine: ENGINE_MINIMAX,
+      files: { modelDir },
+      config: { threads: 4 }
+    })
+    await gen.load()
+    t.teardown(() => gen.destroy())
+
+    const { data } = await runAudioGen(gen, {
+      caption: 'A short warm piano note.',
+      opts: {
+        lyrics: '[Instrumental]',
+        maxFrames: 1,
+        seed: 7,
+        inferenceSteps: 1,
+        cfgScale: 1.7
+      }
+    })
+
+    t.ok(data.sampleCount > 0, 'MiniMax produced audio')
+    t.is(data.channels, 2, 'MiniMax produced stereo output')
+    t.is(data.sampleRate, 44100, 'MiniMax produced 44.1 kHz output')
+    t.ok(data.stages.includes('ar'), 'MiniMax reported autoregressive progress')
+    t.ok(data.stages.includes('flow'), 'MiniMax reported flow progress')
+    t.is(data.stats.backendDevice, 0, 'MiniMax used the CPU')
+    t.is(data.stats.backendId, 0, 'MiniMax reported the CPU backend')
+
+    const cancelledResponse = await gen.run('A longer orchestral build.', {
+      maxFrames: 32,
+      seed: 11
+    })
+    await gen.cancel()
+    try {
+      await cancelledResponse.await()
+      t.fail('MiniMax cancellation must reject the response')
+    } catch (error) {
+      t.is(error.code, ERR_CODES.CANCELLED, 'MiniMax cancellation is terminal')
+    }
+  }
+)

--- a/packages/audiogen-ggml/test/types/commonjs-api.ts
+++ b/packages/audiogen-ggml/test/types/commonjs-api.ts
@@ -1,13 +1,23 @@
 import {
   AudioGen,
+  ENGINE_MINIMAX,
   ERR_CODES,
   QvacErrorAudioGen,
+  type AudioGenEngine,
   type AudiogenOutputChunk
 } from '../../index'
 
 const audioGen = new AudioGen()
 const errorCode: number = ERR_CODES.INVALID_INPUT
 const errorConstructor: typeof QvacErrorAudioGen = QvacErrorAudioGen
+const engine: AudioGenEngine = ENGINE_MINIMAX
+const minimax = new AudioGen({
+  engine,
+  files: {
+    lmModel: '/models/mm3-lm.gguf',
+    synthModel: '/models/mm3-synth.gguf'
+  }
+})
 const output: AudiogenOutputChunk = {
   outputArray: new Int16Array(0),
   sampleRate: 48000,
@@ -17,4 +27,5 @@ const output: AudiogenOutputChunk = {
 void audioGen
 void errorCode
 void errorConstructor
+void minimax
 void output

--- a/packages/audiogen-ggml/test/unit/generate-options.test.js
+++ b/packages/audiogen-ggml/test/unit/generate-options.test.js
@@ -82,6 +82,11 @@ test('AudioGen.run rejects invalid sampler and DCW controls before native dispat
   }
 })
 
+test('AudioGen.run rejects MiniMax-only controls for ACE-Step', async (t) => {
+  const { gen } = createHarness()
+  await t.exception(() => gen.run('test', { maxFrames: 10 }), /ACE-Step does not accept maxFrames/)
+})
+
 test('AudioGen.run forwards reference/source audio, taskType and cover strengths', async (t) => {
   const { gen, received } = createHarness()
   const referenceAudio = new Float32Array([0.1, -0.1, 0.2, -0.2])

--- a/packages/audiogen-ggml/test/unit/lifecycle.test.js
+++ b/packages/audiogen-ggml/test/unit/lifecycle.test.js
@@ -107,9 +107,22 @@ test('cancel settles the active response', async (t) => {
   const { gen, cancelCalls } = createHarness(() => Promise.resolve(true))
   const response = await gen.run('cancel me')
 
-  await gen.cancel()
+  const cancellation = gen.cancel()
+  emitEnd(gen)
+  await cancellation
 
   t.is(cancelCalls(), 1)
+  t.is(await errorCode(response.await()), ERR_CODES.CANCELLED)
+})
+
+test('cancel consumes the native cancellation error before settling', async (t) => {
+  const { gen } = createHarness(() => Promise.resolve(true))
+  const response = await gen.run('cancel with native error')
+
+  const cancellation = gen.cancel()
+  gen._addonOutputCallback(null, null, null, 'MiniMax generation cancelled')
+  await cancellation
+
   t.is(await errorCode(response.await()), ERR_CODES.CANCELLED)
 })
 
@@ -137,6 +150,9 @@ test('cancel holds the next admission until native cancellation finishes', async
   t.is(admissions, 1)
 
   cancellation.resolve()
+  await Promise.resolve()
+  t.is(admissions, 1, 'second run waits for the cancelled native terminal event')
+  emitEnd(gen)
   await cancelPromise
   t.is(await errorCode(first.await()), ERR_CODES.CANCELLED)
   const second = await secondPromise
@@ -174,6 +190,7 @@ test('concurrent cancellation requests share one native cancellation', async (t)
   const first = gen.cancel()
   const second = gen.cancel()
   cancellation.resolve()
+  emitEnd(gen)
   await Promise.all([first, second])
 
   t.is(nativeCancelCalls, 1)

--- a/packages/audiogen-ggml/test/unit/minimax.test.js
+++ b/packages/audiogen-ggml/test/unit/minimax.test.js
@@ -1,0 +1,184 @@
+'use strict'
+
+const test = require('brittle')
+const {
+  AudioGen,
+  ENGINE_ACESTEP,
+  ENGINE_MINIMAX,
+  MINIMAX_DEFAULT_MAX_FRAMES,
+  detectEngineType
+} = require('../../index.js')
+
+function createHarness(options = {}) {
+  let received
+  const gen = new AudioGen({
+    engine: ENGINE_MINIMAX,
+    files: { modelDir: '/models/minimax' },
+    ...options
+  })
+  gen.addon = {
+    runJob(data) {
+      received = data
+      gen._addonOutputCallback(null, null, { totalTimeMs: 0 }, null)
+      return Promise.resolve(true)
+    },
+    cancel: () => Promise.resolve(),
+    destroyInstance: () => Promise.resolve()
+  }
+  return { gen, received: () => received }
+}
+
+test('detectEngineType selects MiniMax from synth path', (t) => {
+  t.is(
+    detectEngineType({ lmModel: '/models/lm.gguf', synthModel: '/models/synth.gguf' }),
+    ENGINE_MINIMAX
+  )
+  t.is(detectEngineType({ modelDir: '/models/acestep' }), ENGINE_ACESTEP)
+  t.is(detectEngineType({}, ENGINE_MINIMAX), ENGINE_MINIMAX)
+})
+
+test('AudioGen configures the MiniMax native engine', (t) => {
+  const { gen } = createHarness({
+    files: {
+      lmModel: '/models/mm3-lm-q8.gguf',
+      synthModel: '/models/mm3-synth-q8.gguf'
+    },
+    config: { threads: 6, inferenceSteps: 12, cfgScale: 1.8 }
+  })
+
+  t.is(gen._configuration.engineType, ENGINE_MINIMAX)
+  t.is(gen._configuration.lmModelPath, '/models/mm3-lm-q8.gguf')
+  t.is(gen._configuration.synthModelPath, '/models/mm3-synth-q8.gguf')
+  t.is(gen._configuration.threads, 6)
+})
+
+test('AudioGen forwards MiniMax frame and flow controls', async (t) => {
+  const { gen, received } = createHarness({
+    config: { inferenceSteps: 8, cfgScale: 1.5 }
+  })
+
+  const response = await gen.run('warm piano', {
+    duration: 2.5,
+    seed: 7,
+    lyrics: '[Instrumental]'
+  })
+  await response.await()
+
+  const job = received()
+  t.is(job.maxFrames, 63)
+  t.is(job.inferenceSteps, 8)
+  t.is(job.cfgScale, 1.5)
+  t.is(job.seed, 7)
+})
+
+test('AudioGen lets MiniMax run controls override config defaults', async (t) => {
+  const { gen, received } = createHarness({
+    config: { inferenceSteps: 8, cfgScale: 1.5 }
+  })
+
+  const response = await gen.run('ambient strings', {
+    maxFrames: 4,
+    inferenceSteps: 2,
+    cfgScale: 1.7
+  })
+  await response.await()
+
+  const job = received()
+  t.is(job.maxFrames, 4)
+  t.is(job.inferenceSteps, 2)
+  t.is(job.cfgScale, 1.7)
+})
+
+test('AudioGen uses the MiniMax default frame cap', async (t) => {
+  const { gen, received } = createHarness()
+  const response = await gen.run('short melody')
+  await response.await()
+  t.is(received().maxFrames, MINIMAX_DEFAULT_MAX_FRAMES)
+})
+
+test('AudioGen rejects unsupported MiniMax construction options', (t) => {
+  t.exception(
+    () =>
+      new AudioGen({
+        engine: ENGINE_MINIMAX,
+        files: { modelDir: '/models/minimax' },
+        config: { useGPU: true }
+      }),
+    /CPU inference only/
+  )
+  t.exception(
+    () =>
+      new AudioGen({
+        engine: ENGINE_MINIMAX,
+        files: { modelDir: '/models/minimax' },
+        config: { useGPU: 1 }
+      }),
+    /useGPU must be a boolean/
+  )
+  t.exception(
+    () => new AudioGen({ engine: ENGINE_MINIMAX, files: { lmModel: '/models/lm.gguf' } }),
+    /requires modelDir or both lmModel and synthModel/
+  )
+  t.exception(
+    () =>
+      new AudioGen({
+        engine: ENGINE_MINIMAX,
+        files: { modelDir: '/models/minimax', ditModel: '/models/dit.gguf' }
+      }),
+    /does not accept ACE-Step/
+  )
+})
+
+test('AudioGen rejects unsupported MiniMax generation options', async (t) => {
+  const { gen } = createHarness()
+  await t.exception(() => gen.run('test', { bpm: 120 }), /MiniMax does not accept bpm/)
+  await t.exception(
+    () => gen.run('test', { duration: 2, maxFrames: 50 }),
+    /either maxFrames or duration/
+  )
+  await t.exception(() => gen.run('test', { maxFrames: 0 }), /maxFrames must be at least 1/)
+  await t.exception(
+    () => gen.run('test', { maxFrames: Number.MAX_SAFE_INTEGER + 1 }),
+    /maxFrames must be a safe integer/
+  )
+  await t.exception(
+    () => gen.run('test', { inferenceSteps: -1 }),
+    /inferenceSteps must be between 0 and 1000/
+  )
+  await t.exception(
+    () => gen.run('test', { inferenceSteps: 1001 }),
+    /inferenceSteps must be between 0 and 1000/
+  )
+  await t.exception(
+    () => gen.run('test', { cfgScale: Number.MAX_VALUE }),
+    /cfgScale must be 0 or a positive float32 value/
+  )
+  await t.exception(
+    () => gen.run('test', { cfgScale: 1e-100 }),
+    /cfgScale must be 0 or a positive float32 value/
+  )
+})
+
+test('AudioGen rejects out-of-range MiniMax constructor controls', (t) => {
+  t.exception(
+    () =>
+      createHarness({
+        config: { inferenceSteps: 1001 }
+      }),
+    /inferenceSteps must be between 0 and 1000/
+  )
+  t.exception(
+    () =>
+      createHarness({
+        config: { cfgScale: -1 }
+      }),
+    /cfgScale must be 0 or a positive float32 value/
+  )
+  t.exception(
+    () =>
+      createHarness({
+        config: { threads: Number.MAX_SAFE_INTEGER }
+      }),
+    /threads must be between 0 and 2147483647/
+  )
+})

--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "cf1500e91d595db131c41421d4e1455f9143ec6e",
+    "baseline": "fe1bec6b60940eb63a918850264789f1560306a9",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [


### PR DESCRIPTION
## Summary
- expose the merged MiniMax-Music3 engine through `@qvac/audiogen-ggml` on Linux, macOS, and Windows CPU builds while preserving ACE-Step and mobile behavior
- add local LM/synthesis GGUF configuration, engine-specific options, progress, cancellation ordering, numeric safety, and generated TypeScript exports
- document local usage and add unit, native-bridge, and skippable model-backed regressions; hosted GGUF registry publication remains separate

Depends on the merged backend [qvac-ext-lib-whisper.cpp#151](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/151) and registry [qvac-registry-vcpkg#320](https://github.com/tetherto/qvac-registry-vcpkg/pull/320).

## Test plan
- [x] `npm run build:native`
- [x] `npm run test:types`
- [x] `npm run lint:ts`
- [x] `npm run test:unit` (125 tests, 403 assertions)
- [x] `npx brittle-bare test/integration/minimax-input-safety.test.js test/integration/minimax.test.js` (native safety passes; model-backed test skips without local GGUFs)
- [ ] Run the model-backed test with `AUDIOGEN_TEST_MINIMAX_MODELS_DIR` after the GGUF pair is available
- [ ] `npm run lint-cpp` (`clang-tidy` is unavailable in the current environment)