### PR TITLE
fix[addons][notask]: align registry-client peer resolution with the SDK pin

### DIFF
--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -127,7 +127,7 @@
   "homepage": "https://qvac.tether.io",
   "devDependencies": {
     "@qvac/decoder-audio": "^0.5.0",
-    "@qvac/registry-client": "^0.4.0",
+    "@qvac/registry-client": "^0.6.1",
     "@types/node": "^22.15.3",
     "bare-buffer": "^3.4.2",
     "bare-ffmpeg": "^1.0.0-32",

--- a/packages/audiogen-ggml/test/package/package-contract.test.js
+++ b/packages/audiogen-ggml/test/package/package-contract.test.js
@@ -40,6 +40,11 @@ const REQUIRED_PATHS = [
 ]
 const FORBIDDEN_PREFIXES = ['package/test/integration/', 'package/test/mobile/']
 
+function sdkDependencyRange(moduleName) {
+  const sdkManifestPath = path.resolve(PACKAGE_ROOT, '..', 'sdk', 'package.json')
+  return JSON.parse(fs.readFileSync(sdkManifestPath, 'utf8')).dependencies[moduleName]
+}
+
 function run(command, args, cwd) {
   const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
   if (result.error) throw result.error
@@ -200,6 +205,11 @@ test('published package contains only consumer contract files', (t) => {
   t.ok(
     packedPackage.peerDependenciesMeta['@qvac/registry-client'].optional,
     'package marks the downloader runtime as an optional peer'
+  )
+  t.is(
+    packedPackage.peerDependencies['@qvac/registry-client'],
+    sdkDependencyRange('@qvac/registry-client'),
+    'optional peer range tracks the range @qvac/sdk pins (drift makes npm install fail with ERESOLVE for SDK consumers)'
   )
   t.is(
     packedPackage.dependencies['bare-process'],

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -74,7 +74,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://qvac.tether.io",
   "devDependencies": {
-    "@qvac/registry-client": "^0.4.0",
+    "@qvac/registry-client": "^0.6.1",
     "@types/node": "^24.2.1",
     "bare-stream": "^2.7.0",
     "bare-subprocess": "^5.2.1",

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-20
+
 ### Fixed
 
+- Declare `@qvac/registry-client` and `bare-fetch` as direct dependencies
+  instead of optional peers. The optional peer range `^0.4.0` disagreed with the
+  `^0.6.1` that `@qvac/sdk` pins, so `npm install` failed with `ERESOLVE` for
+  every SDK consumer. `bun install` resolved a second copy instead and hid it.
 - Declare all runtime modules required by the published model fetchers, mobile
   tests, and integration tests.
-- Declare lazy model downloader integrations as optional peers, report how to
-  install them when requested, and preserve nested missing-module errors.
+- Report how to install the lazy model downloader integrations when they are
+  missing, and preserve nested missing-module errors.
 
 ## [0.10.0] - 2026-08-18
 

--- a/packages/translation-nmtcpp/README.md
+++ b/packages/translation-nmtcpp/README.md
@@ -113,16 +113,10 @@ Install the main translation package via npm:
 npm i @qvac/translation-nmtcpp
 ```
 
-Local model files require no downloader integration. To use automatic model
-downloads, install the integration for the selected source:
-
-```bash
-# Bergamot downloads from the Firefox CDN
-npm i bare-fetch
-
-# IndicTrans downloads from the QVAC model registry
-npm i @qvac/registry-client
-```
+The automatic model downloaders ship with the package: `bare-fetch` (Bergamot
+downloads from the Firefox CDN) and `@qvac/registry-client` (IndicTrans
+downloads from the QVAC model registry) are installed as dependencies. Local
+model files require neither.
 
 ## Usage
 
@@ -764,11 +758,7 @@ Bergamot weights are published by Mozilla's
 [firefox-translations-models](https://github.com/mozilla/firefox-translations-models)
 project. `lib/bergamot-model-fetcher` resolves and downloads a language pair
 from the Firefox CDN (using Remote Settings metadata) into a local directory.
-Automatic downloads require `bare-fetch`:
-
-```bash
-npm i bare-fetch
-```
+Automatic downloads use `bare-fetch`, which ships as a dependency.
 
 ```javascript
 const {
@@ -789,12 +779,7 @@ hosted in the QVAC model registry for CI and `@qvac/inference` consumption.
 
 IndicTrans2 GGML weights are hosted in the QVAC model registry.
 `lib/indictrans-model-fetcher` downloads them through `@qvac/registry-client`
-(peer-to-peer, checksum-verified). Install the registry client before using
-automatic downloads:
-
-```bash
-npm i @qvac/registry-client
-```
+(peer-to-peer, checksum-verified), which ships as a dependency.
 
 ```javascript
 const {

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {
@@ -77,9 +77,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://qvac.tether.io",
   "devDependencies": {
-    "@qvac/registry-client": "^0.4.0",
     "@types/node": "^24.2.1",
-    "bare-fetch": "^3.0.1",
     "bare-stream": "^2.7.0",
     "cmake-bare": "^1.7.5",
     "cmake-vcpkg": "^1.1.0",
@@ -96,24 +94,14 @@
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",
+    "@qvac/registry-client": "^0.6.1",
+    "bare-fetch": "^3.0.1",
     "bare-fs": "^4.5.1",
     "bare-os": "^3.9.3",
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.2",
     "bare-url": "^2.1.6",
     "brittle": "^3.4.0"
-  },
-  "peerDependencies": {
-    "@qvac/registry-client": "^0.4.0",
-    "bare-fetch": "^3.0.1"
-  },
-  "peerDependenciesMeta": {
-    "@qvac/registry-client": {
-      "optional": true
-    },
-    "bare-fetch": {
-      "optional": true
-    }
   },
   "exports": {
     "./package": "./package.json",

--- a/packages/translation-nmtcpp/test/package/package-contract.test.js
+++ b/packages/translation-nmtcpp/test/package/package-contract.test.js
@@ -29,7 +29,8 @@ const REQUIRED_FILES = [
   'lib/indictrans-model-fetcher.d.ts',
   'test/mobile/integration-runtime.cjs'
 ]
-const OPTIONAL_MODULES = ['bare-fetch', '@qvac/registry-client']
+const REGISTRY_CLIENT_MODULE = '@qvac/registry-client'
+const LAZY_MODULES = ['bare-fetch', REGISTRY_CLIENT_MODULE]
 const TRANSITIVE_MISSING_MODULE = 'translation-nmtcpp-transitive-missing'
 const NODE_BARE_MODULE_SHIM = `
 const Module = require('node:module')
@@ -92,12 +93,34 @@ function isExternalModule(specifier) {
   )
 }
 
-function optionalPeerModules(packageJson) {
-  return new Set(
-    Object.keys(packageJson.peerDependencies || {}).filter(
-      (moduleName) => packageJson.peerDependenciesMeta?.[moduleName]?.optional === true
-    )
+function sdkDependencyRange(moduleName) {
+  const sdkManifestPath = path.resolve(PACKAGE_ROOT, '..', 'sdk', 'package.json')
+  return JSON.parse(fs.readFileSync(sdkManifestPath, 'utf8')).dependencies?.[moduleName]
+}
+
+function assertNoPeerDependencies(packageJson) {
+  assert.equal(
+    packageJson.peerDependencies,
+    undefined,
+    'addons must not declare peer dependencies: an optional peer range that disagrees with @qvac/sdk makes npm install fail with ERESOLVE'
   )
+  assert.equal(packageJson.peerDependenciesMeta, undefined)
+}
+
+function assertRegistryClientMatchesSdk(packageJson) {
+  assert.equal(
+    packageJson.dependencies[REGISTRY_CLIENT_MODULE],
+    sdkDependencyRange(REGISTRY_CLIENT_MODULE),
+    `${REGISTRY_CLIENT_MODULE} must track the range @qvac/sdk pins`
+  )
+}
+
+function assertLazyDependenciesAreDirect(packageJson) {
+  LAZY_MODULES.forEach((moduleName) => {
+    assert.ok(packageJson.dependencies?.[moduleName], `${moduleName} must be a direct dependency`)
+  })
+  assertNoPeerDependencies(packageJson)
+  assertRegistryClientMatchesSdk(packageJson)
 }
 
 function assertFileImportsDeclared(packageRoot, filePath, declaredModules) {
@@ -111,10 +134,7 @@ function assertFileImportsDeclared(packageRoot, filePath, declaredModules) {
 }
 
 function assertDeclaredImports(packageRoot, packageJson, packedFiles) {
-  const declaredModules = new Set([
-    ...Object.keys(packageJson.dependencies || {}),
-    ...optionalPeerModules(packageJson)
-  ])
+  const declaredModules = new Set(Object.keys(packageJson.dependencies || {}))
   packedFiles
     .filter((filePath) => JAVASCRIPT_FILE_PATTERN.test(filePath))
     .forEach((filePath) => assertFileImportsDeclared(packageRoot, filePath, declaredModules))
@@ -143,18 +163,18 @@ require.resolve('@qvac/translation-nmtcpp/marian')
   assert.equal(result.status, 0, `${result.stdout}${result.stderr}`)
 }
 
-function optionalModuleRoot(consumerRoot, moduleName) {
+function lazyModuleRoot(consumerRoot, moduleName) {
   return path.join(consumerRoot, 'node_modules', ...moduleName.split('/'))
 }
 
-function removeOptionalModules(consumerRoot) {
-  OPTIONAL_MODULES.forEach((moduleName) => {
-    fs.rmSync(optionalModuleRoot(consumerRoot, moduleName), { recursive: true, force: true })
+function removeLazyModules(consumerRoot) {
+  LAZY_MODULES.forEach((moduleName) => {
+    fs.rmSync(lazyModuleRoot(consumerRoot, moduleName), { recursive: true, force: true })
   })
 }
 
-function writeOptionalModule(consumerRoot, moduleName, source) {
-  const moduleRoot = optionalModuleRoot(consumerRoot, moduleName)
+function writeLazyModule(consumerRoot, moduleName, source) {
+  const moduleRoot = lazyModuleRoot(consumerRoot, moduleName)
   fs.mkdirSync(moduleRoot, { recursive: true })
   fs.writeFileSync(
     path.join(moduleRoot, 'package.json'),
@@ -163,13 +183,13 @@ function writeOptionalModule(consumerRoot, moduleName, source) {
   fs.writeFileSync(path.join(moduleRoot, 'index.js'), source)
 }
 
-function writeOptionalModules(consumerRoot, sourceForModule) {
-  OPTIONAL_MODULES.forEach((moduleName) => {
-    writeOptionalModule(consumerRoot, moduleName, sourceForModule(moduleName))
+function writeLazyModules(consumerRoot, sourceForModule) {
+  LAZY_MODULES.forEach((moduleName) => {
+    writeLazyModule(consumerRoot, moduleName, sourceForModule(moduleName))
   })
 }
 
-function optionalDependencyProbe(expectedBergamotMessage, expectedIndicTransMessage) {
+function lazyDependencyProbe(expectedBergamotMessage, expectedIndicTransMessage) {
   return `
 const bergamot = require('@qvac/translation-nmtcpp/lib/bergamot-model-fetcher')
 const indictrans = require('@qvac/translation-nmtcpp/lib/indictrans-model-fetcher')
@@ -222,25 +242,25 @@ function assertProbeAcrossRuntimes(consumerRoot, probe) {
   assertProbe(BARE_COMMAND, consumerRoot, probe)
 }
 
-function assertDirectMissingOptionalDependencies(consumerRoot) {
-  removeOptionalModules(consumerRoot)
+function assertDirectMissingLazyDependencies(consumerRoot) {
+  removeLazyModules(consumerRoot)
   assertProbeAcrossRuntimes(
     consumerRoot,
-    optionalDependencyProbe(
+    lazyDependencyProbe(
       'Install bare-fetch to download Bergamot translation models',
       'Install @qvac/registry-client to download IndicTrans translation models'
     )
   )
 }
 
-function assertOptionalDependencyInitializationErrors(consumerRoot) {
-  writeOptionalModules(
+function assertLazyDependencyInitializationErrors(consumerRoot) {
+  writeLazyModules(
     consumerRoot,
     (moduleName) => `throw new Error(${JSON.stringify(`${moduleName} initialization failed`)})\n`
   )
   assertProbeAcrossRuntimes(
     consumerRoot,
-    optionalDependencyProbe(
+    lazyDependencyProbe(
       'bare-fetch initialization failed',
       '@qvac/registry-client initialization failed'
     )
@@ -248,19 +268,16 @@ function assertOptionalDependencyInitializationErrors(consumerRoot) {
 }
 
 function assertTransitiveMissingDependencies(consumerRoot) {
-  writeOptionalModules(
-    consumerRoot,
-    () => `require(${JSON.stringify(TRANSITIVE_MISSING_MODULE)})\n`
-  )
+  writeLazyModules(consumerRoot, () => `require(${JSON.stringify(TRANSITIVE_MISSING_MODULE)})\n`)
   assertProbeAcrossRuntimes(
     consumerRoot,
-    optionalDependencyProbe(TRANSITIVE_MISSING_MODULE, TRANSITIVE_MISSING_MODULE)
+    lazyDependencyProbe(TRANSITIVE_MISSING_MODULE, TRANSITIVE_MISSING_MODULE)
   )
 }
 
-function assertOptionalDependencyErrors(consumerRoot) {
-  assertDirectMissingOptionalDependencies(consumerRoot)
-  assertOptionalDependencyInitializationErrors(consumerRoot)
+function assertLazyDependencyErrors(consumerRoot) {
+  assertDirectMissingLazyDependencies(consumerRoot)
+  assertLazyDependencyInitializationErrors(consumerRoot)
   assertTransitiveMissingDependencies(consumerRoot)
 }
 
@@ -294,13 +311,10 @@ test('packed tarball preserves the public package contract', () => {
     assert.equal(packageJson.devDependencies['bare-os'], undefined)
     assert.equal(packageJson.devDependencies['bare-process'], undefined)
     assert.equal(packageJson.devDependencies.brittle, undefined)
-    assert.equal(packageJson.peerDependencies['bare-fetch'], '^3.0.1')
-    assert.equal(packageJson.peerDependencies['@qvac/registry-client'], '^0.4.0')
-    assert.equal(packageJson.peerDependenciesMeta['bare-fetch'].optional, true)
-    assert.equal(packageJson.peerDependenciesMeta['@qvac/registry-client'].optional, true)
+    assertLazyDependenciesAreDirect(packageJson)
     assertDeclaredImports(installedRoot, packageJson, packedFiles)
     assertRuntimeProbe(consumerRoot, installedRoot)
-    assertOptionalDependencyErrors(consumerRoot)
+    assertLazyDependencyErrors(consumerRoot)
   } finally {
     fs.rmSync(temporaryRoot, { recursive: true, force: true })
   }

--- a/packages/translation-nmtcpp/test/package/package-contract.test.js
+++ b/packages/translation-nmtcpp/test/package/package-contract.test.js
@@ -107,20 +107,16 @@ function assertNoPeerDependencies(packageJson) {
   assert.equal(packageJson.peerDependenciesMeta, undefined)
 }
 
-function assertRegistryClientMatchesSdk(packageJson) {
-  assert.equal(
-    packageJson.dependencies[REGISTRY_CLIENT_MODULE],
-    sdkDependencyRange(REGISTRY_CLIENT_MODULE),
-    `${REGISTRY_CLIENT_MODULE} must track the range @qvac/sdk pins`
-  )
-}
-
 function assertLazyDependenciesAreDirect(packageJson) {
   LAZY_MODULES.forEach((moduleName) => {
     assert.ok(packageJson.dependencies?.[moduleName], `${moduleName} must be a direct dependency`)
+    assert.equal(
+      packageJson.dependencies[moduleName],
+      sdkDependencyRange(moduleName),
+      `${moduleName} must track the range @qvac/sdk pins`
+    )
   })
   assertNoPeerDependencies(packageJson)
-  assertRegistryClientMatchesSdk(packageJson)
 }
 
 function assertFileImportsDeclared(packageRoot, filePath, declaredModules) {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- #3919 declared `@qvac/registry-client` as an optional peer of `@qvac/translation-nmtcpp` at `^0.4.0`, while `@qvac/sdk` (and `audiogen-ggml`/`tts-ggml`) pin `^0.6.1`.
- npm validates optional peer ranges against the resolved tree, so every SDK consumer `npm install` failed with `ERESOLVE` — breaking the **SDK Pod Checks** on every SDK PR (e.g. #3932).
- The monorepo's `bun install` masked the conflict by silently resolving a second `registry-client` copy, which is why it passed locally in #3919.

## 📝 How does it solve it?

- `translation-nmtcpp` **0.10.1**: drop the `peerDependencies`/`peerDependenciesMeta` blocks and declare `@qvac/registry-client@^0.6.1` and `bare-fetch@^3.0.1` as direct dependencies. The model fetchers stay lazy-loaded; they now simply ship with the package (README/CHANGELOG updated accordingly).
- `asr-ggml`, `ocr-ggml`: bump the `@qvac/registry-client` devDependency `^0.4.0 → ^0.6.1` to keep the monorepo on one version (dev-only, no version bump/release needed).
- Hardened `translation-nmtcpp`'s package-contract test to prevent a repeat: it now rejects any `peerDependencies` on the addon and asserts the `@qvac/registry-client` range tracks the exact range `@qvac/sdk` pins, so future drift fails the addon's own tests instead of every SDK PR.

## 🧪 How was it tested?

- `translation-nmtcpp` package-contract test updated to enforce the new invariants (direct lazy deps, no peers, SDK-pinned range) and still covers the missing/failing lazy-module error paths across Node and Bare.
- The failing scenario reproduces exactly in the SDK Pod Checks consumer-install step (`ERESOLVE` on `@qvac/registry-client`); this PR's own SDK Pod Checks run validates the fix end-to-end.

## 💥 Breaking Changes

None. `@qvac/registry-client` and `bare-fetch` move from optional peers to direct dependencies of `@qvac/translation-nmtcpp`; consumers that installed them manually keep working, and the public API is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
