### PR TITLE
chore[notask]: release @qvac/openclaw-plugin 0.2.1

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.1]
+
+Release Date: 2026-08-21
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.1
+
+## Runs Against the CLI 0.12 Line
+
+The plugin now requires `@qvac/cli@^0.12.0`, so the bundled `local-service.js` launcher starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime. That serve also brings the model catalog endpoint and lazy loading for models configured with `preload: false`.
+
+Nothing changes in the plugin's own behaviour, configuration, or onboarding — no re-onboarding is needed for this release. Installs that pin `@qvac/cli` to `0.11.x` will need to move to `0.12.x` alongside the plugin, since a 0.x caret range does not cross a minor.
+
 ## [0.2.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.0

--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -6,11 +6,17 @@ Release Date: 2026-08-21
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.1
 
+## Switching Models No Longer Fails
+
+The plugin's own code is unchanged, but moving to `@qvac/cli@^0.12.0` fixes a user-visible problem in how it runs.
+
+The launcher writes every model in the QVAC catalog into the serve config, and marks only your selected model `preload: true`. On the CLI 0.11 line a `preload: false` model was registered but never loaded, so picking any other model in OpenClaw returned `503 model_not_ready` — permanently, until you changed the configured model and restarted. CLI 0.12 loads such a model on first request instead, so every model in the picker now works; the first turn after switching waits for a cold load, and later turns are fast.
+
 ## Runs Against the CLI 0.12 Line
 
-The plugin now requires `@qvac/cli@^0.12.0`, so the bundled `local-service.js` launcher starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime. That serve also brings the model catalog endpoint and lazy loading for models configured with `preload: false`.
+The bundled `local-service.js` launcher now starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime, which also brings the serve model catalog endpoint.
 
-Nothing changes in the plugin's own behaviour, configuration, or onboarding — no re-onboarding is needed for this release. Installs that pin `@qvac/cli` to `0.11.x` will need to move to `0.12.x` alongside the plugin, since a 0.x caret range does not cross a minor.
+Configuration and onboarding are unchanged — no re-onboarding is needed for this release. Installs that pin `@qvac/cli` to `0.11.x` will need to move to `0.12.x` alongside the plugin, since a 0.x caret range does not cross a minor.
 
 ## [0.2.0]
 

--- a/plugins/openclaw/changelog/0.2.1/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.2.1/CHANGELOG.md
@@ -5,3 +5,4 @@ Release Date: 2026-08-21
 ## 🐞 Fixes
 
 - Require the `@qvac/cli` `0.12.x` line, so the bundled launcher starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime.
+- Selecting a model other than the configured one no longer fails with `503 model_not_ready`. The launcher writes every catalog model into the serve config with `preload: false` except the selected one, and CLI 0.12 lazy-loads those on first request instead of leaving them permanently unloaded.

--- a/plugins/openclaw/changelog/0.2.1/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.2.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.1
+
+Release Date: 2026-08-21
+
+## 🐞 Fixes
+
+- Require the `@qvac/cli` `0.12.x` line, so the bundled launcher starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime.

--- a/plugins/openclaw/changelog/0.2.1/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.2.1/CHANGELOG_LLM.md
@@ -4,8 +4,14 @@ Release Date: 2026-08-21
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.1
 
+## Switching Models No Longer Fails
+
+The plugin's own code is unchanged, but moving to `@qvac/cli@^0.12.0` fixes a user-visible problem in how it runs.
+
+The launcher writes every model in the QVAC catalog into the serve config, and marks only your selected model `preload: true`. On the CLI 0.11 line a `preload: false` model was registered but never loaded, so picking any other model in OpenClaw returned `503 model_not_ready` — permanently, until you changed the configured model and restarted. CLI 0.12 loads such a model on first request instead, so every model in the picker now works; the first turn after switching waits for a cold load, and later turns are fast.
+
 ## Runs Against the CLI 0.12 Line
 
-The plugin now requires `@qvac/cli@^0.12.0`, so the bundled `local-service.js` launcher starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime. That serve also brings the model catalog endpoint and lazy loading for models configured with `preload: false`.
+The bundled `local-service.js` launcher now starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime, which also brings the serve model catalog endpoint.
 
