### PR TITLE
QVAC-23752 feat[bc]: drop n_discarded from the SDK config schema

### DIFF
--- a/.cursor/rules/sdk/docs/kv-cache-system.mdc
+++ b/.cursor/rules/sdk/docs/kv-cache-system.mdc
@@ -210,23 +210,28 @@ See `schemas/delete-cache.ts` for the request schema.
 
 ## Context Overflow with KV Cache
 
-When using KV Cache with sliding window (`n_discarded`), the context doesn't overflow because:
-1. Cache stores the compressed KV state, not raw tokens
-2. Sliding window discards oldest tokens when context fills
-3. **First message (system prompt + tools) is NEVER removed** — protected from `n_discarded`
-4. Only the last message is appended to the cached context
+Nothing is evicted from the cache to make room. A conversation that grows past
+`ctx_size` runs out of context, and there are two ways to see it:
 
-**Required config for long conversations:**
+1. A prompt that does not fit is refused before any decoding, with a context-overflow error.
+2. A generation that fills the window stops and reports `stopReason: "contextOverflow"`, keeping the tokens it already produced.
+
+The second one is a normal completion, not an error, so a caller can tell a full
+context from a `predict` cutoff.
+
+**Config for long conversations:** size `ctx_size` for the whole conversation you
+intend to hold.
 
 ```typescript
 const modelId = await loadModel({
   modelSrc: MODEL,
   modelType: "llm",
-  modelConfig: { ctx_size: 2048, n_discarded: 512 },
+  modelConfig: { ctx_size: 8192 },
 });
 ```
 
-**Note:** `n_discarded` only works during token generation, not during prefill. Ensure your initial prompt fits in `ctx_size`.
+**Note:** the sliding-window option `n_discarded` was removed. Passing it now
+fails model load as an unknown option.
 
 ## Debug Logging
 
@@ -244,7 +249,7 @@ KV Cache works with MCP tools. Complete canonical tool definitions are hashed: o
 | Issue | Cause | Fix |
 |-------|-------|-----|
 | Cache not reused (full history sent, slow TTFT) | Different system prompt or tools between requests | Ensure consistent system prompt and tools for same cache key |
-| Context overflow at prefill | `n_discarded` not configured | Add `n_discarded` to `modelConfig` |
+| Context overflow at prefill | Conversation outgrew `ctx_size`; nothing is evicted to make room | Raise `ctx_size`, or start a new cache key for a fresh conversation |
 | Tools changed mid-session | Expected behavior | New cache created automatically; old cache preserved |
 
 ## See Also

