### PR TITLE
chore[notask]: release @qvac/opencode-plugin 0.3.0

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.3.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.3.0
+
+This release pairs the plugin with the `@qvac/cli` 0.12 line. The SDK removed the dynamic tools mode, so the plugin no longer pins the field that used to select it — a behaviour-neutral change on its own, but one that ties this version to the newer host.
+
+## Breaking Changes
+
+### Requires the @qvac/cli 0.12 line
+
+The plugin stops sending `toolsMode: 'static'` in the managed serve's model configuration. The SDK removed that field from its llamacpp config schema, and passing it now fails validation rather than being quietly ignored. A `0.2.x` plugin therefore cannot drive a `@qvac/cli` 0.12 / `@qvac/sdk` 0.18 serve, so the plugin and its host must move together — a normal `npm install` of this package does that.
+
+Nothing changes about how tools are handled. `static` was the only mode this plugin ever selected, and it is now the sole behaviour: tool definitions are always prepended after the system message.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/cli@^0.12.0` for `qvac serve` (SDK 0.18 runtime), which also brings the serve model catalog and lazy loading of models configured with `preload: false`
+- `@qvac/ai-sdk-provider@^0.6.0` for managed mode, unchanged — the range already covers the 0.6.1 peer-range release
+
 ## [0.2.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.2.0

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -148,10 +148,10 @@ running `opencode` from the terminal.
   for managed mode (AI SDK 7). The host proxies on behalf of the managed serve,
   so it needs the provider's `ManagedQvacProvider.apiKey` getter — see
   [Provider compatibility](#provider-compatibility).
-- [`@qvac/cli@^0.11.0`](https://www.npmjs.com/package/@qvac/cli) available so the
-  host can run `qvac serve` (SDK 0.17 runtime). 0.11.0 is also the first CLI that
-  accepts `--api-key-file`, which keeps the managed serve's bearer key out of the
-  process command line.
+- [`@qvac/cli@^0.12.0`](https://www.npmjs.com/package/@qvac/cli) available so the
+  host can run `qvac serve` (SDK 0.18 runtime). `--api-key-file`, which keeps the
+  managed serve's bearer key out of the process command line, has been accepted
+  since CLI 0.11.0.
 - Node.js 22 or newer.
 
 ### Provider compatibility

--- a/plugins/opencode/changelog/0.3.0/CHANGELOG.md
+++ b/plugins/opencode/changelog/0.3.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.3.0
+
+Release Date: 2026-08-21
+
+## 🐞 Fixes
+
+- Stop pinning `toolsMode: 'static'` on the managed serve's model config. The field was removed from the SDK's llamacpp schema and is now rejected rather than ignored. (see PR [#3380](https://github.com/tetherto/qvac/pull/3380)) - See [breaking changes](./breaking.md)

--- a/plugins/opencode/changelog/0.3.0/CHANGELOG_LLM.md
+++ b/plugins/opencode/changelog/0.3.0/CHANGELOG_LLM.md
@@ -1,0 +1,20 @@
+# QVAC OpenCode Plugin v0.3.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.3.0
+
+This release pairs the plugin with the `@qvac/cli` 0.12 line. The SDK removed the dynamic tools mode, so the plugin no longer pins the field that used to select it — a behaviour-neutral change on its own, but one that ties this version to the newer host.
+
+## Breaking Changes
+
+### Requires the @qvac/cli 0.12 line
+
+The plugin stops sending `toolsMode: 'static'` in the managed serve's model configuration. The SDK removed that field from its llamacpp config schema, and passing it now fails validation rather than being quietly ignored. A `0.2.x` plugin therefore cannot drive a `@qvac/cli` 0.12 / `@qvac/sdk` 0.18 serve, so the plugin and its host must move together — a normal `npm install` of this package does that.
+
+Nothing changes about how tools are handled. `static` was the only mode this plugin ever selected, and it is now the sole behaviour: tool definitions are always prepended after the system message.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/cli@^0.12.0` for `qvac serve` (SDK 0.18 runtime), which also brings the serve model catalog and lazy loading of models configured with `preload: false`
+- `@qvac/ai-sdk-provider@^0.6.0` for managed mode, unchanged — the range already covers the 0.6.1 peer-range release

