### PR TITLE
QVAC-23832 fix: keep TTS WER ASR as a development dependency

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Keep `@qvac/asr-ggml` as a development dependency for desktop WER checks
+  instead of shipping `@qvac/transcription-whispercpp` at runtime. Consumer
+  installs no longer pull an unused ASR native addon.
+
 ## [0.7.3] - 2026-08-18
 
 ### Changed

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -955,7 +955,8 @@ files are absent.  They cover, across the engines:
   warning),
 * multilingual Chatterbox sweep (es/fr/de/pt) via `chatterbox-mtl.test.js`,
 * on darwin the Chatterbox English batch path is additionally verified
-  for WER against the synthesized audio (whisper-small).
+  for WER against the synthesized audio (whisper-small via the
+  `@qvac/asr-ggml` development dependency).
 
 To stress-test long inputs, set `INPUT_SENTENCES=medium` (or `long`)
 and re-run the integration suite — `addon.test.js` reads the env var to

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -124,6 +124,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://qvac.tether.io",
   "devDependencies": {
+    "@qvac/asr-ggml": "^0.3.2",
     "cmake-bare": "^1.7.5",
     "cmake-vcpkg": "^1.1.0",
     "eslint": "^9.39.4",
@@ -143,7 +144,6 @@
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/logging": "^0.1.0",
     "@qvac/registry-client": "^0.6.1",
-    "@qvac/transcription-whispercpp": "^0.10.1",
     "bare-fs": "^4.5.6",
     "bare-https": "^3.0.0",
     "bare-os": "^3.8.0",

--- a/packages/tts-ggml/scripts/__tests__/package-contract.test.js
+++ b/packages/tts-ggml/scripts/__tests__/package-contract.test.js
@@ -25,7 +25,6 @@ const runtimeProbes = [
   '@qvac/tts-ggml/text-chunker',
   '@qvac/tts-ggml/text-stream-accumulator',
   '@qvac/langdetect-text',
-  '@qvac/transcription-whispercpp',
   'bare-https',
   'bare-process',
   'bare-stream',
@@ -76,6 +75,14 @@ function externalSpecifiers(source) {
   return specifiers
 }
 
+function declaredPackagesFor(filePath) {
+  const runtime = declaredRuntimePackages()
+  if (filePath.startsWith('test/')) {
+    return new Set([...runtime, ...Object.keys(packageJson.devDependencies || {})])
+  }
+  return runtime
+}
+
 function undeclaredImports(filePath, declaredPackages) {
   if (!runtimeExtensions.has(path.extname(filePath))) return []
   const source = fs.readFileSync(path.join(packageRoot, filePath), 'utf8')
@@ -86,10 +93,9 @@ function undeclaredImports(filePath, declaredPackages) {
 }
 
 function undeclaredPublishedImports(files) {
-  const declaredPackages = declaredRuntimePackages()
   const undeclared = []
   for (const filePath of files) {
-    undeclared.push(...undeclaredImports(filePath, declaredPackages))
+    undeclared.push(...undeclaredImports(filePath, declaredPackagesFor(filePath)))
   }
   return [...new Set(undeclared)].sort()
 }
@@ -140,6 +146,16 @@ test('enhanced examples have package scripts', () => {
   )
 })
 
+test('WER helper uses asr-ggml as a development dependency', () => {
+  assert.equal(packageJson.dependencies['@qvac/transcription-whispercpp'], undefined)
+  assert.equal(packageJson.dependencies['@qvac/asr-ggml'], undefined)
+  assert.equal(packageJson.devDependencies['@qvac/asr-ggml'], '^0.3.2')
+  const source = fs.readFileSync(path.join(packageRoot, 'test/utils/runWhisper.js'), 'utf8')
+  assert.match(source, /@qvac\/asr-ggml/)
+  assert.doesNotMatch(source, /transcription-whispercpp/)
+  assert.match(source, /function loadAsrGgml/)
+})
+
 test('published commands include their runtime files', () => {
   // ^0.6.1 keeps the transitive hyperdb on the v6 line shared by the rest of
   // the @qvac ecosystem; 0.4.x pinned hyperdb@4 and broke the SDK consumer
@@ -166,6 +182,15 @@ test('production tarball install includes promoted runtime modules', () => {
     writeConsumerPackage(consumerRoot)
     installTarball(consumerRoot, path.join(temporaryRoot, packed.filename))
     assertRuntimeProbesResolve(consumerRoot)
+    const asrProbe = spawnSync(process.execPath, ['-e', "require.resolve('@qvac/asr-ggml')"], {
+      cwd: consumerRoot,
+      encoding: 'utf8'
+    })
+    assert.notEqual(
+      asrProbe.status,
+      0,
+      'production install must not include @qvac/asr-ggml'
+    )
   } finally {
     fs.rmSync(temporaryRoot, { recursive: true, force: true })
   }

--- a/packages/tts-ggml/scripts/__tests__/package-contract.test.js
+++ b/packages/tts-ggml/scripts/__tests__/package-contract.test.js
@@ -186,11 +186,7 @@ test('production tarball install includes promoted runtime modules', () => {
       cwd: consumerRoot,
       encoding: 'utf8'
     })
-    assert.notEqual(
-      asrProbe.status,
-      0,
-      'production install must not include @qvac/asr-ggml'
-    )
+    assert.notEqual(asrProbe.status, 0, 'production install must not include @qvac/asr-ggml')
   } finally {
     fs.rmSync(temporaryRoot, { recursive: true, force: true })
   }

--- a/packages/tts-ggml/test/utils/runWhisper.js
+++ b/packages/tts-ggml/test/utils/runWhisper.js
@@ -1,4 +1,3 @@
-const TranscriptionWhispercpp = require('@qvac/transcription-whispercpp')
 const { Readable } = require('bare-stream')
 const path = require('bare-path')
 const os = require('bare-os')
@@ -13,29 +12,34 @@ function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
+function loadAsrGgml() {
+  // Defer the native addon until WER actually runs. Requiring it at module
+  // load would dlopen asr-ggml during TTS tests that only import this helper.
+  return require('@qvac/asr-ggml')
+}
+
 async function loadWhisper(params = {}) {
   const defaultPath = path.join(getBaseDir(), 'models', 'whisper')
   const modelName = params.modelName || 'ggml-tiny.bin'
   const diskPath = params.diskPath || defaultPath
   console.log('>>> [WHISPER] Loading model from:', diskPath)
 
-  const constructorArgs = {
+  const ASRGgml = loadAsrGgml()
+  const whisperModel = new ASRGgml({
     files: {
       model: path.join(diskPath, modelName)
+    },
+    enableStats: true,
+    config: {
+      engine: 'whisper',
+      whisperConfig: {
+        audio_format: 's16le',
+        language: params.language || 'en',
+        temperature: 0.0
+      }
     }
-  }
-  const config = {
-    opts: { stats: true },
-    whisperConfig: {
-      audio_format: 's16le',
-      language: params.language || 'en',
-      translate: false,
-      temperature: 0.0
-    }
-  }
-
-  const whisperModel = new TranscriptionWhispercpp(constructorArgs, config)
-  await whisperModel._load()
+  })
+  await whisperModel.load()
   console.log('>>> [WHISPER] Model loaded')
 
   return whisperModel


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/tts-ggml` 0.7.3 still declared `@qvac/transcription-whispercpp` as a runtime dependency even though only the desktop WER test helper used it.
- That unused native addon was installed into consumer Android apps. Closing the Bare worklet then `dlclose()`'d it and crashed while destroying a mutex.

## 📝 How does it solve it?

- Remove `@qvac/transcription-whispercpp` from runtime `dependencies`.
- Point the WER helper at `@qvac/asr-ggml` (`engine: 'whisper'`) and declare it as a `devDependency`.
- Lazy-require the ASR addon so TTS tests that only import the helper do not `dlopen` it.
- Tighten the package-contract tests so a production (`--omit=dev`) tarball install does not resolve `@qvac/asr-ggml`.

## 🧪 How was it tested?

- `node --test scripts/__tests__/package-contract.test.js` in `packages/tts-ggml` (7/7 passed), including the production tarball install probe.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217644063181472