### PR TITLE
QVAC-23758 fix: drain queued streaming output before JobEnded in parakeet endStreaming

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -12,6 +12,12 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 [`docs/WHISPER-CHANGELOG.md`](https://github.com/tetherto/qvac/blob/main/packages/asr-ggml/docs/WHISPER-CHANGELOG.md) and
 [`docs/PARAKEET-CHANGELOG.md`](https://github.com/tetherto/qvac/blob/main/packages/asr-ggml/docs/PARAKEET-CHANGELOG.md).
 
+## [0.3.3] - 2026-08-19
+
+### Fixed
+
+- **Parakeet duplex streaming no longer drops the tail of the transcript when the audio stream ends while the engine still has a buffered backlog (QVAC-23758).** `endStreaming()` joins the native worker only after it has drained all buffered audio, but the drained segments are delivered to JS asynchronously (uv_async); the parakeet driver then cleared the active job and emitted a synthetic `JobEnded` *before* those queued `Output` events arrived, so `_addonOutputCallback` discarded every one of them (`jobId === null`). Apps feeding audio faster than realtime (e.g. the SDK's `transcribeStream` fed from a file, then `end()`) lost most of the un-processed tail. `ParakeetStreamingProcessor` now queues a terminal `RuntimeStats` object (real `audioDurationMs` / `totalSamples`) through the **same FIFO output queue** as the drained segments after `finalize()` — exactly how the whisper engine's `StreamingProcessor` already signals completion — and the JS wrapper waits for that terminal event to flow through the normal output-callback path, so every drained segment is delivered, in order, before the job resolves. The synthetic `JobEnded` remains only as a fallback when no native session existed (`cleaned: false`).
+
 ## [0.3.2] - 2026-08-18
 
 ### Changed

--- a/packages/asr-ggml/addon/src/model-interface/ParakeetStreamingProcessor.cpp
+++ b/packages/asr-ggml/addon/src/model-interface/ParakeetStreamingProcessor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <exception>
 #include <iomanip>
 #include <sstream>
@@ -252,6 +253,33 @@ void ParakeetStreamingProcessor::processLoop() {
                 e.what());
       }
       emitPending();
+      // Queue the terminal stats through the SAME FIFO output queue as
+      // the segments (mirroring whisper's StreamingProcessor, which calls
+      // queueJobEnded() here). Delivery to the JS output callback is
+      // asynchronous (uv_async), so this is the only ordering-safe way to
+      // signal job completion: the JS driver waits for this event instead
+      // of synthesising a JobEnded of its own, which raced ahead of the
+      // drained backlog and cut the tail off the transcript (QVAC-23758).
+      // ParakeetModel::runtimeStats() is bypassed by the duplex path, so
+      // the stats are built from this processor's own counters.
+      {
+        qvac_lib_inference_addon_cpp::RuntimeStats terminal;
+        terminal.emplace_back("totalTime", static_cast<int64_t>(0));
+        terminal.emplace_back("audioDurationMs", audio_seconds_ * 1000.0);
+        terminal.emplace_back(
+            "totalSamples",
+            static_cast<int64_t>(std::llround(
+                audio_seconds_ * static_cast<double>(config_.sampleRate))));
+        try {
+          output_queue_->queueResult(std::any(std::move(terminal)));
+        } catch (const std::exception& e) {
+          QLOG(
+              logger::Priority::WARNING,
+              std::string(
+                  "ParakeetStreamingProcessor: terminal queueResult failed: ") +
+                  e.what());
+        }
+      }
       break;
     }
   }

