### PR TITLE
QVAC-23195 feat[api]: bump @qvac/fabric to ^0.6.0 in classification-ggml

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-08-19
+
+### Changed
+
+- `@qvac/fabric` dependency bumped `^0.5.0` -> `^0.6.0`, which carries `qvac-fabric`
+  `10069.1.0` -> `10069.1.1` (fixes MoE models emitting garbage on Adreno 830 OpenCL,
+  and re-enables the GPU MoE kernels that were falling back to CPU). This package
+  consumes the shared runtime via npm rather than building the vcpkg port, so the range
+  bump is what picks up the new fabric. A caret on a `0.x` version locks the minor, so
+  `^0.5.0` would not have resolved `0.6.0` on its own. No API change for this package.
+
+  This addon runs MobileNetV3-Small on CPU, so the Adreno fix does not change its own
+  inference path — the bump keeps it on the current shared runtime build rather than
+  leaving it on a superseded fabric.
+
 ## [0.19.1] - 2026-08-18
 
 ### Fixed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {
@@ -84,7 +84,7 @@
     "typescript-eslint": "^8.63.0"
   },
   "dependencies": {
-    "@qvac/fabric": "^0.5.0",
+    "@qvac/fabric": "^0.6.0",
     "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",
     "bare-env": "^3.0.0",


### PR DESCRIPTION
## Summary

`classification-ggml` consumes the shared ggml runtime through the published `@qvac/fabric`
npm package rather than building the `qvac-fabric` vcpkg port, so a caret range bump is what
picks up a new fabric. It was therefore not part of the 7-consumer vcpkg rollout in #3929 and
needs this follow-up instead.

`@qvac/fabric` 0.6.0 (published today from #3929) carries `qvac-fabric` 10069.1.1, which fixes
MoE models emitting garbage on Adreno 830 OpenCL and re-enables the GPU MoE kernels that were
falling back to CPU. A caret on a `0.x` version locks the minor, so `^0.5.0` would not have
resolved `0.6.0` on its own.

| | before | after |
|---|---|---|
| `@qvac/classification-ggml` | 0.19.1 | 0.20.0 |
| `@qvac/fabric` | `^0.5.0` | `^0.6.0` |

This addon runs MobileNetV3-Small on CPU, so the Adreno fix does not change its own inference
path. The bump keeps it on the current shared runtime build rather than leaving it on a
superseded fabric. No API change for this package.

This is the same shape as #3918, which did the `^0.4.0` -> `^0.5.0` crossing for the 10069.1.0
rollout.

## Context

Completes the QVAC-23195 rollout. All seven vcpkg consumers published earlier today:

| package | version | tag |
|---|---|---|
| `@qvac/fabric` | 0.6.0 | `fabric-v0.6.0` |
| `@qvac/llm-llamacpp` | 0.45.0 | `llamacpp-llm-v0.45.0` |
| `@qvac/ocr-ggml` | 0.18.0 | `ocr-ggml-v0.18.0` |
| `@qvac/vla-ggml` | 0.21.0 | `vla-v0.21.0` |
| `@qvac/translation-nmtcpp` | 0.10.0 | `v0.10.0` |
| `@qvac/embed-llamacpp` | 0.34.0 | `llamacpp-embed-v0.34.0` |
| `@qvac/model-fit` | 0.4.0 | `model-fit-v0.4.0` |

## Test plan

- [ ] CI green (this is a dependency-range and version change only; no source changes)
- [ ] `@qvac/fabric@^0.6.0` resolves to `0.6.0` — confirmed against the registry
- [ ] `CHANGELOG.md` carries a bracketed `## [0.20.0] - <date>` heading, as the
      release-merge-guard requires for the follow-up release
