### PR TITLE
infra[notask]: fix create-release-tag treating a missing tag as existing

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -60,9 +60,15 @@ jobs:
           fi
 
           # SHA the tag currently points at, or empty when the tag is absent.
+          # `gh api` writes the error body to STDOUT on a 404, so only the exit
+          # status distinguishes absent from present -- capturing the output
+          # alone yields the {"message":"Not Found",...} JSON and reads as a SHA.
           tag_sha() {
-            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" \
-              --jq '.object.sha' 2>/dev/null || true
+            local out
+            if out="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" \
+              --jq '.object.sha' 2>/dev/null)"; then
+              printf '%s\n' "${out}"
+            fi
           }
 
           # Already present? Succeed only if it points where we expect; a tag


### PR DESCRIPTION
## Summary

`create-release-tag.yml` fails to create a tag whenever the tag does not already
exist — which is the normal path for every release. Introduced in #3348 and live on
`main` since earlier today.

`tag_sha()` captured `gh api`'s output and used non-emptiness to decide whether the tag
exists:

```bash
tag_sha() {
  gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" \
    --jq '.object.sha' 2>/dev/null || true
}
```

`gh api` writes the error body to **stdout** on a 404. `2>/dev/null` redirects only
stderr and `|| true` discards only the exit code, so for an absent tag `existing` is set
to the literal `{"message":"Not Found",...,"status":"404"}` JSON. The script concludes the
tag exists, compares that JSON against the target commit, and errors out:

```
::error::Tag classification-ggml-v0.20.0 already exists at
{"message":"Not Found","documentation_url":"...","status":"404"},
expected 2d9dc7e9486fc2d3e2a54e0b7d8311ff127e7867
```

The fix keys off the exit status rather than the captured output. A 404 now yields empty
and the tag gets created; a real hit still returns the SHA, so the idempotent
"already exists at the expected SHA" path that #3348 added is unchanged.

## Impact

`create-tag` runs **after** `publish-npm`, so an affected release still publishes and then
reports red — leaving the package **published but untagged**.

This already happened: `@qvac/classification-ggml@0.20.0` is live on npm, but
`classification-ggml-v0.20.0` does not exist and the newest tag for that package is still
`classification-ggml-v0.19.1`. Run
[32264163108](https://github.com/tetherto/qvac/actions/runs/32264163108) shows
`publish-release-npm` success, `create-tag` failure. A rerun failed identically, confirming
it is deterministic rather than transient.

The same helper is called a second time inside the POST retry loop, so the retry path was
dead as well: a genuine transient POST failure re-checked, read the 404 body as an existing
SHA, and hard-failed instead of retrying — the opposite of what #3348 set out to do. One
change fixes both call sites.

### Why today's earlier releases were unaffected

The seven `qvac-fabric 10069.1.1` consumer releases published earlier today were cut from
`6620d695d`, which predates #3348, so they used the previous script and tagged cleanly. The
classification release branch was cut from `2d9dc7e94`, which contains #3348.

| base commit | contains #3348 | `create-tag` |
|---|---|---|
| `6620d695d` — the 7 fabric consumer releases | no | all succeeded |
| `2d9dc7e94` — classification-ggml 0.20.0 | yes | failed |
| `origin/main` | yes | all future releases affected |

## Test plan

- [x] Reproduced the failure mode against a fake `gh` that mimics the real one (404 body on
      stdout, exit 1): the old helper returns the JSON (non-empty → "tag exists"), the new
      one returns empty → tag is created.
- [x] Confirmed the present-tag case is unchanged: both return the SHA, so the idempotent
      path and the SHA-mismatch guard still behave identically.
- [x] YAML parses; `jobs: [create-tag]` unchanged.
- [ ] Next release to run through `create-tag` should tag successfully.

## Follow-up (not in this PR)

`classification-ggml-v0.20.0` is still missing and needs to be created at `2d9dc7e94` by
whoever owns that release; this PR only stops the bleeding for subsequent ones.