--- a/packages/asr-ggml/engines/parakeet/parakeet.d.ts
+++ b/packages/asr-ggml/engines/parakeet/parakeet.d.ts
@@ -62,6 +62,7 @@ export type ParakeetOutputCallback = (addon: unknown, event: unknown, jobId: num
 export type ParakeetStateCallback = (addon: ParakeetInterface, newState: string) => void;
 type NativeOutputCallback = (addon: unknown, event: unknown, data: unknown, error: unknown) => void;
 interface StreamingTeardown {
+    cleaned?: unknown;
     audioDurationMs?: unknown;
     totalSamples?: unknown;
 }
@@ -96,6 +97,7 @@ export declare class ParakeetInterface {
     private _nextJobId;
     private _activeJobId;
     private _onCancelComplete;
+    private _onStreamEndComplete;
     private _bufferedAudio;
     private _bufferedBytes;
     private _config;
@@ -107,6 +109,7 @@ export declare class ParakeetInterface {
     private _looksLikeTranscript;
     private _mapAddonEvent;
     private _resolvePendingCancel;
+    private _resolveStreamEndWaiter;
     private _addonOutputCallback;
     private _emitSyntheticError;
     loadWeights(weightsData: WeightData): Promise<boolean>;

--- a/packages/asr-ggml/engines/parakeet/parakeet.js
+++ b/packages/asr-ggml/engines/parakeet/parakeet.js
@@ -48,6 +48,7 @@ class ParakeetInterface {
     _nextJobId;
     _activeJobId;
     _onCancelComplete;
+    _onStreamEndComplete;
     _bufferedAudio;
     _bufferedBytes;
     _config;
@@ -60,6 +61,7 @@ class ParakeetInterface {
         this._nextJobId = 1;
         this._activeJobId = null;
         this._onCancelComplete = null;
+        this._onStreamEndComplete = null;
         this._bufferedAudio = [];
         this._bufferedBytes = 0;
         this._config = this._applyDefaults(configurationParams);
@@ -84,6 +86,7 @@ class ParakeetInterface {
         this._config = configurationParams;
         this._activeJobId = null;
         this._onCancelComplete = null;
+        this._resolveStreamEndWaiter();
         this._bufferedAudio = [];
         this._bufferedBytes = 0;
         this._handle = this._binding.createInstance(this, this._config, this._addonOutputCallback.bind(this), this._stateCallback);
@@ -129,24 +132,36 @@ class ParakeetInterface {
         resolve();
         return true;
     }
+    _resolveStreamEndWaiter() {
+        if (!this._onStreamEndComplete)
+            return;
+        const resolve = this._onStreamEndComplete;
+        this._onStreamEndComplete = null;
+        resolve();
+    }
     _addonOutputCallback(addon, event, data, error) {
         const isError = typeof error === "string" && error.length > 0;
         const mappedEvent = this._mapAddonEvent(event, data, isError);
         const isTerminal = mappedEvent === "Error" || mappedEvent === "JobEnded";
         const jobId = this._activeJobId;
         if (jobId === null) {
-            if (isTerminal)
+            if (isTerminal) {
                 this._resolvePendingCancel();
+                this._resolveStreamEndWaiter();
+            }
             return;
         }
-        if (isTerminal && this._resolvePendingCancel())
+        if (isTerminal && this._resolvePendingCancel()) {
+            this._resolveStreamEndWaiter();
             return;
+        }
         if (mappedEvent === "Output")
             this._setState(state.PROCESSING);
         this._outputCallback(addon, mappedEvent, jobId, data, isError ? error : null);
         if (isTerminal) {
             this._activeJobId = null;
             this._setState(state.LISTENING);
+            this._resolveStreamEndWaiter();
         }
     }
     _emitSyntheticError(jobId, error) {
@@ -339,6 +354,7 @@ class ParakeetInterface {
             this._binding.destroyInstance(this._handle);
             this._handle = null;
             this._activeJobId = null;
+            this._resolveStreamEndWaiter();
             this._bufferedAudio = [];
             this._bufferedBytes = 0;
             this._setState(state.IDLE);
@@ -415,7 +431,28 @@ class ParakeetInterface {
             if (this._activeJobId === null)
                 return Promise.resolve();
             const jobId = this._activeJobId;
+            // binding.endStreaming joins the native worker AFTER it has drained
+            // all buffered audio, so on return every remaining Output batch —
+            // plus the terminal RuntimeStats the ParakeetStreamingProcessor
+            // queues after finalize() — sits in the addon's output queue in
+            // FIFO order. Delivery to _addonOutputCallback is asynchronous
+            // (uv_async), so the active job MUST NOT be cleared here: doing so
+            // made _addonOutputCallback drop the entire drained backlog
+            // (jobId === null) and cut the tail off the transcript
+            // (QVAC-23758).
             const teardown = this._binding.endStreaming(this._handle) || {};
+            if (teardown.cleaned) {
+                // Wait for the queued terminal event (JobEnded or Error) to flow
+                // through _addonOutputCallback, which clears the job, flips the
+                // state machine, and resolves the response with the processor's
+                // real stats.
+                return new Promise((resolve) => {
+                    this._onStreamEndComplete = resolve;
+                });
+            }
+            // No native session existed (already torn down elsewhere): the
+            // queue carries no terminal event, so synthesise the JobEnded here
+            // to keep the response chain resolving as before.
             this._activeJobId = null;
             this._setState(state.LISTENING);
             this._outputCallback(this, "JobEnded", jobId, {
@@ -430,6 +467,7 @@ class ParakeetInterface {
             return Promise.resolve();
         }
         catch (error) {
+            this._onStreamEndComplete = null;
             const normalized = normalizeError(error);
             return Promise.reject(createParakeetError(error_1.ERR_CODES_PARAKEET.FAILED_TO_RESET, normalized.message, error));
         }

--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/asr-ggml",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Multi-engine ASR (Whisper + NVIDIA Parakeet) inference addon for qvac on the Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/asr-ggml/src/engines/parakeet/parakeet.ts
+++ b/packages/asr-ggml/src/engines/parakeet/parakeet.ts
@@ -110,6 +110,7 @@ type NativeOutputCallback = (
 ) => void;
 
 interface StreamingTeardown {
+  cleaned?: unknown;
   audioDurationMs?: unknown;
   totalSamples?: unknown;
 }
@@ -181,6 +182,7 @@ export class ParakeetInterface {
   private _nextJobId: number;
   private _activeJobId: number | null;
   private _onCancelComplete: (() => void) | null;
+  private _onStreamEndComplete: (() => void) | null;
   private _bufferedAudio: Float32Array[];
   private _bufferedBytes: number;
   private _config: ParakeetConfigurationParams;
@@ -199,6 +201,7 @@ export class ParakeetInterface {
     this._nextJobId = 1;
     this._activeJobId = null;
     this._onCancelComplete = null;
+    this._onStreamEndComplete = null;
     this._bufferedAudio = [];
     this._bufferedBytes = 0;
 
@@ -231,6 +234,7 @@ export class ParakeetInterface {
     this._config = configurationParams;
     this._activeJobId = null;
     this._onCancelComplete = null;
+    this._resolveStreamEndWaiter();
     this._bufferedAudio = [];
     this._bufferedBytes = 0;
     this._handle = this._binding.createInstance(
@@ -290,6 +294,13 @@ export class ParakeetInterface {
     return true;
   }
 
+  private _resolveStreamEndWaiter(): void {
+    if (!this._onStreamEndComplete) return;
+    const resolve = this._onStreamEndComplete;
+    this._onStreamEndComplete = null;
+    resolve();
+  }
+
   private _addonOutputCallback(
     addon: unknown,
     event: unknown,
@@ -303,10 +314,16 @@ export class ParakeetInterface {
     const jobId = this._activeJobId;
 
     if (jobId === null) {
-      if (isTerminal) this._resolvePendingCancel();
+      if (isTerminal) {
+        this._resolvePendingCancel();
+        this._resolveStreamEndWaiter();
+      }
       return;
     }
-    if (isTerminal && this._resolvePendingCancel()) return;
+    if (isTerminal && this._resolvePendingCancel()) {
+      this._resolveStreamEndWaiter();
+      return;
+    }
     if (mappedEvent === "Output") this._setState(state.PROCESSING);
 
     this._outputCallback(
@@ -320,6 +337,7 @@ export class ParakeetInterface {
     if (isTerminal) {
       this._activeJobId = null;
       this._setState(state.LISTENING);
+      this._resolveStreamEndWaiter();
     }
   }
 
@@ -576,6 +594,7 @@ export class ParakeetInterface {
       this._binding.destroyInstance(this._handle);
       this._handle = null;
       this._activeJobId = null;
+      this._resolveStreamEndWaiter();
       this._bufferedAudio = [];
       this._bufferedBytes = 0;
       this._setState(state.IDLE);
@@ -678,7 +697,28 @@ export class ParakeetInterface {
     try {
       if (this._activeJobId === null) return Promise.resolve();
       const jobId = this._activeJobId;
+      // binding.endStreaming joins the native worker AFTER it has drained
+      // all buffered audio, so on return every remaining Output batch —
+      // plus the terminal RuntimeStats the ParakeetStreamingProcessor
+      // queues after finalize() — sits in the addon's output queue in
+      // FIFO order. Delivery to _addonOutputCallback is asynchronous
+      // (uv_async), so the active job MUST NOT be cleared here: doing so
+      // made _addonOutputCallback drop the entire drained backlog
+      // (jobId === null) and cut the tail off the transcript
+      // (QVAC-23758).
       const teardown = this._binding.endStreaming(this._handle) || {};
+      if (teardown.cleaned) {
+        // Wait for the queued terminal event (JobEnded or Error) to flow
+        // through _addonOutputCallback, which clears the job, flips the
+        // state machine, and resolves the response with the processor's
+        // real stats.
+        return new Promise((resolve) => {
+          this._onStreamEndComplete = resolve;
+        });
+      }
+      // No native session existed (already torn down elsewhere): the
+      // queue carries no terminal event, so synthesise the JobEnded here
+      // to keep the response chain resolving as before.
       this._activeJobId = null;
       this._setState(state.LISTENING);
       this._outputCallback(
@@ -700,6 +740,7 @@ export class ParakeetInterface {
       );
       return Promise.resolve();
     } catch (error) {
+      this._onStreamEndComplete = null;
       const normalized = normalizeError(error);
       return Promise.reject(
         createParakeetError(

--- a/packages/asr-ggml/test/integration/parakeet-duplex-streaming.test.js
+++ b/packages/asr-ggml/test/integration/parakeet-duplex-streaming.test.js
@@ -14,9 +14,12 @@
  *     as the engine emits them, with stable session state across
  *     chunks (rolling encoder context, EOU detector, Sortformer
  *     history all preserved);
- *   - `endStreaming` synthesises a JobEnded event in JS so the
- *     wrapper response chain (`onUpdate(...).await()`) resolves
- *     when the input iterable completes.
+ *   - `endStreaming` drains the buffered backlog, then the native
+ *     ParakeetStreamingProcessor queues a terminal RuntimeStats
+ *     (surfaced as JobEnded) through the same FIFO output queue as
+ *     the drained segments, so the wrapper response chain
+ *     (`onUpdate(...).await()`) resolves only after every segment
+ *     has been delivered (QVAC-23758).
  *
  * Coverage:
  *
@@ -28,7 +31,7 @@
  *      offline `run()` path cannot satisfy this since it batches
  *      everything in JS until end-of-input).
  *   3. The response settles cleanly after `endStreaming` -- proves
- *      the JS-side synthetic JobEnded path actually resolves the
+ *      the queue-delivered terminal JobEnded actually resolves the
  *      response chain.
  *
  * Skips cleanly when no GGUF is available (matching the rest of the

--- a/packages/asr-ggml/test/mocks/ParakeetMockedBinding.js
+++ b/packages/asr-ggml/test/mocks/ParakeetMockedBinding.js
@@ -31,6 +31,8 @@ class MockedBinding {
     this._streamingActive = false
     this._streamingChunkIndex = 0
     this._streamingConfig = null
+    this._streamingSamplesFed = 0
+    this._streamingDropOutputs = false
     // History of streaming actions for tests to assert against
     // (counts of starts / appends / ends / cancels, plus the
     // last streamingConfig that was passed). Reset implicitly via
@@ -116,6 +118,8 @@ class MockedBinding {
     if (this._streamingActive) {
       this._streamingActive = false
       this._streamingChunkIndex = 0
+      this._streamingSamplesFed = 0
+      this._streamingDropOutputs = true
       this._streamingLog.cancels++
     }
     if (this.transitionCb) {
@@ -128,8 +132,11 @@ class MockedBinding {
   // `appendStreamingAudio`, `endStreaming`) plus the cancel-with-
   // streaming hook. Each appended chunk synthesises one Output event
   // so the wrapper's `onUpdate(...)` fires at the same cadence the
-  // real binding would; endStreaming returns the teardown object the
-  // JS wrapper turns into a synthetic JobEnded (see parakeet.ts).
+  // real binding would. Like the real binding, a graceful endStreaming
+  // queues a terminal RuntimeStats event BEHIND any still-undelivered
+  // Output events (FIFO via process.nextTick), and the JS wrapper waits
+  // for it before marking the job finished (see parakeet.ts ->
+  // endStreaming). Only cancel drops undelivered outputs.
   startStreaming(handle, config = {}) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (this._streamingActive) {
@@ -138,6 +145,8 @@ class MockedBinding {
     this._streamingActive = true
     this._streamingChunkIndex = 0
     this._streamingConfig = config
+    this._streamingSamplesFed = 0
+    this._streamingDropOutputs = false
     this._streamingLog.starts++
     this._streamingLog.lastConfig = config
     return true
@@ -158,8 +167,12 @@ class MockedBinding {
     const sampleRate = 16000
     const startS = (chunkIndex * audioLength) / sampleRate
     const endS = ((chunkIndex + 1) * audioLength) / sampleRate
+    this._streamingSamplesFed = (this._streamingSamplesFed || 0) + audioLength
     process.nextTick(() => {
-      if (!this._streamingActive) return
+      // Graceful endStreaming must NOT drop outputs queued before it —
+      // that's the real binding's FIFO drain contract. Only a cancel
+      // (forceful teardown) discards undelivered outputs.
+      if (this._streamingDropOutputs) return
       this._callCallbacks(
         'Output',
         [
@@ -183,18 +196,32 @@ class MockedBinding {
     if (!this._streamingActive) {
       return { cleaned: false, audioDurationMs: 0, totalSamples: 0 }
     }
-    const samplesFed =
-      (this._streamingLog.appends *
-        (this._streamingConfig?.sampleRate || 16000) *
-        (this._streamingConfig?.chunkMs || 1000)) /
-      1000
+    const samplesFed = this._streamingSamplesFed || 0
+    const audioDurationMs = samplesFed / 16
     this._streamingActive = false
     this._streamingChunkIndex = 0
     this._streamingConfig = null
+    this._streamingSamplesFed = 0
     this._streamingLog.ends++
+    // Mirror the real binding: ParakeetStreamingProcessor queues the
+    // terminal RuntimeStats through the same FIFO channel as the Output
+    // events, so it lands AFTER every output scheduled before this call.
+    // The JS wrapper's endStreaming awaits its arrival instead of
+    // synthesising a JobEnded of its own.
+    process.nextTick(() => {
+      this._callCallbacks(
+        'RuntimeStats',
+        {
+          totalTime: 0,
+          audioDurationMs,
+          totalSamples: Math.round(samplesFed)
+        },
+        null
+      )
+    })
     return {
       cleaned: true,
-      audioDurationMs: samplesFed > 0 ? samplesFed / 16 : 0,
+      audioDurationMs,
       totalSamples: Math.round(samplesFed)
     }
   }
@@ -297,6 +324,8 @@ class MockedBinding {
     this._streamingActive = false
     this._streamingChunkIndex = 0
     this._streamingConfig = null
+    this._streamingSamplesFed = 0
+    this._streamingDropOutputs = true
     console.log('Destroyed the addon')
     this._state = state.IDLE
     if (this.transitionCb) {

--- a/packages/asr-ggml/test/unit/parakeet-streaming-duplex.test.js
+++ b/packages/asr-ggml/test/unit/parakeet-streaming-duplex.test.js
@@ -17,11 +17,14 @@
  *     wrapper's `onUpdate(...)` channel (incremental, not batched);
  *   - `appendStreamingAudio` resolves the boolean back-pressure signal
  *     the merged binding returns (false iff zero samples decoded);
- *   - `endStreaming` returns the { cleaned, audioDurationMs, totalSamples }
- *     teardown object and the JS layer synthesises a JobEnded from it so
- *     the wrapper's response chain (`response.onUpdate(...).await()`)
- *     resolves cleanly, which is the contract the live-mic example
- *     depends on;
+ *   - `endStreaming` waits for the binding's queue-delivered terminal
+ *     RuntimeStats (surfaced as JobEnded) so every drained Output event
+ *     is delivered BEFORE the job is marked finished and the wrapper's
+ *     response chain (`response.onUpdate(...).await()`) resolves — the
+ *     tail-cut regression (QVAC-23758) was the JS wrapper clearing the
+ *     active job before undelivered outputs arrived, dropping them; the
+ *     synthetic JobEnded built from the teardown object survives only as
+ *     a fallback when no native session existed (`cleaned: false`);
  *   - a concurrent run()/runStreaming() during an open session rejects
  *     with the structured STREAMING_SESSION_ACTIVE error;
  *   - cancellation tears the session down via the existing
@@ -140,6 +143,63 @@ test('runStreaming surfaces one Output per pushed chunk and one JobEnded on clos
   t.is(log.appends, 3, 'appendStreamingAudio called once per pushed chunk')
   t.is(log.ends, 1, 'endStreaming called once on stream close')
   t.is(log.cancels, 0, 'No cancellations on the happy path')
+
+  await model.unload()
+})
+
+test('endStreaming delivers undelivered Output backlog before JobEnded (QVAC-23758 tail-cut)', async (t) => {
+  // Drive the wrapper directly: append several chunks and call
+  // endStreaming() IMMEDIATELY, while the per-chunk Output events are
+  // still queued for asynchronous delivery (process.nextTick in the
+  // mock, uv_async in the real binding). Before the fix the wrapper
+  // cleared _activeJobId synchronously inside endStreaming, so every
+  // not-yet-delivered Output was dropped in _addonOutputCallback
+  // (jobId === null) — cutting the tail off streamed transcripts.
+  const events = []
+  const model = createMockedModel({
+    onOutput: (addon, event, jobId, output, error) => {
+      events.push({ event, jobId, output, error })
+    }
+  })
+  await model.load()
+  const addon = getAddon(model)
+
+  await addon.startStreaming({ chunkMs: 2000 })
+  // Fire the appends and the endStreaming in ONE synchronous turn (no
+  // awaits in between): the async wrappers hit the binding synchronously,
+  // so all three Output events are still queued (undelivered) when
+  // endStreaming tears the session down — exactly the fast-feed +
+  // immediate-end() shape the SDK repro used.
+  await Promise.all([
+    addon.appendStreamingAudio(new Float32Array(1024)),
+    addon.appendStreamingAudio(new Float32Array(1024)),
+    addon.appendStreamingAudio(new Float32Array(1024)),
+    addon.endStreaming()
+  ])
+
+  const outputEvents = events.filter((e) => e.event === 'Output')
+  t.is(outputEvents.length, 3, 'All three backlog Output events were delivered, none dropped')
+
+  const jobEndedEvents = events.filter((e) => e.event === 'JobEnded')
+  t.is(jobEndedEvents.length, 1, 'Exactly one terminal JobEnded')
+  t.is(
+    events
+      .filter((e) => e.event === 'Output' || e.event === 'JobEnded')
+      .findIndex((e) => e.event === 'JobEnded'),
+    3,
+    'JobEnded arrives strictly AFTER every drained Output event'
+  )
+  t.ok(
+    jobEndedEvents[0].jobId !== null && jobEndedEvents[0].jobId !== undefined,
+    'Terminal event still carries the streaming jobId'
+  )
+  t.is(jobEndedEvents[0].output.totalSamples, 3072, 'Terminal stats reflect the audio actually fed')
+
+  t.is(
+    await addon.status(),
+    'listening',
+    'Wrapper state machine returned to listening after the drain'
+  )
 
   await model.unload()
 })
@@ -310,7 +370,7 @@ test('endStreaming on a binding with no active session is a no-op', async (t) =>
   await addon.destroyInstance()
 })
 
-test('endStreaming teardown object feeds the synthetic JobEnded payload', async (t) => {
+test('endStreaming terminal JobEnded carries the streamed audio stats', async (t) => {
   const events = []
   const model = createMockedModel({
     onOutput: (addon, event, jobId, output, error) => {
@@ -329,14 +389,14 @@ test('endStreaming teardown object feeds the synthetic JobEnded payload', async 
   await wait()
 
   const jobEnded = events.find((e) => e.event === 'JobEnded')
-  t.ok(jobEnded, 'JobEnded synthesised on endStreaming')
+  t.ok(jobEnded, 'Terminal JobEnded delivered on endStreaming')
   t.ok(
     typeof jobEnded.output.audioDurationMs === 'number' && jobEnded.output.audioDurationMs > 0,
-    'Synthetic JobEnded carries the teardown audio duration'
+    'Terminal JobEnded carries the streamed audio duration'
   )
   t.ok(
     typeof jobEnded.output.totalSamples === 'number' && jobEnded.output.totalSamples > 0,
-    'Synthetic JobEnded carries the teardown sample count'
+    'Terminal JobEnded carries the streamed sample count'
   )
 
   await model.unload()


### PR DESCRIPTION
## Summary

Fixes the Parakeet duplex-streaming tail-cut reported in QVAC-23758 ([Asana](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1217548655428314)): when the audio input stream ended while the engine still had a buffered backlog, the end of the transcript was silently dropped.

> **Note:** originally implemented against `packages/transcription-parakeet`; rebased and ported to `packages/asr-ggml` after the whisper/parakeet unification (#3553) landed on main. The bug carried over verbatim into the unified package's parakeet driver.

### Root cause

The native `endStreaming` joins the worker thread only **after** it drains all buffered audio and finalizes — every tail segment is queued into the addon's output queue correctly. But delivery of those queued events to JS is asynchronous (`uv_async`), and the parakeet driver (`src/engines/parakeet/parakeet.ts`) cleared `_activeJobId` and emitted a synthetic `JobEnded` synchronously right after the native call returned. When the drained segments arrived at `_addonOutputCallback`, `jobId === null` → all discarded. Apps feeding faster than realtime (e.g. the SDK's `transcribeStream` fed from a file, then `end()`) lost most of the unprocessed tail.

### Fix (mirrors the whisper engine's `StreamingProcessor`)

- **`addon/src/model-interface/ParakeetStreamingProcessor.cpp`** — after `finalize()` on the graceful end path, queue a terminal `RuntimeStats` (real `audioDurationMs` / `totalSamples` from the processor's own counters — `ParakeetModel::runtimeStats()` is bypassed by the duplex path) through the **same FIFO output queue** as the drained segments, so it can never outrun them. This is exactly where whisper's `StreamingProcessor` calls `queueJobEnded()`.
- **`src/engines/parakeet/parakeet.ts`** — `endStreaming()` no longer clears the job or synthesises a `JobEnded`; it waits for the queue-delivered terminal event to flow through the normal output-callback path, so every drained segment is delivered in order before the response resolves. The synthetic `JobEnded` remains only as a fallback when no native session existed (`cleaned: false`). Waiter resolution is also wired into the cancel/destroy paths so nothing can hang. Generated `engines/parakeet/parakeet.{js,d.ts}` rebuilt via `build:ts` (`check:generated` passes).
- **`test/mocks/ParakeetMockedBinding.js`** — mimics the new contract (graceful end keeps undelivered outputs; terminal stats delivered FIFO after them; only cancel discards).
- **`test/unit/parakeet-streaming-duplex.test.js`** — regression test that appends chunks and calls `endStreaming()` in one synchronous turn: fails against the old driver (0/3 backlog outputs delivered), passes with the fix.
- Bumped `@qvac/asr-ggml` to `0.3.3` with a changelog entry.

No SDK changes required — the duplex handler and client already behave correctly once events are not dropped.

## Testing

- Unit suite: **168/168 tests, 709/709 asserts**.
- `npm run lint`: clean (prettier + lunte + eslint + typecheck + dts + `check:generated`).
- Regression test verified to fail against the pre-fix driver (via `git stash`) and pass with the fix.
- The C++ change compiles via the CI prebuild workflow (local `bare-make generate` for speech packages needs the post-#312 registry state).

## Follow-up (out of scope)

The streaming path also re-emits overlapping content across chunks (429 words vs the one-shot reference's 301 on the repro audio) due to the rolling-history window — a quality issue, tracked separately per the Asana ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
