### PR TITLE
chore[notask]: release @qvac/ai-sdk-provider 0.6.1

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.1]
+
+Release Date: 2026-08-21
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.1
+
+## Managed Mode Supports CLI 0.12
+
+`@qvac/ai-sdk-provider` now accepts the `@qvac/cli` `0.12.x` line alongside `0.10.x` and `0.11.x` as its optional managed-mode CLI peer. This lets strict package managers install the provider next to CLI 0.12, which brings in the `@qvac/sdk` 0.18.x runtime and the serve model catalog.
+
+The older lines remain accepted, so existing installs are unaffected. No provider API changes are included in this patch release.
+
 ## [0.6.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.0

--- a/packages/ai-sdk-provider/changelog/0.6.1/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.6.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.6.1
+
+Release Date: 2026-08-21
+
+## 🐞 Fixes
+
+- Accept the `@qvac/cli` `0.12.x` line as the optional managed-mode peer, so strict package managers can install the provider alongside CLI 0.12 and its `@qvac/sdk` 0.18.x runtime.

--- a/packages/ai-sdk-provider/changelog/0.6.1/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.6.1/CHANGELOG_LLM.md
@@ -1,0 +1,11 @@
+# QVAC AI SDK Provider v0.6.1 Release Notes
+
+Release Date: 2026-08-21
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.1
+
+## Managed Mode Supports CLI 0.12
+
+`@qvac/ai-sdk-provider` now accepts the `@qvac/cli` `0.12.x` line alongside `0.10.x` and `0.11.x` as its optional managed-mode CLI peer. This lets strict package managers install the provider next to CLI 0.12, which brings in the `@qvac/sdk` 0.18.x runtime and the serve model catalog.
+
+The older lines remain accepted, so existing installs are unaffected. No provider API changes are included in this patch release.

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^3.0",
-    "@qvac/cli": "^0.10.0 || ^0.11.0",
+    "@qvac/cli": "^0.10.0 || ^0.11.0 || ^0.12.0",
     "ai": "^7.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/ai-sdk-provider` declares its optional managed-mode peer as `@qvac/cli` `^0.10.0 || ^0.11.0`. With CLI 0.12.0 cutting (#3990), strict package managers would refuse to install the provider alongside it.
- Second package in the agent-stack cascade (`cli` → **`ai-sdk-provider`** → `opencode-plugin` / `openclaw-plugin`).

## 📝 How does it solve it?

- `packages/ai-sdk-provider/package.json` — version `0.6.0` → `0.6.1`
- `packages/ai-sdk-provider/package.json` — `peerDependencies["@qvac/cli"]` `^0.10.0 || ^0.11.0` → `^0.10.0 || ^0.11.0 || ^0.12.0`
- `packages/ai-sdk-provider/changelog/0.6.1/` — `CHANGELOG.md`, `CHANGELOG_LLM.md`
- `packages/ai-sdk-provider/CHANGELOG.md` — aggregate rebuilt (9 versions)

Patch bump per the 0.x policy: the peer range is **extended**, not replaced, so `0.10.x` and `0.11.x` consumers are unaffected. No source changes have landed in this package since 0.6.0, and no `[bc]`/`[api]` surface moves — this is dependency-range alignment only. This mirrors the 0.2.2 release, which widened the same peer for the CLI 0.7 line.

The changelog was hand-authored rather than generated. The only commit touching this package since the 0.6.0 cut is the 0.6.0 release commit itself, which reached `main` via its backmerge (#3837) with a `release …` subject that the generator's backmerge filter does not catch — running the generator would have emitted that as a spurious entry.

No third-party dependency changed, so `NOTICE` is unchanged and was not regenerated.

**Release-order note:** publish only after `@qvac/cli@0.12.0` is live on npm (which itself waits on `@qvac/sdk@0.18.0`).

## 🧪 How was it tested?

- Release metadata only — no source changes, so no behavioural test surface.
- `prettier --check` clean on `changelog/0.6.1/**/*.md` and `CHANGELOG.md`.
- Peer range verified as additive: `^0.10.0 || ^0.11.0` is a strict subset of the new range, so no existing consumer resolution changes.
