### PR TITLE
QVAC-23327 chore: bump vla-ggml to 0.21.1 + changelog

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.21.1] - 2026-08-19
+
+### Fixed
+
+- SmolVLA weight loads on a CPU backend now map the model file instead of
+  allocating a private copy of it. The check that decides between the two read
+  the device off the buffer type, and ggml declares the CPU buffer type with no
+  device attached, so every CPU load fell back to allocate-and-copy and charged
+  the whole model (~1.9 GB for the q8 LIBERO file) to the process. On iOS that
+  pushed the process against its memory limit and the load failed with a bare
+  `Failed to load SmolVLA model` — intermittently, and more often later in a
+  long run once other models had already been resident. The check now takes the
+  device from the backend being loaded onto, which is where the host-pointer
+  capability the mapped path needs is actually reported. GPU loads are
+  unaffected; they already resolved a device.
+- A failed SmolVLA load now reports why it failed. The error carried no reason,
+  so an exhausted allocation, an unreadable file and a malformed GGUF were
+  indistinguishable in application logs.
+- The mapped path now rejects a GGUF whose per-tensor offsets fall outside the
+  mapped region or ignore the file's own declared alignment, falling back to
+  allocate-and-copy rather than wiring tensors that would later be read out of
+  bounds. When it bails part-way it also releases the tensors it had already
+  wired before unmapping, so none is left pointing into an unmapped range.
+
+### Pull Requests
+
+- [#3905](https://github.com/tetherto/qvac/pull/3905) - QVAC-23327 fix: use the
+  mmap weights path for CPU SmolVLA loads
+
 ## [0.21.0] - 2026-08-18
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 Problem

The CPU SmolVLA mapped-weights load fix merged to `main` in #3905, but `packages/vla-ggml/package.json` still carries `0.21.0` — the version already published to npm as `latest` and tagged `vla-v0.21.0` at a commit that predates the fix. The fix is therefore on `main` and unreleasable: `/release` refuses to cut a release branch without a bump, and `release-merge-guard` requires `package.json` to match the version in the release branch name.

#3905 also carried no changelog entry, so there is nothing for a release to extract even once a version exists.

## 📝 How

Patch bump `0.21.0` → `0.21.1`, plus a dated `## [0.21.1] - 2026-08-19` entry describing the three user-visible effects of #3905: a CPU SmolVLA load now maps the model file instead of allocating a private copy of it, a failed load reports why it failed, and the mapped path rejects a GGUF whose per-tensor offsets are out of bounds or unaligned instead of wiring tensors it would later read past.

Patch rather than minor because the release adds no API surface:

- No new or changed public method, no new load config key, no new `hparams` field. The exported surface is identical to `0.21.0`.
- The behaviour change is which memory strategy a CPU weight load picks. A load that succeeded before still succeeds, with a lower peak footprint.
- The load error message gains a reason. It was previously a bare `Failed to load SmolVLA model`; error codes are unchanged.

Two files change and nothing else — no `vcpkg.json`, no `vcpkg-configuration.json` baseline, no source.

## 🧪 Tested

- `npm view @qvac/vla-ggml version` reads `0.21.0`, and `vla-v0.21.0` resolves to `6620d695d` — a commit before #3905 landed — so the fix is genuinely unreleased and no bump was already pending.
- `git log vla-v0.21.0..origin/main -- packages/vla-ggml/` returns exactly one commit, `220fedc65` (#3905), which is the work this version documents. Nothing else is silently riding along.
- Simulated the release extraction locally with the same bounds logic `.github/actions/verify-changelog-notes` uses (`^## \[<version>\]` to the next `^## \[`): the `0.21.1` block resolves to 23 non-empty lines, so the GitHub release body will not be empty and the heading is bracketed rather than the unbracketed form that only fails later at release time.
- `git diff --stat origin/main` shows exactly `packages/vla-ggml/package.json` and `packages/vla-ggml/CHANGELOG.md`.

No source changes, so there is nothing new to build or test here. #3905 carried the coverage for the fix itself: 62 green checks on its final head, including C++ unit tests (a new test asserts the CPU load maps rather than copies), desktop integration tests on linux-x64/arm64 and darwin-arm64 asserting the mapped path from native log markers, and iOS Device Farm runs on iPhone 16 and 17 with the four previously-failing VLA tests passing.

## ⚠️ Breaking changes

None. Version bump plus changelog, and the release it enables changes no API.

Worth knowing about the release it enables:

- Consumers on a `^0.21.0` range pick `0.21.1` up automatically. `packages/sdk` pins `^0.19.0` and `packages/inference` pins `^0.17.0`, so neither resolves `0.21.x` at all today — carrying the fix into the SDK needs its own range bump, which is out of scope here and unchanged by this PR.
