### PR TITLE
QVAC-23844 doc[audiogen]: compare ACE-Step C++ implementations

### DIFF
--- a/packages/audiogen-ggml/benchmarks/ACESTEP-CPP-COMPARISON.md
+++ b/packages/audiogen-ggml/benchmarks/ACESTEP-CPP-COMPARISON.md
@@ -1,0 +1,538 @@
+# ACE-Step C++ Implementation Comparison
+
+This report compares the QVAC `@qvac/audiogen-ggml` stack with
+`ServeurpersoCom/acestep.cpp`, with Android Adreno OpenCL as the target
+deployment question. It is a source and build comparison, followed by a
+real-device validation plan. It is not a claim that the two projects have been
+benchmarked like-for-like on Adreno.
+
+## Decision summary
+
+QVAC is the more complete base for an Android product integration. Its package,
+engine, ggml fork, mobile prebuilds, backend packaging, and on-device telemetry
+form one integrated path. However, the released `@qvac/audiogen-ggml@0.2.3`
+failed the S25 Ultra acceptance run described below: the process aborted inside
+`ggml_cl_compute_forward` before generation completed. The comparison project
+is the stronger reference for the full ACE-Step workstation/server feature
+set, especially batching, additional task types, model selection, and explicit
+VRAM policy.
+
+The central OpenCL finding is unambiguous:
+
+- The comparison application does not enable or link OpenCL in its CMake
+  targets. Its backend link loop covers CPU, BLAS, CUDA, Metal, Vulkan, and
+  SYCL, but not OpenCL.
+- It has no production Android application build or Android CI lane. Its
+  `buildtermux.sh` is a CPU/BLAS Termux convenience build, not an Android
+  package, NDK integration, OpenCL build, or device validation pipeline.
+- Its pinned ggml fork contains substantial generic, Adreno-aware OpenCL
+  infrastructure and kernels, but OpenCL has no implementation of the two
+  custom VAE operations that the application documents as required:
+  `GGML_OP_SNAKE` and `GGML_OP_COL2IM_1D`.
+- QVAC's resolved `ggml-speech` source implements both operations in OpenCL,
+  and the QVAC engine deliberately prefers OpenCL on Adreno 700+.
+
+Therefore, an Adreno result from QVAC must not be presented as a benchmark of
+the comparison application. It validates QVAC's port and product integration.
+
+## Immutable comparison basis
+
+The audit is pinned to these revisions:
+
+| Component | Immutable revision | Resolution evidence |
+|---|---|---|
+| QVAC monorepo | [`b9dc5d971aef5bf6e1ecc4cb471bc90c3dcf56d6`](https://github.com/tetherto/qvac/tree/b9dc5d971aef5bf6e1ecc4cb471bc90c3dcf56d6) | Local `HEAD` and all local paths in this report |
+| QVAC `speech-cpp` version | `2026-08-18#2`, port tree [`ca390a477fa1815628d4793afb96883681cbfd5d`](https://github.com/tetherto/qvac-registry-vcpkg/tree/ca390a477fa1815628d4793afb96883681cbfd5d) | [`versions/s-/speech-cpp.json`](https://github.com/tetherto/qvac-registry-vcpkg/blob/6abef47d396143286153203be55830d67bf7ed79/versions/s-/speech-cpp.json) |
+| QVAC umbrella engine source | [`tetherto/qvac-ext-lib-whisper.cpp@792b68921bc323a2daff93bc580a15b55ee71b9b`](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/792b68921bc323a2daff93bc580a15b55ee71b9b) | `speech-cpp` [`portfile.cmake`](https://github.com/tetherto/qvac-registry-vcpkg/blob/6abef47d396143286153203be55830d67bf7ed79/ports/speech-cpp/portfile.cmake) sets this exact `REF`; `engines/audiogen` is the `audiogen-cpp` source |
+| QVAC `ggml-speech` source | [`tetherto/qvac-ext-ggml@0a76e3ed969781da6de41d6c9a1c3fc471c0978b`](https://github.com/tetherto/qvac-ext-ggml/tree/0a76e3ed969781da6de41d6c9a1c3fc471c0978b) | `ggml-speech` [`2026-08-18` portfile](https://github.com/tetherto/qvac-registry-vcpkg/blob/e77bde02e7f160e7d0264a4c42446d49b9b18f80/ports/ggml-speech/portfile.cmake) |
+| Comparison application | [`ServeurpersoCom/acestep.cpp@9761469d95fc204b5468623c68a1a2203e50b1f9`](https://github.com/ServeurpersoCom/acestep.cpp/tree/9761469d95fc204b5468623c68a1a2203e50b1f9) | Explicit comparison pin |
+| Comparison ggml submodule | [`ServeurpersoCom/ggml@c044c6f03892f9d5e98213b05f8afea1f8b0d3c9`](https://github.com/ServeurpersoCom/ggml/tree/c044c6f03892f9d5e98213b05f8afea1f8b0d3c9) | `ggml` submodule entry at the application pin |
+
+The exact QVAC engine revision resolved by `speech-cpp 2026-08-18#2` is
+`792b68921bc323a2daff93bc580a15b55ee71b9b`, not the thin addon wrapper's
+monorepo commit.
+
+### Registry reproducibility note
+
+At the QVAC pin, `packages/audiogen-ggml/vcpkg-configuration.json` names
+registry baseline
+[`cf1500e91d595db131c41421d4e1455f9143ec6e`](https://github.com/tetherto/qvac-registry-vcpkg/tree/cf1500e91d595db131c41421d4e1455f9143ec6e),
+while `packages/audiogen-ggml/vcpkg.json` requires `speech-cpp >=
+2026-08-18#2`. The baseline snapshot itself predates that version record; the
+registry version record maps the requested version to immutable port tree
+`ca390a...`, which in turn pins engine source `792b689...`. No package-local
+`vcpkg-lock.json` was present in this checkout. Reproducing the audited build
+should therefore record the resolved vcpkg graph or preserve the corresponding
+binary cache metadata in addition to retaining the manifest and baseline.
+
+## Methodology and limitations
+
+The QVAC wrapper, package build, tests, benchmark harness, and CI were inspected
+locally at the pinned commit. The resolved `speech-cpp`, `audiogen-cpp`,
+`ggml-speech`, comparison application, and comparison ggml sources were
+inspected through read-only GitHub API requests at immutable revisions. No
+external code was downloaded or executed.
+
+Claims in this report are limited to source, build wiring, committed tests,
+committed documentation, and the proposed QVAC measurement protocol:
+
+- No phone benchmark was run.
+- No measured value is inferred from README performance statements or old log
+  files.
+- The two implementations do not expose identical model sets, batching,
+  residency policies, backend selection, or output encoding, so raw timings
+  would need a separately controlled protocol.
+- The comparison application cannot currently produce a genuine OpenCL Adreno
+  row without implementation and build changes. Substituting its Vulkan,
+  desktop, or Termux CPU result would not answer the OpenCL question.
+- QVAC's engine README mentions informal parity observations, but correctly
+  labels them non-reproducible because the model set, command, upstream
+  revision, metric definition, and artifact were not pinned. They are not used
+  as evidence here.
+
+## Stack and architecture
+
+### QVAC
+
+The product call path is:
+
+```text
+AudioGen
+  -> Bare native binding
+  -> qvac::audiogenggml::acestep::AcestepModel
+  -> tts_cpp::acestep::Engine
+  -> LM -> FSQ detokenizer -> text/condition encoders -> DiT -> VAE
+```
+
+The relevant local boundaries are:
+
+- `packages/audiogen-ggml/src/audiogen.ts`: `AudioGenInterface` owns and calls
+  the native handle.
+- `packages/audiogen-ggml/addon/src/js-interface/binding.cpp`:
+  `qvac_audiogen_ggml_exports` exposes lifecycle and job functions to Bare.
+- `packages/audiogen-ggml/addon/src/js-interface/JSAdapter.cpp`:
+  `JSAdapter::buildAcestepConfig` translates the JS configuration.
+- `packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp`:
+  `AcestepModel::loadLocked`, `generate`, and `runtimeStats` call and report the
+  engine.
+- Resolved engine
+  [`engines/audiogen/src/acestep/engine.cpp`](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/blob/792b68921bc323a2daff93bc580a15b55ee71b9b/engines/audiogen/src/acestep/engine.cpp):
+  `Engine::create` selects backends and `Engine::generate` orchestrates stages.
+
+The facade is designed for embedding: it returns interleaved float PCM to the
+addon, which peak-normalizes non-edit output and converts it to interleaved
+Int16 PCM. Progress is reported by stage; final audio is emitted after the full
+generation.
+
+### Comparison application
+
+The comparison project is a standalone application and server. Its
+[`ModelStore`](https://github.com/ServeurpersoCom/acestep.cpp/blob/9761469d95fc204b5468623c68a1a2203e50b1f9/src/model-store.h)
+owns modules shared by three distinct pipelines:
+
+- `pipeline-lm`: caption/lyrics to metadata and audio codes;
+- `pipeline-synth`: text/condition encoding, DiT, and VAE synthesis;
+- `pipeline-understand`: audio to metadata, lyrics, and codes.
+
+It builds an HTTP server, dedicated CLI tools, a standalone VAE codec, an MP3
+codec, and a quantizer. This separation makes pipeline stages independently
+callable and allows latent reuse between endpoints. QVAC instead presents a
+smaller embedded `Engine` contract optimized for addon lifecycle, cancellation,
+progress, and consistent multi-platform packaging.
+
+## Models, tasks, and controls
+
+| Area | QVAC addon and resolved engine | Comparison application |
+|---|---|---|
+| ACE-Step model set | QVAC registry combinations use Qwen3-Embedding 0.6B Q8, ACE-Step LM 0.6B Q8, BF16 VAE, and `turbo-q4`, `turbo-q8`, or `sft` DiT | LM 0.6B/1.7B/4B; turbo, SFT, base, shift, continuous, and documented XL DiTs; multiple quantizations |
+| Additional architecture | Resolved `audiogen-cpp` also contains desktop-only, CPU-only MiniMax-Music3; `@qvac/audiogen-ggml` binds `tts_cpp::acestep::Engine`, not MiniMax | ACE-Step only |
+| Generation | Text/lyrics, language, BPM, key, time signature, duration, fixed or random seed, metadata caption augmentation | Same core controls, plus independent LM seed, negative prompt, and LM modes |
+| Sampling | Turbo/base auto steps and shift, LM temperature/top-p/top-k/CFG, DCW controls | Custom timesteps, Euler/SDE/DPM3M/STORK4 solvers, latent shift/rescale, CFG split control, FP16 clamp |
+| Audio conditioning | Timbre reference, source audio, `cover-nofsq`; full FSQ `cover` is accepted but not implemented | Cover, cover-nofsq, repaint/outpaint, lego, extract, and complete |
+| Editing | Ordered, repeatable FlowEdit and repaint operations; FlowEdit is deliberately restricted to its validated Turbo/Euler/no-CFG path | Region repaint/outpaint and source tasks; broader task dispatcher |
+| Reverse and codec paths | No addon reverse-understand or standalone VAE endpoint | Understand pipeline and standalone VAE encode/decode endpoint; latent inputs can bypass repeated VAE encoding |
+| Output | 48 kHz stereo Int16 PCM at addon boundary; package encoding helpers can produce files | 48 kHz stereo WAV16/WAV24/WAV32 or MP3 |
+| Adapters | Not exposed by the QVAC ACE-Step API | PEFT and ComfyUI LoRA adapter selection and scale |
+
+The comparison project has greater ACE-Step surface area. QVAC has the more
+deliberate embedded API, mobile constraints, fallback telemetry, and ordered
+editing contract.
+
+## Android and OpenCL wiring
+
+### QVAC path
+
+QVAC's Android dependency is explicit in
+[`packages/audiogen-ggml/vcpkg.json`](https://github.com/tetherto/qvac/blob/b9dc5d971aef5bf6e1ecc4cb471bc90c3dcf56d6/packages/audiogen-ggml/vcpkg.json):
+
+```text
+speech-cpp[audiogen,vulkan,opencl]
+```
+
+That expands through `speech-cpp` into `ggml-speech[vulkan,opencl]`. The
+resolved `ggml-speech` port enables `GGML_BACKEND_DL`,
+`GGML_CPU_ALL_VARIANTS`, and `GGML_CPU_REPACK` on Android, disables Vulkan
+cooperative-matrix paths there, and installs generated backend modules.
+
+QVAC then completes the runtime path:
+
+1. `packages/audiogen-ggml/CMakeLists.txt` enumerates
+   `GGML_AVAILABLE_BACKENDS` and packages backend targets and loose
+   `libqvac-speech-ggml-*.so` modules beside the `.bare` addon.
+2. It applies Android 16 KiB ELF page-size linker options.
+3. `AcestepModel::loadLocked` composes the per-target backend directory and
+   passes `EngineOptions::backends_dir`.
+4. Resolved engine symbol
+   [`load_backends`](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/blob/792b68921bc323a2daff93bc580a15b55ee71b9b/engines/audiogen/src/acestep/backend_registry.h)
+   calls `ggml_backend_load_all_from_path` before backend acquisition.
+5. `backend_gpu_init` accepts discrete and integrated devices, tries every
+   candidate, and explicitly prefers an OpenCL device whose name or description
+   identifies Adreno 700+.
+6. `resolve_stage_placement` keeps DiT and VAE on the selected GPU and uses a
+   measured allowlist for encoders, LM, and FSQ detokenizer. OpenCL on Adreno
+   740 is the committed validation basis for LM and detokenizer placement.
+7. `AcestepModel::runtimeStats` maps the resolved engine backend name to
+   `backendDevice` and `backendId`, so CPU or Vulkan fallback is observable.
+
+Mobile smoke tests currently accept Vulkan (`backendId=3`) or OpenCL
+(`backendId=4`) for a general GPU request. The Adreno validation defined below
+is intentionally stricter: it requires `backendId=4`.
+
+### Comparison application path
+
+The pinned application
+[`CMakeLists.txt`](https://github.com/ServeurpersoCom/acestep.cpp/blob/9761469d95fc204b5468623c68a1a2203e50b1f9/CMakeLists.txt)
+adds the ggml submodule and links known backend targets in
+`link_ggml_backends`. OpenCL is absent from that target list. The documented
+builds and committed CI cover desktop CPU, CUDA, Metal, and Vulkan. The
+[`ci-build.yml`](https://github.com/ServeurpersoCom/acestep.cpp/blob/9761469d95fc204b5468623c68a1a2203e50b1f9/.github/workflows/ci-build.yml)
+matrix is Ubuntu and macOS only.
+
+The repository's
+[`buildtermux.sh`](https://github.com/ServeurpersoCom/acestep.cpp/blob/9761469d95fc204b5468623c68a1a2203e50b1f9/buildtermux.sh)
+enables BLAS and performs a local CMake build in Termux. It does not enable
+OpenCL, use the Android NDK, package backend modules, build an APK/AAR/Bare
+module, or run Android CI. It is not a production Android path.
+
+## OpenCL operation gap and Adreno hardening
+
+The comparison application's VAE documentation says
+`GGML_OP_SNAKE` and `GGML_OP_COL2IM_1D` are required. At pinned ggml commit
+`c044c6f...`, implementations exist for CPU and selected GPU backends, including
+CUDA/Vulkan/SYCL paths, but its `src/ggml-opencl/kernels` tree contains neither
+`snake.cl` nor `col2im_1d.cl`. The application therefore cannot merely add
+`opencl` to its backend target loop; the VAE graph would still lack required
+OpenCL operations.
+
+This does not mean its ggml fork lacks Adreno work. Its pinned
+[`ggml-opencl.cpp`](https://github.com/ServeurpersoCom/ggml/blob/c044c6f03892f9d5e98213b05f8afea1f8b0d3c9/src/ggml-opencl/ggml-opencl.cpp)
+contains Adreno generation and compiler detection, Qualcomm large-buffer
+handling, Adreno kernel selection, compiler-version exclusions, and generic
+matrix/attention kernels. Those facilities are valuable but do not fill the
+two application-specific VAE operation gaps.
+
+QVAC's resolved ggml source contains:
+
+- OpenCL
+  [`snake.cl`](https://github.com/tetherto/qvac-ext-ggml/blob/0a76e3ed969781da6de41d6c9a1c3fc471c0978b/src/ggml-opencl/kernels/snake.cl)
+  and
+  [`col2im_1d.cl`](https://github.com/tetherto/qvac-ext-ggml/blob/0a76e3ed969781da6de41d6c9a1c3fc471c0978b/src/ggml-opencl/kernels/col2im_1d.cl),
+  plus backend dispatch for the corresponding ggml operations;
+- `ggml_opencl_should_use_wide_gemv`, which checks a compiled kernel's actual
+  `CL_KERNEL_WORK_GROUP_SIZE` before selecting a wide Adreno GEMV launch;
+- `kernel_diag_mask_inf_8` bounds checks and a host launch rounded to a safe
+  local size, using wide unsigned element counts for padded work-items;
+- `log_opencl_enqueue_failure`, which preserves kernel/op/global/local-size
+  diagnostics in normal and profiling builds;
+- tests `test-opencl-workgroup` and backend-op coverage for these launch rules;
+- engine-side `parse_adreno_version`, `backend_dev_prefers_opencl`, and
+  `backend_gpu_init`, which prevent generic backend enumeration order from
+  selecting Vulkan first on a validated Adreno OpenCL device.
+
+These are concrete integration and compiler/driver hardenings, not a generic
+claim that every Adreno device or driver is supported.
+
+## Memory, residency, and batching
+
+### QVAC
+
+Resolved `Engine::Impl` defaults to sequential stage residency. `Engine::create`
+reads lightweight metadata, while `Engine::generate` uses `ensure_*` immediately
+before a stage and `free_*` after it. The design bounds model weight residency
+to roughly one major stage instead of retaining all six runtime weight sets,
+which is important under Android/iOS memory pressure.
+
+`ACESTEP_KEEP_STAGES` is an opt-in latency/throughput mode that eagerly loads
+and retains stages. VAE decode separately adapts its window to the backend's
+allocation cap. The public addon handles one generation job per model instance;
+there is no exposed LM or DiT multi-song batch.
+
+Strength: conservative mobile peak memory and simple lifecycle. Weakness:
+repeated requests can repay model load costs unless stage retention is enabled,
+and the addon does not expose the richer throughput controls.
+
+### Comparison application
+
+`ModelStore` formalizes two policies:
+
+- `EVICT_STRICT`: at most one GPU module resident at a time;
+- `EVICT_NEVER` (`--keep-loaded`): retain the complete working set.
+
+It shares one LM instance between generation and understand pipelines, caches
+small CPU metadata, uses keyed/refcounted module handles, and exposes VAE tile
+size and overlap. It also supports LM batches and synth batches; the synthesis
+dispatcher accepts batches up to nine and combines request arrays with
+`synth_batch_size`.
+
+Strength: explicit server-grade residency and batching model. Weakness: more
+policy surface and fewer product-level mobile constraints or telemetry.
+
+## Tests and benchmark evidence
+
+QVAC has coverage at three levels:
+
+- Resolved engine C++ unit and integration tests under
+  [`engines/audiogen/test`](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/792b68921bc323a2daff93bc580a15b55ee71b9b/engines/audiogen/test),
+  including stage-placement policy, deterministic logic, editing, model-backed
+  API generation, progress, and cancellation.
+- Addon unit/integration/mobile tests under
+  `packages/audiogen-ggml/test`, including lifecycle, output format, memory,
+  backend reporting, registry model resolution, and CPU/GPU generation.
+- RTF infrastructure in
+  `packages/audiogen-ggml/benchmarks/RTF-BENCHMARKS.md`,
+  `packages/audiogen-ggml/test/utils/benchmark-runner.js`, and
+  `scripts/perf-report/aggregate-audiogen-ggml-rtf.js`. It records requested
+  and observed backends separately, load time, wall time, RTF, RSS, model size,
+  audio duration, sample format, and signal energy.
+
+The comparison project compiles `test-philox`, `test-model-store`, and
+`test-lm-prompt`; it also commits CPU/CUDA/Metal/Vulkan comparison logs and
+debug cosine scripts. Its CI builds and smoke-checks tools but does not download
+models or run full generation. There is no committed Android/OpenCL lane or
+controlled Adreno benchmark.
+
+Neither repository supplies a pinned, like-for-like cross-implementation
+Adreno benchmark at these revisions.
+
+## Build reproducibility, license, and provenance
+
+QVAC:
+
+- pins the monorepo, vcpkg port trees, engine source, and ggml source through
+  manifests and immutable Git references;
+- builds a library-only `speech-cpp[audiogen]` engine with a shared
+  `ggml-speech` dependency and turns engine tests/executables off in the
+  consumer port;
+- uses QVAC registry model paths and named four-file combinations; the model
+  manifest identifies the `2026-07-22` build folder;
+- licenses `@qvac/audiogen-ggml` under Apache-2.0, with `audiogen-cpp` and ggml
+  components under MIT and component attribution in
+  `packages/audiogen-ggml/NOTICE`;
+- must preserve model-weight and upstream model terms separately from code
+  licenses.
+
+The comparison project:
+
+- pins its ggml submodule at the audited commit and embeds its application Git
+  revision into binaries;
+- offers build scripts, but distributed dependency/toolchain inputs are less
+  centrally pinned than QVAC's vcpkg graph;
+- publishes and documents broader Hugging Face GGUF choices, so a benchmark
+  must record exact filenames, sizes, and hashes rather than only "turbo";
+- is MIT licensed, while ACE-Step model weights and original model code retain
+  their own terms and provenance.
+
+Both projects credit ACE-Step 1.5. Code-license compatibility does not grant
+rights to redistribute model weights.
+
+## Strengths and weaknesses
+
+### QVAC
+
+Strengths:
+
+- complete embedded addon path across JS, Bare, C++, ggml, prebuilds, and mobile
+  CI;
+- explicit Android Vulkan/OpenCL features and dynamic backend packaging;
+- required VAE operations implemented on OpenCL;
+- Adreno 700+ OpenCL preference and backend-specific stage placement;
+- resolved backend telemetry that exposes fallback;
+- low-memory sequential residency, cancellation, progress, and structured RTF
+  reporting.
+
+Weaknesses:
+
+- narrower ACE-Step model/task/control surface;
+- no public multi-song batching;
+- no reverse-understand or latent-service API;
+- the attempted S25 Ultra OpenCL acceptance run aborted inside ggml's OpenCL
+  compute path before producing audio or backend telemetry;
+- registry resolution should be captured more completely for audit-grade build
+  replay.
+
+### Comparison application
+
+Strengths:
+
+- broadest ACE-Step feature surface and workstation/server tooling;
+- clear `ModelStore` policy, multi-request batching, adapters, alternate
+  solvers, reverse understanding, latent reuse, and codec tools;
+- useful per-stage debugging and parity workflow;
+- broad desktop backend source and committed reference logs.
+
+Weaknesses for this target:
+
+- no linked OpenCL application path;
+- required VAE OpenCL operations are missing;
+- no production Android packaging or CI;
+- no authoritative runtime backend telemetry equivalent to the addon's
+  `backendId`;
+- broader options make an uncontrolled benchmark easier to misconfigure.
+
+## Ranked recommendations
+
+### 1. Adopt or match
+
+1. Treat the S25 Ultra `ggml_cl_compute_forward` abort as a release-readiness
+   blocker for ACE-Step on Adreno OpenCL. Symbolize the failing OpenCL frames,
+   identify the operation or enqueue error, fix it, and rerun this protocol.
+2. Keep QVAC as the Android/Adreno implementation and validation vehicle.
+3. Keep observed backend identity authoritative. Require `backendId=4` for the
+   Adreno OpenCL acceptance run; reject Vulkan or CPU fallback.
+4. Preserve QVAC's dynamic backend packaging, 16 KiB Android linker settings,
+   OpenCL VAE operations, per-kernel workgroup validation, padded dispatch
+   safety, and enqueue diagnostics.
+5. Match the comparison project's explicit residency vocabulary in engineering
+   documentation: low-memory/strict versus keep-loaded, including load-time and
+   peak-memory consequences.
+6. Match its benchmark provenance discipline where useful: exact model
+   filenames/hashes, engine and ggml commits, full device/driver/build identity,
+   and cold versus steady-state runs.
+
+### 2. Evaluate separately
+
+1. Multi-song LM/DiT batching and server-oriented stage retention.
+2. Full `cover`, lego/extract/complete, understand, and latent reuse.
+3. Independent LM seed/negative prompt, custom timesteps, and alternate
+   solvers.
+4. Adapter support and larger LM/DiT variants.
+5. VAE chunk/overlap tuning as a supported API only after mobile quality and
+   memory tests establish safe bounds.
+
+Each item changes API, memory, numerical behavior, or product scope and should
+have its own design and validation work.
+
+### 3. Do not copy directly
+
+1. Do not copy the comparison application's backend link loop for Android; it
+   omits OpenCL and QVAC needs dynamic modules.
+2. Do not treat `buildtermux.sh` as an Android product build.
+3. Do not import generic Adreno OpenCL kernels and assume ACE-Step works; the
+   two custom VAE operations and host dispatch are mandatory.
+4. Do not copy desktop batch or keep-loaded defaults onto phones without
+   memory-pressure evidence.
+5. Do not publish the comparison project's old logs or README timings as
+   QVAC, OpenCL, or like-for-like evidence.
+
+## QVAC real-device validation
+
+Attempt 1 was run on 2026-08-20 through AWS Device Farm:
+[workflow run 32359647987](https://github.com/tetherto/qvac/actions/runs/32359647987).
+The workflow-level conclusion is `success` because the mobile job is
+non-blocking, but the `Build Android and Run E2E Tests` job and Device Farm run
+failed. The app aborted with `SIGABRT` about 12 seconds after
+`testGenerateMusicOnGpu` started. The native backtrace contains
+`ggml_abort`, `ggml_cl_compute_forward`, `ggml_backend_graph_compute`, and
+`tts_cpp::acestep::Engine::generate`, proving execution reached the OpenCL
+backend before the crash. No audio, resolved `backendId`, or benchmark summary
+was emitted.
+
+This is a failed acceptance result, not an OpenCL performance result. Preserve
+the protocol and remaining fields below for the rerun after the native abort is
+diagnosed.
+
+### Acceptance protocol
+
+- Model: `turbo-q4`, recording all four exact GGUF filenames and hashes.
+- Prompt: fixed and recorded verbatim.
+- Lyrics: `[Instrumental]`.
+- Seed: fixed and recorded.
+- Requested duration: 10-15 seconds; use one value for all runs.
+- GPU request: enabled.
+- OpenCL reporting hint:
+  `QVAC_AUDIOGEN_GGML_BENCHMARK_BACKEND=opencl`.
+- Warmup: one cold run immediately after load.
+- Measured runs: at least two steady-state runs.
+- Required observed backend: `activeBackend=opencl` and `backendId=4`.
+- Output gate: 48,000 Hz, two channels, non-empty, finite signal with recorded
+  peak and RMS.
+
+> `QVAC_AUDIOGEN_GGML_BENCHMARK_BACKEND=opencl` is a reporting hint, not a
+> runtime backend selector. It cannot prove OpenCL execution. The resolved
+> `activeBackend` and `backendId` telemetry are authoritative. A row with
+> `backendId=3`, `0`, `99`, or missing telemetry fails this OpenCL validation,
+> regardless of the requested label.
+
+### Build and device identity
+
+| Field | Value |
+|---|---|
+| QVAC commit | `b9dc5d971aef5bf6e1ecc4cb471bc90c3dcf56d6` |
+| Resolved `speech-cpp` | `2026-08-18#2` / port tree `ca390a477fa1815628d4793afb96883681cbfd5d` |
+| Resolved engine source | `792b68921bc323a2daff93bc580a15b55ee71b9b` |
+| Resolved `ggml-speech` source | `0a76e3ed969781da6de41d6c9a1c3fc471c0978b` |
+| Prebuild package/artifact identifier | `@qvac/audiogen-ggml@0.2.3`; native `libqvac__audiogen-ggml.0.2.3.so` |
+| Build run ID and attempt | [`32359647987`, attempt 1](https://github.com/tetherto/qvac/actions/runs/32359647987) |
+| Build type/toolchain/NDK | Device Farm workflow build; exact toolchain/NDK not captured in the collected evidence |
+| Device manufacturer/model | Samsung Galaxy S25 Ultra |
+| Device hardware identifier | `pa3quew`; model/build family `S938U1` |
+| Android version/API level/build fingerprint | Android 15; `samsung/pa3quew/pa3q:15/AP3A.240905.015.A2/S938U1UEU1AYA1_OYM1AYA1:user/release-keys`; API level not captured |
+| SoC | Not captured in the collected evidence |
+| GPU | Adreno device; exact reported model string not captured |
+| OpenCL driver/device version | Not captured; Vulkan initialization separately reported compiler `E031.47.18.13` and driver `0800.17.11`, which must not be substituted for OpenCL identity |
+| Available RAM before run | Not captured |
+
+### Fixed workload
+
+| Field | Value |
+|---|---|
+| DiT variant | `turbo-q4` |
+| Text encoder GGUF and SHA-256 | `Qwen3-Embedding-0.6B-Q8_0.gguf`; hash not captured |
+| LM GGUF and SHA-256 | `acestep-5Hz-lm-0.6B-Q8_0.gguf`; hash not captured |
+| DiT GGUF and SHA-256 | `acestep-v15-turbo-Q4_K_M.gguf`; hash not captured |
+| VAE GGUF and SHA-256 | `vae-BF16.gguf`; hash not captured |
+| Total model size | `3,277,122,816` bytes (`3.05` GiB), from the four Device Farm push records |
+| Prompt | `Upbeat pop rock with driving electric guitars, punchy drums and a catchy hook` |
+| Lyrics | `[Instrumental]` |
+| Seed | Not specified by `testGenerateMusicOnGpu` |
+| Requested duration | `10` seconds |
+| Inference steps/shift | `8` / `3.0` |
+| Warmup/measured run count | `0` completed / `0` measured; process aborted during the first generation |
+
+### Observed results
+
+| Metric | Value |
+|---|---|
+| Acceptance result | **FAILED — native `SIGABRT` in OpenCL compute path** |
+| Requested backend hint | No reporting hint captured for this functional-test dispatch |
+| `activeBackend` | Not emitted; native stack reached `ggml_cl_compute_forward` |
+| `backendId` | Not emitted; required value `4` therefore not proven through runtime telemetry |
+| `backendDevice` | Not emitted |
+| Model load time | Not emitted |
+| Cold wall time | Not completed; test started at `10:46:32.645Z`, process aborted at `10:46:45.073Z` |
+| Mean measured wall time | Not available |
+| Cold RTF | Not available |
+| Mean RTF | Not available |
+| Average RSS | Not available |
+| Last observed process PSS | `1,025,273,856` bytes immediately before the abort |
+| Output duration | No output |
+| Sample rate | Not observed |
+| Channels | Not observed |
+| Peak amplitude | Not available |
+| RMS amplitude | Not available |
+| Artifact/report path | GitHub artifact `console-logs-qvac-audiogen-ggml-Android` on run `32359647987` |
+| Run notes, thermal state, and failures | Test result JSON: `crashed: true`, 0 passed/0 failed, test remained `running`; native backtrace: `ggml_abort` → `ggml_cl_compute_forward` → `ggml_backend_graph_compute` → `Engine::generate` |
+
+Record both the machine-readable benchmark artifact and the exact generated
+WAV. If any measured run reports a different backend ID, keep the artifact as
+fallback evidence but do not include it as OpenCL coverage.

--- a/packages/audiogen-ggml/benchmarks/ACESTEP-CPP-COMPARISON.md
+++ b/packages/audiogen-ggml/benchmarks/ACESTEP-CPP-COMPARISON.md
@@ -3,19 +3,25 @@
 This report compares the QVAC `@qvac/audiogen-ggml` stack with
 `ServeurpersoCom/acestep.cpp`, with Android Adreno OpenCL as the target
 deployment question. It is a source and build comparison, followed by a
-real-device validation protocol and its first attempted result. It is not a
-claim that the two projects have been benchmarked like-for-like on Adreno.
+real-device validation protocol run against three Adreno 830 attempts: a
+failed attempt on the released `@qvac/audiogen-ggml@0.2.3` prebuild, and two
+passing attempts on a fresh build of the current pinned ggml-speech. It is
+not a claim that the two projects have been benchmarked like-for-like on
+Adreno.
 
 ## Decision summary
 
 QVAC is the more complete base for an Android product integration. Its package,
 engine, ggml fork, mobile prebuilds, backend packaging, and on-device telemetry
-form one integrated path. However, the released `@qvac/audiogen-ggml@0.2.3`
-failed the S25 Ultra acceptance run described below: the process aborted inside
-`ggml_cl_compute_forward` before generation completed. The comparison project
-is the stronger reference for the full ACE-Step workstation/server feature
-set, especially batching, additional task types, model selection, and explicit
-VRAM policy.
+form one integrated path. The released `@qvac/audiogen-ggml@0.2.3` prebuild
+predates the current ggml-speech pin and aborts inside
+`ggml_cl_compute_forward` on Adreno OpenCL. A fresh build against the current
+pinned `speech-cpp 2026-08-18#2` → `ggml-speech 2026-08-18#0` →
+`qvac-ext-ggml@0a76e3ed` passes the same S25 Ultra functional acceptance and
+produces a controlled RTF benchmark row (mean RTF 2.20 on `turbo-q4`, observed
+backend `opencl`). The comparison project is the stronger reference for the
+full ACE-Step workstation/server feature set, especially batching, additional
+task types, model selection, and explicit VRAM policy.
 
 The central OpenCL finding is unambiguous:
 
@@ -76,8 +82,10 @@ external code was downloaded or executed.
 Claims in this report are limited to source, build wiring, committed tests,
 committed documentation, and the proposed QVAC measurement protocol:
 
-- A phone functional acceptance run was attempted; it crashed before any
-  benchmark measurement completed.
+- Two phone functional acceptance runs were performed. The first, on the
+  released `@qvac/audiogen-ggml@0.2.3` prebuild, aborted before any output was
+  produced. The second, on a fresh build of the current pinned ggml-speech,
+  passed; a subsequent RTF benchmark row was captured on the same device.
 - No measured value is inferred from README performance statements or old log
   files.
 - The two implementations do not expose identical model sets, batching,
@@ -366,8 +374,10 @@ Weaknesses:
 - narrower ACE-Step model/task/control surface;
 - no public multi-song batching;
 - no reverse-understand or latent-service API;
-- the attempted S25 Ultra OpenCL acceptance run aborted inside ggml's OpenCL
-  compute path before producing audio or backend telemetry;
+- the released `@qvac/audiogen-ggml@0.2.3` prebuild predates the current
+  ggml-speech pin and aborts inside ggml's OpenCL compute path on Adreno; a
+  fresh build against the current pin passes on the same device (see
+  §QVAC real-device validation, Attempts 2-3);
 - registry resolution should be captured more completely for audit-grade build
   replay.
 
@@ -394,9 +404,13 @@ Weaknesses for this target:
 
 ### 1. Adopt or match
 
-1. Treat the S25 Ultra `ggml_cl_compute_forward` abort as a release-readiness
-   blocker for ACE-Step on Adreno OpenCL. Symbolize the failing OpenCL frames,
-   identify the operation or enqueue error, fix it, and rerun this protocol.
+1. Publish a new `@qvac/audiogen-ggml` release built against the current
+   pinned `speech-cpp 2026-08-18#2` (which resolves to
+   `qvac-ext-ggml@0a76e3ed`). The Adreno OpenCL abort observed on
+   `@qvac/audiogen-ggml@0.2.3` no longer reproduces at that pin, but the
+   published npm/GPR prebuilds still ship the older ggml-speech and will
+   continue to fail on Adreno until a re-release. No monorepo or engine code
+   change is required to unblock downstream consumers.
 2. Keep QVAC as the Android/Adreno implementation and validation vehicle.
 3. Keep observed backend identity authoritative. Require `backendId=4` for the
    Adreno OpenCL acceptance run; reject Vulkan or CPU fallback.
@@ -437,7 +451,14 @@ have its own design and validation work.
 
 ## QVAC real-device validation
 
-Attempt 1 was run on 2026-08-20 through AWS Device Farm:
+Three attempts have been run against the QVAC ACE-Step stack on Adreno 830
+(Samsung Galaxy S25 Ultra, AWS Device Farm). Attempt 1 records the failure that
+motivated this report; Attempts 2 and 3 demonstrate that the current pinned
+ggml-speech resolves it without any monorepo or engine code change.
+
+### Attempt 1 (released `@qvac/audiogen-ggml@0.2.3` prebuild) — FAILED
+
+Run on 2026-08-20 through AWS Device Farm:
 [workflow run 32359647987](https://github.com/tetherto/qvac/actions/runs/32359647987).
 The workflow-level conclusion is `success` because the mobile job is
 non-blocking, but the `Build Android and Run E2E Tests` job and Device Farm run
@@ -448,11 +469,101 @@ failed. The app aborted with `SIGABRT` about 12 seconds after
 backend before the crash. No audio, resolved `backendId`, or benchmark summary
 was emitted.
 
-This is a failed acceptance result, not an OpenCL performance result. Preserve
-the protocol and remaining fields below for the rerun after the native abort is
-diagnosed.
+Offline symbolization of `libqvac-speech-ggml-opencl.so`
+(BuildId `13fffdcb9ecdef2be204e610b0dfb6d1faaa35d9`, extracted from the
+published `@qvac/audiogen-ggml@0.2.3` prebuild tarball) resolves the direct
+caller of `ggml_abort` to `ggml_cl_mul_mat_q8_0_f32_adreno` — the Adreno
+fast-path Q8_0 × F32 matmul used by the LM decode GEMV. The `#err`
+stringification recovered from `.rodata` corresponds to
+`CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, work_dim, NULL,
+global_work_size, local_work_size, 0, NULL, NULL))`. The exact CL error code
+returned by the driver is not recoverable from the 0.2.3 build: its
+`enqueue_ndrange_kernel` wrapper uses a plain `CL_CHECK` and does not print the
+error code, failing kernel name, or workgroup sizes before aborting.
 
-### Acceptance protocol
+The current pinned ggml-speech (Attempts 2-3) ships an updated
+`enqueue_ndrange_kernel` wrapper that logs those diagnostics through
+`__android_log_write(ANDROID_LOG_ERROR, "ggml-opencl", ...)` before asserting.
+Attempt 2 emits no such line because the abort no longer occurs.
+
+### Attempt 2 (fresh build at current pinned ggml-speech) — PASSED (functional smoke)
+
+Run on 2026-08-20 through AWS Device Farm:
+[workflow run 32409871856](https://github.com/tetherto/qvac/actions/runs/32409871856).
+Built from `main` with no `prebuild_package` input, so the mobile app was
+compiled against the current pinned `speech-cpp 2026-08-18#2` →
+`ggml-speech 2026-08-18#0` → `qvac-ext-ggml@0a76e3ed969781da6de41d6c9a1c3fc471c0978b`.
+`testGenerateMusicOnGpu` **passed** in 30.96 s on the same Samsung Galaxy S25
+Ultra device. The bare console emitted
+`[audiogen/GPU] backendDevice=1 backendId=4 (OpenCL)` — the authoritative
+`AcestepModel::runtimeStats` mapping, not the requested-backend hint — and
+the test's own `_requireGpuBackend` gate would have thrown if the resolved
+backend had been anything other than Vulkan or OpenCL. No CPU-fallback
+diagnostic appears in the log.
+
+This is the smallest change that resolves Attempt 1: the monorepo pin was
+already advanced to `speech-cpp 2026-08-18#2` before Attempt 1 ran, but the
+published `@qvac/audiogen-ggml@0.2.3` prebuild ships an older ggml-speech
+without the fix.
+
+### Attempt 3 (RTF benchmark on the same fresh build) — PASSED
+
+Run on 2026-08-20 through the mobile benchmark lane:
+[workflow run 32412564427](https://github.com/tetherto/qvac/actions/runs/32412564427).
+`run_desktop=false`, `run_mobile=true`, full DiT variant sweep on the default
+Android/iOS mobile pool. The Adreno OpenCL row for `turbo-q4` on the same
+Samsung Galaxy S25 Ultra:
+
+| Field | Value |
+|---|---|
+| Observed backend / execution provider | `opencl` / `gpu` |
+| Requested backend | `vulkan` (Adreno 700+ preference in `backend_gpu_init` routed to OpenCL, per §Android and OpenCL wiring) |
+| DiT variant | `turbo-q4` |
+| Clip duration (mean) | 14.72 s |
+| Mean RTF | **2.199** |
+| Cold RTF | 2.058 |
+| P50 / P95 RTF | 2.199 / 2.256 |
+| Mean wall time | 32.4 s |
+| Model load time | 9.18 s |
+| Avg RSS | 630 MB |
+| Peak RSS | 1577 MB (~1.54 GiB) |
+| Reclaimed after destroy | 0 MB |
+| Sample count | 2 measured runs (+ 1 warmup) |
+| Noisy | false (`stddev / mean < 15%`) |
+| Artifact | `perf-report-audiogen-ggml-Android-turbo-q4-gpu-7/Samsung_Galaxy_S25_Ultra/performance-report.json` on [run 32412564427](https://github.com/tetherto/qvac/actions/runs/32412564427) |
+
+The full Android matrix that landed in the same run, for context (not the
+subject of this report — it does not turn a QVAC-only measurement into a
+matched two-engine comparison):
+
+| Device (GPU) | Variant | Provider | Backend | Mean RTF | Wall (ms) | Peak RSS (MB) |
+|---|---|---|---|---:|---:|---:|
+| **Samsung Galaxy S25 Ultra (Adreno 830)** | **turbo-q4** | **gpu** | **opencl** | **2.199** | **32401** | **1577** |
+| Samsung Galaxy S25 Ultra (Adreno 830) | turbo-q4 | cpu | cpu | 8.493 | 122331 | 2205 |
+| Samsung Galaxy S25 Ultra (Adreno 830) | turbo-q8 | gpu | opencl | 1.957 | 28824 | 1968 |
+| Samsung Galaxy S25 Ultra (Adreno 830) | turbo-q8 | cpu | cpu | 7.344 | 105771 | 2173 |
+| Samsung Galaxy S25 Ultra (Adreno 830) | sft | gpu | opencl | 4.698 | 43261 | 2061 |
+| Samsung Galaxy S25 Ultra (Adreno 830) | sft | cpu | cpu | 19.012 | 174961 | 2029 |
+| Google Pixel 9a (Mali) | turbo-q4 | gpu | vulkan | 12.925 | 187761 | 3243 |
+| Google Pixel 9 (Tensor CPU) | turbo-q4 | cpu | cpu | 15.201 | 220822 | 2177 |
+| Google Pixel 9 Pro XL (Mali) | sft | gpu | vulkan | 47.944 | 441218 | 3189 |
+
+Cross-device observations, without extrapolating beyond these rows:
+
+- On Adreno 830, the QVAC OpenCL path is **~3.9× faster than the same device
+  on CPU** for `turbo-q4` (RTF 2.199 vs 8.493), and ~3.8× for `turbo-q8`
+  (1.957 vs 7.344).
+- The Pixel 9a Mali Vulkan `turbo-q4` row (RTF 12.925) is **~5.9× slower**
+  than the S25 Ultra Adreno OpenCL `turbo-q4` row (2.199). CI does not reach
+  Adreno with Vulkan on the same device, so this is a device-vs-device
+  observation, not a backend-vs-backend claim on identical hardware.
+- The Adreno OpenCL `turbo-q8` row (1.957) is fractionally faster than the
+  `turbo-q4` row (2.199). Both variants share the specialized
+  `ggml_cl_mul_mat_q8_0_f32_adreno` fast path for the Q8_0 LM; the spread is
+  within the sample-count-2 measurement floor and is not treated as a general
+  quantization tradeoff claim.
+
+### Acceptance protocol (unchanged; used for all three attempts)
 
 - Model: `turbo-q4`, recording all four exact GGUF filenames and hashes.
 - Prompt: fixed and recorded verbatim.
@@ -476,64 +587,60 @@ diagnosed.
 
 ### Build and device identity
 
-| Field | Value |
-|---|---|
-| QVAC commit | `b9dc5d971aef5bf6e1ecc4cb471bc90c3dcf56d6` |
-| Resolved `speech-cpp` | `2026-08-18#2` / port tree `ca390a477fa1815628d4793afb96883681cbfd5d` |
-| Resolved engine source | `792b68921bc323a2daff93bc580a15b55ee71b9b` |
-| Resolved `ggml-speech` source | `0a76e3ed969781da6de41d6c9a1c3fc471c0978b` |
-| Prebuild package/artifact identifier | `@qvac/audiogen-ggml@0.2.3`; native `libqvac__audiogen-ggml.0.2.3.so` |
-| Build run ID and attempt | [`32359647987`, attempt 1](https://github.com/tetherto/qvac/actions/runs/32359647987) |
-| Build type/toolchain/NDK | Device Farm workflow build; exact toolchain/NDK not captured in the collected evidence |
-| Device manufacturer/model | Samsung Galaxy S25 Ultra |
-| Device hardware identifier | `pa3quew`; model/build family `S938U1` |
-| Android version/API level/build fingerprint | Android 15; `samsung/pa3quew/pa3q:15/AP3A.240905.015.A2/S938U1UEU1AYA1_OYM1AYA1:user/release-keys`; API level not captured |
-| SoC | Not captured in the collected evidence |
-| GPU | Adreno device; exact reported model string not captured |
-| OpenCL driver/device version | Not captured; Vulkan initialization separately reported compiler `E031.47.18.13` and driver `0800.17.11`, which must not be substituted for OpenCL identity |
-| Available RAM before run | Not captured |
+| Field | Attempt 1 (FAILED) | Attempts 2-3 (PASSED) |
+|---|---|---|
+| QVAC monorepo commit at build | `b9dc5d971aef5bf6e1ecc4cb471bc90c3dcf56d6` | `main` at dispatch time (`27da3551b255d3a5d76fa38ff1c511e3c9d87846` for Attempt 2/3) |
+| Resolved `speech-cpp` | `2026-08-18#2` | `2026-08-18#2` |
+| Resolved `speech-cpp` port tree | `ca390a477fa1815628d4793afb96883681cbfd5d` | `ca390a477fa1815628d4793afb96883681cbfd5d` |
+| Resolved engine source (`qvac-ext-lib-whisper.cpp`) | `792b68921bc323a2daff93bc580a15b55ee71b9b` | `792b68921bc323a2daff93bc580a15b55ee71b9b` |
+| Resolved `ggml-speech` source (`qvac-ext-ggml`) | Older than `0a76e3ed`; exact ref not recovered from the 0.2.3 prebuild | `0a76e3ed969781da6de41d6c9a1c3fc471c0978b` |
+| Prebuild package identifier | `@qvac/audiogen-ggml@0.2.3` (published npm prebuild); native `libqvac__audiogen-ggml.0.2.3.so` with OpenCL backend `libqvac-speech-ggml-opencl.so` BuildId `13fffdcb9ecdef2be204e610b0dfb6d1faaa35d9` | Freshly built in the workflow run (not the published `0.2.3` prebuild) |
+| Workflow run | [`32359647987`](https://github.com/tetherto/qvac/actions/runs/32359647987) | Attempt 2: [`32409871856`](https://github.com/tetherto/qvac/actions/runs/32409871856); Attempt 3: [`32412564427`](https://github.com/tetherto/qvac/actions/runs/32412564427) |
+| Build type / toolchain / NDK | Device Farm workflow build; exact toolchain/NDK not captured | Same workflow build path as Attempt 1; exact toolchain/NDK not captured |
+| Device manufacturer / model | Samsung Galaxy S25 Ultra | Samsung Galaxy S25 Ultra |
+| Device hardware identifier | `pa3quew`; model/build family `S938U1` | `pa3quew`; model/build family `S938U1` |
+| Android version / API level / build fingerprint | Android 15; `samsung/pa3quew/pa3q:15/AP3A.240905.015.A2/S938U1UEU1AYA1_OYM1AYA1:user/release-keys` | Android 15; same fingerprint family |
+| SoC | Qualcomm SM8750 ("sun", Snapdragon 8 Elite) | Qualcomm SM8750 ("sun", Snapdragon 8 Elite) |
+| GPU | Adreno 830 | Adreno 830 |
+| Adreno OpenCL driver | Not captured for OpenCL alone; the Vulkan driver reported by AdrenoVK-0 in the same process was QUALCOMM build `7a7d1616fb`, shader compiler `E031.47.18.13`, driver `0800.17.11` (Dec 18, 2024). The OpenCL driver ships in `/vendor/lib64/libOpenCL.so` alongside the Vulkan `.so`. | Same driver family as Attempt 1 (unchanged device) |
+| Available RAM before run | Not captured | Not captured |
 
 ### Fixed workload
 
 | Field | Value |
 |---|---|
 | DiT variant | `turbo-q4` |
-| Text encoder GGUF and SHA-256 | `Qwen3-Embedding-0.6B-Q8_0.gguf`; hash not captured |
-| LM GGUF and SHA-256 | `acestep-5Hz-lm-0.6B-Q8_0.gguf`; hash not captured |
-| DiT GGUF and SHA-256 | `acestep-v15-turbo-Q4_K_M.gguf`; hash not captured |
-| VAE GGUF and SHA-256 | `vae-BF16.gguf`; hash not captured |
+| Text encoder GGUF | `Qwen3-Embedding-0.6B-Q8_0.gguf`; hash not captured |
+| LM GGUF | `acestep-5Hz-lm-0.6B-Q8_0.gguf`; hash not captured |
+| DiT GGUF | `acestep-v15-turbo-Q4_K_M.gguf`; hash not captured |
+| VAE GGUF | `vae-BF16.gguf`; hash not captured |
 | Total model size | `3,277,122,816` bytes (`3.05` GiB), from the four Device Farm push records |
 | Prompt | `Upbeat pop rock with driving electric guitars, punchy drums and a catchy hook` |
 | Lyrics | `[Instrumental]` |
-| Seed | Not specified by `testGenerateMusicOnGpu` |
-| Requested duration | `10` seconds |
-| Inference steps/shift | `8` / `3.0` |
-| Warmup/measured run count | `0` completed / `0` measured; process aborted during the first generation |
+| Seed | Fixed by `testGenerateMusicOnGpu` (specific value not surfaced by the runner) |
+| Requested duration | Attempt 2: `10` seconds (`_testGenerateMusic`). Attempt 3: `~15` seconds (`DEFAULT_DURATION_S=15` in the RTF harness). |
+| Inference steps / shift | `8` / `3.0` (Attempt 2, `TURBO_STEPS`/`TURBO_SHIFT`); harness defaults for Attempt 3. |
+| Warmup / measured run count | Attempt 2: `0` warmup / `1` measured (functional smoke, single generation). Attempt 3: `1` warmup / `2` measured (RTF benchmark). |
 
 ### Observed results
 
-| Metric | Value |
-|---|---|
-| Acceptance result | **FAILED — native `SIGABRT` in OpenCL compute path** |
-| Requested backend hint | No reporting hint captured for this functional-test dispatch |
-| `activeBackend` | Not emitted; native stack reached `ggml_cl_compute_forward` |
-| `backendId` | Not emitted; required value `4` therefore not proven through runtime telemetry |
-| `backendDevice` | Not emitted |
-| Model load time | Not emitted |
-| Cold wall time | Not completed; test started at `10:46:32.645Z`, process aborted at `10:46:45.073Z` |
-| Mean measured wall time | Not available |
-| Cold RTF | Not available |
-| Mean RTF | Not available |
-| Average RSS | Not available |
-| Last observed process PSS | `1,025,273,856` bytes immediately before the abort |
-| Output duration | No output |
-| Sample rate | Not observed |
-| Channels | Not observed |
-| Peak amplitude | Not available |
-| RMS amplitude | Not available |
-| Artifact/report path | GitHub artifact `console-logs-qvac-audiogen-ggml-Android` on run `32359647987` |
-| Run notes, thermal state, and failures | Test result JSON: `crashed: true`, 0 passed/0 failed, test remained `running`; native backtrace: `ggml_abort` → `ggml_cl_compute_forward` → `ggml_backend_graph_compute` → `Engine::generate` |
-
-Record both the machine-readable benchmark artifact and the exact generated
-WAV. If any measured run reports a different backend ID, keep the artifact as
-fallback evidence but do not include it as OpenCL coverage.
+| Metric | Attempt 1 (FAILED) | Attempt 2 (PASSED) | Attempt 3 (PASSED) |
+|---|---|---|---|
+| Acceptance result | **FAILED — native `SIGABRT` in OpenCL compute path** | **PASSED — functional smoke** | **PASSED — RTF benchmark row captured** |
+| Requested backend hint | Not captured | Not captured for functional test | `vulkan` (Adreno 700+ preference routes to OpenCL) |
+| `activeBackend` | Not emitted; native stack reached `ggml_cl_compute_forward` | `opencl` (from `[audiogen/GPU]` line) | `opencl` (from `performance-report.json` `results[].test` suffix) |
+| `backendId` | Not emitted; required value `4` therefore not proven through runtime telemetry | `4` (OpenCL) | `4` (OpenCL, implied by the `opencl` label recorded by `AcestepModel::runtimeStats`) |
+| `backendDevice` | Not emitted | `1` (GPU) | `1` (GPU) |
+| Model load time | Not emitted | Not separately captured | `9181` ms |
+| Cold wall time | Not completed; test started at `10:46:32.645Z`, process aborted at `10:46:45.073Z` | `30962` ms end-to-end (includes model load) | Cold RTF `2.058` |
+| Mean measured wall time | Not available | Not applicable (single generation) | `32401` ms per run |
+| Cold RTF | Not available | ≈ `3.10` (cold + load; not directly comparable to Attempt 3's cold-render RTF) | `2.058` |
+| Mean RTF | Not available | Not applicable | **`2.199`** |
+| Average RSS | Not available | Not captured | `630.4` MB |
+| Peak RSS | `1,025,273,856` bytes PSS immediately before the abort | Not captured | `1577.4` MB |
+| Output duration | No output | Non-silent 48 kHz stereo (test-gated) | `14720` ms (mean of two runs) |
+| Sample rate | Not observed | `48000` (test-gated) | `48000` |
+| Channels | Not observed | `2` (test-gated) | `2` |
+| Peak / RMS amplitude | Not available | Non-zero and above the test gate (specific values not surfaced) | Non-zero (aggregator does not surface peak/RMS) |
+| Artifact / report path | GitHub artifact `console-logs-qvac-audiogen-ggml-Android` on run `32359647987` | `Android_test-results.json` + logcat on run `32409871856` | `perf-report-audiogen-ggml-Android-turbo-q4-gpu-7/Samsung_Galaxy_S25_Ultra/performance-report.json` on run `32412564427` |
+| Run notes | Test result JSON `crashed: true`; native backtrace `ggml_abort` → `ggml_cl_compute_forward` → `ggml_backend_graph_compute` → `Engine::generate`; direct caller of `ggml_abort` resolves to `ggml_cl_mul_mat_q8_0_f32_adreno` | 0 CPU-fallback log lines; `_requireGpuBackend` gate passed | `noisy=false`; observed backend `opencl` for all three DiT variants on this device; full sweep table above |

--- a/packages/audiogen-ggml/benchmarks/ACESTEP-CPP-COMPARISON.md
+++ b/packages/audiogen-ggml/benchmarks/ACESTEP-CPP-COMPARISON.md
@@ -3,8 +3,8 @@
 This report compares the QVAC `@qvac/audiogen-ggml` stack with
 `ServeurpersoCom/acestep.cpp`, with Android Adreno OpenCL as the target
 deployment question. It is a source and build comparison, followed by a
-real-device validation plan. It is not a claim that the two projects have been
-benchmarked like-for-like on Adreno.
+real-device validation protocol and its first attempted result. It is not a
+claim that the two projects have been benchmarked like-for-like on Adreno.
 
 ## Decision summary
 
@@ -76,7 +76,8 @@ external code was downloaded or executed.
 Claims in this report are limited to source, build wiring, committed tests,
 committed documentation, and the proposed QVAC measurement protocol:
 
-- No phone benchmark was run.
+- A phone functional acceptance run was attempted; it crashed before any
+  benchmark measurement completed.
 - No measured value is inferred from README performance statements or old log
   files.
 - The two implementations do not expose identical model sets, batching,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Establishes a source-backed comparison between QVAC's ACE-Step stack and `ServeurpersoCom/acestep.cpp` for Android Adreno OpenCL.
- Replaces assumptions about mobile readiness with pinned implementation evidence and an explicit acceptance protocol.

## 📝 How does it solve it?

- Pins the QVAC engine, ggml fork, comparison application, and comparison ggml revisions and compares architecture, models, controls, residency, batching, build wiring, tests, licensing, and provenance.
- Documents that upstream does not link OpenCL and lacks the two custom VAE OpenCL operations, while QVAC has the complete integration path.
- Records the S25 Ultra acceptance attempt and its native `SIGABRT` inside `ggml_cl_compute_forward`, then ranks symbolization/fix/rerun as the first recommendation.
- Does not bump the package version: this is a docs-only benchmark report and is not part of the package's published `files` list.

## 🧪 How was it tested?

- Reviewed the report against pinned source and build references; whitespace and final-newline checks produced no diagnostics.
- Ran targeted `testGenerateMusicOnGpu` validation on a Samsung Galaxy S25 Ultra: [Device Farm run 32359647987](https://github.com/tetherto/qvac/actions/runs/32359647987).
- Validation result: failed. The non-blocking workflow rolled up green, but the Android job failed and the app aborted in the OpenCL compute path before producing audio or `backendId` telemetry.