--- a/plugins/opencode/changelog/0.3.0/breaking.md
+++ b/plugins/opencode/changelog/0.3.0/breaking.md
@@ -1,0 +1,13 @@
+# 💥 Breaking Changes v0.3.0
+
+## Requires the @qvac/cli 0.12 line
+
+PR: [#3380](https://github.com/tetherto/qvac/pull/3380)
+
+_No migration code — the managed serve config is private to the plugin and the host it bundles._
+
+- The plugin no longer sends `toolsMode: 'static'` in the managed serve's model config. The SDK removed that field from its llamacpp config schema, and passing it now fails validation instead of being ignored, so plugin `0.2.x` cannot drive a `@qvac/cli` 0.12 / `@qvac/sdk` 0.18 serve. Upgrade the plugin and the host together — installing this package does that.
+- Behaviour is otherwise unchanged. `static` was the only mode this plugin ever selected, and it is now the sole behaviour: tools are always prepended after the system message.
+- The `@qvac/cli` dependency floor moves from `^0.11.0` to `^0.12.0` accordingly.
+
+---

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/opencode-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenCode plugin that runs a local, managed QVAC serve so `opencode` works against on-device models with no second terminal",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -59,7 +59,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.0",
     "@qvac/ai-sdk-provider": "^0.6.0",
-    "@qvac/cli": "^0.11.0",
+    "@qvac/cli": "^0.12.0",
     "ai": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- #3380 removed the SDK's dynamic tools mode and, as part of that, stopped the plugin pinning `toolsMode: 'static'` on the managed serve's model config. That change is unreleased.
- Because the SDK now **rejects** `toolsMode` rather than ignoring it, a `0.2.x` plugin cannot drive a `@qvac/cli` 0.12 / `@qvac/sdk` 0.18 serve. The plugin needs a release whose manifest ties it to the new host.
- Third package in the agent-stack cascade (`cli` → `ai-sdk-provider` → **`opencode-plugin`** / `openclaw-plugin`).

## 📝 How does it solve it?

- `plugins/opencode/package.json` — version `0.2.0` → `0.3.0`
- `plugins/opencode/package.json` — `@qvac/cli` `^0.11.0` → `^0.12.0`
- `plugins/opencode/README.md` — Requirements now name CLI `^0.12.0` / SDK 0.18 runtime
- `plugins/opencode/changelog/0.3.0/` — `CHANGELOG.md`, `CHANGELOG_LLM.md`, `breaking.md`
- `plugins/opencode/CHANGELOG.md` — aggregate rebuilt (5 versions)

`@qvac/ai-sdk-provider` stays at `^0.6.0` — the caret already covers the 0.6.1 peer-range release (#3992), so no floor move is needed.

Minor bump per the 0.x policy: the required `@qvac/cli` floor crosses a minor, and 0.x carets do not cross minors, so consumers pinned to CLI 0.11 are affected.

**On the changelog wording:** the generator rendered #3380 under Features using the SDK-side PR title, and produced a `breaking.md` copied from the SDK's migration example plus that PR's internal release-coordination notes and an Asana link. Both were rewritten to describe the *plugin's* change. #3380 states outright that the plugin-side edit is behaviour-neutral (`static` was already the default), so this release is titled `chore[notask]`, not `[bc]` — the plugin's own surface does not break. `breaking.md` is kept, scoped to the one thing that genuinely breaks for installers: the plugin and host must now move together.

No third-party dependency changed, so `NOTICE` is unchanged and was not regenerated.

**Release-order note:** publish only after `@qvac/cli@0.12.0` is live on npm (which itself waits on `@qvac/sdk@0.18.0`).

## 🧪 How was it tested?

- Release metadata and README only — the single source change (dropping the `toolsMode` pin) already merged and was tested in #3380.
- `prettier --check` clean on `changelog/0.3.0/**/*.md`, `CHANGELOG.md`, and `README.md`.
- Verified the AI SDK majors still line up, so this plugin is not blocked: the plugin depends on `ai@^7.0.0` and `@ai-sdk/openai-compatible@^3.0.0`, matching the provider's `ai@^7.0` / `^3.0` peers.
