### PR TITLE
test[notask]: scoped benchmark-nx leaf run (llm + diffusion) [DO NOT MERGE]

### DIFF
--- a/.github/workflows/benchmark-performance-nx.yml
+++ b/.github/workflows/benchmark-performance-nx.yml
@@ -2,6 +2,12 @@
 name: "Benchmark Performance (nx)"
 
 on:
+  # TEMP (tmp-benchmark-leaf-test only): benchmark-nx cannot be workflow_dispatch'd
+  # because the file is not on the default branch. This scoped pull_request trigger
+  # lets a PR into feature-nx-workflow-consolidation fire it so nx-set-shas computes
+  # affected == {llm-llamacpp, diffusion-cpp} from the 2 marker files. Revert before merge.
+  pull_request:
+    branches: [feature-nx-workflow-consolidation]
   workflow_dispatch:
     inputs:
       base-ref:
@@ -85,7 +91,8 @@ jobs:
 
   desktop-benchmarks:
     needs: [matrix, context, prebuild]
-    if: needs.matrix.outputs.any == 'true' && !cancelled() && inputs.run_desktop && needs.prebuild.result == 'success'
+    # TEMP (tmp-benchmark-leaf-test): admit pull_request so the desktop leg runs without inputs.run_desktop. Revert before merge.
+    if: needs.matrix.outputs.any == 'true' && !cancelled() && (inputs.run_desktop || github.event_name == 'pull_request') && needs.prebuild.result == 'success'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/benchmark-performance-nx.yml
+++ b/.github/workflows/benchmark-performance-nx.yml
@@ -81,6 +81,9 @@ jobs:
       packages: write
       pull-requests: write
       id-token: write
+      # prebuilds-nx's prebuild job requests actions: read (reuse action lists
+      # prior runs); the calling job must grant at least that or startup fails.
+      actions: read
     uses: ./.github/workflows/prebuilds-nx.yml
     secrets: inherit
     with:

--- a/.github/workflows/benchmark-performance-nx.yml
+++ b/.github/workflows/benchmark-performance-nx.yml
@@ -45,6 +45,7 @@ jobs:
       matrix: ${{ steps.compute.outputs.matrix }}
       any: ${{ steps.compute.outputs.any }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - id: compute
         uses: ./.github/actions/nx-project-matrix
         with:

--- a/packages/diffusion-cpp/BENCHMARK_TEST_TOUCH.md
+++ b/packages/diffusion-cpp/BENCHMARK_TEST_TOUCH.md
@@ -1,0 +1,4 @@
+# Synthetic touch — benchmark-performance-nx leaf test
+
+Marks diffusion-cpp nx-affected so a scoped `benchmark-performance-nx` dispatch
+runs only {llm-llamacpp (carve-out), diffusion-cpp (folded)}. Delete after the test.

--- a/packages/llm-llamacpp/BENCHMARK_TEST_TOUCH.md
+++ b/packages/llm-llamacpp/BENCHMARK_TEST_TOUCH.md
@@ -1,0 +1,4 @@
+# Synthetic touch — benchmark-performance-nx leaf test
+
+Marks llm-llamacpp nx-affected so a scoped `benchmark-performance-nx` dispatch
+runs only {llm-llamacpp (carve-out), diffusion-cpp (folded)}. Delete after the test.


### PR DESCRIPTION
## What

Throwaway test PR to exercise `benchmark-performance-nx.yml` (never run once).

benchmark-nx is `workflow_dispatch`-only and the file is not on the default
branch, so `gh workflow run` 404s. This PR adds a **temporary** scoped
`pull_request` trigger (base `feature-nx-workflow-consolidation`) plus a one-line
`desktop-benchmarks` `if:` tweak so the desktop leg runs without `inputs.run_desktop`.

Two synthetic marker files (`packages/llm-llamacpp/BENCHMARK_TEST_TOUCH.md`,
`packages/diffusion-cpp/BENCHMARK_TEST_TOUCH.md`) make nx-set-shas compute
`affected == {llm-llamacpp, diffusion-cpp}` — one carve-out + one folded package,
covering the two desktop-benchmark routing paths without running all 5.

benchmark-nx is desktop-only (mobile job removed in 74c9bf524) — no Device Farm.

## Do NOT merge

Throwaway. Revert the trigger, the `if:` tweak, and both marker files before any real merge.