-Nothing changes in the plugin's own behaviour, configuration, or onboarding — no re-onboarding is needed for this release. Installs that pin `@qvac/cli` to `0.11.x` will need to move to `0.12.x` alongside the plugin, since a 0.x caret range does not cross a minor.
+Configuration and onboarding are unchanged — no re-onboarding is needed for this release. Installs that pin `@qvac/cli` to `0.11.x` will need to move to `0.12.x` alongside the plugin, since a 0.x caret range does not cross a minor.

--- a/plugins/openclaw/changelog/0.2.1/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.2.1/CHANGELOG_LLM.md
@@ -1,0 +1,11 @@
+# QVAC OpenClaw Plugin v0.2.1 Release Notes
+
+Release Date: 2026-08-21
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.1
+
+## Runs Against the CLI 0.12 Line
+
+The plugin now requires `@qvac/cli@^0.12.0`, so the bundled `local-service.js` launcher starts a `qvac serve` on the `@qvac/sdk` 0.18.x runtime. That serve also brings the model catalog endpoint and lazy loading for models configured with `preload: false`.
+
+Nothing changes in the plugin's own behaviour, configuration, or onboarding — no re-onboarding is needed for this release. Installs that pin `@qvac/cli` to `0.11.x` will need to move to `0.12.x` alongside the plugin, since a 0.x caret range does not cross a minor.

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qvac",
   "name": "QVAC",
   "description": "Local QVAC provider for OpenClaw",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "providers": ["qvac"],
   "modelSupport": {
     "modelPrefixes": ["qwen3.5-", "qwen3.6-", "gpt-oss-", "gemma4-"]

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@qvac/ai-sdk-provider": "^0.6.0",
-    "@qvac/cli": "^0.11.0"
+    "@qvac/cli": "^0.12.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/openclaw-plugin` pins `@qvac/cli` at `^0.11.0`. With CLI 0.12.0 cutting (#3990), that range no longer resolves to the host the bundled `local-service.js` launcher should start, and a 0.x caret does not cross a minor.
- Last package in the agent-stack cascade (`cli` → `ai-sdk-provider` → `opencode-plugin` / **`openclaw-plugin`**).

## 📝 How does it solve it?

- `plugins/openclaw/package.json` — version `0.2.0` → `0.2.1`
- `plugins/openclaw/package.json` — `@qvac/cli` `^0.11.0` → `^0.12.0`
- `plugins/openclaw/openclaw.plugin.json` — manifest `version` `0.2.0` → `0.2.1`
- `plugins/openclaw/changelog/0.2.1/` — `CHANGELOG.md`, `CHANGELOG_LLM.md`
- `plugins/openclaw/CHANGELOG.md` — aggregate rebuilt (6 versions)

`@qvac/ai-sdk-provider` stays at `^0.6.0` — the caret already covers the 0.6.1 peer-range release (#3992).

Patch bump per the 0.x policy: no source change has landed in this package since 0.2.0 — the only commit touching it is its own `[skiplog]` backmerge (#3842) — so this is dependency-floor alignment only, with no `[bc]`/`[api]` surface move and no `breaking.md`. Unlike the OpenCode plugin in this same cascade (#3994), OpenClaw had no `toolsMode` pin to drop, so there is no code change and no host-pairing break to document.

The changelog was hand-authored: with the only in-range commit carrying `[skiplog]`, the generator has nothing to emit.

`README.md` is unchanged. Its "older than 0.11.0" mention describes the launcher's runtime CLI-version detection and `--api-key` fallback, which is still accurate — it is not a dependency-floor statement.

No third-party dependency changed, so `NOTICE` is unchanged and was not regenerated.

**Release-order note:** publish only after `@qvac/cli@0.12.0` is live on npm (which itself waits on `@qvac/sdk@0.18.0`).

## 🧪 How was it tested?

- Release metadata only — no source changes, so no behavioural test surface.
- `prettier --check` clean on `changelog/0.2.1/**/*.md`, `CHANGELOG.md`, and `openclaw.plugin.json`.
- Confirmed the two version fields that must move together (`package.json` and `openclaw.plugin.json`) are both at `0.2.1`.
