### PR TITLE
QVAC-23755 chore: bump speech addon patch versions

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -12,6 +12,13 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 [`docs/WHISPER-CHANGELOG.md`](https://github.com/tetherto/qvac/blob/main/packages/asr-ggml/docs/WHISPER-CHANGELOG.md) and
 [`docs/PARAKEET-CHANGELOG.md`](https://github.com/tetherto/qvac/blob/main/packages/asr-ggml/docs/PARAKEET-CHANGELOG.md).
 
+## [0.3.3] - 2026-08-20
+
+### Changed
+
+- Bump `@qvac/registry-client` from `^0.4.0` to `^0.6.1` as a development
+  dependency so in-repo download and test tooling stays on the hyperdb v6 line.
+
 ## [0.3.2] - 2026-08-18
 
 ### Changed

--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/asr-ggml",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Multi-engine ASR (Whisper + NVIDIA Parakeet) inference addon for qvac on the Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-08-20
+
 ### Changed
 
 - Keep `@qvac/registry-client` as a `^0.6.1` development dependency for registry

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-20
+
 ### Changed
 
 - Keep `@qvac/registry-client` as a `^0.6.1` development dependency for

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-08-20
+
 ### Changed
 
 - Move `@qvac/registry-client` from a runtime dependency to a `^0.6.1`

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## What problem does this PR solve?

- Publish patch releases for the four speech addons whose `@qvac/registry-client` placement changed in #3935, so consumers can install versions that no longer pull registry-client / hyperdb 4.x through those packages.

## How does it solve it?

- Bump package versions and fold Unreleased changelog notes:
  - `@qvac/audiogen-ggml` `0.2.3` → `0.2.4` (registry-client stays a `^0.6.1` devDependency, not an optional peer)
  - `@qvac/asr-ggml` `0.3.2` → `0.3.3` (registry-client pin `^0.4.0` → `^0.6.1` as a devDependency)
  - `@qvac/tts-ggml` `0.7.4` → `0.7.5` (registry-client moved from runtime dependency to `^0.6.1` devDependency)
  - `@qvac/translation-nmtcpp` `0.10.0` → `0.10.1` (registry-client stays a `^0.6.1` devDependency, not an optional `^0.4.0` peer)

## How was it tested?

- Version and changelog-only PR against `main` after #3935.
- Registry-client placement is covered by each package's contract tests on `main`.