--- a/packages/inference/src/plugins/builtin/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/inference/src/plugins/builtin/llamacpp-completion/ops/completion-stream.ts
@@ -260,8 +260,7 @@ function prepareMessagesForCache(
   turn: TurnHandle,
   cacheExists: boolean,
   history: HistoryMsg[],
-  tools?: Tool[],
-  toolBlockEvictable = false
+  tools?: Tool[]
 ): CachePayload {
   const toolBlock = tools?.length ? transformMessages(tools) : []
 
@@ -297,9 +296,8 @@ function prepareMessagesForCache(
   // conversation. Skip it only when the prefix is known to hold a rendered
   // one: `toolBlockCached` records that a previous turn actually got it into
   // the cache, which a committed message count does not prove. A stale
-  // boundary means we are resending the whole conversation anyway, and an
-  // evictable block can no longer be assumed present.
-  const skipToolBlock = turn.toolBlockCached && !clearStaleCount && !toolBlockEvictable
+  // boundary means we are resending the whole conversation anyway.
+  const skipToolBlock = turn.toolBlockCached && !clearStaleCount
   const blockToSend = skipToolBlock ? [] : toolBlock
 
   return {
@@ -399,13 +397,6 @@ export async function* completion(
   const modelConfig = getModelConfig(modelId)
   const toolsEnabled = (modelConfig as { tools?: boolean }).tools === true
   const toolsActive = !!tools?.length && toolsEnabled
-  // Sliding is opt-in (`n_discarded` defaults to 0). Once on, the addon's
-  // discard window opens at the end of the primed prefix — which is where the
-  // tool block sits, since the prime is the system prompt alone — and nothing
-  // protects it. So while sliding is possible the block cannot be assumed to
-  // survive, and it has to travel with every turn.
-  const toolBlockEvictable = ((modelConfig as { n_discarded?: number }).n_discarded ?? 0) > 0
-
   const dialect =
     tools && tools.length > 0 ? (params.toolDialect ?? detectToolDialect(modelId)) : undefined
 
@@ -549,8 +540,7 @@ export async function* completion(
     turn,
     /* cacheExists */ true,
     history,
-    toolsActive ? tools : undefined,
-    toolBlockEvictable
+    toolsActive ? tools : undefined
   )
   const messagesToSend = payload.messages
   logMessagesToAddon(messagesToSend, 'PROMPT_SEND')

--- a/packages/inference/src/plugins/builtin/llamacpp-completion/ops/context-overflow.ts
+++ b/packages/inference/src/plugins/builtin/llamacpp-completion/ops/context-overflow.ts
@@ -30,41 +30,80 @@ export function isAddonContextOverflowError(err: unknown): boolean {
   const message = (err as { message?: unknown }).message
   return (
     typeof message === 'string' &&
-    /(?:context overflow at prefill step|processPromptImpl: context overflow)/i.test(message)
+    /(?:context overflow at (?:batch )?prefill step|processPromptImpl: context overflow)/i.test(
+      message
+    )
   )
 }
 
 /**
+ * One entry per guard that formats numbers into a `ContextOverflow`
+ * message, ordered most specific first. Each pattern keeps its numbers
+ * inside a single clause (no `[^]*?` cross-newline walk) so a wrapper
+ * that pastes overflow text alongside unrelated numbers cannot produce a
+ * mismatched set.
+ *
+ * Every pattern captures the context size LAST and the quantities that
+ * make up the failing requirement before it, so `promptTokens` is the sum
+ * of the leading groups and `ctxSize` is the final one. That one rule
+ * covers both shapes: the guards that report a warm cache capture the
+ * cached size and the appended prompt, and it is their sum that
+ * overflowed, while the rest capture a single figure and the sum is that
+ * figure. Reporting the appended prompt alone would render as "31 prompt
+ * tokens exceeds the 8192-token context window", which is impossible on
+ * its face and useless to truncation logic. Where a guard reports both
+ * positions and KV cells, capture the cells: they are the binding
+ * measure, since M-RoPE media occupies more cells than positions.
+ *
+ * Keep this in step with the guards in `TextLlmContext.cpp` and
+ * `MtmdLlmContext.cpp`. A guard whose wording drifts out of this list
+ * does not fail loudly, it silently returns `undefined` for both fields.
+ */
+const MESSAGE_PATTERNS: RegExp[] = [
+  // "cached tokens C plus prompt tokens N exceed the max context tokens M"
+  /cached tokens (\d+) plus prompt tokens (\d+) exceeds? the max context tokens (\d+)/i,
+  // "cached P positions / C KV cells plus P2 positions / N KV cells of
+  //  prompt exceed the max context tokens M"
+  /cached \d+ positions \/ (\d+) KV cells plus \d+ positions \/ (\d+) KV cells of prompt exceeds? the max context tokens (\d+)/i,
+  // "prompt tokens N, max context tokens M"
+  /prompt tokens (\d+)[,\s]+max context tokens (\d+)/i,
+  // "prompt spans P positions / N KV cells, max context tokens M"
+  /prompt spans \d+ positions \/ (\d+) KV cells,\s*max context tokens (\d+)/i,
+  // "(N tokens, P positions, max M)"
+  /\((\d+)\s+tokens,\s*\d+\s+positions,\s*max\s+(\d+)\)/i,
+  // "(N tokens, max M)", the pre-multimodal short form
+  /\((\d+)\s+tokens,\s*max\s+(\d+)\)/i
+]
+
+/**
  * Best-effort extraction of `promptTokens` / `ctxSize` from the addon
  * error message. The C++ paths in `TextLlmContext.cpp` and
- * `MtmdLlmContext.cpp` format both numbers into the message; the
+ * `MtmdLlmContext.cpp` format the numbers into the message; the
  * `LlamaModel::processPromptImpl` fallback path emits a bare
- * `"<func>: context overflow\n"` with neither number. Returning
- * `undefined` for either field is fine — `ContextOverflowError` holds
+ * `"<func>: context overflow\n"` with none of them. Returning
+ * `undefined` for either field is fine, `ContextOverflowError` holds
  * them as optional and the message factory degrades gracefully.
+ *
+ * `promptTokens` is what did not fit, which on a warm cache is the
+ * cached conversation plus the appended prompt rather than the appended
+ * prompt alone. The name predates caching. If a caller ever needs the
+ * two halves apart, that wants new typed fields on
+ * `ContextOverflowError`, not a narrower reading of this one.
  */
 export function parseContextOverflowMessage(message: string): {
   promptTokens?: number
   ctxSize?: number
 } {
-  // "[TextLlm] context overflow at prefill step: prompt tokens N, max context tokens M\n"
-  // Same-clause separator (no `[^]*?` cross-newline walk) so a future
-  // wrapper that pastes overflow text alongside unrelated numbers can't
-  // produce a mismatched pair.
-  const longForm = message.match(/prompt tokens (\d+)[,\s]+max context tokens (\d+)/i)
-  if (longForm?.[1] && longForm[2]) {
+  for (const pattern of MESSAGE_PATTERNS) {
+    const match = message.match(pattern)
+    if (!match) continue
+    const numbers = match.slice(1).map(Number)
+    const ctxSize = numbers.pop()
+    if (ctxSize === undefined || numbers.length === 0) continue
+    if (Number.isNaN(ctxSize) || numbers.some(Number.isNaN)) continue
     return {
-      promptTokens: Number(longForm[1]),
-      ctxSize: Number(longForm[2])
-    }
-  }
-  // "[TextLlm] context overflow at prefill step (N tokens, max M)\n"
-  // "[MtmdLlm] context overflow at prefill step (N tokens, max M)\n"
-  const shortForm = message.match(/\((\d+)\s+tokens,\s*max\s+(\d+)\)/i)
-  if (shortForm?.[1] && shortForm[2]) {
-    return {
-      promptTokens: Number(shortForm[1]),
-      ctxSize: Number(shortForm[2])
+      promptTokens: numbers.reduce((sum, value) => sum + value, 0),
+      ctxSize
     }
   }
   return {}

--- a/packages/inference/src/schemas/llamacpp-config.ts
+++ b/packages/inference/src/schemas/llamacpp-config.ts
@@ -88,12 +88,6 @@ export const llmConfigBaseSchema = z.object({
     .describe(
       'Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`).'
     ),
-  n_discarded: z
-    .number()
-    .optional()
-    .describe(
-      'Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`).'
-    ),
   parallel: z
     .number()
     .int()

--- a/packages/inference/test/completion-kvcache-tools.test.ts
+++ b/packages/inference/test/completion-kvcache-tools.test.ts
@@ -328,19 +328,17 @@ test('completion: kv-cache resends the tool block after a turn that could not re
   clearRegistry()
 })
 
-// With `n_discarded > 0` the addon may slide its context window, and the
-// discard region opens exactly where a static tool block sits — the protected
-// prefix ends at the primed system prompt. While the block can be evicted it
-// has to travel with every turn.
-test('completion: kv-cache resends the tool block when the context window can slide', async (t) => {
+// `n_discarded` is retired, so a config that still carries it must not change
+// caching: the warm turn skips the tool block like any other.
+test('completion: kv-cache still skips the tool block when a retired slide key is present', async (t) => {
   await setIsolatedHome()
   clearRegistry()
 
-  const modelId = `kvcache-tools-sliding-${Date.now()}`
+  const modelId = `kvcache-tools-retired-slide-key-${Date.now()}`
   const calls: RecordedCall[] = []
   registerRecordingModel(modelId, calls, { tools: true, n_discarded: 64 })
 
-  const complete = completer(modelId, 'tools-sliding-key')
+  const complete = completer(modelId, 'tools-retired-slide-key')
   const first = user('Area of a triangle, base 10 height 5?')
   await complete([first], [areaTool])
   await complete([first, assistant('25.'), user('And base 4 height 3?')], [areaTool])
@@ -355,8 +353,8 @@ test('completion: kv-cache resends the tool block when the context window can sl
   )
   t.alike(
     toolNames(turnCalls[1]!),
-    ['calculate_triangle_area'],
-    'the warm turn carries it again because a slide may have evicted it'
+    [],
+    'the warm turn does not resend it, the retired key no longer forces a resend'
   )
 
   unregisterModel(modelId)

--- a/packages/inference/test/context-overflow.test.ts
+++ b/packages/inference/test/context-overflow.test.ts
@@ -74,6 +74,17 @@ test('isAddonContextOverflowError: message fallback is anchored to known C++ for
     isAddonContextOverflowError(new Error('context overflow at prefill step (5 tokens, max 4)')),
     true
   )
+  // The batch guards say "at batch prefill step". Without the optional
+  // "batch " these reached the client raw and `instanceof
+  // ContextOverflowError` failed on the message-only path.
+  t.is(
+    isAddonContextOverflowError(
+      new Error(
+        '[TextLlm] context overflow at batch prefill step: prompt tokens 9, max context tokens 4'
+      )
+    ),
+    true
+  )
   t.is(isAddonContextOverflowError(new Error('processPromptImpl: context overflow\n')), true)
 })
 
@@ -105,6 +116,70 @@ test('parseContextOverflowMessage: extracts from short-form bracketed message', 
     promptTokens: 1024,
     ctxSize: 512
   })
+})
+
+// One case per guard that formats numbers, using the strings the addon
+// actually emits at this commit.
+test('parseContextOverflowMessage: covers every current addon guard', (t) => {
+  // TextLlmContext.cpp, first batch-prefill guard.
+  t.alike(
+    parseContextOverflowMessage(
+      '[TextLlm] context overflow at batch prefill step: prompt tokens 4013, max context tokens 512\n'
+    ),
+    { promptTokens: 4013, ctxSize: 512 }
+  )
+  // TextLlmContext.cpp, cached-plus-prompt guard. The "exceed the" wording
+  // is what broke the original single pattern. The reported figure is the
+  // sum, because that is what did not fit: reporting the appended 31 alone
+  // renders as "31 prompt tokens exceeds the 8192-token context window".
+  t.alike(
+    parseContextOverflowMessage(
+      '[TextLlm] context overflow at batch prefill step: cached tokens 8170 plus prompt tokens 31 exceed the max context tokens 8192\n'
+    ),
+    { promptTokens: 8201, ctxSize: 8192 }
+  )
+  // MtmdLlmContext.cpp, single-prompt guard.
+  t.alike(
+    parseContextOverflowMessage(
+      '[MtmdLlm] context overflow at prefill step (31 tokens, 24 positions, max 8192)\n'
+    ),
+    { promptTokens: 31, ctxSize: 8192 }
+  )
+  // MtmdLlmContext.cpp, cached-plus-prompt guard. KV cells are the binding
+  // measure, and again it is the sum that overflowed. These are the real
+  // numbers from the linux-x64 run that first hit this path.
+  t.alike(
+    parseContextOverflowMessage(
+      '[MtmdLlm] context overflow at prefill step: cached 5364 positions / 8172 KV cells plus 24 positions / 31 KV cells of prompt exceed the max context tokens 8192\n'
+    ),
+    { promptTokens: 8203, ctxSize: 8192 }
+  )
+  // MtmdLlmContext.cpp, batch guard.
+  t.alike(
+    parseContextOverflowMessage(
+      '[MtmdLlm] context overflow at batch prefill step: prompt spans 24 positions / 31 KV cells, max context tokens 8192\n'
+    ),
+    { promptTokens: 31, ctxSize: 8192 }
+  )
+})
+
+// The figure handed to `ContextOverflowError` is formatted as
+// "<promptTokens> prompt tokens exceeds the <ctxSize>-token context window",
+// so it has to be larger than the window or the message is nonsense and any
+// truncation logic reading it gets the wrong quantity.
+test('parseContextOverflowMessage: cached overflow reports more than the window', (t) => {
+  const cases = [
+    '[TextLlm] context overflow at batch prefill step: cached tokens 8170 plus prompt tokens 31 exceed the max context tokens 8192\n',
+    '[MtmdLlm] context overflow at prefill step: cached 5364 positions / 8172 KV cells plus 24 positions / 31 KV cells of prompt exceed the max context tokens 8192\n'
+  ]
+  for (const message of cases) {
+    const { promptTokens, ctxSize } = parseContextOverflowMessage(message)
+    t.ok(promptTokens !== undefined && ctxSize !== undefined, `both fields parsed: ${message}`)
+    t.ok(
+      promptTokens !== undefined && ctxSize !== undefined && promptTokens > ctxSize,
+      `${promptTokens} must exceed ${ctxSize}`
+    )
+  }
 })
 
 test('parseContextOverflowMessage: empty result when numbers are absent', (t) => {

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
@@ -6740,12 +6740,6 @@ class LoadModelSrcRequestLlamacppCompletionModelConfig(GeneratedBaseModel):
             description="Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`)."
         ),
     ] = None
-    n_discarded: Annotated[
-        float | None,
-        Field(
-            description="Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`)."
-        ),
-    ] = None
     parallel: Annotated[
         int | None,
         Field(

--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -8145,10 +8145,6 @@
                         "type": "string"
                       }
                     },
-                    "n_discarded": {
-                      "description": "Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`).",
-                      "type": "number"
-                    },
                     "parallel": {
                       "description": "Concurrent sequence slots for continuous batching (1–256). Default 1 (sequential, batching off); `>= 2` enables batched decoding and splits the KV cache evenly across slots.",
                       "type": "integer",

--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -105,13 +105,13 @@ const resources = new ResourceManager({
 resources.define('llm', {
   constant: LLAMA_3_2_1B_INST_Q4_0,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+  config: { verbosity: 0, ctx_size: 2048 }
 })
 
 resources.define('llm-batch', {
   constant: LLAMA_3_2_1B_INST_Q4_0,
   type: 'llm',
-  config: { verbosity: 0, ctx_size: 4096, n_discarded: 256, parallel: 4 }
+  config: { verbosity: 0, ctx_size: 4096, parallel: 4 }
 })
 
 resources.define('tools-batch', {
@@ -123,13 +123,13 @@ resources.define('tools-batch', {
 resources.define('finetune-llm', {
   constant: QWEN3_1_7B_INST_Q4,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+  config: { verbosity: 0, ctx_size: 2048 }
 })
 
 resources.define('finetune-llm-qwen35', {
   constant: QWEN3_5_0_8B_MULTIMODAL_Q8_0,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+  config: { verbosity: 0, ctx_size: 2048 }
 })
 
 resources.define('embeddings', {
@@ -250,7 +250,7 @@ resources.define('sharded-embeddings', {
 resources.define('sharded-llm', {
   constant: LLAMA_3_2_1B_INST_Q4_0_SHARD,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 },
+  config: { verbosity: 0, ctx_size: 2048 },
   skipPreDownload: true
 })
 

--- a/packages/sdk/e2e/tests/electron/consumer.ts
+++ b/packages/sdk/e2e/tests/electron/consumer.ts
@@ -102,13 +102,13 @@ const resources = new ResourceManager({
 resources.define('llm', {
   constant: LLAMA_3_2_1B_INST_Q4_0,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+  config: { verbosity: 0, ctx_size: 2048 }
 })
 
 resources.define('llm-batch', {
   constant: LLAMA_3_2_1B_INST_Q4_0,
   type: 'llm',
-  config: { verbosity: 0, ctx_size: 4096, n_discarded: 256, parallel: 4 }
+  config: { verbosity: 0, ctx_size: 4096, parallel: 4 }
 })
 
 resources.define('tools-batch', {
@@ -202,7 +202,7 @@ resources.define('sharded-embeddings', {
 resources.define('sharded-llm', {
   constant: LLAMA_3_2_1B_INST_Q4_0_SHARD,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 },
+  config: { verbosity: 0, ctx_size: 2048 },
   skipPreDownload: true
 })
 

--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -88,13 +88,13 @@ const resources = new ResourceManager({
 resources.define('llm', {
   constant: LLAMA_3_2_1B_INST_Q4_0,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+  config: { verbosity: 0, ctx_size: 2048 }
 })
 
 resources.define('llm-batch', {
   constant: LLAMA_3_2_1B_INST_Q4_0,
   type: 'llm',
-  config: { verbosity: 0, ctx_size: 4096, n_discarded: 256, parallel: 4 }
+  config: { verbosity: 0, ctx_size: 4096, parallel: 4 }
 })
 
 resources.define('tools-batch', {
@@ -184,7 +184,7 @@ resources.define('sharded-embeddings', {
 resources.define('sharded-llm', {
   constant: LLAMA_3_2_1B_INST_Q4_0_SHARD,
   type: 'llamacpp-completion',
-  config: { verbosity: 0, ctx_size: 2048, n_discarded: 256 },
+  config: { verbosity: 0, ctx_size: 2048 },
   skipPreDownload: true
 })
 

--- a/packages/sdk/e2e/tests/shared/executors/model-loading-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/model-loading-executor.ts
@@ -68,7 +68,7 @@ export class ModelLoadingExecutor extends AbstractModelExecutor<typeof modelLoad
     const modelId = await loadModel({
       modelSrc: LLAMA_3_2_1B_INST_Q4_0,
       modelType: 'llamacpp-completion',
-      modelConfig: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+      modelConfig: { verbosity: 0, ctx_size: 2048 }
     })
     this.resources.register('llm', modelId)
     return ValidationHelpers.validate(modelId, expectation)
@@ -170,7 +170,7 @@ export class ModelLoadingExecutor extends AbstractModelExecutor<typeof modelLoad
         modelId = await loadModel({
           modelSrc,
           modelType: 'llamacpp-completion',
-          modelConfig: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+          modelConfig: { verbosity: 0, ctx_size: 2048 }
         })
         this.resources.register('llm', modelId)
       } else {
@@ -192,7 +192,7 @@ export class ModelLoadingExecutor extends AbstractModelExecutor<typeof modelLoad
     const modelId = await loadModel({
       modelSrc: LLAMA_3_2_1B_INST_Q4_0,
       modelType: 'llamacpp-completion',
-      modelConfig: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+      modelConfig: { verbosity: 0, ctx_size: 2048 }
     })
     this.resources.register('llm', modelId)
     return ValidationHelpers.validate(modelId, expectation)
@@ -210,7 +210,7 @@ export class ModelLoadingExecutor extends AbstractModelExecutor<typeof modelLoad
     const modelId = await loadModel({
       modelSrc: LLAMA_3_2_1B_INST_Q4_0,
       modelType: 'llamacpp-completion',
-      modelConfig: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+      modelConfig: { verbosity: 0, ctx_size: 2048 }
     })
     this.resources.register('llm', modelId)
     return ValidationHelpers.validate(modelId, expectation)
@@ -228,7 +228,7 @@ export class ModelLoadingExecutor extends AbstractModelExecutor<typeof modelLoad
     const modelId = await loadModel({
       modelSrc: LLAMA_3_2_1B_INST_Q4_0,
       modelType: 'llamacpp-completion',
-      modelConfig: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+      modelConfig: { verbosity: 0, ctx_size: 2048 }
     })
     this.resources.register('llm', modelId)
     return ValidationHelpers.validate(modelId, expectation)
@@ -240,7 +240,7 @@ export class ModelLoadingExecutor extends AbstractModelExecutor<typeof modelLoad
   ): Promise<TestResult> {
     const modelId = await loadModel({
       modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-      modelConfig: { verbosity: 0, ctx_size: 2048, n_discarded: 256 }
+      modelConfig: { verbosity: 0, ctx_size: 2048 }
     })
     this.resources.register('llm', modelId)
     return ValidationHelpers.validate(modelId, expectation)

--- a/packages/sdk/schemas/llamacpp-config.ts
+++ b/packages/sdk/schemas/llamacpp-config.ts
@@ -88,12 +88,6 @@ export const llmConfigBaseSchema = z.object({
     .describe(
       'Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`).'
     ),
-  n_discarded: z
-    .number()
-    .optional()
-    .describe(
-      'Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`).'
-    ),
   parallel: z
     .number()
     .int()

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
@@ -260,8 +260,7 @@ function prepareMessagesForCache(
   turn: TurnHandle,
   cacheExists: boolean,
   history: HistoryMsg[],
-  tools?: Tool[],
-  toolBlockEvictable = false
+  tools?: Tool[]
 ): CachePayload {
   const toolBlock = tools?.length ? transformMessages(tools) : []
 
@@ -297,9 +296,8 @@ function prepareMessagesForCache(
   // conversation. Skip it only when the prefix is known to hold a rendered
   // one: `toolBlockCached` records that a previous turn actually got it into
   // the cache, which a committed message count does not prove. A stale
-  // boundary means we are resending the whole conversation anyway, and an
-  // evictable block can no longer be assumed present.
-  const skipToolBlock = turn.toolBlockCached && !clearStaleCount && !toolBlockEvictable
+  // boundary means we are resending the whole conversation anyway.
+  const skipToolBlock = turn.toolBlockCached && !clearStaleCount
   const blockToSend = skipToolBlock ? [] : toolBlock
 
   return {
@@ -399,13 +397,6 @@ export async function* completion(
   const modelConfig = getModelConfig(modelId)
   const toolsEnabled = (modelConfig as { tools?: boolean }).tools === true
   const toolsActive = !!tools?.length && toolsEnabled
-  // Sliding is opt-in (`n_discarded` defaults to 0). Once on, the addon's
-  // discard window opens at the end of the primed prefix — which is where the
-  // tool block sits, since the prime is the system prompt alone — and nothing
-  // protects it. So while sliding is possible the block cannot be assumed to
-  // survive, and it has to travel with every turn.
-  const toolBlockEvictable = ((modelConfig as { n_discarded?: number }).n_discarded ?? 0) > 0
-
   const dialect =
     tools && tools.length > 0 ? (params.toolDialect ?? detectToolDialect(modelId)) : undefined
 
@@ -549,8 +540,7 @@ export async function* completion(
     turn,
     /* cacheExists */ true,
     history,
-    toolsActive ? tools : undefined,
-    toolBlockEvictable
+    toolsActive ? tools : undefined
   )
   const messagesToSend = payload.messages
   logMessagesToAddon(messagesToSend, 'PROMPT_SEND')

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/context-overflow.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/context-overflow.ts
@@ -30,41 +30,80 @@ export function isAddonContextOverflowError(err: unknown): boolean {
   const message = (err as { message?: unknown }).message
   return (
     typeof message === 'string' &&
-    /(?:context overflow at prefill step|processPromptImpl: context overflow)/i.test(message)
+    /(?:context overflow at (?:batch )?prefill step|processPromptImpl: context overflow)/i.test(
+      message
+    )
   )
 }
 
 /**
+ * One entry per guard that formats numbers into a `ContextOverflow`
+ * message, ordered most specific first. Each pattern keeps its numbers
+ * inside a single clause (no `[^]*?` cross-newline walk) so a wrapper
+ * that pastes overflow text alongside unrelated numbers cannot produce a
+ * mismatched set.
+ *
+ * Every pattern captures the context size LAST and the quantities that
+ * make up the failing requirement before it, so `promptTokens` is the sum
+ * of the leading groups and `ctxSize` is the final one. That one rule
+ * covers both shapes: the guards that report a warm cache capture the
+ * cached size and the appended prompt, and it is their sum that
+ * overflowed, while the rest capture a single figure and the sum is that
+ * figure. Reporting the appended prompt alone would render as "31 prompt
+ * tokens exceeds the 8192-token context window", which is impossible on
+ * its face and useless to truncation logic. Where a guard reports both
+ * positions and KV cells, capture the cells: they are the binding
+ * measure, since M-RoPE media occupies more cells than positions.
+ *
+ * Keep this in step with the guards in `TextLlmContext.cpp` and
+ * `MtmdLlmContext.cpp`. A guard whose wording drifts out of this list
+ * does not fail loudly, it silently returns `undefined` for both fields.
+ */
+const MESSAGE_PATTERNS: RegExp[] = [
+  // "cached tokens C plus prompt tokens N exceed the max context tokens M"
+  /cached tokens (\d+) plus prompt tokens (\d+) exceeds? the max context tokens (\d+)/i,
+  // "cached P positions / C KV cells plus P2 positions / N KV cells of
+  //  prompt exceed the max context tokens M"
+  /cached \d+ positions \/ (\d+) KV cells plus \d+ positions \/ (\d+) KV cells of prompt exceeds? the max context tokens (\d+)/i,
+  // "prompt tokens N, max context tokens M"
+  /prompt tokens (\d+)[,\s]+max context tokens (\d+)/i,
+  // "prompt spans P positions / N KV cells, max context tokens M"
+  /prompt spans \d+ positions \/ (\d+) KV cells,\s*max context tokens (\d+)/i,
+  // "(N tokens, P positions, max M)"
+  /\((\d+)\s+tokens,\s*\d+\s+positions,\s*max\s+(\d+)\)/i,
+  // "(N tokens, max M)", the pre-multimodal short form
+  /\((\d+)\s+tokens,\s*max\s+(\d+)\)/i
+]
+
+/**
  * Best-effort extraction of `promptTokens` / `ctxSize` from the addon
  * error message. The C++ paths in `TextLlmContext.cpp` and
- * `MtmdLlmContext.cpp` format both numbers into the message; the
+ * `MtmdLlmContext.cpp` format the numbers into the message; the
  * `LlamaModel::processPromptImpl` fallback path emits a bare
- * `"<func>: context overflow\n"` with neither number. Returning
- * `undefined` for either field is fine — `ContextOverflowError` holds
+ * `"<func>: context overflow\n"` with none of them. Returning
+ * `undefined` for either field is fine, `ContextOverflowError` holds
  * them as optional and the message factory degrades gracefully.
+ *
+ * `promptTokens` is what did not fit, which on a warm cache is the
+ * cached conversation plus the appended prompt rather than the appended
+ * prompt alone. The name predates caching. If a caller ever needs the
+ * two halves apart, that wants new typed fields on
+ * `ContextOverflowError`, not a narrower reading of this one.
  */
 export function parseContextOverflowMessage(message: string): {
   promptTokens?: number
   ctxSize?: number
 } {
-  // "[TextLlm] context overflow at prefill step: prompt tokens N, max context tokens M\n"
-  // Same-clause separator (no `[^]*?` cross-newline walk) so a future
-  // wrapper that pastes overflow text alongside unrelated numbers can't
-  // produce a mismatched pair.
-  const longForm = message.match(/prompt tokens (\d+)[,\s]+max context tokens (\d+)/i)
-  if (longForm?.[1] && longForm[2]) {
+  for (const pattern of MESSAGE_PATTERNS) {
+    const match = message.match(pattern)
+    if (!match) continue
+    const numbers = match.slice(1).map(Number)
+    const ctxSize = numbers.pop()
+    if (ctxSize === undefined || numbers.length === 0) continue
+    if (Number.isNaN(ctxSize) || numbers.some(Number.isNaN)) continue
     return {
-      promptTokens: Number(longForm[1]),
-      ctxSize: Number(longForm[2])
-    }
-  }
-  // "[TextLlm] context overflow at prefill step (N tokens, max M)\n"
-  // "[MtmdLlm] context overflow at prefill step (N tokens, max M)\n"
-  const shortForm = message.match(/\((\d+)\s+tokens,\s*max\s+(\d+)\)/i)
-  if (shortForm?.[1] && shortForm[2]) {
-    return {
-      promptTokens: Number(shortForm[1]),
-      ctxSize: Number(shortForm[2])
+      promptTokens: numbers.reduce((sum, value) => sum + value, 0),
+      ctxSize
     }
   }
   return {}

--- a/packages/sdk/test/bare/completion-kvcache-tools.test.ts
+++ b/packages/sdk/test/bare/completion-kvcache-tools.test.ts
@@ -328,19 +328,17 @@ test('completion: kv-cache resends the tool block after a turn that could not re
   clearRegistry()
 })
 
-// With `n_discarded > 0` the addon may slide its context window, and the
-// discard region opens exactly where the tool block sits — the protected
-// prefix ends at the primed system prompt, and nothing guards the block.
-// While the block can be evicted it has to travel with every turn.
-test('completion: kv-cache resends the tool block when the context window can slide', async (t) => {
+// `n_discarded` is retired, so a config that still carries it must not change
+// caching: the warm turn skips the tool block like any other.
+test('completion: kv-cache still skips the tool block when a retired slide key is present', async (t) => {
   await setIsolatedHome()
   clearRegistry()
 
-  const modelId = `kvcache-tools-sliding-${Date.now()}`
+  const modelId = `kvcache-tools-retired-slide-key-${Date.now()}`
   const calls: RecordedCall[] = []
   registerRecordingModel(modelId, calls, { tools: true, n_discarded: 64 })
 
-  const complete = completer(modelId, 'tools-sliding-key')
+  const complete = completer(modelId, 'tools-retired-slide-key')
   const first = user('Area of a triangle, base 10 height 5?')
   await complete([first], [areaTool])
   await complete([first, assistant('25.'), user('And base 4 height 3?')], [areaTool])
@@ -355,8 +353,8 @@ test('completion: kv-cache resends the tool block when the context window can sl
   )
   t.alike(
     toolNames(turnCalls[1]!),
-    ['calculate_triangle_area'],
-    'the warm turn carries it again because a slide may have evicted it'
+    [],
+    'the warm turn does not resend it, the retired key no longer forces a resend'
   )
 
   unregisterModel(modelId)

--- a/packages/sdk/test/unit/context-overflow.test.ts
+++ b/packages/sdk/test/unit/context-overflow.test.ts
@@ -74,6 +74,17 @@ test('isAddonContextOverflowError: message fallback is anchored to known C++ for
     isAddonContextOverflowError(new Error('context overflow at prefill step (5 tokens, max 4)')),
     true
   )
+  // The batch guards say "at batch prefill step". Without the optional
+  // "batch " these reached the client raw and `instanceof
+  // ContextOverflowError` failed on the message-only path.
+  t.is(
+    isAddonContextOverflowError(
+      new Error(
+        '[TextLlm] context overflow at batch prefill step: prompt tokens 9, max context tokens 4'
+      )
+    ),
+    true
+  )
   t.is(isAddonContextOverflowError(new Error('processPromptImpl: context overflow\n')), true)
 })
 
@@ -105,6 +116,70 @@ test('parseContextOverflowMessage: extracts from short-form bracketed message', 
     promptTokens: 1024,
     ctxSize: 512
   })
+})
+
+// One case per guard that formats numbers, using the strings the addon
+// actually emits at this commit.
+test('parseContextOverflowMessage: covers every current addon guard', (t) => {
+  // TextLlmContext.cpp, first batch-prefill guard.
+  t.alike(
+    parseContextOverflowMessage(
+      '[TextLlm] context overflow at batch prefill step: prompt tokens 4013, max context tokens 512\n'
+    ),
+    { promptTokens: 4013, ctxSize: 512 }
+  )
+  // TextLlmContext.cpp, cached-plus-prompt guard. The "exceed the" wording
+  // is what broke the original single pattern. The reported figure is the
+  // sum, because that is what did not fit: reporting the appended 31 alone
+  // renders as "31 prompt tokens exceeds the 8192-token context window".
+  t.alike(
+    parseContextOverflowMessage(
+      '[TextLlm] context overflow at batch prefill step: cached tokens 8170 plus prompt tokens 31 exceed the max context tokens 8192\n'
+    ),
+    { promptTokens: 8201, ctxSize: 8192 }
+  )
+  // MtmdLlmContext.cpp, single-prompt guard.
+  t.alike(
+    parseContextOverflowMessage(
+      '[MtmdLlm] context overflow at prefill step (31 tokens, 24 positions, max 8192)\n'
+    ),
+    { promptTokens: 31, ctxSize: 8192 }
+  )
+  // MtmdLlmContext.cpp, cached-plus-prompt guard. KV cells are the binding
+  // measure, and again it is the sum that overflowed. These are the real
+  // numbers from the linux-x64 run that first hit this path.
+  t.alike(
+    parseContextOverflowMessage(
+      '[MtmdLlm] context overflow at prefill step: cached 5364 positions / 8172 KV cells plus 24 positions / 31 KV cells of prompt exceed the max context tokens 8192\n'
+    ),
+    { promptTokens: 8203, ctxSize: 8192 }
+  )
+  // MtmdLlmContext.cpp, batch guard.
+  t.alike(
+    parseContextOverflowMessage(
+      '[MtmdLlm] context overflow at batch prefill step: prompt spans 24 positions / 31 KV cells, max context tokens 8192\n'
+    ),
+    { promptTokens: 31, ctxSize: 8192 }
+  )
+})
+
+// The figure handed to `ContextOverflowError` is formatted as
+// "<promptTokens> prompt tokens exceeds the <ctxSize>-token context window",
+// so it has to be larger than the window or the message is nonsense and any
+// truncation logic reading it gets the wrong quantity.
+test('parseContextOverflowMessage: cached overflow reports more than the window', (t) => {
+  const cases = [
+    '[TextLlm] context overflow at batch prefill step: cached tokens 8170 plus prompt tokens 31 exceed the max context tokens 8192\n',
+    '[MtmdLlm] context overflow at prefill step: cached 5364 positions / 8172 KV cells plus 24 positions / 31 KV cells of prompt exceed the max context tokens 8192\n'
+  ]
+  for (const message of cases) {
+    const { promptTokens, ctxSize } = parseContextOverflowMessage(message)
+    t.ok(promptTokens !== undefined && ctxSize !== undefined, `both fields parsed: ${message}`)
+    t.ok(
+      promptTokens !== undefined && ctxSize !== undefined && promptTokens > ctxSize,
+      `${promptTokens} must exceed ${ctxSize}`
+    )
+  }
 })
 
 test('parseContextOverflowMessage: empty result when numbers are absent', (t) => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The llm-llamacpp addon stops consuming `n_discarded` in #3938, so the key reaches llama's own argument parser and fails model load as an unknown option. Every in-repo consumer still sends it.
- `parseContextOverflowMessage` matched one of the addon's five numeric overflow wordings. The two that report a warm cache parsed as nothing, and on a warm cache it reported the appended prompt alone, which renders as "31 prompt tokens exceeds the 8192-token context window".
- `isAddonContextOverflowError` did not know about `at batch prefill step`, which both text guards and the MTMD batch guard emit, so on the message-only path those errors reached the client raw and `instanceof ContextOverflowError` failed.

## 📝 How does it solve it?

- `n_discarded` removed from both zod schemas, so it is no longer accepted or forwarded, and `contract/schema.json` plus the sdk-python client regenerated from them with the pinned generators. One field each.
- Removed from every e2e config that passed `n_discarded: 256`.
- `toolBlockEvictable` is gone. It existed because the addon's discard window opened exactly where the static tool block sat, so while sliding was possible the block had to travel with every turn. Nothing evicts it now, so a warm turn skips it whenever the prefix is known to hold a rendered one.
- Every overflow pattern now captures the context size last and the parts of the failing requirement before it, so `promptTokens` is the sum of the leading groups. One rule covers both shapes: the cached guards have two leading groups, the rest have one and the sum is that figure. Where a guard reports positions and KV cells, the cells are captured, since M-RoPE media occupies more cells than positions.
- The KV-cache guide told readers to add `n_discarded` for long conversations and named it as the fix for a prefill overflow. It now describes the two ways a caller runs out of context.

**Ordering.** This does not depend on #3938 shipping first. The old patterns are kept alongside the new ones, so the parsers match what `0.45.0` emits today and what #3938 will emit later, and no addon version pin moves here. Worth knowing for review: the e2e configs passed `n_discarded: 256`, which with the currently published addon turns sliding **on**, so dropping it means those runs no longer slide. That is the permanent behaviour once #3938 is released.

## 🧪 How was it tested?

- Context-overflow parser suite: 10/10 in both `sdk` and `inference`, with one case per addon guard using the exact emitted strings, the pre-existing older wordings kept as regression cases, and a case asserting the reported figure exceeds the window, which is what makes the formatted message coherent.
- KV-cache tool-block suite: 5/5 in both packages. The case that asserted a resend under sliding now asserts that a config still carrying the retired key does not force one, so the removal keeps a regression guard.
- `contract:check` and the sdk-python `generate.py --check` both clean, so the generated files match their sources.
- `prettier` and `lint` clean in both packages.

## 💥 Breaking Changes

`n_discarded` is no longer accepted in the llamacpp model config, and it is gone from the exported contract and the generated Python client.

**BEFORE:**

```typescript
await loadModel({
  modelSrc: MODEL,
  modelType: 'llm',
  modelConfig: { ctx_size: 2048, n_discarded: 256 }
})
```

**AFTER:**

```typescript
await loadModel({
  modelSrc: MODEL,
  modelType: 'llm',
  modelConfig: { ctx_size: 2048 }
})
```
