### PR TITLE
QVAC-23933 chore: release @qvac/sdk 0.18.1

### DIFF
--- a/docs/website/content/docs/reference/release-notes/index.mdx
+++ b/docs/website/content/docs/reference/release-notes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK Release Notes — v0.18.x (latest)
-description: Release notes for QVAC SDK v0.18.0.
+description: Lists all releases from v0.18.0 to v0.18.1.
 ---
 
 ## v0.18.0
@@ -228,3 +228,26 @@ VISIONPSY_NANO_460M_MULTIMODAL_Q8_0_1
 ```text
 TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
 ```
+
+## v0.18.1
+
+### @qvac/sdk
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1
+
+QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. Load and inference behavior is unchanged.
+
+#### New APIs
+
+##### Config schemas at `@qvac/sdk/schemas`
+
+`@qvac/sdk/schemas` exports `llamacppCompletionConfigSchema`, `llamacppEmbeddingConfigSchema`, and `modelSourceSchema`. Field `.describe()` text comes from the addon README / `index.d.ts` (or an existing SDK description) and is written into `contract/schema.json`. The same descriptions land on the generated Python pydantic fields.
+
+```typescript
+import { llamacppCompletionConfigSchema } from '@qvac/sdk/schemas'
+
+llamacppCompletionConfigSchema.shape.ctx_size.description
+// "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+```
+
+The internal schema identifiers are unchanged.

--- a/docs/website/content/docs/reference/release-notes/index.mdx
+++ b/docs/website/content/docs/reference/release-notes/index.mdx
@@ -235,7 +235,7 @@ TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1
 
-QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. Load and inference behavior is unchanged.
+QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. The CosyVoice3 companion-set cache key also changes, so the first load after upgrade uses a new companion cache folder. Load APIs are otherwise unchanged.
 
 #### New APIs
 
@@ -251,3 +251,9 @@ llamacppCompletionConfigSchema.shape.ctx_size.description
 ```
 
 The internal schema identifiers are unchanged.
+
+#### Bug Fixes
+
+##### CosyVoice3 companion cache folder
+
+CosyVoice3 companion files still download with the LLM, as in 0.18.0. The companion-set cache key for `TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0` changed, so the first load after upgrading fills a new cache folder. Later loads reuse that folder. Speech APIs and `pace` / `instruct` rules are unchanged.

--- a/docs/website/src/lib/versions.ts
+++ b/docs/website/src/lib/versions.ts
@@ -40,7 +40,7 @@ export interface VersionedSection {
 
 export const API_SECTION: VersionedSection = {
   basePath: '/reference/api',
-  latest: 'v0.18.0',
+  latest: 'v0.18.1',
   latestSeries: 'v0.18.x',
   versions: [
     { label: 'v0.18.x (latest)', value: 'v0.18.x', isLatest: true },
@@ -59,7 +59,7 @@ export const API_SECTION: VersionedSection = {
 
 export const RELEASE_NOTES_SECTION: VersionedSection = {
   basePath: '/reference/release-notes',
-  latest: 'v0.18.0',
+  latest: 'v0.18.1',
   latestSeries: 'v0.18.x',
   versions: [
     { label: 'v0.18.x (latest)', value: 'v0.18.x', isLatest: true },

--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/inference",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Bare-only in-process core of the QVAC SDK. Runs inference directly on the Bare runtime with explicit plugin assembly and no RPC, worker, or subprocess layer.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/inference/src/models/registry/models.ts
+++ b/packages/inference/src/models/registry/models.ts
@@ -16998,7 +16998,7 @@ export const models = [
     quantization: 'q8_0',
     params: '0.5B',
     companionSet: {
-      setKey: '377f9721d0592b7c',
+      setKey: 'b75e001ce19bae4c',
       primaryKey: 'modelPath',
       files: [
         {

--- a/packages/inference/src/models/update-models/companions.ts
+++ b/packages/inference/src/models/update-models/companions.ts
@@ -28,6 +28,13 @@ import { BERGAMOT_MODEL_RE } from '../../surface'
  *     Primary: `char.bin`
  *     Companions in same directory: dicrc, matrix.bin, mecabrc, sys.dic, unk.dic
  *     The TTS addon receives the containing directory for Japanese tokenization.
+ *
+ *   CosyVoice3 TTS sets (directory-based):
+ *     Primary: `cosyvoice3-llm-*.gguf` under a `/cosy_voice/` path
+ *     Companions in same directory: flow, HiFT, vocab.json, merges.txt, voice-en.gguf
+ *     `voice-en.gguf` is written as `voice.gguf` so the addon finds it next to the LLM.
+ *     Companion files stay as standalone catalog entries (same as the original
+ *     hand-patch); only the LLM primary carries `companionSet` for directory load.
  */
 export function groupCompanionSets(models: ProcessedModel[]): ProcessedModel[] {
   const bySourcePath = new Map<string, ProcessedModel>()
@@ -41,6 +48,7 @@ export function groupCompanionSets(models: ProcessedModel[]): ProcessedModel[] {
   groupBergamotCompanions(models, bySourcePath, companionKeys)
   groupBciCompanions(models, bySourcePath, companionKeys)
   groupMecabCompanions(models, bySourcePath, companionKeys)
+  groupCosyvoiceCompanions(models, bySourcePath)
 
   return models.map((model) => {
     const key = sourceKey(model.registrySource, model.registryPath)
@@ -281,6 +289,91 @@ function groupMecabCompanions(
       files: [primaryEntry, ...companionEntries]
     }
   }
+}
+
+const COSYVOICE_DIR_MARKER = '/cosy_voice/'
+const COSYVOICE_COMPANIONS = [
+  { filename: 'cosyvoice3-flow-f32.gguf', key: 'flowPath', targetName: 'cosyvoice3-flow-f32.gguf' },
+  { filename: 'cosyvoice3-hift-f32.gguf', key: 'hiftPath', targetName: 'cosyvoice3-hift-f32.gguf' },
+  { filename: 'vocab.json', key: 'vocabPath', targetName: 'vocab.json' },
+  { filename: 'merges.txt', key: 'mergesPath', targetName: 'merges.txt' },
+  { filename: 'voice-en.gguf', key: 'voicePath', targetName: 'voice.gguf' }
+] as const
+
+function isCosyvoiceLlmFilename(filename: string): boolean {
+  return filename.startsWith('cosyvoice3-llm-') && filename.endsWith('.gguf')
+}
+
+function groupCosyvoiceCompanions(
+  models: ProcessedModel[],
+  bySourcePath: Map<string, ProcessedModel>
+): void {
+  for (const model of models) {
+    if (!model.registryPath.includes(COSYVOICE_DIR_MARKER)) continue
+
+    const lastSep = model.registryPath.lastIndexOf('/')
+    const filename = lastSep >= 0 ? model.registryPath.slice(lastSep + 1) : model.registryPath
+    if (!isCosyvoiceLlmFilename(filename)) continue
+
+    const dirPrefix = lastSep >= 0 ? model.registryPath.slice(0, lastSep + 1) : ''
+    const source = model.registrySource
+    const companions = findCosyvoiceCompanions(source, dirPrefix, bySourcePath)
+    if (companions.length !== COSYVOICE_COMPANIONS.length) continue
+
+    const setKey = shortHash(`${source}:${model.registryPath}`)
+    const primaryEntry: CompanionSetMetadataEntry = {
+      key: 'modelPath',
+      registryPath: model.registryPath,
+      registrySource: source,
+      targetName: filename,
+      expectedSize: model.expectedSize,
+      sha256Checksum: model.sha256Checksum,
+      blobCoreKey: model.blobCoreKey,
+      blobBlockOffset: model.blobBlockOffset,
+      blobBlockLength: model.blobBlockLength,
+      blobByteOffset: model.blobByteOffset,
+      primary: true
+    }
+
+    const companionEntries = companions.map(({ key, targetName, model: comp }) => ({
+      key,
+      registryPath: comp.registryPath,
+      registrySource: comp.registrySource,
+      targetName,
+      expectedSize: comp.expectedSize,
+      sha256Checksum: comp.sha256Checksum,
+      blobCoreKey: comp.blobCoreKey,
+      blobBlockOffset: comp.blobBlockOffset,
+      blobBlockLength: comp.blobBlockLength,
+      blobByteOffset: comp.blobByteOffset
+    }))
+
+    model.companionSet = {
+      setKey,
+      primaryKey: 'modelPath',
+      files: [primaryEntry, ...companionEntries]
+    }
+  }
+}
+
+function findCosyvoiceCompanions(
+  source: string,
+  dirPrefix: string,
+  bySourcePath: Map<string, ProcessedModel>
+): { key: string; targetName: string; model: ProcessedModel }[] {
+  const found: { key: string; targetName: string; model: ProcessedModel }[] = []
+
+  for (const companion of COSYVOICE_COMPANIONS) {
+    const model = bySourcePath.get(sourceKey(source, `${dirPrefix}${companion.filename}`))
+    if (!model) return []
+    found.push({
+      key: companion.key,
+      targetName: companion.targetName,
+      model
+    })
+  }
+
+  return found
 }
 
 function findBergamotCompanions(

--- a/packages/inference/src/schemas/llamacpp-config.ts
+++ b/packages/inference/src/schemas/llamacpp-config.ts
@@ -19,85 +19,161 @@ const verbositySchema = z.enum(VERBOSITY)
 
 // Base schema - validates types, all fields optional (for input validation)
 export const llmConfigBaseSchema = z.object({
-  ctx_size: z.number().optional(),
-  temp: z.number().min(0).max(2).optional(),
-  top_p: z.number().min(0).max(1).optional(),
-  top_k: z.number().int().min(0).max(128).optional(),
-  seed: z.number().optional(),
-  gpu_layers: z.number().optional(),
-  lora: z.string().optional(),
-  device: z.string().optional(),
+  ctx_size: z
+    .number()
+    .optional()
+    .describe(
+      "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+    ),
+  temp: z.number().min(0).max(2).optional().describe('Sampling temperature (0–2). Default 0.8.'),
+  top_p: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe('Top-p (nucleus) sampling cutoff (0–1). Default 0.9.'),
+  top_k: z
+    .number()
+    .int()
+    .min(0)
+    .max(128)
+    .optional()
+    .describe('Top-k sampling — keep only the top K tokens (0–128). Default 40.'),
+  seed: z.number().optional().describe('Sampling RNG seed; `-1` (default) picks a random seed.'),
+  gpu_layers: z
+    .number()
+    .optional()
+    .describe('Number of model layers to offload to the GPU. Default 99 (offload all).'),
+  lora: z
+    .string()
+    .optional()
+    .describe('Path to a LoRA adapter file to apply on top of the base model.'),
+  device: z
+    .string()
+    .optional()
+    .describe("Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`."),
   predict: z
     .union([
       z.literal(-1), // special: until stop token
       z.literal(-2), // special: until context filled
       z.number().int().min(1) // positive integer: fixed token count
     ])
-    .optional(),
-  /** JS-side only: seeds conversation history. Never forwarded to the C++ addon. */
-  system_prompt: z.string().optional(),
-  no_mmap: z.boolean().optional(),
-  verbosity: verbositySchema.optional(),
-  presence_penalty: z.number().optional(),
-  frequency_penalty: z.number().optional(),
-  repeat_penalty: z.number().optional(),
-  stop_sequences: z.array(z.string()).optional(),
-  n_discarded: z.number().optional(),
-  /**
-   * Concurrent sequence slots for continuous batching. Defaults to 1
-   * (sequential, batching disabled); values >= 2 enable batched decoding in
-   * @qvac/llm-llamacpp.
-   */
-  parallel: z.number().int().min(1).optional(),
-  tools: z.boolean().optional(),
-  'cache-type-k': z.string().optional(),
-  'cache-type-v': z.string().optional(),
-  'main-gpu': z.union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])]).optional(),
-  'split-mode': z.enum(['none', 'layer', 'row']).optional(),
-  'tensor-split': z.string().optional(),
-  /**
-   * Writable directory for OpenCL kernel binary cache. Required on Android
-   * for fast GPU startup.
-   */
-  openclCacheDir: z.string().optional(),
-  /**
-   * Reasoning channel token budget. `-1` = unrestricted, `0` = disabled, any
-   * positive integer caps the reasoning channel at that many tokens (the
-   * sampler force-emits the closing think tag once the budget is exhausted).
-   */
-  reasoning_budget: z.number().int().min(-1).max(REASONING_BUDGET_MAX).optional(),
-  projectionModelSrc: modelSrcInputSchema.optional(),
-  /**
-   * Qwen3.5-VL multi-tile image encoding mode (multimodal models only):
-   *   - `"sequential"` (default): encode image tiles one tile at a time.
-   *   - `"batched"`: encode all tiles in a single batched pass.
-   *   - `"disabled"`: no multi-tile encoding (single tile).
-   * Ignored by text-only models. Default is `"sequential"`.
-   */
-  image_tile_mode: z.enum(['disabled', 'batched', 'sequential']).optional(),
-  /**
-   * idefics3-style image preprocessing rule (multimodal models only):
-   *   - `"on"`: round the image's long side up to a whole number of slices and
-   *     cap it, so an image smaller than the cap keeps its own resolution and
-   *     becomes far fewer slices.
-   *   - `"off"`: always stretch the long side to the cap.
-   * When unset, the model's own GGUF value is used. Ignored with a warning by
-   * models that do not use idefics3-style preprocessing. Changes the number of
-   * image tokens, and therefore both accuracy and encode time, so a checkpoint
-   * whose GGUF omits the key needs this set to preprocess correctly.
-   */
-  image_no_upscale: z.enum(['on', 'off']).optional(),
-  /**
-   * Run the multimodal projector (mmproj / vision encoder) on the GPU
-   * (multimodal models only). `true` forces GPU, `false` forces CPU. When
-   * unset, the llm-llamacpp addon auto-selects the backend per device class:
-   * GPU on desktop/iOS and positively-detected Android Adreno 800+ GPUs; CPU on
-   * every other Android GPU — Mali, Adreno <800, and any tier that can't be
-   * detected (only Adreno 800+ is benchmarked to encode the projector faster on
-   * the GPU than the CPU). Only honoured when the model itself runs on a GPU
-   * backend — ignored with a warning on CPU.
-   */
-  'mmproj-use-gpu': z.boolean().optional()
+    .optional()
+    .describe('Max tokens to predict. `-1` = until stop token, `-2` = until context filled.'),
+  system_prompt: z
+    .string()
+    .optional()
+    .describe(
+      "Seeds conversation history on the JS side only; never forwarded to the addon. Default `'You are a helpful assistant.'`"
+    ),
+  no_mmap: z.boolean().optional().describe('Disable memory-mapped model loading. Default false.'),
+  verbosity: verbositySchema
+    .optional()
+    .describe('Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.'),
+  presence_penalty: z
+    .number()
+    .optional()
+    .describe('Presence penalty applied to tokens that have already appeared. Default 0.'),
+  frequency_penalty: z
+    .number()
+    .optional()
+    .describe('Frequency penalty applied to tokens by their frequency so far. Default 0.'),
+  repeat_penalty: z
+    .number()
+    .optional()
+    .describe('Repetition penalty applied to repeated tokens. Default 1.1.'),
+  stop_sequences: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`).'
+    ),
+  n_discarded: z
+    .number()
+    .optional()
+    .describe(
+      'Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`).'
+    ),
+  parallel: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      'Concurrent sequence slots for continuous batching (1–256). Default 1 (sequential, batching off); `>= 2` enables batched decoding and splits the KV cache evenly across slots.'
+    ),
+  tools: z
+    .boolean()
+    .optional()
+    .describe("Enable tool calling via the model's jinja chat template. Default false."),
+  'cache-type-k': z
+    .string()
+    .optional()
+    .describe(
+      'KV-cache key quantization type (`f16`, `f32`, `bf16`, `q8_0`, `q4_0`, …). Unset selects a backend-safe default.'
+    ),
+  'cache-type-v': z
+    .string()
+    .optional()
+    .describe(
+      'KV-cache value quantization type; quantizing the value cache requires flash attention. Unset selects a backend-safe default.'
+    ),
+  'main-gpu': z
+    .union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])])
+    .optional()
+    .describe(
+      "GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class."
+    ),
+  'split-mode': z
+    .enum(['none', 'layer', 'row'])
+    .optional()
+    .describe(
+      "How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism)."
+    ),
+  'tensor-split': z
+    .string()
+    .optional()
+    .describe(
+      "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25)."
+    ),
+  openclCacheDir: z
+    .string()
+    .optional()
+    .describe(
+      'Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.'
+    ),
+  reasoning_budget: z
+    .number()
+    .int()
+    .min(-1)
+    .max(REASONING_BUDGET_MAX)
+    .optional()
+    .describe(
+      'Reasoning-channel token budget. `-1` (default) unrestricted, `0` disables it, any positive integer caps the reasoning channel at that many tokens (the closing think tag is force-emitted once the budget is spent).'
+    ),
+  projectionModelSrc: modelSrcInputSchema
+    .optional()
+    .describe(
+      'Multimodal projection (mmproj / vision encoder) model source; multimodal models only.'
+    ),
+  image_tile_mode: z
+    .enum(['disabled', 'batched', 'sequential'])
+    .optional()
+    .describe(
+      "Qwen3.5-VL multi-tile image encoding mode (multimodal models only): `'sequential'` (default) encodes image tiles one at a time, `'batched'` encodes all tiles in a single batched pass, `'disabled'` does no multi-tile encoding (single tile). Ignored by text-only models."
+    ),
+  image_no_upscale: z
+    .enum(['on', 'off'])
+    .optional()
+    .describe(
+      "idefics3-style image preprocessing rule (multimodal models only): `'on'` rounds the image's long side up to a whole number of slices and caps it, so an image smaller than the cap keeps its own resolution and becomes far fewer slices; `'off'` always stretches the long side to the cap. When unset, the model's own GGUF value is used; ignored with a warning by models that do not use idefics3-style preprocessing. Changes the number of image tokens (and therefore both accuracy and encode time), so a checkpoint whose GGUF omits the key needs this set to preprocess correctly."
+    ),
+  'mmproj-use-gpu': z
+    .boolean()
+    .optional()
+    .describe(
+      'Run the multimodal projector (mmproj / vision encoder) on the GPU (multimodal models only). `true` forces GPU, `false` forces CPU. When unset, the backend is auto-selected per device class: GPU on desktop/iOS and Android Adreno 800+; CPU on every other Android GPU (Arm Mali, Adreno <800, and undetectable Adreno tiers), with the LLM layers still on the GPU. Only honoured when the model itself runs on a GPU backend — ignored with a warning on CPU.'
+    )
 })
 
 export type LlmConfigInput = z.infer<typeof llmConfigBaseSchema>
@@ -121,22 +197,69 @@ export type LlmConfig = z.infer<typeof llmConfigSchema>
 
 // Base schema - validates types, all fields optional (for input validation)
 export const embedConfigBaseSchema = z.object({
-  gpuLayers: z.number().int().optional(),
-  device: z.enum(['gpu', 'cpu']).optional(),
-  batchSize: z.number().int().min(1).optional(),
-  pooling: z.enum(['none', 'mean', 'cls', 'last', 'rank']).optional(),
-  attention: z.enum(['causal', 'non-causal']).optional(),
-  embdNormalize: z.number().int().optional(),
-  flashAttention: z.enum(['on', 'off', 'auto']).optional(),
-  mainGpu: z.union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])]).optional(),
-  splitMode: z.enum(['none', 'layer', 'row']).optional(),
-  tensorSplit: z.string().optional(),
-  verbosity: verbositySchema.optional(),
-  /**
-   * Writable directory for OpenCL kernel binary cache. Required on Android
-   * for fast GPU startup.
-   */
-  openclCacheDir: z.string().optional()
+  gpuLayers: z
+    .number()
+    .int()
+    .optional()
+    .describe('Number of model layers to offload to the GPU. Default 99 (offload all).'),
+  device: z
+    .enum(['gpu', 'cpu'])
+    .optional()
+    .describe("Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`."),
+  batchSize: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Tokens processed per batch (input throughput). Default 1024.'),
+  pooling: z
+    .enum(['none', 'mean', 'cls', 'last', 'rank'])
+    .optional()
+    .describe(
+      "Pooling strategy collapsing token embeddings into one sequence vector: `'none'`, `'mean'`, `'cls'`, `'last'`, or `'rank'`. Unset uses the model default."
+    ),
+  attention: z
+    .enum(['causal', 'non-causal'])
+    .optional()
+    .describe("Attention type: `'causal'` or `'non-causal'`. Unset uses the model default."),
+  embdNormalize: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Embedding normalization: `-1` none, `0` max-abs int16, `1` taxicab, `2` euclidean, `>2` p-norm. Default 2 (euclidean).'
+    ),
+  flashAttention: z
+    .enum(['on', 'off', 'auto'])
+    .optional()
+    .describe("Flash attention: `'on'`, `'off'`, or `'auto'`. Default `'auto'`."),
+  mainGpu: z
+    .union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])])
+    .optional()
+    .describe(
+      "GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class."
+    ),
+  splitMode: z
+    .enum(['none', 'layer', 'row'])
+    .optional()
+    .describe(
+      "How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism)."
+    ),
+  tensorSplit: z
+    .string()
+    .optional()
+    .describe(
+      "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25)."
+    ),
+  verbosity: verbositySchema
+    .optional()
+    .describe('Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.'),
+  openclCacheDir: z
+    .string()
+    .optional()
+    .describe(
+      'Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.'
+    )
 })
 
 export type EmbedConfigInput = z.infer<typeof embedConfigBaseSchema>

--- a/packages/inference/test/companion-detection.test.ts
+++ b/packages/inference/test/companion-detection.test.ts
@@ -246,3 +246,133 @@ test('groupCompanionSets: bergamot cross-source not paired', (t) => {
 
   t.absent(result[0]!.companionSet)
 })
+
+// --- CosyVoice3 companion detection ---
+
+const COSYVOICE_DIR = 'qvac_models_compiled/ggml/cosy_voice/2026-07-23/'
+
+function makeCosyvoiceSet() {
+  return {
+    llm: makeModel({
+      registryPath: `${COSYVOICE_DIR}cosyvoice3-llm-q8_0.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    flow: makeModel({
+      registryPath: `${COSYVOICE_DIR}cosyvoice3-flow-f32.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    hift: makeModel({
+      registryPath: `${COSYVOICE_DIR}cosyvoice3-hift-f32.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    vocab: makeModel({
+      registryPath: `${COSYVOICE_DIR}vocab.json`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    merges: makeModel({
+      registryPath: `${COSYVOICE_DIR}merges.txt`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    voiceEn: makeModel({
+      registryPath: `${COSYVOICE_DIR}voice-en.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    voiceZh: makeModel({
+      registryPath: `${COSYVOICE_DIR}voice-zh-female.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    })
+  }
+}
+
+test('groupCompanionSets: cosyvoice llm + directory companions (6-file set)', (t) => {
+  const files = makeCosyvoiceSet()
+  const result = groupCompanionSets([
+    files.llm,
+    files.flow,
+    files.hift,
+    files.vocab,
+    files.merges,
+    files.voiceEn,
+    files.voiceZh
+  ])
+
+  t.ok(result[0]!.companionSet, 'primary has companionSet')
+  t.is(result[0]!.companionSet!.primaryKey, 'modelPath')
+  t.is(result[0]!.companionSet!.files.length, 6)
+  t.is(result[0]!.companionSet!.files[0]!.primary, true)
+  t.is(result[0]!.companionSet!.files[0]!.key, 'modelPath')
+  t.is(result[0]!.companionSet!.files[0]!.targetName, 'cosyvoice3-llm-q8_0.gguf')
+  t.absent(result[0]!.isCompanionOnly)
+
+  const keys = result[0]!.companionSet!.files.map((f) => f.key)
+  t.alike(keys, ['modelPath', 'flowPath', 'hiftPath', 'vocabPath', 'mergesPath', 'voicePath'])
+  t.is(result[0]!.companionSet!.files[5]!.targetName, 'voice.gguf')
+  t.is(result[0]!.companionSet!.files[5]!.registryPath, `${COSYVOICE_DIR}voice-en.gguf`)
+
+  t.absent(result[1]!.isCompanionOnly, 'flow stays a standalone catalog entry')
+  t.absent(result[6]!.companionSet, 'extra voices are not pulled into the set')
+  t.absent(result[6]!.isCompanionOnly)
+})
+
+test('groupCompanionSets: cosyvoice llm without companions gets no set', (t) => {
+  const llm = makeModel({
+    registryPath: `${COSYVOICE_DIR}cosyvoice3-llm-q8_0.gguf`,
+    registrySource: 's3'
+  })
+
+  const result = groupCompanionSets([llm])
+
+  t.absent(result[0]!.companionSet)
+  t.absent(result[0]!.isCompanionOnly)
+})
+
+test('groupCompanionSets: cosyvoice cross-source not paired', (t) => {
+  const files = makeCosyvoiceSet()
+  files.flow.registrySource = 'github'
+
+  const result = groupCompanionSets([
+    files.llm,
+    files.flow,
+    files.hift,
+    files.vocab,
+    files.merges,
+    files.voiceEn
+  ])
+
+  t.absent(result[0]!.companionSet)
+})
+
+test('groupCompanionSets: cosyvoice llm outside /cosy_voice/ is skipped', (t) => {
+  const files = makeCosyvoiceSet()
+  files.llm.registryPath = 'other/cosyvoice3-llm-q8_0.gguf'
+  files.flow.registryPath = 'other/cosyvoice3-flow-f32.gguf'
+  files.hift.registryPath = 'other/cosyvoice3-hift-f32.gguf'
+  files.vocab.registryPath = 'other/vocab.json'
+  files.merges.registryPath = 'other/merges.txt'
+  files.voiceEn.registryPath = 'other/voice-en.gguf'
+
+  const result = groupCompanionSets([
+    files.llm,
+    files.flow,
+    files.hift,
+    files.vocab,
+    files.merges,
+    files.voiceEn
+  ])
+
+  t.absent(result[0]!.companionSet)
+})

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
@@ -6546,7 +6546,14 @@ class LoadModelSrcRequestLlamacppCompletionDelegate(GeneratedBaseModel):
 
 
 class Predict(RootModel[int]):
-    root: Annotated[int, Field(ge=1, le=9007199254740991)]
+    root: Annotated[
+        int,
+        Field(
+            description="Max tokens to predict. `-1` = until stop token, `-2` = until context filled.",
+            ge=1,
+            le=9007199254740991,
+        ),
+    ]
 
 
 class LoadModelSrcRequestLlamacppCompletionModelConfigVerbosity(Enum):
@@ -6557,7 +6564,14 @@ class LoadModelSrcRequestLlamacppCompletionModelConfigVerbosity(Enum):
 
 
 class MainGpu(RootModel[int]):
-    root: Annotated[int, Field(ge=0, le=9007199254740991)]
+    root: Annotated[
+        int,
+        Field(
+            description="GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class.",
+            ge=0,
+            le=9007199254740991,
+        ),
+    ]
 
 
 class LoadModelSrcRequestLlamacppCompletionModelConfigMainGpu(Enum):
@@ -6631,57 +6645,200 @@ class LoadModelSrcRequestLlamacppCompletionModelConfigImageNoUpscale(Enum):
 
 
 class LoadModelSrcRequestLlamacppCompletionModelConfig(GeneratedBaseModel):
-    ctx_size: float | None = None
-    temp: Annotated[float | None, Field(ge=0.0, le=2.0)] = None
-    top_p: Annotated[float | None, Field(ge=0.0, le=1.0)] = None
-    top_k: Annotated[int | None, Field(ge=0, le=128)] = None
-    seed: float | None = None
-    gpu_layers: float | None = None
-    lora: str | None = None
-    device: str | None = None
-    predict: Literal[-1] | Literal[-2] | Predict | None = None
-    system_prompt: str | None = None
-    no_mmap: bool | None = None
+    ctx_size: Annotated[
+        float | None,
+        Field(
+            description="Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+        ),
+    ] = None
+    temp: Annotated[
+        float | None,
+        Field(description="Sampling temperature (0–2). Default 0.8.", ge=0.0, le=2.0),
+    ] = None
+    top_p: Annotated[
+        float | None,
+        Field(
+            description="Top-p (nucleus) sampling cutoff (0–1). Default 0.9.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None
+    top_k: Annotated[
+        int | None,
+        Field(
+            description="Top-k sampling — keep only the top K tokens (0–128). Default 40.",
+            ge=0,
+            le=128,
+        ),
+    ] = None
+    seed: Annotated[
+        float | None,
+        Field(description="Sampling RNG seed; `-1` (default) picks a random seed."),
+    ] = None
+    gpu_layers: Annotated[
+        float | None,
+        Field(
+            description="Number of model layers to offload to the GPU. Default 99 (offload all)."
+        ),
+    ] = None
+    lora: Annotated[
+        str | None,
+        Field(
+            description="Path to a LoRA adapter file to apply on top of the base model."
+        ),
+    ] = None
+    device: Annotated[
+        str | None,
+        Field(
+            description="Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`."
+        ),
+    ] = None
+    predict: Annotated[
+        Literal[-1] | Literal[-2] | Predict | None,
+        Field(
+            description="Max tokens to predict. `-1` = until stop token, `-2` = until context filled."
+        ),
+    ] = None
+    system_prompt: Annotated[
+        str | None,
+        Field(
+            description="Seeds conversation history on the JS side only; never forwarded to the addon. Default `'You are a helpful assistant.'`"
+        ),
+    ] = None
+    no_mmap: Annotated[
+        bool | None,
+        Field(description="Disable memory-mapped model loading. Default false."),
+    ] = None
     verbosity: Annotated[
         LoadModelSrcRequestLlamacppCompletionModelConfigVerbosity | None,
-        Field(title="LoadModelSrcRequestLlamacppCompletionModelConfigVerbosity"),
+        Field(
+            description="Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.",
+            title="LoadModelSrcRequestLlamacppCompletionModelConfigVerbosity",
+        ),
     ] = None
-    presence_penalty: float | None = None
-    frequency_penalty: float | None = None
-    repeat_penalty: float | None = None
-    stop_sequences: list[str] | None = None
-    n_discarded: float | None = None
-    parallel: Annotated[int | None, Field(ge=1, le=9007199254740991)] = None
-    tools: bool | None = None
-    cache_type_k: Annotated[str | None, Field(alias="cache-type-k")] = None
-    cache_type_v: Annotated[str | None, Field(alias="cache-type-v")] = None
+    presence_penalty: Annotated[
+        float | None,
+        Field(
+            description="Presence penalty applied to tokens that have already appeared. Default 0."
+        ),
+    ] = None
+    frequency_penalty: Annotated[
+        float | None,
+        Field(
+            description="Frequency penalty applied to tokens by their frequency so far. Default 0."
+        ),
+    ] = None
+    repeat_penalty: Annotated[
+        float | None,
+        Field(
+            description="Repetition penalty applied to repeated tokens. Default 1.1."
+        ),
+    ] = None
+    stop_sequences: Annotated[
+        list[str] | None,
+        Field(
+            description="Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`)."
+        ),
+    ] = None
+    n_discarded: Annotated[
+        float | None,
+        Field(
+            description="Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`)."
+        ),
+    ] = None
+    parallel: Annotated[
+        int | None,
+        Field(
+            description="Concurrent sequence slots for continuous batching (1–256). Default 1 (sequential, batching off); `>= 2` enables batched decoding and splits the KV cache evenly across slots.",
+            ge=1,
+            le=9007199254740991,
+        ),
+    ] = None
+    tools: Annotated[
+        bool | None,
+        Field(
+            description="Enable tool calling via the model's jinja chat template. Default false."
+        ),
+    ] = None
+    cache_type_k: Annotated[
+        str | None,
+        Field(
+            alias="cache-type-k",
+            description="KV-cache key quantization type (`f16`, `f32`, `bf16`, `q8_0`, `q4_0`, …). Unset selects a backend-safe default.",
+        ),
+    ] = None
+    cache_type_v: Annotated[
+        str | None,
+        Field(
+            alias="cache-type-v",
+            description="KV-cache value quantization type; quantizing the value cache requires flash attention. Unset selects a backend-safe default.",
+        ),
+    ] = None
     main_gpu: Annotated[
         MainGpu | LoadModelSrcRequestLlamacppCompletionModelConfigMainGpu | None,
-        Field(alias="main-gpu"),
+        Field(
+            alias="main-gpu",
+            description="GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class.",
+        ),
     ] = None
     split_mode: Annotated[
         LoadModelSrcRequestLlamacppCompletionModelConfigSplitMode | None,
         Field(
             alias="split-mode",
+            description="How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism).",
             title="LoadModelSrcRequestLlamacppCompletionModelConfigSplitMode",
         ),
     ] = None
-    tensor_split: Annotated[str | None, Field(alias="tensor-split")] = None
-    opencl_cache_dir: Annotated[str | None, Field(alias="openclCacheDir")] = None
-    reasoning_budget: Annotated[int | None, Field(ge=-1, le=2147483647)] = None
+    tensor_split: Annotated[
+        str | None,
+        Field(
+            alias="tensor-split",
+            description="Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25).",
+        ),
+    ] = None
+    opencl_cache_dir: Annotated[
+        str | None,
+        Field(
+            alias="openclCacheDir",
+            description="Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.",
+        ),
+    ] = None
+    reasoning_budget: Annotated[
+        int | None,
+        Field(
+            description="Reasoning-channel token budget. `-1` (default) unrestricted, `0` disables it, any positive integer caps the reasoning channel at that many tokens (the closing think tag is force-emitted once the budget is spent).",
+            ge=-1,
+            le=2147483647,
+        ),
+    ] = None
     projection_model_src: Annotated[
         str | LoadModelSrcRequestLlamacppCompletionModelConfigProjectionModelSrc | None,
-        Field(alias="projectionModelSrc"),
+        Field(
+            alias="projectionModelSrc",
+            description="Multimodal projection (mmproj / vision encoder) model source; multimodal models only.",
+        ),
     ] = None
     image_tile_mode: Annotated[
         LoadModelSrcRequestLlamacppCompletionModelConfigImageTileMode | None,
-        Field(title="LoadModelSrcRequestLlamacppCompletionModelConfigImageTileMode"),
+        Field(
+            description="Qwen3.5-VL multi-tile image encoding mode (multimodal models only): `'sequential'` (default) encodes image tiles one at a time, `'batched'` encodes all tiles in a single batched pass, `'disabled'` does no multi-tile encoding (single tile). Ignored by text-only models.",
+            title="LoadModelSrcRequestLlamacppCompletionModelConfigImageTileMode",
+        ),
     ] = None
     image_no_upscale: Annotated[
         LoadModelSrcRequestLlamacppCompletionModelConfigImageNoUpscale | None,
-        Field(title="LoadModelSrcRequestLlamacppCompletionModelConfigImageNoUpscale"),
+        Field(
+            description="idefics3-style image preprocessing rule (multimodal models only): `'on'` rounds the image's long side up to a whole number of slices and caps it, so an image smaller than the cap keeps its own resolution and becomes far fewer slices; `'off'` always stretches the long side to the cap. When unset, the model's own GGUF value is used; ignored with a warning by models that do not use idefics3-style preprocessing. Changes the number of image tokens (and therefore both accuracy and encode time), so a checkpoint whose GGUF omits the key needs this set to preprocess correctly.",
+            title="LoadModelSrcRequestLlamacppCompletionModelConfigImageNoUpscale",
+        ),
     ] = None
-    mmproj_use_gpu: Annotated[bool | None, Field(alias="mmproj-use-gpu")] = None
+    mmproj_use_gpu: Annotated[
+        bool | None,
+        Field(
+            alias="mmproj-use-gpu",
+            description="Run the multimodal projector (mmproj / vision encoder) on the GPU (multimodal models only). `true` forces GPU, `false` forces CPU. When unset, the backend is auto-selected per device class: GPU on desktop/iOS and Android Adreno 800+; CPU on every other Android GPU (Arm Mali, Adreno <800, and undetectable Adreno tiers), with the LLM layers still on the GPU. Only honoured when the model itself runs on a GPU backend — ignored with a warning on CPU.",
+        ),
+    ] = None
 
 
 class LoadModelSrcRequestLlamacppCompletion(GeneratedBaseModel):
@@ -7440,51 +7597,97 @@ class LoadModelSrcRequestLlamacppEmbeddingModelConfigVerbosity(Enum):
 
 class LoadModelSrcRequestLlamacppEmbeddingModelConfig(GeneratedBaseModel):
     gpu_layers: Annotated[
-        int | None, Field(alias="gpuLayers", ge=-9007199254740991, le=9007199254740991)
+        int | None,
+        Field(
+            alias="gpuLayers",
+            description="Number of model layers to offload to the GPU. Default 99 (offload all).",
+            ge=-9007199254740991,
+            le=9007199254740991,
+        ),
     ] = None
     device: Annotated[
         LoadModelSrcRequestLlamacppEmbeddingModelConfigDevice | None,
-        Field(title="LoadModelSrcRequestLlamacppEmbeddingModelConfigDevice"),
+        Field(
+            description="Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`.",
+            title="LoadModelSrcRequestLlamacppEmbeddingModelConfigDevice",
+        ),
     ] = None
     batch_size: Annotated[
-        int | None, Field(alias="batchSize", ge=1, le=9007199254740991)
+        int | None,
+        Field(
+            alias="batchSize",
+            description="Tokens processed per batch (input throughput). Default 1024.",
+            ge=1,
+            le=9007199254740991,
+        ),
     ] = None
     pooling: Annotated[
         LoadModelSrcRequestLlamacppEmbeddingModelConfigPooling | None,
-        Field(title="LoadModelSrcRequestLlamacppEmbeddingModelConfigPooling"),
+        Field(
+            description="Pooling strategy collapsing token embeddings into one sequence vector: `'none'`, `'mean'`, `'cls'`, `'last'`, or `'rank'`. Unset uses the model default.",
+            title="LoadModelSrcRequestLlamacppEmbeddingModelConfigPooling",
+        ),
     ] = None
     attention: Annotated[
         LoadModelSrcRequestLlamacppEmbeddingModelConfigAttention | None,
-        Field(title="LoadModelSrcRequestLlamacppEmbeddingModelConfigAttention"),
+        Field(
+            description="Attention type: `'causal'` or `'non-causal'`. Unset uses the model default.",
+            title="LoadModelSrcRequestLlamacppEmbeddingModelConfigAttention",
+        ),
     ] = None
     embd_normalize: Annotated[
         int | None,
-        Field(alias="embdNormalize", ge=-9007199254740991, le=9007199254740991),
+        Field(
+            alias="embdNormalize",
+            description="Embedding normalization: `-1` none, `0` max-abs int16, `1` taxicab, `2` euclidean, `>2` p-norm. Default 2 (euclidean).",
+            ge=-9007199254740991,
+            le=9007199254740991,
+        ),
     ] = None
     flash_attention: Annotated[
         LoadModelSrcRequestLlamacppEmbeddingModelConfigFlashAttention | None,
         Field(
             alias="flashAttention",
+            description="Flash attention: `'on'`, `'off'`, or `'auto'`. Default `'auto'`.",
             title="LoadModelSrcRequestLlamacppEmbeddingModelConfigFlashAttention",
         ),
     ] = None
     main_gpu: Annotated[
         MainGpu | LoadModelSrcRequestLlamacppEmbeddingModelConfigMainGpu | None,
-        Field(alias="mainGpu"),
+        Field(
+            alias="mainGpu",
+            description="GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class.",
+        ),
     ] = None
     split_mode: Annotated[
         LoadModelSrcRequestLlamacppEmbeddingModelConfigSplitMode | None,
         Field(
             alias="splitMode",
+            description="How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism).",
             title="LoadModelSrcRequestLlamacppEmbeddingModelConfigSplitMode",
         ),
     ] = None
-    tensor_split: Annotated[str | None, Field(alias="tensorSplit")] = None
+    tensor_split: Annotated[
+        str | None,
+        Field(
+            alias="tensorSplit",
+            description="Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25).",
+        ),
+    ] = None
     verbosity: Annotated[
         LoadModelSrcRequestLlamacppEmbeddingModelConfigVerbosity | None,
-        Field(title="LoadModelSrcRequestLlamacppEmbeddingModelConfigVerbosity"),
+        Field(
+            description="Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.",
+            title="LoadModelSrcRequestLlamacppEmbeddingModelConfigVerbosity",
+        ),
     ] = None
-    opencl_cache_dir: Annotated[str | None, Field(alias="openclCacheDir")] = None
+    opencl_cache_dir: Annotated[
+        str | None,
+        Field(
+            alias="openclCacheDir",
+            description="Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.",
+        ),
+    ] = None
 
 
 class LoadModelSrcRequestLlamacppEmbedding(GeneratedBaseModel):

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/sdk_version.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/sdk_version.py
@@ -5,6 +5,6 @@ connects to must be this version. Sourced from packages/sdk/package.json.
 
 from __future__ import annotations
 
-SDK_VERSION = "0.18.0"
+SDK_VERSION = "0.18.1"
 
 __all__ = ["SDK_VERSION"]

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -42,25 +42,25 @@ QVAC SDK 0.18.0 adds VisionPsy Nano multimodal constants, Audio8 and CosyVoice3 
 **Before:**
 
 ```typescript
-import { loadModel, TOOLS_MODE } from "@qvac/sdk";
+import { loadModel, TOOLS_MODE } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic },
-});
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic }
+})
 ```
 
 **After:**
 
 ```typescript
-import { loadModel } from "@qvac/sdk";
+import { loadModel } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, tools: true },
-});
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, tools: true }
+})
 ```
 
 Existing automatic KV-cache prefixes that were primed under dynamic tools mode are not reusable; the next turn rebuilds the prefix.
@@ -72,13 +72,13 @@ Existing automatic KV-cache prefixes that were primed under dynamic tools mode a
 **Before:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: "very fast" });
+textToSpeech({ modelId, text, pace: 'very fast' })
 ```
 
 **After:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: "fast" });
+textToSpeech({ modelId, text, pace: 'fast' })
 ```
 
 ## New APIs
@@ -88,12 +88,10 @@ textToSpeech({ modelId, text, pace: "fast" });
 One loaded LLM can run several `completion` calls at once. A new request takes a free slot without waiting for the whole batch to drain. Cancelling one request leaves the others running, and each result reports its own timings. Single-slot models and fine-tuning stay one-at-a-time.
 
 ```typescript
-const runs = prompts.map((p) =>
-  completion({ modelId, history: p, stream: true }),
-);
-const outputs = await Promise.all(runs.map((r) => r.final));
+const runs = prompts.map((p) => completion({ modelId, history: p, stream: true }))
+const outputs = await Promise.all(runs.map((r) => r.final))
 
-await cancel({ requestId: runs[0].requestId });
+await cancel({ requestId: runs[0].requestId })
 ```
 
 ### loadModel fallbackSrc
@@ -101,12 +99,12 @@ await cancel({ requestId: runs[0].requestId });
 If the primary `modelSrc` cannot be fetched, `loadModel` retries from `fallbackSrc` (URL or local path) so callers do not have to build their own origin failover.
 
 ```typescript
-import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  fallbackSrc: "https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf",
-});
+  fallbackSrc: 'https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf'
+})
 ```
 
 ### AudioGen Cover From a Source Track
@@ -116,14 +114,14 @@ AudioGen can now generate a cover from source audio, not only a text caption. Pa
 ```typescript
 const cover = audioGen({
   modelId,
-  caption: "orchestral arrangement with dramatic strings",
-  lyrics: "[Instrumental]",
-  taskType: "cover-nofsq",
-  sourceAudio: "/path/to/source.wav",
-  referenceAudio: "/path/to/reference.mp3",
+  caption: 'orchestral arrangement with dramatic strings',
+  lyrics: '[Instrumental]',
+  taskType: 'cover-nofsq',
+  sourceAudio: '/path/to/source.wav',
+  referenceAudio: '/path/to/reference.mp3',
   audioCoverStrength: 1,
-  coverNoiseStrength: 0.75,
-});
+  coverNoiseStrength: 0.75
+})
 ```
 
 ### CosyVoice3 TTS
@@ -134,17 +132,17 @@ Load CosyVoice3 with `ttsEngine: "cosyvoice3"`. Companion files download with th
 const modelId = await loadModel({
   modelSrc: TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0,
   modelConfig: {
-    ttsEngine: "cosyvoice3",
-    instruct: { dialect: "cantonese" },
-    seed: 42,
-  },
-});
+    ttsEngine: 'cosyvoice3',
+    instruct: { dialect: 'cantonese' },
+    seed: 42
+  }
+})
 const result = textToSpeech({
   modelId,
-  text: "Hey there!",
+  text: 'Hey there!',
   stream: false,
-  emotion: "happy",
-});
+  emotion: 'happy'
+})
 ```
 
 ### Audio8 TTS
@@ -155,13 +153,13 @@ Audio8 is a multilingual LM + codec stack with optional zero-shot cloning via re
 await loadModel({
   modelSrc: TTS_LM_MULTILINGUAL_AUDIO8_Q8_0,
   modelConfig: {
-    ttsEngine: "audio8",
+    ttsEngine: 'audio8',
     audio8CodecDecoderModelSrc: TTS_CODEC_DECODER_AUDIO8_Q8_0,
     audio8CodecEncoderModelSrc: TTS_CODEC_ENCODER_AUDIO8_Q8_0,
-    referenceAudioSrc: "file:///path/to/voice.wav",
-    referenceText: "Exactly what the recording says.",
-  },
-});
+    referenceAudioSrc: 'file:///path/to/voice.wav',
+    referenceText: 'Exactly what the recording says.'
+  }
+})
 ```
 
 ### Streaming Transcription Stats
@@ -169,12 +167,12 @@ await loadModel({
 `transcribeStream` sessions now expose `stats` after the stream ends (`audioDuration`, `realTimeFactor`).
 
 ```typescript
-const session = await transcribeStream({ modelId });
+const session = await transcribeStream({ modelId })
 for await (const event of session) {
   // streamed events
 }
-const stats = await session.stats;
-console.log(stats?.audioDuration, stats?.realTimeFactor);
+const stats = await session.stats
+console.log(stats?.audioDuration, stats?.realTimeFactor)
 ```
 
 ### Vision image_no_upscale
@@ -183,13 +181,13 @@ VisionPsy (and other llama.cpp multimodal loads) can set `image_no_upscale: "on"
 
 ```typescript
 await loadModel({
-  modelType: "llm",
+  modelType: 'llm',
   modelSrc: VISIONPSY_NANO_460M_MULTIMODAL_Q4_K_M,
   modelConfig: {
     projectionModelSrc: MMPROJ_VISIONPSY_NANO_460M_MULTIMODAL_Q8_0,
-    image_no_upscale: "on",
-  },
-});
+    image_no_upscale: 'on'
+  }
+})
 ```
 
 ## Features
@@ -591,13 +589,13 @@ Image generation now supports Ideogram 4 through the `sdcpp-generation` model ty
 ```typescript
 const modelId = await loadModel({
   modelSrc: IDEOGRAM_MODEL_URL,
-  modelType: "sdcpp-generation",
+  modelType: 'sdcpp-generation',
   modelConfig: {
     llmModelSrc: QWEN3_VL_MODEL_URL,
     vaeModelSrc: VAE_MODEL_URL,
-    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL,
-  },
-});
+    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL
+  }
+})
 ```
 
 ### Per-Phase Diffusion Timing Stats
@@ -605,12 +603,12 @@ const modelId = await loadModel({
 Diffusion results now include a per-phase timing breakdown, so you can see where generation time goes — conditioning, the denoising loop, VAE decode, post-processing, and overall throughput.
 
 ```typescript
-const { stats } = await result;
-console.log(stats.conditionerMs); // prompt conditioning time (ms)
-console.log(stats.denoiseMs); // denoising loop time (ms)
-console.log(stats.vaeMs); // VAE decode time (ms)
-console.log(stats.postProcessMs); // encode/upscale/mux time (ms)
-console.log(stats.stepsPerSecond); // denoising throughput (steps/s)
+const { stats } = await result
+console.log(stats.conditionerMs) // prompt conditioning time (ms)
+console.log(stats.denoiseMs) // denoising loop time (ms)
+console.log(stats.vaeMs) // VAE decode time (ms)
+console.log(stats.postProcessMs) // encode/upscale/mux time (ms)
+console.log(stats.stepsPerSecond) // denoising throughput (steps/s)
 ```
 
 ### Python SDK Client
@@ -641,19 +639,19 @@ async with Client() as client:
 The VLA SDK now exposes GR00T as a first-class model, including its registry entry, hyperparameters, and helpers. GR00T uses a patch-based image input mode: when `hparams.imageInputMode` is `"patches"`, each camera image is supplied as a pre-patchified float buffer. A runnable usage example and desktop e2e ship alongside it.
 
 ```typescript
-import { loadModel, vlaHparams, vla, vlaPadState } from "@qvac/sdk";
+import { loadModel, vlaHparams, vla, vlaPadState } from '@qvac/sdk'
 
-const modelId = await loadModel({ modelSrc, modelType: "ggml-vla" });
-const { hparams } = await vlaHparams({ modelId });
+const modelId = await loadModel({ modelSrc, modelType: 'ggml-vla' })
+const { hparams } = await vlaHparams({ modelId })
 
-if (hparams.imageInputMode === "patches") {
+if (hparams.imageInputMode === 'patches') {
   // GR00T: each images[] entry is a pre-patchified buffer of imagePatchElems floats
   const images = Array.from(
     { length: hparams.numCameras },
-    () => new Float32Array(hparams.imagePatchElems),
-  );
-  const state = vlaPadState(robotState, hparams.maxStateDim);
-  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim);
+    () => new Float32Array(hparams.imagePatchElems)
+  )
+  const state = vlaPadState(robotState, hparams.maxStateDim)
+  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim)
 
   const { actions, actionDim, chunkSize } = await vla({
     modelId,
@@ -663,8 +661,8 @@ if (hparams.imageInputMode === "patches") {
     state,
     tokens, // Qwen3-VL tokens, length hparams.tokenizerMaxLength
     mask,
-    noise,
-  });
+    noise
+  })
 }
 ```
 
@@ -807,41 +805,37 @@ QVAC SDK 0.15.0 introduces single-job batch completion for running many prompts 
 `batchCompletion` runs many prompts through a single loaded model in one job, streaming per-prompt deltas and returning ordered results. Each prompt can carry its own history, generation parameters, and optional per-prompt tools or MCP-sourced tools.
 
 ```typescript
-import {
-  batchCompletion,
-  loadModel,
-  LLAMA_3_2_1B_INST_Q4_0,
-} from "@qvac/sdk";
+import { batchCompletion, loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, parallel: 4 },
-});
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, parallel: 4 }
+})
 
 const run = batchCompletion({
   modelId,
   prompts: [
     {
-      id: "a",
-      history: [{ role: "user", content: "Reply with only APPLE." }],
-      generationParams: { temp: 0, predict: 16 },
+      id: 'a',
+      history: [{ role: 'user', content: 'Reply with only APPLE.' }],
+      generationParams: { temp: 0, predict: 16 }
     },
     {
-      id: "b",
-      history: [{ role: "user", content: "What's the weather in Paris?" }],
+      id: 'b',
+      history: [{ role: 'user', content: "What's the weather in Paris?" }],
       tools: [getWeatherTool], // optional per-prompt tools
-      generationParams: { temp: 0, predict: 64 },
-    },
-  ],
-});
+      generationParams: { temp: 0, predict: 64 }
+    }
+  ]
+})
 
 for await (const { id, event } of run.events) {
-  if (event.type === "contentDelta") process.stdout.write(`[${id}] ${event.text}`);
+  if (event.type === 'contentDelta') process.stdout.write(`[${id}] ${event.text}`)
 }
 
-const results = await run.results; // ordered, all-or-nothing on stream-level failure
-const stats = await run.stats; // batch-level CompletionStats | undefined
+const results = await run.results // ordered, all-or-nothing on stream-level failure
+const stats = await run.stats // batch-level CompletionStats | undefined
 ```
 
 ### GPU Placement for Multimodal Vision Encoders
@@ -853,9 +847,9 @@ await loadModel({
   modelSrc: SMOLVLM2_500M_MULTIMODAL_Q8_0,
   modelConfig: {
     projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
-    "mmproj-use-gpu": true, // true = GPU, false = CPU; omit to auto-select
-  },
-});
+    'mmproj-use-gpu': true // true = GPU, false = CPU; omit to auto-select
+  }
+})
 ```
 
 ## Features
@@ -866,14 +860,14 @@ Supertonic TTS gains optional LavaSR post-processing: an enhancer and a denoiser
 
 ```typescript
 await sdk.loadModel({
-  ttsEngine: "supertonic",
+  ttsEngine: 'supertonic',
   modelSrc: TTS_MULTILINGUAL_SUPERTONIC3_Q8_0.src,
   // LavaSR post-processing (both optional)
   lavasrDenoiserModelSrc: TTS_DENOISER_LAVASR_FP16.src,
   lavasrEnhancerModelSrc: TTS_ENHANCER_LAVASR_FP16.src,
   // Supertonic-only output sample rate (8000-192000 Hz)
-  outputSampleRate: 48000,
-});
+  outputSampleRate: 48000
+})
 ```
 
 ### Japanese and Chinese Chatterbox TTS
@@ -886,30 +880,30 @@ import {
   TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_MECAB_IPADIC_CHATTERBOX,
-  TTS_CANGJIE_ZH_CHATTERBOX,
-} from "@qvac/sdk";
+  TTS_CANGJIE_ZH_CHATTERBOX
+} from '@qvac/sdk'
 
 // Japanese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "ja",
+    ttsEngine: 'chatterbox',
+    language: 'ja',
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX,
-  },
-});
+    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX
+  }
+})
 
 // Chinese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "zh",
+    ttsEngine: 'chatterbox',
+    language: 'zh',
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX,
-  },
-});
+    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX
+  }
+})
 ```
 
 ## Bug Fixes
@@ -971,7 +965,7 @@ The SDK and its native backends (llama.cpp / ggml) no longer print to the consol
 
 ```typescript
 // SDK and native logs printed to the console by default.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
 // → console fills with SDK + native output
 ```
 
@@ -979,7 +973,7 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
 
 ```typescript
 // Silent by default — no console output.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
 
 // Opt in:
 //   qvac.config.json → { "loggerConsoleOutput": true }                          // SDK logs
@@ -995,14 +989,14 @@ The bundled `bare-process` shim has been removed in favor of Bare primitives. Co
 
 ```typescript
 // process available as a global
-process.exit(0);
+process.exit(0)
 ```
 
 **After:**
 
 ```typescript
-import process from "bare-process";
-process.exit(0);
+import process from 'bare-process'
+process.exit(0)
 ```
 
 ### OCR Now Runs on GGML
@@ -1016,14 +1010,14 @@ The SDK's OCR path moves from ONNX to GGML-OCR 0.4.0. The legacy ONNX OCR model 
 `subscribeServerLogs` registers a single handler that receives all server-side logs, removing the need for per-ID `loggingStream()` calls.
 
 ```typescript
-import { subscribeServerLogs } from "@qvac/sdk";
+import { subscribeServerLogs } from '@qvac/sdk'
 
 const unsubscribe = subscribeServerLogs((log) => {
-  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
-});
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`)
+})
 
 // later
-unsubscribe();
+unsubscribe()
 ```
 
 ### Field-Level Validation Errors
@@ -1031,13 +1025,13 @@ unsubscribe();
 Invalid input now produces readable, field-level errors instead of opaque failures. A `RequestValidationFailedError` carries a message that points at the offending field.
 
 ```typescript
-import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
 
 try {
-  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } })
 } catch (err) {
   if (err instanceof RequestValidationFailedError) {
-    console.error(err.message);
+    console.error(err.message)
     // Invalid request:
     // ✖ Unrecognized key: "dtx_size"
     //   → at modelConfig
@@ -1052,20 +1046,20 @@ Completions can now cap or disable the reasoning channel per request or at load 
 ```typescript
 // Per-request: cap the reasoning channel at 128 tokens for a single run()
 await session.run({
-  history: [{ role: "user", content: "Solve this step by step" }],
-  reasoning_budget: 128, // -1 = unrestricted, 0 = disabled, N = cap at N tokens
-});
+  history: [{ role: 'user', content: 'Solve this step by step' }],
+  reasoning_budget: 128 // -1 = unrestricted, 0 = disabled, N = cap at N tokens
+})
 
 // Load-time default
-await loadModel(src, { reasoning_budget: 256 });
+await loadModel(src, { reasoning_budget: 256 })
 ```
 
 ```typescript
 // Drop this turn's reasoning block from the KV cache after generation
 await model.completion({
   history,
-  generationParams: { remove_thinking_from_context: true },
-});
+  generationParams: { remove_thinking_from_context: true }
+})
 ```
 
 The same `remove_thinking_from_context` flag is accepted on the CLI's OpenAI-compatible `/v1/chat/completions` request body.
@@ -1077,9 +1071,9 @@ A new `image_tile_mode` config controls how multimodal images are tiled before i
 ```typescript
 await loadModel({
   modelSrc: QWEN3_5_VL_MODEL,
-  modelType: "llamacpp-completion",
-  modelConfig: { image_tile_mode: "sequential" }, // "disabled" | "batched" | "sequential" (default: "sequential")
-});
+  modelType: 'llamacpp-completion',
+  modelConfig: { image_tile_mode: 'sequential' } // "disabled" | "batched" | "sequential" (default: "sequential")
+})
 ```
 
 ### Per-Engine TTS Language Validation and More Languages
@@ -1091,24 +1085,24 @@ import {
   TTS_CHATTERBOX_LANGUAGES,
   TTS_SUPERTONIC_LANGUAGES,
   type TtsChatterboxLanguage,
-  type TtsSupertonicLanguage,
-} from "@qvac/sdk";
+  type TtsSupertonicLanguage
+} from '@qvac/sdk'
 
 await loadModel({
   modelSrc: TTS_T3_TURBO_EN_CHATTERBOX_Q8_0,
-  modelType: "tts-ggml",
+  modelType: 'tts-ggml',
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "en",
+    ttsEngine: 'chatterbox',
+    language: 'en',
     s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX.src,
     streamChunkTokens: 25,
     streamFirstChunkTokens: 10,
     cfmSteps: 1,
     threads: 8,
     nGpuLayers: 99,
-    seed: 42,
-  },
-});
+    seed: 42
+  }
+})
 ```
 
 ### Parakeet 0.8 Runtime Fields and Explicit BCI Embedder Loading
@@ -1120,10 +1114,10 @@ const modelId = await loadModel({
   modelSrc: BCI_WINDOWED,
   modelConfig: {
     embedderModelSrc: BCI_EMBEDDER,
-    whisperConfig: { language: "en", temperature: 0.0 },
-    bciConfig: { day_idx: 1 },
-  },
-});
+    whisperConfig: { language: 'en', temperature: 0.0 },
+    bciConfig: { day_idx: 1 }
+  }
+})
 ```
 
 ## Bug Fixes
@@ -1300,20 +1294,20 @@ QVAC SDK 0.13.0 broadens the SDK across video, neural-signal transcription, robo
 The video API now supports image-to-video generation for Wan image-to-video pipelines. Consumers can provide an initial frame through `init_image` and control denoising with `strength`, making it possible to animate a source image instead of generating entirely from text.
 
 ```typescript
-import fs from "node:fs";
-import { video } from "@qvac/sdk";
+import fs from 'node:fs'
+import { video } from '@qvac/sdk'
 
-const firstFrame = fs.readFileSync("portrait.png");
+const firstFrame = fs.readFileSync('portrait.png')
 const { outputs } = video({
   modelId,
-  mode: "img2vid",
-  prompt: "the subject slowly turns and smiles, cinematic lighting",
+  mode: 'img2vid',
+  prompt: 'the subject slowly turns and smiles, cinematic lighting',
   init_image: firstFrame,
-  strength: 0.85,
-});
+  strength: 0.85
+})
 
-const buffers = await outputs;
-fs.writeFileSync("output.avi", buffers[0]);
+const buffers = await outputs
+fs.writeFileSync('output.avi', buffers[0])
 ```
 
 This change also moves video dimension validation to the SDK schema boundary. Width and height now need to be multiples of 16, so invalid dimensions fail before they reach the native addon.
@@ -1321,13 +1315,13 @@ This change also moves video dimension validation to the SDK schema boundary. Wi
 **Before:**
 
 ```typescript
-video({ modelId, mode: "txt2vid", prompt: "...", width: 520, height: 264 });
+video({ modelId, mode: 'txt2vid', prompt: '...', width: 520, height: 264 })
 ```
 
 **After:**
 
 ```typescript
-video({ modelId, mode: "txt2vid", prompt: "...", width: 528, height: 272 });
+video({ modelId, mode: 'txt2vid', prompt: '...', width: 528, height: 272 })
 ```
 
 ## Worker Failures Are Now Typed SDK Errors
@@ -1335,15 +1329,15 @@ video({ modelId, mode: "txt2vid", prompt: "...", width: 528, height: 272 });
 Bare worker crashes and SDK shutdown now surface as structured RPC errors instead of ambiguous failures. Applications can distinguish an unexpected worker death from an in-flight request that was cancelled because the SDK is closing.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
 
 try {
-  await sdk.embed({ modelId, text: "hi" });
+  await sdk.embed({ modelId, text: 'hi' })
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
-    console.error(err.exitCode, err.exitSignal);
+    console.error(err.exitCode, err.exitSignal)
   } else if (err instanceof WorkerShutdownError) {
-    console.error("The SDK closed while this request was in flight.");
+    console.error('The SDK closed while this request was in flight.')
   }
 }
 ```
@@ -1353,18 +1347,18 @@ try {
 The new Electron Forge plugin helps packaged desktop apps include only the native addon trees needed by their QVAC configuration. This reduces accidental bundling of unused prebuilds and keeps app packages closer to the target platform set.
 
 ```typescript
-const QvacForgePlugin = require("@qvac/sdk/electron-forge");
+const QvacForgePlugin = require('@qvac/sdk/electron-forge')
 
 module.exports = {
-  packagerConfig: { name: "MyApp" },
+  packagerConfig: { name: 'MyApp' },
   plugins: [
     new QvacForgePlugin({
-      configPath: "./qvac.config.json",
-      hosts: ["darwin-arm64", "darwin-x64"],
-      logLevel: "info",
-    }),
-  ],
-};
+      configPath: './qvac.config.json',
+      hosts: ['darwin-arm64', 'darwin-x64'],
+      logLevel: 'info'
+    })
+  ]
+}
 ```
 
 ## Completion and Transcription Metadata Are More Precise
@@ -1376,10 +1370,10 @@ Whisper transcription metadata now exposes backend and GPU stats in the final st
 ```typescript
 for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) {
   if (ev.done && ev.stats) {
-    console.log(ev.stats.backendDevice);
-    console.log(ev.stats.backendId);
-    console.log(ev.stats.gpuMemTotalMb);
-    console.log(ev.stats.gpuMemFreeMb);
+    console.log(ev.stats.backendDevice)
+    console.log(ev.stats.backendId)
+    console.log(ev.stats.gpuMemTotalMb)
+    console.log(ev.stats.gpuMemFreeMb)
   }
 }
 ```
@@ -1389,29 +1383,29 @@ for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) 
 The SDK now includes BCI transcription backed by whisper.cpp. It supports both batch transcription from a `.bin` path or `Uint8Array`, and streaming duplex sessions over neural-signal chunks.
 
 ```typescript
-import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from "@qvac/sdk";
+import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from '@qvac/sdk'
 
-const modelId = await loadModel({ modelSrc: BCI_WINDOWED });
-const text = await bciTranscribe({ modelId, neuralData: "./signal.bin" });
+const modelId = await loadModel({ modelSrc: BCI_WINDOWED })
+const text = await bciTranscribe({ modelId, neuralData: './signal.bin' })
 
-const session = await bciTranscribeStream({ modelId, emit: "delta" });
-session.write(chunk);
-session.end();
+const session = await bciTranscribeStream({ modelId, emit: 'delta' })
+session.write(chunk)
+session.end()
 
 for await (const token of session) {
-  process.stdout.write(token);
+  process.stdout.write(token)
 }
 ```
 
 This release also integrates the pi05 VLA model path for robot-action inference. The VLA API can inspect model hparams, preprocess camera frames, and run action generation with the required image, token, mask, and noise inputs.
 
 ```typescript
-import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from "@qvac/sdk";
+import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from '@qvac/sdk'
 
-const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: "ggml-vla" });
-const { hparams } = await vlaHparams({ modelId });
-const size = hparams.visionImageSize;
-const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }));
+const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: 'ggml-vla' })
+const { hparams } = await vlaHparams({ modelId })
+const size = hparams.visionImageSize
+const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }))
 
 const { actions } = await vla({
   modelId,
@@ -1421,8 +1415,8 @@ const { actions } = await vla({
   state: new Float32Array(0),
   tokens,
   mask,
-  noise,
-});
+  noise
+})
 ```
 
 ## Runtime Fixes and Dependency Cleanup
@@ -1474,9 +1468,9 @@ This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk
 React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
 
 ```typescript
-import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
+import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk/models'
 // or on Bare-only clients:
-import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
+import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/bare-sdk/models'
 ```
 
 ## Bug Fixes
@@ -1505,10 +1499,10 @@ v0.12.1 introduces two structured RPC errors that propagate from the worker brid
 - `WorkerShutdownError` — the SDK is shutting down (`sdk.close()` was called) while this request was still in flight. Safe to swallow on intentional teardown; surfaces an actionable label for callers who want to log it.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
 
 try {
-  await sdk.embed({ modelId, text: "hi" });
+  await sdk.embed({ modelId, text: 'hi' })
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
     // err.exitCode, err.exitSignal — worker died, decide whether to respawn.
@@ -1545,27 +1539,27 @@ The SDK TTS plugin now targets `@qvac/tts-ggml` instead of `@qvac/tts-onnx`. The
 ```typescript
 await loadModel({
   modelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
-  modelType: "tts",
+  modelType: 'tts',
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "en",
+    ttsEngine: 'chatterbox',
+    language: 'en',
     ttsSpeechEncoderSrc: TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX.src,
     ttsEmbedTokensSrc: TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX.src,
     ttsConditionalDecoderSrc: TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX.src,
-    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
-  },
-});
+    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src
+  }
+})
 ```
 
 **After:**
 
 ```typescript
-import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from "@qvac/sdk";
+import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from '@qvac/sdk'
 
 await loadModel({
   modelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX,
-  modelType: "tts",
-});
+  modelType: 'tts'
+})
 ```
 
 New registry constants cover Chatterbox and Supertonic variants in GGUF form (`TTS_S3GEN_*`, `TTS_T3_*`, `TTS_*_SUPERTONIC_*`).
@@ -1578,26 +1572,26 @@ Building on the 0.11.0 single-file GGUF migration, Parakeet now targets `@qvac/t
 
 ```typescript
 await loadModel({
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "tdt",
+    modelType: 'tdt',
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR,
-  },
-});
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR
+  }
+})
 ```
 
 **After:**
 
 ```typescript
-import { PARAKEET_TDT_0_6B_V3_Q8_0 } from "@qvac/sdk";
+import { PARAKEET_TDT_0_6B_V3_Q8_0 } from '@qvac/sdk'
 
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: "parakeet",
-});
+  modelType: 'parakeet'
+})
 ```
 
 ### `@qvac/bare-sdk` requires explicit plugin registration
@@ -1607,25 +1601,25 @@ Bare consumers that previously called `getRPC()` against the full `@qvac/sdk` wo
 **Before:**
 
 ```typescript
-import { getRPC } from "@qvac/sdk";
+import { getRPC } from '@qvac/sdk'
 
-const rpc = await getRPC();
-await rpc.loadModel({ /* any built-in modelType works */ });
+const rpc = await getRPC()
+await rpc.loadModel({/* any built-in modelType works */})
 ```
 
 **After:**
 
 ```typescript
-import { plugins } from "@qvac/bare-sdk";
-import { nmtPlugin } from "@qvac/bare-sdk/nmtcpp-translation/plugin";
-import { llmPlugin } from "@qvac/bare-sdk/llamacpp-completion/plugin";
+import { plugins } from '@qvac/bare-sdk'
+import { nmtPlugin } from '@qvac/bare-sdk/nmtcpp-translation/plugin'
+import { llmPlugin } from '@qvac/bare-sdk/llamacpp-completion/plugin'
 
-const sdk = plugins([nmtPlugin, llmPlugin]);
+const sdk = plugins([nmtPlugin, llmPlugin])
 
 await sdk.loadModel({
   modelSrc: BERGAMOT_EN_FR,
-  modelType: "nmt",
-});
+  modelType: 'nmt'
+})
 ```
 
 Install matching addon packages (`@qvac/translation-nmtcpp`, `@qvac/llm-llamacpp`, etc.) alongside `@qvac/bare-sdk`. `@qvac/sdk` remains the right choice for Node and Expo apps that want the full default worker.
@@ -1647,20 +1641,20 @@ import {
   vlaHparams,
   vlaPreprocessImage,
   vlaPadState,
-  SMOLVLA_LIBERO_VISION_Q8,
-} from "@qvac/sdk";
+  SMOLVLA_LIBERO_VISION_Q8
+} from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: SMOLVLA_LIBERO_VISION_Q8,
-  modelType: "vla",
-  modelConfig: { backend: "auto" },
-});
+  modelType: 'vla',
+  modelConfig: { backend: 'auto' }
+})
 
-const { hparams } = await vlaHparams({ modelId });
+const { hparams } = await vlaHparams({ modelId })
 const image = vlaPreprocessImage(pixels, width, height, {
-  size: hparams.visionImageSize,
-});
-const state = vlaPadState(robotState, hparams.maxStateDim);
+  size: hparams.visionImageSize
+})
+const state = vlaPadState(robotState, hparams.maxStateDim)
 
 const { actions, actionDim, chunkSize } = await vla({
   modelId,
@@ -1669,8 +1663,8 @@ const { actions, actionDim, chunkSize } = await vla({
   imgHeight: hparams.visionImageSize,
   state,
   tokens,
-  mask,
-});
+  mask
+})
 ```
 
 ### Image classification
@@ -1678,14 +1672,14 @@ const { actions, actionDim, chunkSize } = await vla({
 Classify JPEG/PNG buffers or raw RGB bytes with bundled MobileNetV3-Small or a custom GGUF:
 
 ```typescript
-import { loadModel, classify } from "@qvac/sdk";
+import { loadModel, classify } from '@qvac/sdk'
 
 const modelId = await loadModel({
-  modelType: "classification",
-  modelConfig: { topK: 3 },
-});
+  modelType: 'classification',
+  modelConfig: { topK: 3 }
+})
 
-const results = await classify({ modelId, image: jpegBytes });
+const results = await classify({ modelId, image: jpegBytes })
 // → [{ label: "food", confidence: 0.91 }, ...]
 ```
 
@@ -1694,24 +1688,24 @@ const results = await classify({ modelId, image: jpegBytes });
 Generate video frames from text prompts using WAN models:
 
 ```typescript
-import { video } from "@qvac/sdk";
+import { video } from '@qvac/sdk'
 
 const run = video({
   modelId,
-  mode: "txt2vid",
-  prompt: "a cat surfing a wave at sunset",
+  mode: 'txt2vid',
+  prompt: 'a cat surfing a wave at sunset',
   width: 480,
   height: 832,
   video_frames: 17,
   fps: 16,
-  steps: 20,
-});
+  steps: 20
+})
 
 for await (const tick of run.progressStream) {
-  console.log(`step ${tick.step}/${tick.totalSteps}`);
+  console.log(`step ${tick.step}/${tick.totalSteps}`)
 }
 
-const frames = await run.outputs;
+const frames = await run.outputs
 ```
 
 ### `@qvac/sdk/commands` for bundling and verification
@@ -1719,14 +1713,14 @@ const frames = await run.outputs;
 Programmatic access to worker bundling and prebuild verification — the same primitives `qvac bundle` and `qvac verify bundle` use:
 
 ```typescript
-import { bundleSdk, verifyBundle } from "@qvac/sdk/commands";
+import { bundleSdk, verifyBundle } from '@qvac/sdk/commands'
 
-await bundleSdk({ projectRoot: process.cwd(), configPath: "./qvac.config.json" });
+await bundleSdk({ projectRoot: process.cwd(), configPath: './qvac.config.json' })
 await verifyBundle({
   projectRoot: process.cwd(),
-  addonsSource: "./qvac/worker.bundle.js",
-  hosts: ["android-arm64", "ios-arm64"],
-});
+  addonsSource: './qvac/worker.bundle.js',
+  hosts: ['android-arm64', 'ios-arm64']
+})
 ```
 
 ### RAG cancellation detection
@@ -1734,7 +1728,7 @@ await verifyBundle({
 Detect cancelled RAG operations without importing `@qvac/rag/errors`:
 
 ```typescript
-import { RAG_ERROR_CODES } from "@qvac/sdk";
+import { RAG_ERROR_CODES } from '@qvac/sdk'
 
 if (err.code === RAG_ERROR_CODES.OPERATION_CANCELLED) {
   // ingest was cancelled
@@ -1758,17 +1752,15 @@ Expo config plugins resolve `@qvac/sdk` from ancestor `node_modules` directories
 LLM completion now surfaces real input token counts in stats and throws a typed `ContextOverflowError` when the prompt exceeds the model context window — including across the Bare RPC boundary:
 
 ```typescript
-import { ContextOverflowError } from "@qvac/sdk";
+import { ContextOverflowError } from '@qvac/sdk'
 
-const run = sdk.completion({ /* ... */ });
+const run = sdk.completion({/* ... */})
 try {
-  const final = await run.final;
-  console.log(final.stats?.promptTokens);
+  const final = await run.final
+  console.log(final.stats?.promptTokens)
 } catch (err) {
   if (err instanceof ContextOverflowError) {
-    console.warn(
-      `prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`,
-    );
+    console.warn(`prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`)
   }
 }
 ```
@@ -1847,20 +1839,20 @@ override.
 **Before (Bare):**
 
 ```typescript
-import { unloadModel } from "@qvac/sdk";
+import { unloadModel } from '@qvac/sdk'
 
-await unloadModel({ modelId });
+await unloadModel({ modelId })
 // RPC connection closed → Bare worker host terminated.
 ```
 
 **After (Bare):**
 
 ```typescript
-import { unloadModel } from "@qvac/sdk";
+import { unloadModel } from '@qvac/sdk'
 
-await unloadModel({ modelId });
+await unloadModel({ modelId })
 // Worker survives; opt in to closing explicitly:
-await unloadModel({ modelId, autoClose: true });
+await unloadModel({ modelId, autoClose: true })
 ```
 
 ### Parakeet plugin moves to the 0.4.0 single-file GGUF API
@@ -1877,24 +1869,24 @@ Sortformer from GGUF metadata.
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_ENCODER_INT8,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
-  },
-});
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8
+  }
+})
 
 await loadModel({
   modelSrc: PARAKEET_CTC_FP32,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "ctc",
+    modelType: 'ctc',
     parakeetCtcModelSrc: PARAKEET_CTC_FP32,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
-  },
-});
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
+  }
+})
 ```
 
 **After:**
@@ -1902,13 +1894,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: "parakeet",
-});
+  modelType: 'parakeet'
+})
 
 await loadModel({
   modelSrc: PARAKEET_CTC_0_6B_Q8_0,
-  modelType: "parakeet",
-});
+  modelType: 'parakeet'
+})
 ```
 
 The new GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`,
@@ -1927,47 +1919,47 @@ hatch.
 **Before — downloadAsset:**
 
 ```typescript
-import { downloadAsset, cancel } from "@qvac/sdk";
+import { downloadAsset, cancel } from '@qvac/sdk'
 
-const op = downloadAsset({ assetSrc, onProgress });
-await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
+const op = downloadAsset({ assetSrc, onProgress })
+await cancel({ operation: 'downloadAsset', downloadKey: assetSrc.key, clearCache: true })
 ```
 
 **After — downloadAsset:** the decorated promise now exposes `op.requestId`
 synchronously, and `clearCache` is honoured on the `requestId` path.
 
 ```typescript
-import { downloadAsset, cancel } from "@qvac/sdk";
+import { downloadAsset, cancel } from '@qvac/sdk'
 
-const op = downloadAsset({ assetSrc, onProgress });
-await cancel({ requestId: op.requestId, clearCache: true });
+const op = downloadAsset({ assetSrc, onProgress })
+await cancel({ requestId: op.requestId, clearCache: true })
 ```
 
 **Before — rag:**
 
 ```typescript
-import { ragIngest, cancel } from "@qvac/sdk";
+import { ragIngest, cancel } from '@qvac/sdk'
 
-ragIngest({ workspace: "my-workspace", documents });
-await cancel({ operation: "rag", workspace: "my-workspace" });
+ragIngest({ workspace: 'my-workspace', documents })
+await cancel({ operation: 'rag', workspace: 'my-workspace' })
 ```
 
 **After — rag (primary path, by `requestId`):**
 
 ```typescript
-import { ragIngest, cancel } from "@qvac/sdk";
+import { ragIngest, cancel } from '@qvac/sdk'
 
-const op = ragIngest({ workspace: "my-workspace", documents });
-await cancel({ requestId: op.requestId });
+const op = ragIngest({ workspace: 'my-workspace', documents })
+await cancel({ requestId: op.requestId })
 ```
 
 **After — rag (broad escape hatch, no `requestId` to hand):**
 
 ```typescript
-import { cancel } from "@qvac/sdk";
+import { cancel } from '@qvac/sdk'
 
 // Cancel every in-flight RAG operation running on the embedding model:
-await cancel({ modelId: ragEmbeddingModelId, kind: "rag" });
+await cancel({ modelId: ragEmbeddingModelId, kind: 'rag' })
 ```
 
 Every other `cancel(...)` shape still works: `cancel({ operation: "inference",
@@ -1987,33 +1979,26 @@ network round-trip. The pattern covers `completion`, `loadModel`, `embed`,
 the three cancellable RAG ops (`ragIngest`, `ragSaveEmbeddings`, `ragReindex`).
 
 ```typescript
-import {
-  completion,
-  loadModel,
-  embed,
-  downloadAsset,
-  ragIngest,
-  cancel,
-} from "@qvac/sdk";
+import { completion, loadModel, embed, downloadAsset, ragIngest, cancel } from '@qvac/sdk'
 
-const run = completion({ modelId, history });
-console.log(run.requestId);
+const run = completion({ modelId, history })
+console.log(run.requestId)
 
-const op = loadModel({ modelSrc: "..." });
-console.log(op.requestId);                    // synchronously, before await
-const modelId = await op;                     // legacy unwrap still works
+const op = loadModel({ modelSrc: '...' })
+console.log(op.requestId) // synchronously, before await
+const modelId = await op // legacy unwrap still works
 
-const handle = embed({ modelId, text: "hello" });
-console.log(handle.requestId);
-await handle;
+const handle = embed({ modelId, text: 'hello' })
+console.log(handle.requestId)
+await handle
 
-const download = downloadAsset({ assetSrc, onProgress });
-stopButton.onclick = () => cancel({ requestId: download.requestId });
-await download;                                // rejects with InferenceCancelledError if cancelled
+const download = downloadAsset({ assetSrc, onProgress })
+stopButton.onclick = () => cancel({ requestId: download.requestId })
+await download // rejects with InferenceCancelledError if cancelled
 
-const ingest = ragIngest({ workspace: "ws-a", modelId, documents });
-console.log(ingest.requestId);
-await ingest;
+const ingest = ragIngest({ workspace: 'ws-a', modelId, documents })
+console.log(ingest.requestId)
+await ingest
 ```
 
 The non-cancellable RAG ops (`ragChunk`, `ragSearch`, `ragDeleteEmbeddings`,
@@ -2037,17 +2022,19 @@ llama.cpp addon's opaque "job already set" error into a typed framework-level
 rejection.
 
 ```typescript
-import { completion, RequestRejectedByPolicyError } from "@qvac/sdk";
+import { completion, RequestRejectedByPolicyError } from '@qvac/sdk'
 
 try {
-  const run = completion({ modelId, history });
-  for await (const event of run.events) { /* ... */ }
+  const run = completion({ modelId, history })
+  for await (const event of run.events) {
+    /* ... */
+  }
 } catch (err) {
   if (err instanceof RequestRejectedByPolicyError) {
-    showBusy({ modelId: err.modelId, reason: err.reason });
-    return;
+    showBusy({ modelId: err.modelId, reason: err.reason })
+    return
   }
-  throw err;
+  throw err
 }
 ```
 
@@ -2059,10 +2046,10 @@ modelId, kind? }`). Two new client sugars wrap the broad shape so callers don't
 have to think about the wire representation:
 
 ```typescript
-import { cancel } from "@qvac/sdk";
+import { cancel } from '@qvac/sdk'
 
-await cancel({ modelId: "llama-3.2-1b", kind: "completion" });
-await cancel({ modelId: "llama-3.2-1b" });
+await cancel({ modelId: 'llama-3.2-1b', kind: 'completion' })
+await cancel({ modelId: 'llama-3.2-1b' })
 ```
 
 ### Plugin authors: declare cancel scope per handler
@@ -2078,7 +2065,7 @@ addon-side cancel actually interrupts compute. Plugin manifests that omit the
 field still load — it's optional.
 
 ```typescript
-import { definePlugin, defineHandler } from "@qvac/sdk";
+import { definePlugin, defineHandler } from '@qvac/sdk'
 
 definePlugin({
   manifestVersion: 1,
@@ -2087,11 +2074,13 @@ definePlugin({
       requestSchema,
       responseSchema,
       streaming: true,
-      cancel: { scope: "model", hard: true },
-      handler: async function* (request, ctx) { /* ... */ },
-    }),
-  },
-});
+      cancel: { scope: 'model', hard: true },
+      handler: async function* (request, ctx) {
+        /* ... */
+      }
+    })
+  }
+})
 ```
 
 ### Multi-GPU `split-mode`, `tensor-split`, and `main-gpu` on LLM and embed
@@ -2105,24 +2094,24 @@ convention (`splitMode`, `tensorSplit`, `mainGpu`).
 // LLM
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
+  modelType: 'llm',
   modelConfig: {
-    "split-mode": "layer",        // "none" | "layer" | "row"
-    "tensor-split": "1,1",        // proportional split across GPUs
-    "main-gpu": 0,                // integer index or "integrated" | "dedicated"
-  },
-});
+    'split-mode': 'layer', // "none" | "layer" | "row"
+    'tensor-split': '1,1', // proportional split across GPUs
+    'main-gpu': 0 // integer index or "integrated" | "dedicated"
+  }
+})
 
 // Embed
 await loadModel({
   modelSrc: EMBEDDING_GEMMA_300M_Q8_0,
-  modelType: "embed",
+  modelType: 'embed',
   modelConfig: {
-    splitMode: "layer",
-    tensorSplit: "1,1",
-    mainGpu: 0,
-  },
-});
+    splitMode: 'layer',
+    tensorSplit: '1,1',
+    mainGpu: 0
+  }
+})
 ```
 
 ### Whisper VAD and end-of-turn events on `transcribeStream`
@@ -2133,23 +2122,24 @@ voice-activity probabilities and turn boundaries, so apps can build push-to-talk
 or barge-in UX without poll-the-text hacks.
 
 ```typescript
-import { transcribeStream } from "@qvac/sdk";
+import { transcribeStream } from '@qvac/sdk'
 
 const session = await transcribeStream({
-  modelId: "whisper-base",
+  modelId: 'whisper-base',
   emitVadEvents: true,
   endOfTurnSilenceMs: 800,
-  vadRunIntervalMs: 100,
-});
+  vadRunIntervalMs: 100
+})
 
 for await (const event of session) {
-  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
-  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
-  else if (event.type === "text") process.stdout.write(event.text);
+  if (event.type === 'vad') console.log('speaking:', event.speaking, event.probability)
+  else if (event.type === 'endOfTurn')
+    console.log('turn ended after', event.silenceDurationMs, 'ms')
+  else if (event.type === 'text') process.stdout.write(event.text)
 }
 
-session.write(audioChunk);
-session.end();
+session.write(audioChunk)
+session.end()
 ```
 
 `TranscribeStreamEvent`, `VadStateEvent`, `EndOfTurnEvent`, and
@@ -2168,20 +2158,20 @@ const session = await transcribeStream({
   modelId,
   parakeetStreamingConfig: {
     chunkMs: 1000,
-    emitPartials: true,
-  },
-});
+    emitPartials: true
+  }
+})
 
-ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
+ffmpeg.stdout.on('data', (chunk: Buffer) => session.write(chunk))
 
 for await (const event of session) {
   switch (event.type) {
-    case "text":
-      process.stdout.write(event.text);
-      break;
-    case "endOfTurn":
-      console.log("\n[endOfTurn] turn boundary detected\n");
-      break;
+    case 'text':
+      process.stdout.write(event.text)
+      break
+    case 'endOfTurn':
+      console.log('\n[endOfTurn] turn boundary detected\n')
+      break
   }
 }
 ```
@@ -2205,16 +2195,16 @@ framing; Gemma4 covers the native
 `<|tool_call>call:NAME{key:<|"|>val<|"|>,...}<tool_call|>` framing.
 
 ```typescript
-import { completion, type ToolDialect } from "@qvac/sdk";
+import { completion, type ToolDialect } from '@qvac/sdk'
 
 const result = completion({
-  modelId,                         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: "harmony",          // optional explicit override
-});
+  toolDialect: 'harmony' // optional explicit override
+})
 
-const dialect: ToolDialect = "harmony";
+const dialect: ToolDialect = 'harmony'
 ```
 
 Qwen3.5 / Qwen3.6 and Gemma4 are auto-detected from the model name; the parsers
@@ -2230,19 +2220,19 @@ unrestricted, `0` = disabled. The SDK exposes it both as a load-time default on
 `LlmConfig` and as a per-request override on `GenerationParams`.
 
 ```typescript
-import { loadModel, completion } from "@qvac/sdk";
+import { loadModel, completion } from '@qvac/sdk'
 
 const modelId = await loadModel({
-  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
-});
+  modelSrc: '/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf',
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 }
+})
 
 const run = completion({
   modelId,
-  history: [{ role: "user", content: "Think step by step." }],
-  generationParams: { reasoning_budget: 0 }, // override per-request
-});
+  history: [{ role: 'user', content: 'Think step by step.' }],
+  generationParams: { reasoning_budget: 0 } // override per-request
+})
 ```
 
 The same bump fixes a regression where `system_prompt` (a JS-only
@@ -2260,26 +2250,26 @@ per-call `lora` field that takes an absolute filesystem path. A new load-time
 model or applied per-call (`"auto" | "immediately" | "at_runtime"`).
 
 ```typescript
-const refA = fs.readFileSync("scientist-a.jpg");
-const refB = fs.readFileSync("scientist-b.jpg");
+const refA = fs.readFileSync('scientist-a.jpg')
+const refB = fs.readFileSync('scientist-b.jpg')
 const { outputs } = diffusion({
   modelId,
-  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
+  prompt: 'a portrait using most visual traits from @image1 and the eyes from @image2',
   init_images: [refA, refB],
   width: 768,
-  height: 768,
-});
+  height: 768
+})
 
 const { outputs: loraOutputs } = diffusion({
   modelId,
-  prompt: "a watercolor cat",
-  lora: "/home/user/loras/watercolor.safetensors",
-});
+  prompt: 'a watercolor cat',
+  lora: '/home/user/loras/watercolor.safetensors'
+})
 
 await loadModel(modelSrc, {
-  modelType: "diffusion",
-  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
-});
+  modelType: 'diffusion',
+  modelConfig: { prediction: 'flux2_flow', lora_apply_mode: 'immediately' }
+})
 ```
 
 Relative LoRA paths are rejected: the SDK runs across processes with differing
@@ -2298,46 +2288,47 @@ without standing up a full diffusion pipeline.
 // Post-step upscale during diffusion
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: "diffusion",
+  modelType: 'diffusion',
   modelConfig: {
-    prediction: "v",
+    prediction: 'v',
     upscaler: {
-      type: "esrgan",
-      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
-      tile_size: 128,
-    },
-  },
-});
+      type: 'esrgan',
+      model_src:
+        'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth',
+      tile_size: 128
+    }
+  }
+})
 
 const { outputs } = diffusion({
   modelId,
-  prompt: "an illustrated red fox portrait",
+  prompt: 'an illustrated red fox portrait',
   width: 128,
   height: 128,
-  upscale: { repeats: 2 },
-});
+  upscale: { repeats: 2 }
+})
 ```
 
 ```typescript
 // Standalone upscale — no diffusion model required
-import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from '@qvac/sdk'
 
 const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
-  modelType: "diffusion",
+  modelType: 'diffusion',
   modelConfig: {
-    mode: "upscale",
-    upscaler: { tile_size: 128 },
-  },
-});
+    mode: 'upscale',
+    upscaler: { tile_size: 128 }
+  }
+})
 
 const { outputs, stats } = upscale({
   modelId,
-  image: pngBytes,        // Uint8Array (PNG/JPEG)
-  repeats: 1,             // each pass multiplies dims by the model's native scale factor
-});
+  image: pngBytes, // Uint8Array (PNG/JPEG)
+  repeats: 1 // each pass multiplies dims by the model's native scale factor
+})
 
-const [upscaledPng] = await outputs;
-console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+const [upscaledPng] = await outputs
+console.log(await stats) // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
 ```
 
 Calling `upscale()` against a model that wasn't loaded with `mode: "upscale"`
@@ -2488,10 +2479,10 @@ The DHT routing table is still populated lazily as `dht.connect()` issues lookup
 
 Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
 
-| Build              | Mean connection time | p50    | p95    |
-| ------------------ | -------------------- | ------ | ------ |
-| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
-| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
+| Build              | Mean connection time | p50   | p95   |
+| ------------------ | -------------------- | ----- | ----- |
+| v0.10.1 (baseline) | 3.82s                | 3.71s | 4.94s |
+| v0.10.2 (this fix) | 1.18s                | 1.12s | 1.49s |
 
 That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
 
@@ -2510,16 +2501,16 @@ This patch release adds a new tool-call dialect for OpenAI's `gpt-oss` (Harmony)
 `completion()` now supports a fourth tool-call dialect, `"harmony"`, used by OpenAI's `gpt-oss` family of models. The new dialect is wired into the same streaming/event surface as the existing dialects (`hermes`, `pythonic`, `json`), so tool calls emitted in Harmony frames are parsed and surfaced through the standard `CompletionEvent` stream. `gpt-oss-20b-Q4_K_M` auto-routes to the Harmony dialect; the `toolDialect` parameter is available as an explicit override on any model.
 
 ```typescript
-import { completion, type ToolDialect } from "@qvac/sdk";
+import { completion, type ToolDialect } from '@qvac/sdk'
 
 const run = completion({
-  modelId,                 // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: "harmony",  // optional explicit override
-});
+  toolDialect: 'harmony' // optional explicit override
+})
 
-const dialect: ToolDialect = "harmony";
+const dialect: ToolDialect = 'harmony'
 // ToolDialect is now "hermes" | "pythonic" | "json" | "harmony"
 ```
 
@@ -2618,20 +2609,22 @@ captured thinking and structured tool framing.
 **Before:**
 
 ```typescript
-const result = completion({ modelId, history, stream: true });
-for await (const token of result.tokenStream) { /* ... */ }
-const stats = await result.stats;
+const result = completion({ modelId, history, stream: true })
+for await (const token of result.tokenStream) {
+  /* ... */
+}
+const stats = await result.stats
 ```
 
 **After:**
 
 ```typescript
-const run = completion({ modelId, history, stream: true, captureThinking: true });
+const run = completion({ modelId, history, stream: true, captureThinking: true })
 for await (const event of run.events) {
-  if (event.type === "contentDelta") process.stdout.write(event.text);
-  if (event.type === "toolCall") console.log(event.call.name);
+  if (event.type === 'contentDelta') process.stdout.write(event.text)
+  if (event.type === 'toolCall') console.log(event.call.name)
 }
-const result = await run.final;
+const result = await run.final
 // result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
 ```
 
@@ -2653,35 +2646,35 @@ and `pluginInvokeStream` paths still surface `PLUGIN_HANDLER_NOT_FOUND` as befor
 **Before:**
 
 ```typescript
-import type { LoadModelOptions } from "@qvac/sdk";
+import type { LoadModelOptions } from '@qvac/sdk'
 
 const opts: LoadModelOptions = {
-  modelSrc: "/path/foo",
-  modelType: "my-custom-plugin",
-  modelConfig: { whatever: 1 },
-};
-await loadModel(opts);
+  modelSrc: '/path/foo',
+  modelType: 'my-custom-plugin',
+  modelConfig: { whatever: 1 }
+}
+await loadModel(opts)
 ```
 
 **After:**
 
 ```typescript
-import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
+import type { LoadCustomPluginModelOptions } from '@qvac/sdk'
 
-const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
-  modelSrc: "/path/foo",
-  modelType: "my-custom-plugin",
-  modelConfig: { whatever: 1 },
-};
-await loadModel(opts);
+const opts: LoadCustomPluginModelOptions<'my-custom-plugin'> = {
+  modelSrc: '/path/foo',
+  modelType: 'my-custom-plugin',
+  modelConfig: { whatever: 1 }
+}
+await loadModel(opts)
 // Or just drop the annotation — TS picks the right overload.
 ```
 
 ```typescript
-import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+import { SDK_SERVER_ERROR_CODES } from '@qvac/sdk'
 
 try {
-  await transcribe({ modelId: llmModelId /* ... */ });
+  await transcribe({ modelId: llmModelId /* ... */ })
 } catch (e) {
   if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
     // Includes requested operation, loaded model type, supported operations,
@@ -2701,7 +2694,9 @@ the field name changed.
 ```typescript
 onProgress: (progress) => {
   if (progress.onnxInfo) {
-    console.log(`[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`);
+    console.log(
+      `[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`
+    )
   }
 }
 ```
@@ -2711,7 +2706,9 @@ onProgress: (progress) => {
 ```typescript
 onProgress: (progress) => {
   if (progress.fileSetInfo) {
-    console.log(`[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`);
+    console.log(
+      `[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`
+    )
   }
 }
 ```
@@ -2741,12 +2738,12 @@ delegated models defer to the provider. Useful for preflighting a built-in SDK c
 before issuing the RPC.
 
 ```typescript
-import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
+import { getLoadedModelInfo, transcribe } from '@qvac/sdk'
 
-const info = await getLoadedModelInfo({ modelId });
+const info = await getLoadedModelInfo({ modelId })
 
-if (info.isDelegated || info.handlers.includes("transcribeStream")) {
-  await transcribe({ modelId /* ... */ });
+if (info.isDelegated || info.handlers.includes('transcribeStream')) {
+  await transcribe({ modelId /* ... */ })
 }
 ```
 
@@ -2758,31 +2755,31 @@ schema-valid JSON. The output is guaranteed to parse against the supplied JSON S
 ```typescript
 const run = completion({
   modelId,
-  history: [{ role: "user", content: "Extract: I'm Alice, 30, data engineer." }],
+  history: [{ role: 'user', content: "Extract: I'm Alice, 30, data engineer." }],
   stream: true,
   responseFormat: {
-    type: "json_schema",
+    type: 'json_schema',
     json_schema: {
-      name: "Person",
+      name: 'Person',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          name: { type: "string" },
-          age: { type: "integer" },
-          occupation: { type: "string" },
+          name: { type: 'string' },
+          age: { type: 'integer' },
+          occupation: { type: 'string' }
         },
-        required: ["name", "age", "occupation"],
-        additionalProperties: false,
-      },
-    },
-  },
-});
+        required: ['name', 'age', 'occupation'],
+        additionalProperties: false
+      }
+    }
+  }
+})
 
 for await (const event of run.events) {
-  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === 'contentDelta') process.stdout.write(event.text)
 }
-const final = await run.final;
-JSON.parse(final.contentText); // schema-valid
+const final = await run.final
+JSON.parse(final.contentText) // schema-valid
 ```
 
 ### Dynamic tools mode
@@ -2793,29 +2790,35 @@ addon trims the previous tool block from the KV cache so rotation is free — no
 invalidate the cache or pin the tool set per-session.
 
 ```typescript
-import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: "llm",
+  modelType: 'llm',
   modelConfig: {
     ctx_size: 4096,
     tools: true,
-    toolsMode: TOOLS_MODE.dynamic,
-  },
-});
+    toolsMode: TOOLS_MODE.dynamic
+  }
+})
 
 // Turn 1 — weather tools.
 const turn1 = completion({
-  modelId, history, kvCache, stream: true,
-  tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
-});
+  modelId,
+  history,
+  kvCache,
+  stream: true,
+  tools: [{ name: 'get_weather', description: '...', parameters: weatherSchema }]
+})
 
 // Turn 2 — same kvCache, different tools. Free rotation.
 const turn2 = completion({
-  modelId, history, kvCache, stream: true,
-  tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
-});
+  modelId,
+  history,
+  kvCache,
+  stream: true,
+  tools: [{ name: 'get_horoscope', description: '...', parameters: horoscopeSchema }]
+})
 ```
 
 ### Tool-call dialect routing
@@ -2827,12 +2830,15 @@ fine-tunes that emit native pythonic headers, which the auto-router defaults to 
 for empirical reasons.
 
 ```typescript
-import { completion, type ToolDialect } from "@qvac/sdk";
+import { completion, type ToolDialect } from '@qvac/sdk'
 
 const result = completion({
-  modelId, history, tools, stream: true,
-  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
-});
+  modelId,
+  history,
+  tools,
+  stream: true,
+  toolDialect: 'pythonic' // "hermes" | "pythonic" | "json"
+})
 ```
 
 ### img2img for diffusion models
@@ -2842,13 +2848,13 @@ SD/SDXL, and in-context conditioning on FLUX.2. `strength` controls how much of 
 source is preserved on SD/SDXL; FLUX.2 ignores it (the path is purely conditional).
 
 ```typescript
-const initImage = new Uint8Array(fs.readFileSync("input.png"));
+const initImage = new Uint8Array(fs.readFileSync('input.png'))
 const { outputs } = diffusion({
   modelId,
-  prompt: "oil painting style, vibrant colors",
+  prompt: 'oil painting style, vibrant colors',
   init_image: initImage,
-  strength: 0.5, // 0 = keep source, 1 = ignore source
-});
+  strength: 0.5 // 0 = keep source, 1 = ignore source
+})
 ```
 
 ### Sentence-level TTS streaming
@@ -2861,22 +2867,22 @@ exposes the int16 PCM samples plus the source sentence and chunk index.
 ```typescript
 const session = await textToSpeechStream({
   modelId: ttsModelId,
-  inputType: "text",
+  inputType: 'text',
   accumulateSentences: true,
-  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
-  flushAfterMs: 400,
-});
+  sentenceDelimiterPreset: 'latin', // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400
+})
 
-(async () => {
+;(async () => {
   for await (const delta of completion({ modelId: llmModelId /* ... */ }).tokenStream) {
-    session.write(delta);
+    session.write(delta)
   }
-  session.end();
-})();
+  session.end()
+})()
 
 for await (const chunk of session) {
   // chunk.buffer / chunk.chunkIndex / chunk.sentenceChunk
-  if (chunk.done) break;
+  if (chunk.done) break
 }
 ```
 
@@ -2888,9 +2894,9 @@ flag — enabling proper subtitle generation and timeline alignment instead of r
 concatenation.
 
 ```typescript
-const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true });
+const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true })
 for (const s of segments) {
-  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`)
 }
 ```
 
@@ -2901,12 +2907,12 @@ suspend/resume races. A new `state()` API reports the current lifecycle phase:
 `active`, `suspending`, `suspended`, or `resuming`.
 
 ```typescript
-import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
+import { state, suspend, resume, type LifecycleState } from '@qvac/sdk'
 
-await suspend();
-const current: LifecycleState = await state();
-if (current !== "active") {
-  await resume();
+await suspend()
+const current: LifecycleState = await state()
+if (current !== 'active') {
+  await resume()
 }
 ```
 
@@ -2917,12 +2923,12 @@ Two new SDK config knobs cover slow/unstable links: `registryDownloadMaxRetries`
 extends the per-block stream timeout beyond the default 60s.
 
 ```typescript
-import { setSDKConfig } from "@qvac/sdk";
+import { setSDKConfig } from '@qvac/sdk'
 
 setSDKConfig({
   registryDownloadMaxRetries: 5,
-  registryStreamTimeoutMs: 180_000,
-});
+  registryStreamTimeoutMs: 180_000
+})
 ```
 
 ### Auto KV-cache: replay the canonical assistant turn
@@ -2934,14 +2940,16 @@ guarantee a cache hit. Tool-call turns aren't auto-cached today and omit the fie
 fall back to `final.contentText` in that case.
 
 ```typescript
-const run = completion({ modelId, history, kvCache: true });
-for await (const _ of run.tokenStream) { /* stream */ }
-const final = await run.final;
+const run = completion({ modelId, history, kvCache: true })
+for await (const _ of run.tokenStream) {
+  /* stream */
+}
+const final = await run.final
 const nextHistory = [
   ...history,
-  { role: "assistant", content: final.cacheableAssistantContent ?? final.contentText },
-  { role: "user", content: "follow-up question" },
-];
+  { role: 'assistant', content: final.cacheableAssistantContent ?? final.contentText },
+  { role: 'user', content: 'follow-up question' }
+]
 ```
 
 ### LLM-addon cache API plumbed through SDK
@@ -3090,22 +3098,22 @@ The `ping()` API has been replaced by `heartbeat()`, which supports both local a
 **Before:**
 
 ```typescript
-import { ping } from "@qvac/sdk";
-const pong = await ping();
+import { ping } from '@qvac/sdk'
+const pong = await ping()
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from "@qvac/sdk";
+import { heartbeat } from '@qvac/sdk'
 
 // Local heartbeat (replaces ping)
-await heartbeat();
+await heartbeat()
 
 // Delegated heartbeat — check if a remote provider is alive
 await heartbeat({
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
-});
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
+})
 ```
 
 ---
@@ -3117,22 +3125,22 @@ await heartbeat({
 The SDK now supports LoRA finetuning of loaded LLM models. Training runs can be started, paused, resumed, cancelled, and inspected — all through a single `finetune()` function. Progress streams provide real-time loss and step metrics.
 
 ```typescript
-import { finetune } from "@qvac/sdk";
+import { finetune } from '@qvac/sdk'
 
 const handle = finetune({
   modelId,
   options: {
-    trainDatasetDir: "./dataset/train",
-    validation: { type: "dataset", path: "./dataset/eval" },
-    outputParametersDir: "./artifacts/lora",
-    numberOfEpochs: 2,
-  },
-});
+    trainDatasetDir: './dataset/train',
+    validation: { type: 'dataset', path: './dataset/eval' },
+    outputParametersDir: './artifacts/lora',
+    numberOfEpochs: 2
+  }
+})
 
 for await (const progress of handle.progressStream) {
-  console.log(progress.global_steps, progress.loss);
+  console.log(progress.global_steps, progress.loss)
 }
-const result = await handle.result;
+const result = await handle.result
 ```
 
 Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` to let the addon auto-detect whether to start fresh or resume.
@@ -3142,26 +3150,26 @@ Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` t
 Stable Diffusion models are now integrated as a first-class SDK capability. Load a diffusion model and generate images with step-by-step progress tracking.
 
 ```typescript
-import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from "@qvac/sdk";
+import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: "diffusion",
-  modelConfig: { prediction: "v" },
-});
+  modelType: 'diffusion',
+  modelConfig: { prediction: 'v' }
+})
 
 const { progressStream, outputs, stats } = diffusion({
   modelId,
-  prompt: "a cat sitting on a windowsill",
+  prompt: 'a cat sitting on a windowsill',
   width: 512,
   height: 512,
-  steps: 20,
-});
+  steps: 20
+})
 
 for await (const { step, totalSteps } of progressStream) {
-  console.log(`${step}/${totalSteps}`);
+  console.log(`${step}/${totalSteps}`)
 }
-const buffers = await outputs;
+const buffers = await outputs
 ```
 
 ### Duplex Streaming Transcription (`transcribeStream`)
@@ -3169,16 +3177,16 @@ const buffers = await outputs;
 A new bidirectional streaming API lets you feed audio incrementally and receive transcription segments as speech is detected, enabling real-time voice interfaces.
 
 ```typescript
-import { transcribeStream } from "@qvac/sdk";
+import { transcribeStream } from '@qvac/sdk'
 
-const session = await transcribeStream({ modelId });
-session.write(audioChunk);
-session.end();
+const session = await transcribeStream({ modelId })
+session.write(audioChunk)
+session.end()
 
 for await (const text of session) {
-  console.log(text);
+  console.log(text)
 }
-session.destroy();
+session.destroy()
 ```
 
 The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern still works but logs a deprecation warning — use `transcribe()` for batch transcription.
@@ -3188,10 +3196,10 @@ The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern sti
 Mobile and desktop apps can now cleanly suspend and resume SDK operations when the app enters the background or foreground, preventing resource leaks and stale state.
 
 ```typescript
-import { suspend, resume } from "@qvac/sdk";
+import { suspend, resume } from '@qvac/sdk'
 
-await suspend(); // app going to background
-await resume();  // app returning to foreground
+await suspend() // app going to background
+await resume() // app returning to foreground
 ```
 
 ### Delegated Cancellation
@@ -3199,15 +3207,15 @@ await resume();  // app returning to foreground
 Remote inference and downloads running on a delegation provider can now be cancelled from the consumer side.
 
 ```typescript
-import { cancel } from "@qvac/sdk";
+import { cancel } from '@qvac/sdk'
 
-await cancel({ operation: "inference", modelId: "delegated-model-id" });
+await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
 
 await cancel({
-  operation: "downloadAsset",
-  downloadKey: "download-key",
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
-});
+  operation: 'downloadAsset',
+  downloadKey: 'download-key',
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
+})
 ```
 
 ### Delegation Health Check Timeout
@@ -3217,14 +3225,14 @@ A new `healthCheckTimeout` option on the delegate config lets you control how lo
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
+  modelType: 'llm',
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000,
-  },
-});
+    healthCheckTimeout: 2000
+  }
+})
 ```
 
 ### Addon Stats Across All Operations
@@ -3232,8 +3240,8 @@ await loadModel({
 All inference operations now return detailed performance stats from the underlying addons. Completion, transcription, translation, TTS, and embedding responses all include stats like `tokensPerSecond`, `timeToFirstToken`, `audioDuration`, and the new `backendDevice` field (`"cpu"` or `"gpu"`).
 
 ```typescript
-const { embedding, stats } = await embed({ modelId, text: "hello" });
-console.log(stats?.backendDevice); // "cpu" | "gpu"
+const { embedding, stats } = await embed({ modelId, text: 'hello' })
+console.log(stats?.backendDevice) // "cpu" | "gpu"
 ```
 
 ---
@@ -3356,22 +3364,22 @@ The `ping()` function has been replaced by `heartbeat()`, which extends health c
 **Before:**
 
 ```typescript
-import { ping } from "@qvac/sdk";
-const pong = await ping();
+import { ping } from '@qvac/sdk'
+const pong = await ping()
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from "@qvac/sdk";
+import { heartbeat } from '@qvac/sdk'
 
 // Local heartbeat (replaces ping)
-await heartbeat();
+await heartbeat()
 
 // Delegated heartbeat — verify a remote provider is reachable
 await heartbeat({
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
-});
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
+})
 ```
 
 ---
@@ -3385,14 +3393,14 @@ Delegated model loading now supports an optional `healthCheckTimeout` parameter.
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
+  modelType: 'llm',
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000, // optional, defaults to 1500ms
-  },
-});
+    healthCheckTimeout: 2000 // optional, defaults to 1500ms
+  }
+})
 ```
 
 ### Delegated Cancellation
@@ -3401,14 +3409,14 @@ Cancel operations now route automatically to remote providers when the target mo
 
 ```typescript
 // Cancel delegated inference (routes automatically via model registry)
-await cancel({ operation: "inference", modelId: "delegated-model-id" });
+await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
 
 // Cancel delegated remote download
 await cancel({
-  operation: "downloadAsset",
-  downloadKey: "download-key",
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
-});
+  operation: 'downloadAsset',
+  downloadKey: 'download-key',
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
+})
 ```
 
 ---
@@ -3453,11 +3461,11 @@ The embedding addon no longer accepts the raw tab-delimited config string. Use t
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: "embeddings",
+  modelType: 'embeddings',
   modelConfig: {
-    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
-  },
-});
+    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
+  }
+})
 ```
 
 **After:**
@@ -3465,13 +3473,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: "embeddings",
+  modelType: 'embeddings',
   modelConfig: {
     gpuLayers: 99,
-    device: "gpu",
-    batchSize: 1024,
-  },
-});
+    device: 'gpu',
+    batchSize: 1024
+  }
+})
 ```
 
 ### Companion Model Sources Moved Into `modelConfig`
@@ -3482,76 +3490,76 @@ Top-level companion source fields (`projectionModelSrc`, `vadModelSrc`, `srcVoca
 
 ```typescript
 await loadModel({
-  modelType: "llm",
-  modelSrc: ".../model.gguf",
-  projectionModelSrc: ".../mmproj.gguf",
-});
+  modelType: 'llm',
+  modelSrc: '.../model.gguf',
+  projectionModelSrc: '.../mmproj.gguf'
+})
 
 await loadModel({
-  modelType: "whisper",
-  modelSrc: ".../model.bin",
-  vadModelSrc: ".../vad.bin",
-});
+  modelType: 'whisper',
+  modelSrc: '.../model.bin',
+  vadModelSrc: '.../vad.bin'
+})
 
 await loadModel({
-  modelType: "nmt",
-  modelSrc: ".../model.intgemm.alphas.bin",
-  srcVocabSrc: ".../srcvocab.spm",
-  dstVocabSrc: ".../trgvocab.spm",
-});
+  modelType: 'nmt',
+  modelSrc: '.../model.intgemm.alphas.bin',
+  srcVocabSrc: '.../srcvocab.spm',
+  dstVocabSrc: '.../trgvocab.spm'
+})
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelType: "llm",
-  modelSrc: ".../model.gguf",
+  modelType: 'llm',
+  modelSrc: '.../model.gguf',
   modelConfig: {
-    projectionModelSrc: ".../mmproj.gguf",
-  },
-});
+    projectionModelSrc: '.../mmproj.gguf'
+  }
+})
 
 await loadModel({
-  modelType: "whisper",
-  modelSrc: ".../model.bin",
+  modelType: 'whisper',
+  modelSrc: '.../model.bin',
   modelConfig: {
-    vadModelSrc: ".../vad.bin",
-  },
-});
+    vadModelSrc: '.../vad.bin'
+  }
+})
 
 await loadModel({
-  modelType: "nmt",
-  modelSrc: ".../model.intgemm.alphas.bin",
+  modelType: 'nmt',
+  modelSrc: '.../model.intgemm.alphas.bin',
   modelConfig: {
-    srcVocabSrc: ".../srcvocab.spm",
-    dstVocabSrc: ".../trgvocab.spm",
-  },
-});
+    srcVocabSrc: '.../srcvocab.spm',
+    dstVocabSrc: '.../trgvocab.spm'
+  }
+})
 ```
 
 Additionally, custom plugins must now provide a `loadConfigSchema`. For plugins that accept any config, use a passthrough schema:
 
 ```typescript
 const myPlugin: QvacPlugin = {
-  modelType: "my-plugin",
-  displayName: "My Plugin",
-  addonPackage: "@my/addon",
+  modelType: 'my-plugin',
+  displayName: 'My Plugin',
+  addonPackage: '@my/addon',
   loadConfigSchema: z.object({}).catchall(z.unknown()),
   createModel: (params) => ({ model, loader }),
-  handlers: {},
-};
+  handlers: {}
+}
 ```
 
 ### Parakeet Model Constants Renamed
 
 All existing Parakeet model constants now include a variant prefix (`TDT_`) to distinguish them from the new CTC and Sortformer variants. This is a find-and-replace migration:
 
-| Old Constant | New Constant |
-|---|---|
-| `PARAKEET_ENCODER_*` | `PARAKEET_TDT_ENCODER_*` |
-| `PARAKEET_DECODER_*` | `PARAKEET_TDT_DECODER_*` |
-| `PARAKEET_VOCAB` | `PARAKEET_TDT_VOCAB` |
+| Old Constant              | New Constant                  |
+| ------------------------- | ----------------------------- |
+| `PARAKEET_ENCODER_*`      | `PARAKEET_TDT_ENCODER_*`      |
+| `PARAKEET_DECODER_*`      | `PARAKEET_TDT_DECODER_*`      |
+| `PARAKEET_VOCAB`          | `PARAKEET_TDT_VOCAB`          |
 | `PARAKEET_PREPROCESSOR_*` | `PARAKEET_TDT_PREPROCESSOR_*` |
 
 ---
@@ -3568,24 +3576,24 @@ import {
   PARAKEET_TDT_ENCODER_DATA_FP32,
   PARAKEET_TDT_DECODER_FP32,
   PARAKEET_TDT_VOCAB,
-  PARAKEET_TDT_PREPROCESSOR_FP32,
-} from "@qvac/sdk";
+  PARAKEET_TDT_PREPROCESSOR_FP32
+} from '@qvac/sdk'
 
 const modelId = await loadModel({
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelSrc: PARAKEET_TDT_ENCODER_FP32,
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
     parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
-  },
-});
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32
+  }
+})
 
-const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
+const stream = transcribeStream({ modelId, audioInput: './audio.mp3' })
 for await (const chunk of stream) {
-  process.stdout.write(chunk);
+  process.stdout.write(chunk)
 }
 ```
 
@@ -3598,21 +3606,21 @@ Translate between language pairs that don't have a direct model by chaining thro
 ```typescript
 await loadModel({
   modelSrc: BERGAMOT_ES_EN,
-  modelType: "nmt",
+  modelType: 'nmt',
   modelConfig: {
-    engine: "Bergamot",
-    from: "es",
-    to: "it",
+    engine: 'Bergamot',
+    from: 'es',
+    to: 'it',
     pivotModel: {
       modelSrc: BERGAMOT_EN_IT,
       beamsize: 4,
       temperature: 0.3,
       topk: 100,
       normalize: 1,
-      lengthpenalty: 1.2,
-    },
-  },
-});
+      lengthpenalty: 1.2
+    }
+  }
+})
 ```
 
 ### SDK Profiler
@@ -3620,28 +3628,25 @@ await loadModel({
 A built-in profiler lets you measure SDK operation performance at runtime. Enable it globally or on a per-call basis:
 
 ```typescript
-import { profiler } from "@qvac/sdk";
+import { profiler } from '@qvac/sdk'
 
 profiler.enable({
-  mode: "verbose",
-  includeServerBreakdown: true,
-});
+  mode: 'verbose',
+  includeServerBreakdown: true
+})
 
 // Run operations, then export results
-console.log(profiler.exportSummary());
-console.log(profiler.exportTable());
-console.log(profiler.exportJSON({ includeRecentEvents: true }));
+console.log(profiler.exportSummary())
+console.log(profiler.exportTable())
+console.log(profiler.exportJSON({ includeRecentEvents: true }))
 
-profiler.disable();
+profiler.disable()
 ```
 
 Per-call profiling control is also available on `embed`, `completion`, `transcribe`, `translate`, `ragSearch`, and `invokePlugin`:
 
 ```typescript
-await embed(
-  { modelId, text: "hello" },
-  { profiling: { enabled: true } },
-);
+await embed({ modelId, text: 'hello' }, { profiling: { enabled: true } })
 ```
 
 ---
@@ -3657,15 +3662,15 @@ The SDK now supports two additional Parakeet model variants beyond the existing 
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_CTC_FP32_1,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "ctc",
+    modelType: 'ctc',
     parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
     parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
-  },
-});
-const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
+  }
+})
+const text = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
 ```
 
 **Sortformer diarization** for speaker identification:
@@ -3673,13 +3678,13 @@ const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_SORTFORMER_FP32,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "sortformer",
-    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
-  },
-});
-const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+    modelType: 'sortformer',
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32
+  }
+})
+const diarization = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
 // Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
 ```
 
@@ -3708,20 +3713,24 @@ The profiler now captures detailed load/download metrics and stream profiling da
 ### Added Models
 
 **OCR:**
+
 - `OCR_DETECTOR_DB_MOBILENET_V3_LARGE`
 - `OCR_DETECTOR_DB_RESNET50`
 - `OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL`
 - `OCR_RECOGNIZER_PARSEQ`
 
 **Parakeet (CTC):**
+
 - `PARAKEET_CTC_FP32`, `PARAKEET_CTC_DATA_FP32`, `PARAKEET_CTC_VOCAB`, `PARAKEET_CTC_INT8`, `PARAKEET_CTC_CONFIG`
 - `PARAKEET_CTC_FP32_1`, `PARAKEET_CTC_DATA_FP32_1`, `PARAKEET_CTC_TOKENIZER`
 
 **Parakeet (Sortformer / EOU):**
+
 - `PARAKEET_SORTFORMER_FP32`
 - `PARAKEET_EOU_ENCODER_FP32`, `PARAKEET_EOU_DECODER_FP32`, `PARAKEET_EOU_TOKENIZER`
 
 **Parakeet (TDT — renamed from unprefixed):**
+
 - `PARAKEET_TDT_ENCODER_FP32`, `PARAKEET_TDT_ENCODER_DATA_FP32`, `PARAKEET_TDT_DECODER_FP32`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_FP32`
 - `PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_PREPROCESSOR_INT8`
 
@@ -3763,30 +3772,30 @@ Model constant names have been normalized for consistency. If your code referenc
 
 ```typescript
 // Before
-import { BERGAMOT_AREN } from "@qvac/sdk";
+import { BERGAMOT_AREN } from '@qvac/sdk'
 
 // After
-import { BERGAMOT_AR_EN } from "@qvac/sdk";
+import { BERGAMOT_AR_EN } from '@qvac/sdk'
 ```
 
 **Whisper models** have simplified names without author/repo prefixes:
 
 ```typescript
 // Before
-import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from "@qvac/sdk";
+import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from '@qvac/sdk'
 
 // After
-import { WHISPER_EN_BASE_Q0F16 } from "@qvac/sdk";
+import { WHISPER_EN_BASE_Q0F16 } from '@qvac/sdk'
 ```
 
 **LLM models** have normalized version prefixes:
 
 ```typescript
 // Before
-import { QWEN_3_1_7B_INST_Q4 } from "@qvac/sdk";
+import { QWEN_3_1_7B_INST_Q4 } from '@qvac/sdk'
 
 // After
-import { QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+import { QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
 ```
 
 ### HyperdriveItem Type Renamed to RegistryItem
@@ -3795,10 +3804,10 @@ The model metadata type has been renamed and restructured to support the new reg
 
 ```typescript
 // Before
-import type { HyperdriveItem } from "@qvac/sdk";
+import type { HyperdriveItem } from '@qvac/sdk'
 
 // After
-import type { RegistryItem } from "@qvac/sdk";
+import type { RegistryItem } from '@qvac/sdk'
 ```
 
 The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
@@ -3812,26 +3821,22 @@ The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replace
 Discover and search models directly through the SDK without needing a separate registry client package.
 
 ```typescript
-import {
-  modelRegistryList,
-  modelRegistrySearch,
-  modelRegistryGetModel,
-} from "@qvac/sdk";
+import { modelRegistryList, modelRegistrySearch, modelRegistryGetModel } from '@qvac/sdk'
 
 // List all available models
-const models = await modelRegistryList();
+const models = await modelRegistryList()
 
 // Search by engine type
-const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
+const llmModels = await modelRegistrySearch({ engine: '@qvac/llm-llamacpp' })
 
 // Search by text filter
-const whisperModels = await modelRegistrySearch({ filter: "whisper" });
+const whisperModels = await modelRegistrySearch({ filter: 'whisper' })
 
 // Search by quantization
-const q4Models = await modelRegistrySearch({ quantization: "q4" });
+const q4Models = await modelRegistrySearch({ quantization: 'q4' })
 
 // Get a specific model by path
-const model = await modelRegistryGetModel(registryPath, registrySource);
+const model = await modelRegistryGetModel(registryPath, registrySource)
 ```
 
 ### Plugin System
@@ -3839,22 +3844,22 @@ const model = await modelRegistryGetModel(registryPath, registrySource);
 Build custom model integrations with the new plugin architecture. Plugins support both request/reply and streaming patterns.
 
 ```typescript
-import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from '@qvac/sdk'
 
 // Invoke a plugin handler
 const result = await invokePlugin<MyResponse>({
   modelId,
-  handler: "myHandler",
-  params: { key: "value" },
-});
+  handler: 'myHandler',
+  params: { key: 'value' }
+})
 
 // Stream responses from a plugin
 for await (const chunk of invokePluginStream<MyStreamResponse>({
   modelId,
-  handler: "myStreamHandler",
-  params: { key: "value" },
+  handler: 'myStreamHandler',
+  params: { key: 'value' }
 })) {
-  console.log(chunk.result);
+  console.log(chunk.result)
 }
 ```
 
@@ -3865,25 +3870,25 @@ Clone voices from reference audio samples with the new Chatterbox engine.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: "tts",
+  modelType: 'tts',
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "en",
+    ttsEngine: 'chatterbox',
+    language: 'en',
     ttsTokenizerSrc,
     ttsSpeechEncoderSrc,
     ttsEmbedTokensSrc,
     ttsConditionalDecoderSrc,
     ttsLanguageModelSrc,
-    referenceAudioSrc, // Your voice sample
-  },
-});
+    referenceAudioSrc // Your voice sample
+  }
+})
 
 const audio = await textToSpeech({
   modelId,
-  text: "Hello in a cloned voice!",
-  inputType: "text",
-  stream: false,
-});
+  text: 'Hello in a cloned voice!',
+  inputType: 'text',
+  stream: false
+})
 ```
 
 ### Supertonic TTS Engine (General Purpose)
@@ -3893,19 +3898,19 @@ High-quality text-to-speech with adjustable speed and inference steps.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: "tts",
+  modelType: 'tts',
   modelConfig: {
-    ttsEngine: "supertonic",
-    language: "en",
+    ttsEngine: 'supertonic',
+    language: 'en',
     ttsTokenizerSrc,
     ttsTextEncoderSrc,
     ttsLatentDenoiserSrc,
     ttsVoiceDecoderSrc,
     ttsVoiceSrc,
-    ttsSpeed: 1.0,           // Playback speed
-    ttsNumInferenceSteps: 5, // Quality vs speed tradeoff
-  },
-});
+    ttsSpeed: 1.0, // Playback speed
+    ttsNumInferenceSteps: 5 // Quality vs speed tradeoff
+  }
+})
 ```
 
 ### CLI SDK Path Option
@@ -3929,10 +3934,10 @@ Model downloads now use `downloadBlob` for more efficient direct registry fetchi
 The `close()` function is now properly async and awaitable for clean shutdown:
 
 ```typescript
-import { close } from "@qvac/sdk";
+import { close } from '@qvac/sdk'
 
 // Now returns a Promise
-await close();
+await close()
 ```
 
 ### Engine-Addon Mapping Utilities
@@ -3940,10 +3945,10 @@ await close();
 Map between engine names and addon types:
 
 ```typescript
-import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
+import { resolveCanonicalEngine, getAddonFromEngine } from '@qvac/sdk'
 
-const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
-const addon = getAddonFromEngine("llamacpp-completion");     // "llm"
+const engine = resolveCanonicalEngine('@qvac/llm-llamacpp') // "llamacpp-completion"
+const addon = getAddonFromEngine('llamacpp-completion') // "llm"
 ```
 
 ---
@@ -4022,9 +4027,9 @@ The RAG system has been restructured for better control and flexibility. The mai
 ```typescript
 await ragSaveEmbeddings({
   modelId,
-  documents: ["Doc 1", "Doc 2"],
-  chunk: false,
-});
+  documents: ['Doc 1', 'Doc 2'],
+  chunk: false
+})
 ```
 
 **After:**
@@ -4045,6 +4050,7 @@ await ragSaveEmbeddings({
 ```
 
 Other RAG changes:
+
 - `ragSaveEmbeddings` no longer returns `droppedIndices`
 - `ragDeleteEmbeddings` now returns `void` instead of `boolean` (throws on failure)
 - `ragDeleteEmbeddings` no longer requires `modelId` (uses cached workspace)
@@ -4058,35 +4064,35 @@ No more string-based config! Use typed properties for embedding model configurat
 
 ```typescript
 await loadModel({
-  modelSrc: "embed-model.gguf",
-  modelType: "embeddings",
+  modelSrc: 'embed-model.gguf',
+  modelType: 'embeddings',
   modelConfig: {
-    config: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
-  },
-});
+    config: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
+  }
+})
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelSrc: "embed-model.gguf",
-  modelType: "embeddings",
+  modelSrc: 'embed-model.gguf',
+  modelType: 'embeddings',
   modelConfig: {
     gpuLayers: 99,
-    device: "gpu",
-    batchSize: 1024,
-  },
-});
+    device: 'gpu',
+    batchSize: 1024
+  }
+})
 
 // Escape hatch for advanced CLI control
 await loadModel({
-  modelSrc: "embed-model.gguf",
-  modelType: "embeddings",
+  modelSrc: 'embed-model.gguf',
+  modelType: 'embeddings',
   modelConfig: {
-    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
-  },
-});
+    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
+  }
+})
 ```
 
 ### Translation Engine Must Be Specified
@@ -4098,9 +4104,9 @@ Loading translation models now requires an explicit `engine` field for type-safe
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: "nmt",
-  modelConfig: { from: "en", to: "it" },
-});
+  modelType: 'nmt',
+  modelConfig: { from: 'en', to: 'it' }
+})
 ```
 
 **After:**
@@ -4108,13 +4114,13 @@ const modelId = await loadModel({
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: "nmt",
+  modelType: 'nmt',
   modelConfig: {
-    engine: "Opus",  // Required: "Opus" | "Bergamot" | "IndicTrans"
-    from: "en",
-    to: "it",
-  },
-});
+    engine: 'Opus', // Required: "Opus" | "Bergamot" | "IndicTrans"
+    from: 'en',
+    to: 'it'
+  }
+})
 ```
 
 ---
@@ -4126,28 +4132,28 @@ const modelId = await loadModel({
 A new translation engine option with support for batch translation and automatic vocabulary file derivation.
 
 ```typescript
-import { loadModel, translate, BERGAMOT_ENFR } from "@qvac/sdk";
+import { loadModel, translate, BERGAMOT_ENFR } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: BERGAMOT_ENFR,
-  modelType: "nmt",
+  modelType: 'nmt',
   modelConfig: {
-    engine: "Bergamot",
-    from: "en",
-    to: "fr",
-    normalize: 1,  // Bergamot-specific option
-  },
-});
+    engine: 'Bergamot',
+    from: 'en',
+    to: 'fr',
+    normalize: 1 // Bergamot-specific option
+  }
+})
 
 // Batch translation
 const result = translate({
   modelId,
-  text: ["Hello world", "How are you?"],
-  modelType: "nmt",
-  stream: false,
-});
+  text: ['Hello world', 'How are you?'],
+  modelType: 'nmt',
+  stream: false
+})
 
-const translated = await result.text;
+const translated = await result.text
 // "Bonjour le monde\nComment allez-vous?"
 ```
 
@@ -4164,23 +4170,23 @@ The SDK now uses import maps internally, improving compatibility across Node.js,
 Extract text from images with bounding boxes and confidence scores.
 
 ```typescript
-import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from "@qvac/sdk";
+import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: OCR_CRAFT_LATIN_RECOGNIZER,
-  modelType: "ocr",
-  modelConfig: { langList: ["en"] },
-});
+  modelType: 'ocr',
+  modelConfig: { langList: ['en'] }
+})
 
 // Get all text blocks at once
-const { blocks, done } = ocr({ modelId, image: "/path/to/image.png" });
-const result = await blocks;
-await done;
+const { blocks, done } = ocr({ modelId, image: '/path/to/image.png' })
+const result = await blocks
+await done
 
 // Or stream blocks as they're detected
-const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true });
+const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true })
 for await (const blocks of blockStream) {
-  console.log(blocks);
+  console.log(blocks)
   // [{ text: "Hello", bbox: [10, 20, 100, 50], confidence: 0.95 }]
 }
 ```
@@ -4192,15 +4198,15 @@ Load large models split across multiple files, from URLs or archives.
 ```typescript
 // Pattern-based sharded URLs (auto-detects shard pattern)
 await loadModel({
-  modelSrc: "https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf",
-  modelType: "llm",
-});
+  modelSrc: 'https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf',
+  modelType: 'llm'
+})
 
 // Archive-based shards (.tar.gz, .tar, .tgz)
 await loadModel({
-  modelSrc: "https://huggingface.co/user/model/resolve/main/model.tar.gz",
-  modelType: "llm",
-});
+  modelSrc: 'https://huggingface.co/user/model/resolve/main/model.tar.gz',
+  modelType: 'llm'
+})
 ```
 
 ### Device-Specific Model Configuration
@@ -4277,13 +4283,13 @@ The SDK now uses a config file instead of the `setConfig()` API. This simplifies
 **Before:**
 
 ```typescript
-import { setConfig, loadModel } from "@qvac/sdk";
+import { setConfig, loadModel } from '@qvac/sdk'
 
 await setConfig({
-  cacheDirectory: "/custom/cache/path",
-});
+  cacheDirectory: '/custom/cache/path'
+})
 
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
 ```
 
 **After:**
@@ -4297,10 +4303,10 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
 ```
 
 ```typescript
-import { loadModel } from "@qvac/sdk";
+import { loadModel } from '@qvac/sdk'
 
 // Config automatically loaded at initialization!
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
 ```
 
 #### Config Resolution Order
@@ -4313,31 +4319,31 @@ The SDK searches for configuration in this order:
 
 #### Supported Formats
 
-| Format     | Filename           | Notes                        |
-| ---------- | ------------------ | ---------------------------- |
-| JSON       | `qvac.config.json` | Simplest option              |
-| JavaScript | `qvac.config.js`   | Use `export default`         |
+| Format     | Filename           | Notes                         |
+| ---------- | ------------------ | ----------------------------- |
+| JSON       | `qvac.config.json` | Simplest option               |
+| JavaScript | `qvac.config.js`   | Use `export default`          |
 | TypeScript | `qvac.config.ts`   | Fully typed with `QvacConfig` |
 
 **TypeScript example:**
 
 ```typescript
 // qvac.config.ts
-import type { QvacConfig } from "@qvac/sdk";
+import type { QvacConfig } from '@qvac/sdk'
 
 const config: QvacConfig = {
-  cacheDirectory: "/custom/cache/path",
-  swarmRelays: ["relay-key-1", "relay-key-2"],
-};
+  cacheDirectory: '/custom/cache/path',
+  swarmRelays: ['relay-key-1', 'relay-key-2']
+}
 
-export default config;
+export default config
 ```
 
 #### Migration Steps
 
 1. Remove all `setConfig()` calls from your code
 2. Create a config file in your project root
-3. *(Optional)* For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
+3. _(Optional)_ For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
 
 ---
 
@@ -4347,14 +4353,14 @@ Some model constants have been renamed for clarity, and duplicate constants have
 
 **Changes:**
 
-| Before                     | After                                             |
-| -------------------------- | ------------------------------------------------- |
-| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                                |
-| `WHISPER_NORWEGIAN_TINY_1` | *(removed — use `WHISPER_NORWEGIAN_TINY`)*        |
-| `WHISPER_TINY_SILERO`      | *(removed — use `WHISPER_TINY`)*                  |
-| `MARIAN_OPUS_EN_FR_Q4_0_1` | *(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)*        |
-| `MARIAN_OPUS_FR_EN_Q4_0_1` | *(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)*        |
-| `MARIAN_OPUS_IT_EN`        | *(removed — use `MARIAN_OPUS_EN_IT`)*             |
+| Before                     | After                                      |
+| -------------------------- | ------------------------------------------ |
+| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                         |
+| `WHISPER_NORWEGIAN_TINY_1` | _(removed — use `WHISPER_NORWEGIAN_TINY`)_ |
+| `WHISPER_TINY_SILERO`      | _(removed — use `WHISPER_TINY`)_           |
+| `MARIAN_OPUS_EN_FR_Q4_0_1` | _(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)_ |
+| `MARIAN_OPUS_FR_EN_Q4_0_1` | _(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)_ |
+| `MARIAN_OPUS_IT_EN`        | _(removed — use `MARIAN_OPUS_EN_IT`)_      |
 
 All model metadata and hyperdrive keys remain unchanged—only the constant names were affected.
 
@@ -4370,7 +4376,7 @@ The logging stream API has been simplified with consistent naming.
 
 ```typescript
 for await (const log of loggingStream({ modelId: myModelId })) {
-  console.log(log.message);
+  console.log(log.message)
 }
 ```
 
@@ -4378,7 +4384,7 @@ for await (const log of loggingStream({ modelId: myModelId })) {
 
 ```typescript
 for await (const log of loggingStream({ id: myModelId })) {
-  console.log(log.message);
+  console.log(log.message)
 }
 ```
 
@@ -4409,17 +4415,17 @@ You can now update a model's configuration without unloading it. Pass the existi
 ```typescript
 // Load model with initial config
 const modelId = await loadModel({
-  modelSrc: "pear://.../whisper.gguf",
-  modelType: "whisper",
-  modelConfig: { language: "en" },
-});
+  modelSrc: 'pear://.../whisper.gguf',
+  modelType: 'whisper',
+  modelConfig: { language: 'en' }
+})
 
 // Hot-reload with new config (same modelId, no reload delay)
 await loadModel({
   modelId,
-  modelType: "whisper",
-  modelConfig: { language: "es" },
-});
+  modelType: 'whisper',
+  modelConfig: { language: 'es' }
+})
 ```
 
 ---
@@ -4431,51 +4437,51 @@ The SDK now supports the Model Context Protocol (MCP) for tool integration. Pass
 **Using MCP clients:**
 
 ```typescript
-import { completion } from "@qvac/sdk";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { completion } from '@qvac/sdk'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 
 // Create and connect your MCP client
-const mcpClient = new Client({ name: "my-app", version: "1.0.0" });
-await mcpClient.connect(transport);
+const mcpClient = new Client({ name: 'my-app', version: '1.0.0' })
+await mcpClient.connect(transport)
 
 // Pass MCP clients to completion
 const result = completion({
   modelId,
   history,
-  mcp: [{ client: mcpClient }],
-});
+  mcp: [{ client: mcpClient }]
+})
 
 // Execute tool calls
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call();
+  const response = await toolCall.call()
 }
 
 // Clean up when done
-await mcpClient.close();
+await mcpClient.close()
 ```
 
 **Using inline tools with handlers:**
 
 ```typescript
-import { z } from "zod";
+import { z } from 'zod'
 
 const result = completion({
   modelId,
   history,
   tools: [
     {
-      name: "get_weather",
-      description: "Get weather for a city",
+      name: 'get_weather',
+      description: 'Get weather for a city',
       parameters: z.object({ city: z.string() }),
       handler: async (args) => {
-        return await fetchWeather(args.city);
-      },
-    },
-  ],
-});
+        return await fetchWeather(args.city)
+      }
+    }
+  ]
+})
 
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call(); // Executes your handler
+  const response = await toolCall.call() // Executes your handler
 }
 ```
 
@@ -4487,10 +4493,10 @@ The `embed()` function now accepts arrays, enabling efficient batch processing. 
 
 ```typescript
 // Single text → returns number[]
-const embedding = await embed({ modelId, text: "hello" });
+const embedding = await embed({ modelId, text: 'hello' })
 
 // Batch texts → returns number[][]
-const embeddings = await embed({ modelId, text: ["a", "b", "c"] });
+const embeddings = await embed({ modelId, text: ['a', 'b', 'c'] })
 ```
 
 Batch processing uses a default batch size of 1024 for optimal throughput.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1
 
-QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. Load and inference behavior is unchanged.
+QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. The CosyVoice3 companion-set cache key also changes, so the first load after upgrade uses a new companion cache folder. Load APIs are otherwise unchanged.
 
 ## New APIs
 
@@ -20,6 +20,12 @@ llamacppCompletionConfigSchema.shape.ctx_size.description
 ```
 
 The internal schema identifiers are unchanged.
+
+## Bug Fixes
+
+### CosyVoice3 companion cache folder
+
+CosyVoice3 companion files still download with the LLM, as in 0.18.0. The companion-set cache key for `TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0` changed, so the first load after upgrading fills a new cache folder. Later loads reuse that folder. Speech APIs and `pace` / `instruct` rules are unchanged.
 
 ## [0.18.0]
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.18.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1
+
+QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. Load and inference behavior is unchanged.
+
+## New APIs
+
+### Config schemas at `@qvac/sdk/schemas`
+
+`@qvac/sdk/schemas` exports `llamacppCompletionConfigSchema`, `llamacppEmbeddingConfigSchema`, and `modelSourceSchema`. Field `.describe()` text comes from the addon README / `index.d.ts` (or an existing SDK description) and is written into `contract/schema.json`. The same descriptions land on the generated Python pydantic fields.
+
+```typescript
+import { llamacppCompletionConfigSchema } from '@qvac/sdk/schemas'
+
+llamacppCompletionConfigSchema.shape.ctx_size.description
+// "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+```
+
+The internal schema identifiers are unchanged.
+
 ## [0.18.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.0
@@ -15,25 +36,25 @@ QVAC SDK 0.18.0 adds VisionPsy Nano multimodal constants, Audio8 and CosyVoice3 
 **Before:**
 
 ```typescript
-import { loadModel, TOOLS_MODE } from '@qvac/sdk'
+import { loadModel, TOOLS_MODE } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic }
-})
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic },
+});
 ```
 
 **After:**
 
 ```typescript
-import { loadModel } from '@qvac/sdk'
+import { loadModel } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, tools: true }
-})
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, tools: true },
+});
 ```
 
 Existing automatic KV-cache prefixes that were primed under dynamic tools mode are not reusable; the next turn rebuilds the prefix.
@@ -45,13 +66,13 @@ Existing automatic KV-cache prefixes that were primed under dynamic tools mode a
 **Before:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: 'very fast' })
+textToSpeech({ modelId, text, pace: "very fast" });
 ```
 
 **After:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: 'fast' })
+textToSpeech({ modelId, text, pace: "fast" });
 ```
 
 ## New APIs
@@ -61,10 +82,12 @@ textToSpeech({ modelId, text, pace: 'fast' })
 One loaded LLM can run several `completion` calls at once. A new request takes a free slot without waiting for the whole batch to drain. Cancelling one request leaves the others running, and each result reports its own timings. Single-slot models and fine-tuning stay one-at-a-time.
 
 ```typescript
-const runs = prompts.map((p) => completion({ modelId, history: p, stream: true }))
-const outputs = await Promise.all(runs.map((r) => r.final))
+const runs = prompts.map((p) =>
+  completion({ modelId, history: p, stream: true }),
+);
+const outputs = await Promise.all(runs.map((r) => r.final));
 
-await cancel({ requestId: runs[0].requestId })
+await cancel({ requestId: runs[0].requestId });
 ```
 
 ### loadModel fallbackSrc
@@ -72,12 +95,12 @@ await cancel({ requestId: runs[0].requestId })
 If the primary `modelSrc` cannot be fetched, `loadModel` retries from `fallbackSrc` (URL or local path) so callers do not have to build their own origin failover.
 
 ```typescript
-import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
+import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  fallbackSrc: 'https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf'
-})
+  fallbackSrc: "https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf",
+});
 ```
 
 ### AudioGen Cover From a Source Track
@@ -87,14 +110,14 @@ AudioGen can now generate a cover from source audio, not only a text caption. Pa
 ```typescript
 const cover = audioGen({
   modelId,
-  caption: 'orchestral arrangement with dramatic strings',
-  lyrics: '[Instrumental]',
-  taskType: 'cover-nofsq',
-  sourceAudio: '/path/to/source.wav',
-  referenceAudio: '/path/to/reference.mp3',
+  caption: "orchestral arrangement with dramatic strings",
+  lyrics: "[Instrumental]",
+  taskType: "cover-nofsq",
+  sourceAudio: "/path/to/source.wav",
+  referenceAudio: "/path/to/reference.mp3",
   audioCoverStrength: 1,
-  coverNoiseStrength: 0.75
-})
+  coverNoiseStrength: 0.75,
+});
 ```
 
 ### CosyVoice3 TTS
@@ -105,17 +128,17 @@ Load CosyVoice3 with `ttsEngine: "cosyvoice3"`. Companion files download with th
 const modelId = await loadModel({
   modelSrc: TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0,
   modelConfig: {
-    ttsEngine: 'cosyvoice3',
-    instruct: { dialect: 'cantonese' },
-    seed: 42
-  }
-})
+    ttsEngine: "cosyvoice3",
+    instruct: { dialect: "cantonese" },
+    seed: 42,
+  },
+});
 const result = textToSpeech({
   modelId,
-  text: 'Hey there!',
+  text: "Hey there!",
   stream: false,
-  emotion: 'happy'
-})
+  emotion: "happy",
+});
 ```
 
 ### Audio8 TTS
@@ -126,13 +149,13 @@ Audio8 is a multilingual LM + codec stack with optional zero-shot cloning via re
 await loadModel({
   modelSrc: TTS_LM_MULTILINGUAL_AUDIO8_Q8_0,
   modelConfig: {
-    ttsEngine: 'audio8',
+    ttsEngine: "audio8",
     audio8CodecDecoderModelSrc: TTS_CODEC_DECODER_AUDIO8_Q8_0,
     audio8CodecEncoderModelSrc: TTS_CODEC_ENCODER_AUDIO8_Q8_0,
-    referenceAudioSrc: 'file:///path/to/voice.wav',
-    referenceText: 'Exactly what the recording says.'
-  }
-})
+    referenceAudioSrc: "file:///path/to/voice.wav",
+    referenceText: "Exactly what the recording says.",
+  },
+});
 ```
 
 ### Streaming Transcription Stats
@@ -140,12 +163,12 @@ await loadModel({
 `transcribeStream` sessions now expose `stats` after the stream ends (`audioDuration`, `realTimeFactor`).
 
 ```typescript
-const session = await transcribeStream({ modelId })
+const session = await transcribeStream({ modelId });
 for await (const event of session) {
   // streamed events
 }
-const stats = await session.stats
-console.log(stats?.audioDuration, stats?.realTimeFactor)
+const stats = await session.stats;
+console.log(stats?.audioDuration, stats?.realTimeFactor);
 ```
 
 ### Vision image_no_upscale
@@ -154,13 +177,13 @@ VisionPsy (and other llama.cpp multimodal loads) can set `image_no_upscale: "on"
 
 ```typescript
 await loadModel({
-  modelType: 'llm',
+  modelType: "llm",
   modelSrc: VISIONPSY_NANO_460M_MULTIMODAL_Q4_K_M,
   modelConfig: {
     projectionModelSrc: MMPROJ_VISIONPSY_NANO_460M_MULTIMODAL_Q8_0,
-    image_no_upscale: 'on'
-  }
-})
+    image_no_upscale: "on",
+  },
+});
 ```
 
 ## Features
@@ -562,13 +585,13 @@ Image generation now supports Ideogram 4 through the `sdcpp-generation` model ty
 ```typescript
 const modelId = await loadModel({
   modelSrc: IDEOGRAM_MODEL_URL,
-  modelType: 'sdcpp-generation',
+  modelType: "sdcpp-generation",
   modelConfig: {
     llmModelSrc: QWEN3_VL_MODEL_URL,
     vaeModelSrc: VAE_MODEL_URL,
-    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL
-  }
-})
+    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL,
+  },
+});
 ```
 
 ### Per-Phase Diffusion Timing Stats
@@ -576,12 +599,12 @@ const modelId = await loadModel({
 Diffusion results now include a per-phase timing breakdown, so you can see where generation time goes — conditioning, the denoising loop, VAE decode, post-processing, and overall throughput.
 
 ```typescript
-const { stats } = await result
-console.log(stats.conditionerMs) // prompt conditioning time (ms)
-console.log(stats.denoiseMs) // denoising loop time (ms)
-console.log(stats.vaeMs) // VAE decode time (ms)
-console.log(stats.postProcessMs) // encode/upscale/mux time (ms)
-console.log(stats.stepsPerSecond) // denoising throughput (steps/s)
+const { stats } = await result;
+console.log(stats.conditionerMs); // prompt conditioning time (ms)
+console.log(stats.denoiseMs); // denoising loop time (ms)
+console.log(stats.vaeMs); // VAE decode time (ms)
+console.log(stats.postProcessMs); // encode/upscale/mux time (ms)
+console.log(stats.stepsPerSecond); // denoising throughput (steps/s)
 ```
 
 ### Python SDK Client
@@ -612,19 +635,19 @@ async with Client() as client:
 The VLA SDK now exposes GR00T as a first-class model, including its registry entry, hyperparameters, and helpers. GR00T uses a patch-based image input mode: when `hparams.imageInputMode` is `"patches"`, each camera image is supplied as a pre-patchified float buffer. A runnable usage example and desktop e2e ship alongside it.
 
 ```typescript
-import { loadModel, vlaHparams, vla, vlaPadState } from '@qvac/sdk'
+import { loadModel, vlaHparams, vla, vlaPadState } from "@qvac/sdk";
 
-const modelId = await loadModel({ modelSrc, modelType: 'ggml-vla' })
-const { hparams } = await vlaHparams({ modelId })
+const modelId = await loadModel({ modelSrc, modelType: "ggml-vla" });
+const { hparams } = await vlaHparams({ modelId });
 
-if (hparams.imageInputMode === 'patches') {
+if (hparams.imageInputMode === "patches") {
   // GR00T: each images[] entry is a pre-patchified buffer of imagePatchElems floats
   const images = Array.from(
     { length: hparams.numCameras },
-    () => new Float32Array(hparams.imagePatchElems)
-  )
-  const state = vlaPadState(robotState, hparams.maxStateDim)
-  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim)
+    () => new Float32Array(hparams.imagePatchElems),
+  );
+  const state = vlaPadState(robotState, hparams.maxStateDim);
+  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim);
 
   const { actions, actionDim, chunkSize } = await vla({
     modelId,
@@ -634,8 +657,8 @@ if (hparams.imageInputMode === 'patches') {
     state,
     tokens, // Qwen3-VL tokens, length hparams.tokenizerMaxLength
     mask,
-    noise
-  })
+    noise,
+  });
 }
 ```
 
@@ -778,37 +801,41 @@ QVAC SDK 0.15.0 introduces single-job batch completion for running many prompts 
 `batchCompletion` runs many prompts through a single loaded model in one job, streaming per-prompt deltas and returning ordered results. Each prompt can carry its own history, generation parameters, and optional per-prompt tools or MCP-sourced tools.
 
 ```typescript
-import { batchCompletion, loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
+import {
+  batchCompletion,
+  loadModel,
+  LLAMA_3_2_1B_INST_Q4_0,
+} from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, parallel: 4 }
-})
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, parallel: 4 },
+});
 
 const run = batchCompletion({
   modelId,
   prompts: [
     {
-      id: 'a',
-      history: [{ role: 'user', content: 'Reply with only APPLE.' }],
-      generationParams: { temp: 0, predict: 16 }
+      id: "a",
+      history: [{ role: "user", content: "Reply with only APPLE." }],
+      generationParams: { temp: 0, predict: 16 },
     },
     {
-      id: 'b',
-      history: [{ role: 'user', content: "What's the weather in Paris?" }],
+      id: "b",
+      history: [{ role: "user", content: "What's the weather in Paris?" }],
       tools: [getWeatherTool], // optional per-prompt tools
-      generationParams: { temp: 0, predict: 64 }
-    }
-  ]
-})
+      generationParams: { temp: 0, predict: 64 },
+    },
+  ],
+});
 
 for await (const { id, event } of run.events) {
-  if (event.type === 'contentDelta') process.stdout.write(`[${id}] ${event.text}`)
+  if (event.type === "contentDelta") process.stdout.write(`[${id}] ${event.text}`);
 }
 
-const results = await run.results // ordered, all-or-nothing on stream-level failure
-const stats = await run.stats // batch-level CompletionStats | undefined
+const results = await run.results; // ordered, all-or-nothing on stream-level failure
+const stats = await run.stats; // batch-level CompletionStats | undefined
 ```
 
 ### GPU Placement for Multimodal Vision Encoders
@@ -820,9 +847,9 @@ await loadModel({
   modelSrc: SMOLVLM2_500M_MULTIMODAL_Q8_0,
   modelConfig: {
     projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
-    'mmproj-use-gpu': true // true = GPU, false = CPU; omit to auto-select
-  }
-})
+    "mmproj-use-gpu": true, // true = GPU, false = CPU; omit to auto-select
+  },
+});
 ```
 
 ## Features
@@ -833,14 +860,14 @@ Supertonic TTS gains optional LavaSR post-processing: an enhancer and a denoiser
 
 ```typescript
 await sdk.loadModel({
-  ttsEngine: 'supertonic',
+  ttsEngine: "supertonic",
   modelSrc: TTS_MULTILINGUAL_SUPERTONIC3_Q8_0.src,
   // LavaSR post-processing (both optional)
   lavasrDenoiserModelSrc: TTS_DENOISER_LAVASR_FP16.src,
   lavasrEnhancerModelSrc: TTS_ENHANCER_LAVASR_FP16.src,
   // Supertonic-only output sample rate (8000-192000 Hz)
-  outputSampleRate: 48000
-})
+  outputSampleRate: 48000,
+});
 ```
 
 ### Japanese and Chinese Chatterbox TTS
@@ -853,30 +880,30 @@ import {
   TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_MECAB_IPADIC_CHATTERBOX,
-  TTS_CANGJIE_ZH_CHATTERBOX
-} from '@qvac/sdk'
+  TTS_CANGJIE_ZH_CHATTERBOX,
+} from "@qvac/sdk";
 
 // Japanese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'ja',
+    ttsEngine: "chatterbox",
+    language: "ja",
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX
-  }
-})
+    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX,
+  },
+});
 
 // Chinese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'zh',
+    ttsEngine: "chatterbox",
+    language: "zh",
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX
-  }
-})
+    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX,
+  },
+});
 ```
 
 ## Bug Fixes
@@ -938,7 +965,7 @@ The SDK and its native backends (llama.cpp / ggml) no longer print to the consol
 
 ```typescript
 // SDK and native logs printed to the console by default.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
 // → console fills with SDK + native output
 ```
 
@@ -946,7 +973,7 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
 
 ```typescript
 // Silent by default — no console output.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
 
 // Opt in:
 //   qvac.config.json → { "loggerConsoleOutput": true }                          // SDK logs
@@ -962,14 +989,14 @@ The bundled `bare-process` shim has been removed in favor of Bare primitives. Co
 
 ```typescript
 // process available as a global
-process.exit(0)
+process.exit(0);
 ```
 
 **After:**
 
 ```typescript
-import process from 'bare-process'
-process.exit(0)
+import process from "bare-process";
+process.exit(0);
 ```
 
 ### OCR Now Runs on GGML
@@ -983,14 +1010,14 @@ The SDK's OCR path moves from ONNX to GGML-OCR 0.4.0. The legacy ONNX OCR model 
 `subscribeServerLogs` registers a single handler that receives all server-side logs, removing the need for per-ID `loggingStream()` calls.
 
 ```typescript
-import { subscribeServerLogs } from '@qvac/sdk'
+import { subscribeServerLogs } from "@qvac/sdk";
 
 const unsubscribe = subscribeServerLogs((log) => {
-  console.log(`[${log.level}] [${log.namespace}] ${log.message}`)
-})
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
+});
 
 // later
-unsubscribe()
+unsubscribe();
 ```
 
 ### Field-Level Validation Errors
@@ -998,13 +1025,13 @@ unsubscribe()
 Invalid input now produces readable, field-level errors instead of opaque failures. A `RequestValidationFailedError` carries a message that points at the offending field.
 
 ```typescript
-import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
 
 try {
-  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } })
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
 } catch (err) {
   if (err instanceof RequestValidationFailedError) {
-    console.error(err.message)
+    console.error(err.message);
     // Invalid request:
     // ✖ Unrecognized key: "dtx_size"
     //   → at modelConfig
@@ -1019,20 +1046,20 @@ Completions can now cap or disable the reasoning channel per request or at load 
 ```typescript
 // Per-request: cap the reasoning channel at 128 tokens for a single run()
 await session.run({
-  history: [{ role: 'user', content: 'Solve this step by step' }],
-  reasoning_budget: 128 // -1 = unrestricted, 0 = disabled, N = cap at N tokens
-})
+  history: [{ role: "user", content: "Solve this step by step" }],
+  reasoning_budget: 128, // -1 = unrestricted, 0 = disabled, N = cap at N tokens
+});
 
 // Load-time default
-await loadModel(src, { reasoning_budget: 256 })
+await loadModel(src, { reasoning_budget: 256 });
 ```
 
 ```typescript
 // Drop this turn's reasoning block from the KV cache after generation
 await model.completion({
   history,
-  generationParams: { remove_thinking_from_context: true }
-})
+  generationParams: { remove_thinking_from_context: true },
+});
 ```
 
 The same `remove_thinking_from_context` flag is accepted on the CLI's OpenAI-compatible `/v1/chat/completions` request body.
@@ -1044,9 +1071,9 @@ A new `image_tile_mode` config controls how multimodal images are tiled before i
 ```typescript
 await loadModel({
   modelSrc: QWEN3_5_VL_MODEL,
-  modelType: 'llamacpp-completion',
-  modelConfig: { image_tile_mode: 'sequential' } // "disabled" | "batched" | "sequential" (default: "sequential")
-})
+  modelType: "llamacpp-completion",
+  modelConfig: { image_tile_mode: "sequential" }, // "disabled" | "batched" | "sequential" (default: "sequential")
+});
 ```
 
 ### Per-Engine TTS Language Validation and More Languages
@@ -1058,24 +1085,24 @@ import {
   TTS_CHATTERBOX_LANGUAGES,
   TTS_SUPERTONIC_LANGUAGES,
   type TtsChatterboxLanguage,
-  type TtsSupertonicLanguage
-} from '@qvac/sdk'
+  type TtsSupertonicLanguage,
+} from "@qvac/sdk";
 
 await loadModel({
   modelSrc: TTS_T3_TURBO_EN_CHATTERBOX_Q8_0,
-  modelType: 'tts-ggml',
+  modelType: "tts-ggml",
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'en',
+    ttsEngine: "chatterbox",
+    language: "en",
     s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX.src,
     streamChunkTokens: 25,
     streamFirstChunkTokens: 10,
     cfmSteps: 1,
     threads: 8,
     nGpuLayers: 99,
-    seed: 42
-  }
-})
+    seed: 42,
+  },
+});
 ```
 
 ### Parakeet 0.8 Runtime Fields and Explicit BCI Embedder Loading
@@ -1087,10 +1114,10 @@ const modelId = await loadModel({
   modelSrc: BCI_WINDOWED,
   modelConfig: {
     embedderModelSrc: BCI_EMBEDDER,
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    bciConfig: { day_idx: 1 }
-  }
-})
+    whisperConfig: { language: "en", temperature: 0.0 },
+    bciConfig: { day_idx: 1 },
+  },
+});
 ```
 
 ## Bug Fixes
@@ -1267,20 +1294,20 @@ QVAC SDK 0.13.0 broadens the SDK across video, neural-signal transcription, robo
 The video API now supports image-to-video generation for Wan image-to-video pipelines. Consumers can provide an initial frame through `init_image` and control denoising with `strength`, making it possible to animate a source image instead of generating entirely from text.
 
 ```typescript
-import fs from 'node:fs'
-import { video } from '@qvac/sdk'
+import fs from "node:fs";
+import { video } from "@qvac/sdk";
 
-const firstFrame = fs.readFileSync('portrait.png')
+const firstFrame = fs.readFileSync("portrait.png");
 const { outputs } = video({
   modelId,
-  mode: 'img2vid',
-  prompt: 'the subject slowly turns and smiles, cinematic lighting',
+  mode: "img2vid",
+  prompt: "the subject slowly turns and smiles, cinematic lighting",
   init_image: firstFrame,
-  strength: 0.85
-})
+  strength: 0.85,
+});
 
-const buffers = await outputs
-fs.writeFileSync('output.avi', buffers[0])
+const buffers = await outputs;
+fs.writeFileSync("output.avi", buffers[0]);
 ```
 
 This change also moves video dimension validation to the SDK schema boundary. Width and height now need to be multiples of 16, so invalid dimensions fail before they reach the native addon.
@@ -1288,13 +1315,13 @@ This change also moves video dimension validation to the SDK schema boundary. Wi
 **Before:**
 
 ```typescript
-video({ modelId, mode: 'txt2vid', prompt: '...', width: 520, height: 264 })
+video({ modelId, mode: "txt2vid", prompt: "...", width: 520, height: 264 });
 ```
 
 **After:**
 
 ```typescript
-video({ modelId, mode: 'txt2vid', prompt: '...', width: 528, height: 272 })
+video({ modelId, mode: "txt2vid", prompt: "...", width: 528, height: 272 });
 ```
 
 ## Worker Failures Are Now Typed SDK Errors
@@ -1302,15 +1329,15 @@ video({ modelId, mode: 'txt2vid', prompt: '...', width: 528, height: 272 })
 Bare worker crashes and SDK shutdown now surface as structured RPC errors instead of ambiguous failures. Applications can distinguish an unexpected worker death from an in-flight request that was cancelled because the SDK is closing.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
 
 try {
-  await sdk.embed({ modelId, text: 'hi' })
+  await sdk.embed({ modelId, text: "hi" });
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
-    console.error(err.exitCode, err.exitSignal)
+    console.error(err.exitCode, err.exitSignal);
   } else if (err instanceof WorkerShutdownError) {
-    console.error('The SDK closed while this request was in flight.')
+    console.error("The SDK closed while this request was in flight.");
   }
 }
 ```
@@ -1320,18 +1347,18 @@ try {
 The new Electron Forge plugin helps packaged desktop apps include only the native addon trees needed by their QVAC configuration. This reduces accidental bundling of unused prebuilds and keeps app packages closer to the target platform set.
 
 ```typescript
-const QvacForgePlugin = require('@qvac/sdk/electron-forge')
+const QvacForgePlugin = require("@qvac/sdk/electron-forge");
 
 module.exports = {
-  packagerConfig: { name: 'MyApp' },
+  packagerConfig: { name: "MyApp" },
   plugins: [
     new QvacForgePlugin({
-      configPath: './qvac.config.json',
-      hosts: ['darwin-arm64', 'darwin-x64'],
-      logLevel: 'info'
-    })
-  ]
-}
+      configPath: "./qvac.config.json",
+      hosts: ["darwin-arm64", "darwin-x64"],
+      logLevel: "info",
+    }),
+  ],
+};
 ```
 
 ## Completion and Transcription Metadata Are More Precise
@@ -1343,10 +1370,10 @@ Whisper transcription metadata now exposes backend and GPU stats in the final st
 ```typescript
 for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) {
   if (ev.done && ev.stats) {
-    console.log(ev.stats.backendDevice)
-    console.log(ev.stats.backendId)
-    console.log(ev.stats.gpuMemTotalMb)
-    console.log(ev.stats.gpuMemFreeMb)
+    console.log(ev.stats.backendDevice);
+    console.log(ev.stats.backendId);
+    console.log(ev.stats.gpuMemTotalMb);
+    console.log(ev.stats.gpuMemFreeMb);
   }
 }
 ```
@@ -1356,29 +1383,29 @@ for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) 
 The SDK now includes BCI transcription backed by whisper.cpp. It supports both batch transcription from a `.bin` path or `Uint8Array`, and streaming duplex sessions over neural-signal chunks.
 
 ```typescript
-import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from '@qvac/sdk'
+import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from "@qvac/sdk";
 
-const modelId = await loadModel({ modelSrc: BCI_WINDOWED })
-const text = await bciTranscribe({ modelId, neuralData: './signal.bin' })
+const modelId = await loadModel({ modelSrc: BCI_WINDOWED });
+const text = await bciTranscribe({ modelId, neuralData: "./signal.bin" });
 
-const session = await bciTranscribeStream({ modelId, emit: 'delta' })
-session.write(chunk)
-session.end()
+const session = await bciTranscribeStream({ modelId, emit: "delta" });
+session.write(chunk);
+session.end();
 
 for await (const token of session) {
-  process.stdout.write(token)
+  process.stdout.write(token);
 }
 ```
 
 This release also integrates the pi05 VLA model path for robot-action inference. The VLA API can inspect model hparams, preprocess camera frames, and run action generation with the required image, token, mask, and noise inputs.
 
 ```typescript
-import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from '@qvac/sdk'
+import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from "@qvac/sdk";
 
-const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: 'ggml-vla' })
-const { hparams } = await vlaHparams({ modelId })
-const size = hparams.visionImageSize
-const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }))
+const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: "ggml-vla" });
+const { hparams } = await vlaHparams({ modelId });
+const size = hparams.visionImageSize;
+const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }));
 
 const { actions } = await vla({
   modelId,
@@ -1388,8 +1415,8 @@ const { actions } = await vla({
   state: new Float32Array(0),
   tokens,
   mask,
-  noise
-})
+  noise,
+});
 ```
 
 ## Runtime Fixes and Dependency Cleanup
@@ -1441,9 +1468,9 @@ This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk
 React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
 
 ```typescript
-import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk/models'
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
 // or on Bare-only clients:
-import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/bare-sdk/models'
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
 ```
 
 ## Bug Fixes
@@ -1472,10 +1499,10 @@ v0.12.1 introduces two structured RPC errors that propagate from the worker brid
 - `WorkerShutdownError` — the SDK is shutting down (`sdk.close()` was called) while this request was still in flight. Safe to swallow on intentional teardown; surfaces an actionable label for callers who want to log it.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
 
 try {
-  await sdk.embed({ modelId, text: 'hi' })
+  await sdk.embed({ modelId, text: "hi" });
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
     // err.exitCode, err.exitSignal — worker died, decide whether to respawn.
@@ -1512,27 +1539,27 @@ The SDK TTS plugin now targets `@qvac/tts-ggml` instead of `@qvac/tts-onnx`. The
 ```typescript
 await loadModel({
   modelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
-  modelType: 'tts',
+  modelType: "tts",
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'en',
+    ttsEngine: "chatterbox",
+    language: "en",
     ttsSpeechEncoderSrc: TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX.src,
     ttsEmbedTokensSrc: TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX.src,
     ttsConditionalDecoderSrc: TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX.src,
-    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src
-  }
-})
+    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
+  },
+});
 ```
 
 **After:**
 
 ```typescript
-import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from '@qvac/sdk'
+import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from "@qvac/sdk";
 
 await loadModel({
   modelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX,
-  modelType: 'tts'
-})
+  modelType: "tts",
+});
 ```
 
 New registry constants cover Chatterbox and Supertonic variants in GGUF form (`TTS_S3GEN_*`, `TTS_T3_*`, `TTS_*_SUPERTONIC_*`).
@@ -1545,26 +1572,26 @@ Building on the 0.11.0 single-file GGUF migration, Parakeet now targets `@qvac/t
 
 ```typescript
 await loadModel({
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'tdt',
+    modelType: "tdt",
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR
-  }
-})
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR,
+  },
+});
 ```
 
 **After:**
 
 ```typescript
-import { PARAKEET_TDT_0_6B_V3_Q8_0 } from '@qvac/sdk'
+import { PARAKEET_TDT_0_6B_V3_Q8_0 } from "@qvac/sdk";
 
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: 'parakeet'
-})
+  modelType: "parakeet",
+});
 ```
 
 ### `@qvac/bare-sdk` requires explicit plugin registration
@@ -1574,25 +1601,25 @@ Bare consumers that previously called `getRPC()` against the full `@qvac/sdk` wo
 **Before:**
 
 ```typescript
-import { getRPC } from '@qvac/sdk'
+import { getRPC } from "@qvac/sdk";
 
-const rpc = await getRPC()
-await rpc.loadModel({/* any built-in modelType works */})
+const rpc = await getRPC();
+await rpc.loadModel({ /* any built-in modelType works */ });
 ```
 
 **After:**
 
 ```typescript
-import { plugins } from '@qvac/bare-sdk'
-import { nmtPlugin } from '@qvac/bare-sdk/nmtcpp-translation/plugin'
-import { llmPlugin } from '@qvac/bare-sdk/llamacpp-completion/plugin'
+import { plugins } from "@qvac/bare-sdk";
+import { nmtPlugin } from "@qvac/bare-sdk/nmtcpp-translation/plugin";
+import { llmPlugin } from "@qvac/bare-sdk/llamacpp-completion/plugin";
 
-const sdk = plugins([nmtPlugin, llmPlugin])
+const sdk = plugins([nmtPlugin, llmPlugin]);
 
 await sdk.loadModel({
   modelSrc: BERGAMOT_EN_FR,
-  modelType: 'nmt'
-})
+  modelType: "nmt",
+});
 ```
 
 Install matching addon packages (`@qvac/translation-nmtcpp`, `@qvac/llm-llamacpp`, etc.) alongside `@qvac/bare-sdk`. `@qvac/sdk` remains the right choice for Node and Expo apps that want the full default worker.
@@ -1614,20 +1641,20 @@ import {
   vlaHparams,
   vlaPreprocessImage,
   vlaPadState,
-  SMOLVLA_LIBERO_VISION_Q8
-} from '@qvac/sdk'
+  SMOLVLA_LIBERO_VISION_Q8,
+} from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: SMOLVLA_LIBERO_VISION_Q8,
-  modelType: 'vla',
-  modelConfig: { backend: 'auto' }
-})
+  modelType: "vla",
+  modelConfig: { backend: "auto" },
+});
 
-const { hparams } = await vlaHparams({ modelId })
+const { hparams } = await vlaHparams({ modelId });
 const image = vlaPreprocessImage(pixels, width, height, {
-  size: hparams.visionImageSize
-})
-const state = vlaPadState(robotState, hparams.maxStateDim)
+  size: hparams.visionImageSize,
+});
+const state = vlaPadState(robotState, hparams.maxStateDim);
 
 const { actions, actionDim, chunkSize } = await vla({
   modelId,
@@ -1636,8 +1663,8 @@ const { actions, actionDim, chunkSize } = await vla({
   imgHeight: hparams.visionImageSize,
   state,
   tokens,
-  mask
-})
+  mask,
+});
 ```
 
 ### Image classification
@@ -1645,14 +1672,14 @@ const { actions, actionDim, chunkSize } = await vla({
 Classify JPEG/PNG buffers or raw RGB bytes with bundled MobileNetV3-Small or a custom GGUF:
 
 ```typescript
-import { loadModel, classify } from '@qvac/sdk'
+import { loadModel, classify } from "@qvac/sdk";
 
 const modelId = await loadModel({
-  modelType: 'classification',
-  modelConfig: { topK: 3 }
-})
+  modelType: "classification",
+  modelConfig: { topK: 3 },
+});
 
-const results = await classify({ modelId, image: jpegBytes })
+const results = await classify({ modelId, image: jpegBytes });
 // → [{ label: "food", confidence: 0.91 }, ...]
 ```
 
@@ -1661,24 +1688,24 @@ const results = await classify({ modelId, image: jpegBytes })
 Generate video frames from text prompts using WAN models:
 
 ```typescript
-import { video } from '@qvac/sdk'
+import { video } from "@qvac/sdk";
 
 const run = video({
   modelId,
-  mode: 'txt2vid',
-  prompt: 'a cat surfing a wave at sunset',
+  mode: "txt2vid",
+  prompt: "a cat surfing a wave at sunset",
   width: 480,
   height: 832,
   video_frames: 17,
   fps: 16,
-  steps: 20
-})
+  steps: 20,
+});
 
 for await (const tick of run.progressStream) {
-  console.log(`step ${tick.step}/${tick.totalSteps}`)
+  console.log(`step ${tick.step}/${tick.totalSteps}`);
 }
 
-const frames = await run.outputs
+const frames = await run.outputs;
 ```
 
 ### `@qvac/sdk/commands` for bundling and verification
@@ -1686,14 +1713,14 @@ const frames = await run.outputs
 Programmatic access to worker bundling and prebuild verification — the same primitives `qvac bundle` and `qvac verify bundle` use:
 
 ```typescript
-import { bundleSdk, verifyBundle } from '@qvac/sdk/commands'
+import { bundleSdk, verifyBundle } from "@qvac/sdk/commands";
 
-await bundleSdk({ projectRoot: process.cwd(), configPath: './qvac.config.json' })
+await bundleSdk({ projectRoot: process.cwd(), configPath: "./qvac.config.json" });
 await verifyBundle({
   projectRoot: process.cwd(),
-  addonsSource: './qvac/worker.bundle.js',
-  hosts: ['android-arm64', 'ios-arm64']
-})
+  addonsSource: "./qvac/worker.bundle.js",
+  hosts: ["android-arm64", "ios-arm64"],
+});
 ```
 
 ### RAG cancellation detection
@@ -1701,7 +1728,7 @@ await verifyBundle({
 Detect cancelled RAG operations without importing `@qvac/rag/errors`:
 
 ```typescript
-import { RAG_ERROR_CODES } from '@qvac/sdk'
+import { RAG_ERROR_CODES } from "@qvac/sdk";
 
 if (err.code === RAG_ERROR_CODES.OPERATION_CANCELLED) {
   // ingest was cancelled
@@ -1725,15 +1752,17 @@ Expo config plugins resolve `@qvac/sdk` from ancestor `node_modules` directories
 LLM completion now surfaces real input token counts in stats and throws a typed `ContextOverflowError` when the prompt exceeds the model context window — including across the Bare RPC boundary:
 
 ```typescript
-import { ContextOverflowError } from '@qvac/sdk'
+import { ContextOverflowError } from "@qvac/sdk";
 
-const run = sdk.completion({/* ... */})
+const run = sdk.completion({ /* ... */ });
 try {
-  const final = await run.final
-  console.log(final.stats?.promptTokens)
+  const final = await run.final;
+  console.log(final.stats?.promptTokens);
 } catch (err) {
   if (err instanceof ContextOverflowError) {
-    console.warn(`prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`)
+    console.warn(
+      `prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`,
+    );
   }
 }
 ```
@@ -1812,20 +1841,20 @@ override.
 **Before (Bare):**
 
 ```typescript
-import { unloadModel } from '@qvac/sdk'
+import { unloadModel } from "@qvac/sdk";
 
-await unloadModel({ modelId })
+await unloadModel({ modelId });
 // RPC connection closed → Bare worker host terminated.
 ```
 
 **After (Bare):**
 
 ```typescript
-import { unloadModel } from '@qvac/sdk'
+import { unloadModel } from "@qvac/sdk";
 
-await unloadModel({ modelId })
+await unloadModel({ modelId });
 // Worker survives; opt in to closing explicitly:
-await unloadModel({ modelId, autoClose: true })
+await unloadModel({ modelId, autoClose: true });
 ```
 
 ### Parakeet plugin moves to the 0.4.0 single-file GGUF API
@@ -1842,24 +1871,24 @@ Sortformer from GGUF metadata.
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_ENCODER_INT8,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8
-  }
-})
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
+  },
+});
 
 await loadModel({
   modelSrc: PARAKEET_CTC_FP32,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'ctc',
+    modelType: "ctc",
     parakeetCtcModelSrc: PARAKEET_CTC_FP32,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
-  }
-})
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
 ```
 
 **After:**
@@ -1867,13 +1896,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: 'parakeet'
-})
+  modelType: "parakeet",
+});
 
 await loadModel({
   modelSrc: PARAKEET_CTC_0_6B_Q8_0,
-  modelType: 'parakeet'
-})
+  modelType: "parakeet",
+});
 ```
 
 The new GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`,
@@ -1892,47 +1921,47 @@ hatch.
 **Before — downloadAsset:**
 
 ```typescript
-import { downloadAsset, cancel } from '@qvac/sdk'
+import { downloadAsset, cancel } from "@qvac/sdk";
 
-const op = downloadAsset({ assetSrc, onProgress })
-await cancel({ operation: 'downloadAsset', downloadKey: assetSrc.key, clearCache: true })
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
 ```
 
 **After — downloadAsset:** the decorated promise now exposes `op.requestId`
 synchronously, and `clearCache` is honoured on the `requestId` path.
 
 ```typescript
-import { downloadAsset, cancel } from '@qvac/sdk'
+import { downloadAsset, cancel } from "@qvac/sdk";
 
-const op = downloadAsset({ assetSrc, onProgress })
-await cancel({ requestId: op.requestId, clearCache: true })
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ requestId: op.requestId, clearCache: true });
 ```
 
 **Before — rag:**
 
 ```typescript
-import { ragIngest, cancel } from '@qvac/sdk'
+import { ragIngest, cancel } from "@qvac/sdk";
 
-ragIngest({ workspace: 'my-workspace', documents })
-await cancel({ operation: 'rag', workspace: 'my-workspace' })
+ragIngest({ workspace: "my-workspace", documents });
+await cancel({ operation: "rag", workspace: "my-workspace" });
 ```
 
 **After — rag (primary path, by `requestId`):**
 
 ```typescript
-import { ragIngest, cancel } from '@qvac/sdk'
+import { ragIngest, cancel } from "@qvac/sdk";
 
-const op = ragIngest({ workspace: 'my-workspace', documents })
-await cancel({ requestId: op.requestId })
+const op = ragIngest({ workspace: "my-workspace", documents });
+await cancel({ requestId: op.requestId });
 ```
 
 **After — rag (broad escape hatch, no `requestId` to hand):**
 
 ```typescript
-import { cancel } from '@qvac/sdk'
+import { cancel } from "@qvac/sdk";
 
 // Cancel every in-flight RAG operation running on the embedding model:
-await cancel({ modelId: ragEmbeddingModelId, kind: 'rag' })
+await cancel({ modelId: ragEmbeddingModelId, kind: "rag" });
 ```
 
 Every other `cancel(...)` shape still works: `cancel({ operation: "inference",
@@ -1952,26 +1981,33 @@ network round-trip. The pattern covers `completion`, `loadModel`, `embed`,
 the three cancellable RAG ops (`ragIngest`, `ragSaveEmbeddings`, `ragReindex`).
 
 ```typescript
-import { completion, loadModel, embed, downloadAsset, ragIngest, cancel } from '@qvac/sdk'
+import {
+  completion,
+  loadModel,
+  embed,
+  downloadAsset,
+  ragIngest,
+  cancel,
+} from "@qvac/sdk";
 
-const run = completion({ modelId, history })
-console.log(run.requestId)
+const run = completion({ modelId, history });
+console.log(run.requestId);
 
-const op = loadModel({ modelSrc: '...' })
-console.log(op.requestId) // synchronously, before await
-const modelId = await op // legacy unwrap still works
+const op = loadModel({ modelSrc: "..." });
+console.log(op.requestId);                    // synchronously, before await
+const modelId = await op;                     // legacy unwrap still works
 
-const handle = embed({ modelId, text: 'hello' })
-console.log(handle.requestId)
-await handle
+const handle = embed({ modelId, text: "hello" });
+console.log(handle.requestId);
+await handle;
 
-const download = downloadAsset({ assetSrc, onProgress })
-stopButton.onclick = () => cancel({ requestId: download.requestId })
-await download // rejects with InferenceCancelledError if cancelled
+const download = downloadAsset({ assetSrc, onProgress });
+stopButton.onclick = () => cancel({ requestId: download.requestId });
+await download;                                // rejects with InferenceCancelledError if cancelled
 
-const ingest = ragIngest({ workspace: 'ws-a', modelId, documents })
-console.log(ingest.requestId)
-await ingest
+const ingest = ragIngest({ workspace: "ws-a", modelId, documents });
+console.log(ingest.requestId);
+await ingest;
 ```
 
 The non-cancellable RAG ops (`ragChunk`, `ragSearch`, `ragDeleteEmbeddings`,
@@ -1995,19 +2031,17 @@ llama.cpp addon's opaque "job already set" error into a typed framework-level
 rejection.
 
 ```typescript
-import { completion, RequestRejectedByPolicyError } from '@qvac/sdk'
+import { completion, RequestRejectedByPolicyError } from "@qvac/sdk";
 
 try {
-  const run = completion({ modelId, history })
-  for await (const event of run.events) {
-    /* ... */
-  }
+  const run = completion({ modelId, history });
+  for await (const event of run.events) { /* ... */ }
 } catch (err) {
   if (err instanceof RequestRejectedByPolicyError) {
-    showBusy({ modelId: err.modelId, reason: err.reason })
-    return
+    showBusy({ modelId: err.modelId, reason: err.reason });
+    return;
   }
-  throw err
+  throw err;
 }
 ```
 
@@ -2019,10 +2053,10 @@ modelId, kind? }`). Two new client sugars wrap the broad shape so callers don't
 have to think about the wire representation:
 
 ```typescript
-import { cancel } from '@qvac/sdk'
+import { cancel } from "@qvac/sdk";
 
-await cancel({ modelId: 'llama-3.2-1b', kind: 'completion' })
-await cancel({ modelId: 'llama-3.2-1b' })
+await cancel({ modelId: "llama-3.2-1b", kind: "completion" });
+await cancel({ modelId: "llama-3.2-1b" });
 ```
 
 ### Plugin authors: declare cancel scope per handler
@@ -2038,7 +2072,7 @@ addon-side cancel actually interrupts compute. Plugin manifests that omit the
 field still load — it's optional.
 
 ```typescript
-import { definePlugin, defineHandler } from '@qvac/sdk'
+import { definePlugin, defineHandler } from "@qvac/sdk";
 
 definePlugin({
   manifestVersion: 1,
@@ -2047,13 +2081,11 @@ definePlugin({
       requestSchema,
       responseSchema,
       streaming: true,
-      cancel: { scope: 'model', hard: true },
-      handler: async function* (request, ctx) {
-        /* ... */
-      }
-    })
-  }
-})
+      cancel: { scope: "model", hard: true },
+      handler: async function* (request, ctx) { /* ... */ },
+    }),
+  },
+});
 ```
 
 ### Multi-GPU `split-mode`, `tensor-split`, and `main-gpu` on LLM and embed
@@ -2067,24 +2099,24 @@ convention (`splitMode`, `tensorSplit`, `mainGpu`).
 // LLM
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
+  modelType: "llm",
   modelConfig: {
-    'split-mode': 'layer', // "none" | "layer" | "row"
-    'tensor-split': '1,1', // proportional split across GPUs
-    'main-gpu': 0 // integer index or "integrated" | "dedicated"
-  }
-})
+    "split-mode": "layer",        // "none" | "layer" | "row"
+    "tensor-split": "1,1",        // proportional split across GPUs
+    "main-gpu": 0,                // integer index or "integrated" | "dedicated"
+  },
+});
 
 // Embed
 await loadModel({
   modelSrc: EMBEDDING_GEMMA_300M_Q8_0,
-  modelType: 'embed',
+  modelType: "embed",
   modelConfig: {
-    splitMode: 'layer',
-    tensorSplit: '1,1',
-    mainGpu: 0
-  }
-})
+    splitMode: "layer",
+    tensorSplit: "1,1",
+    mainGpu: 0,
+  },
+});
 ```
 
 ### Whisper VAD and end-of-turn events on `transcribeStream`
@@ -2095,24 +2127,23 @@ voice-activity probabilities and turn boundaries, so apps can build push-to-talk
 or barge-in UX without poll-the-text hacks.
 
 ```typescript
-import { transcribeStream } from '@qvac/sdk'
+import { transcribeStream } from "@qvac/sdk";
 
 const session = await transcribeStream({
-  modelId: 'whisper-base',
+  modelId: "whisper-base",
   emitVadEvents: true,
   endOfTurnSilenceMs: 800,
-  vadRunIntervalMs: 100
-})
+  vadRunIntervalMs: 100,
+});
 
 for await (const event of session) {
-  if (event.type === 'vad') console.log('speaking:', event.speaking, event.probability)
-  else if (event.type === 'endOfTurn')
-    console.log('turn ended after', event.silenceDurationMs, 'ms')
-  else if (event.type === 'text') process.stdout.write(event.text)
+  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
+  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
+  else if (event.type === "text") process.stdout.write(event.text);
 }
 
-session.write(audioChunk)
-session.end()
+session.write(audioChunk);
+session.end();
 ```
 
 `TranscribeStreamEvent`, `VadStateEvent`, `EndOfTurnEvent`, and
@@ -2131,20 +2162,20 @@ const session = await transcribeStream({
   modelId,
   parakeetStreamingConfig: {
     chunkMs: 1000,
-    emitPartials: true
-  }
-})
+    emitPartials: true,
+  },
+});
 
-ffmpeg.stdout.on('data', (chunk: Buffer) => session.write(chunk))
+ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
 
 for await (const event of session) {
   switch (event.type) {
-    case 'text':
-      process.stdout.write(event.text)
-      break
-    case 'endOfTurn':
-      console.log('\n[endOfTurn] turn boundary detected\n')
-      break
+    case "text":
+      process.stdout.write(event.text);
+      break;
+    case "endOfTurn":
+      console.log("\n[endOfTurn] turn boundary detected\n");
+      break;
   }
 }
 ```
@@ -2168,16 +2199,16 @@ framing; Gemma4 covers the native
 `<|tool_call>call:NAME{key:<|"|>val<|"|>,...}<tool_call|>` framing.
 
 ```typescript
-import { completion, type ToolDialect } from '@qvac/sdk'
+import { completion, type ToolDialect } from "@qvac/sdk";
 
 const result = completion({
-  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId,                         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: 'harmony' // optional explicit override
-})
+  toolDialect: "harmony",          // optional explicit override
+});
 
-const dialect: ToolDialect = 'harmony'
+const dialect: ToolDialect = "harmony";
 ```
 
 Qwen3.5 / Qwen3.6 and Gemma4 are auto-detected from the model name; the parsers
@@ -2193,19 +2224,19 @@ unrestricted, `0` = disabled. The SDK exposes it both as a load-time default on
 `LlmConfig` and as a per-request override on `GenerationParams`.
 
 ```typescript
-import { loadModel, completion } from '@qvac/sdk'
+import { loadModel, completion } from "@qvac/sdk";
 
 const modelId = await loadModel({
-  modelSrc: '/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf',
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, reasoning_budget: -1 }
-})
+  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
+});
 
 const run = completion({
   modelId,
-  history: [{ role: 'user', content: 'Think step by step.' }],
-  generationParams: { reasoning_budget: 0 } // override per-request
-})
+  history: [{ role: "user", content: "Think step by step." }],
+  generationParams: { reasoning_budget: 0 }, // override per-request
+});
 ```
 
 The same bump fixes a regression where `system_prompt` (a JS-only
@@ -2223,26 +2254,26 @@ per-call `lora` field that takes an absolute filesystem path. A new load-time
 model or applied per-call (`"auto" | "immediately" | "at_runtime"`).
 
 ```typescript
-const refA = fs.readFileSync('scientist-a.jpg')
-const refB = fs.readFileSync('scientist-b.jpg')
+const refA = fs.readFileSync("scientist-a.jpg");
+const refB = fs.readFileSync("scientist-b.jpg");
 const { outputs } = diffusion({
   modelId,
-  prompt: 'a portrait using most visual traits from @image1 and the eyes from @image2',
+  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
   init_images: [refA, refB],
   width: 768,
-  height: 768
-})
+  height: 768,
+});
 
 const { outputs: loraOutputs } = diffusion({
   modelId,
-  prompt: 'a watercolor cat',
-  lora: '/home/user/loras/watercolor.safetensors'
-})
+  prompt: "a watercolor cat",
+  lora: "/home/user/loras/watercolor.safetensors",
+});
 
 await loadModel(modelSrc, {
-  modelType: 'diffusion',
-  modelConfig: { prediction: 'flux2_flow', lora_apply_mode: 'immediately' }
-})
+  modelType: "diffusion",
+  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
+});
 ```
 
 Relative LoRA paths are rejected: the SDK runs across processes with differing
@@ -2261,47 +2292,46 @@ without standing up a full diffusion pipeline.
 // Post-step upscale during diffusion
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: 'diffusion',
+  modelType: "diffusion",
   modelConfig: {
-    prediction: 'v',
+    prediction: "v",
     upscaler: {
-      type: 'esrgan',
-      model_src:
-        'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth',
-      tile_size: 128
-    }
-  }
-})
+      type: "esrgan",
+      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+      tile_size: 128,
+    },
+  },
+});
 
 const { outputs } = diffusion({
   modelId,
-  prompt: 'an illustrated red fox portrait',
+  prompt: "an illustrated red fox portrait",
   width: 128,
   height: 128,
-  upscale: { repeats: 2 }
-})
+  upscale: { repeats: 2 },
+});
 ```
 
 ```typescript
 // Standalone upscale — no diffusion model required
-import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from '@qvac/sdk'
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
 
 const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
-  modelType: 'diffusion',
+  modelType: "diffusion",
   modelConfig: {
-    mode: 'upscale',
-    upscaler: { tile_size: 128 }
-  }
-})
+    mode: "upscale",
+    upscaler: { tile_size: 128 },
+  },
+});
 
 const { outputs, stats } = upscale({
   modelId,
-  image: pngBytes, // Uint8Array (PNG/JPEG)
-  repeats: 1 // each pass multiplies dims by the model's native scale factor
-})
+  image: pngBytes,        // Uint8Array (PNG/JPEG)
+  repeats: 1,             // each pass multiplies dims by the model's native scale factor
+});
 
-const [upscaledPng] = await outputs
-console.log(await stats) // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+const [upscaledPng] = await outputs;
+console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
 ```
 
 Calling `upscale()` against a model that wasn't loaded with `mode: "upscale"`
@@ -2452,10 +2482,10 @@ The DHT routing table is still populated lazily as `dht.connect()` issues lookup
 
 Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
 
-| Build              | Mean connection time | p50   | p95   |
-| ------------------ | -------------------- | ----- | ----- |
-| v0.10.1 (baseline) | 3.82s                | 3.71s | 4.94s |
-| v0.10.2 (this fix) | 1.18s                | 1.12s | 1.49s |
+| Build              | Mean connection time | p50    | p95    |
+| ------------------ | -------------------- | ------ | ------ |
+| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
+| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
 
 That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
 
@@ -2474,16 +2504,16 @@ This patch release adds a new tool-call dialect for OpenAI's `gpt-oss` (Harmony)
 `completion()` now supports a fourth tool-call dialect, `"harmony"`, used by OpenAI's `gpt-oss` family of models. The new dialect is wired into the same streaming/event surface as the existing dialects (`hermes`, `pythonic`, `json`), so tool calls emitted in Harmony frames are parsed and surfaced through the standard `CompletionEvent` stream. `gpt-oss-20b-Q4_K_M` auto-routes to the Harmony dialect; the `toolDialect` parameter is available as an explicit override on any model.
 
 ```typescript
-import { completion, type ToolDialect } from '@qvac/sdk'
+import { completion, type ToolDialect } from "@qvac/sdk";
 
 const run = completion({
-  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId,                 // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: 'harmony' // optional explicit override
-})
+  toolDialect: "harmony",  // optional explicit override
+});
 
-const dialect: ToolDialect = 'harmony'
+const dialect: ToolDialect = "harmony";
 // ToolDialect is now "hermes" | "pythonic" | "json" | "harmony"
 ```
 
@@ -2582,22 +2612,20 @@ captured thinking and structured tool framing.
 **Before:**
 
 ```typescript
-const result = completion({ modelId, history, stream: true })
-for await (const token of result.tokenStream) {
-  /* ... */
-}
-const stats = await result.stats
+const result = completion({ modelId, history, stream: true });
+for await (const token of result.tokenStream) { /* ... */ }
+const stats = await result.stats;
 ```
 
 **After:**
 
 ```typescript
-const run = completion({ modelId, history, stream: true, captureThinking: true })
+const run = completion({ modelId, history, stream: true, captureThinking: true });
 for await (const event of run.events) {
-  if (event.type === 'contentDelta') process.stdout.write(event.text)
-  if (event.type === 'toolCall') console.log(event.call.name)
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === "toolCall") console.log(event.call.name);
 }
-const result = await run.final
+const result = await run.final;
 // result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
 ```
 
@@ -2619,35 +2647,35 @@ and `pluginInvokeStream` paths still surface `PLUGIN_HANDLER_NOT_FOUND` as befor
 **Before:**
 
 ```typescript
-import type { LoadModelOptions } from '@qvac/sdk'
+import type { LoadModelOptions } from "@qvac/sdk";
 
 const opts: LoadModelOptions = {
-  modelSrc: '/path/foo',
-  modelType: 'my-custom-plugin',
-  modelConfig: { whatever: 1 }
-}
-await loadModel(opts)
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
 ```
 
 **After:**
 
 ```typescript
-import type { LoadCustomPluginModelOptions } from '@qvac/sdk'
+import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
 
-const opts: LoadCustomPluginModelOptions<'my-custom-plugin'> = {
-  modelSrc: '/path/foo',
-  modelType: 'my-custom-plugin',
-  modelConfig: { whatever: 1 }
-}
-await loadModel(opts)
+const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
 // Or just drop the annotation — TS picks the right overload.
 ```
 
 ```typescript
-import { SDK_SERVER_ERROR_CODES } from '@qvac/sdk'
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
 
 try {
-  await transcribe({ modelId: llmModelId /* ... */ })
+  await transcribe({ modelId: llmModelId /* ... */ });
 } catch (e) {
   if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
     // Includes requested operation, loaded model type, supported operations,
@@ -2667,9 +2695,7 @@ the field name changed.
 ```typescript
 onProgress: (progress) => {
   if (progress.onnxInfo) {
-    console.log(
-      `[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`
-    )
+    console.log(`[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`);
   }
 }
 ```
@@ -2679,9 +2705,7 @@ onProgress: (progress) => {
 ```typescript
 onProgress: (progress) => {
   if (progress.fileSetInfo) {
-    console.log(
-      `[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`
-    )
+    console.log(`[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`);
   }
 }
 ```
@@ -2711,12 +2735,12 @@ delegated models defer to the provider. Useful for preflighting a built-in SDK c
 before issuing the RPC.
 
 ```typescript
-import { getLoadedModelInfo, transcribe } from '@qvac/sdk'
+import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
 
-const info = await getLoadedModelInfo({ modelId })
+const info = await getLoadedModelInfo({ modelId });
 
-if (info.isDelegated || info.handlers.includes('transcribeStream')) {
-  await transcribe({ modelId /* ... */ })
+if (info.isDelegated || info.handlers.includes("transcribeStream")) {
+  await transcribe({ modelId /* ... */ });
 }
 ```
 
@@ -2728,31 +2752,31 @@ schema-valid JSON. The output is guaranteed to parse against the supplied JSON S
 ```typescript
 const run = completion({
   modelId,
-  history: [{ role: 'user', content: "Extract: I'm Alice, 30, data engineer." }],
+  history: [{ role: "user", content: "Extract: I'm Alice, 30, data engineer." }],
   stream: true,
   responseFormat: {
-    type: 'json_schema',
+    type: "json_schema",
     json_schema: {
-      name: 'Person',
+      name: "Person",
       schema: {
-        type: 'object',
+        type: "object",
         properties: {
-          name: { type: 'string' },
-          age: { type: 'integer' },
-          occupation: { type: 'string' }
+          name: { type: "string" },
+          age: { type: "integer" },
+          occupation: { type: "string" },
         },
-        required: ['name', 'age', 'occupation'],
-        additionalProperties: false
-      }
-    }
-  }
-})
+        required: ["name", "age", "occupation"],
+        additionalProperties: false,
+      },
+    },
+  },
+});
 
 for await (const event of run.events) {
-  if (event.type === 'contentDelta') process.stdout.write(event.text)
+  if (event.type === "contentDelta") process.stdout.write(event.text);
 }
-const final = await run.final
-JSON.parse(final.contentText) // schema-valid
+const final = await run.final;
+JSON.parse(final.contentText); // schema-valid
 ```
 
 ### Dynamic tools mode
@@ -2763,35 +2787,29 @@ addon trims the previous tool block from the KV cache so rotation is free — no
 invalidate the cache or pin the tool set per-session.
 
 ```typescript
-import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
+import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: 'llm',
+  modelType: "llm",
   modelConfig: {
     ctx_size: 4096,
     tools: true,
-    toolsMode: TOOLS_MODE.dynamic
-  }
-})
+    toolsMode: TOOLS_MODE.dynamic,
+  },
+});
 
 // Turn 1 — weather tools.
 const turn1 = completion({
-  modelId,
-  history,
-  kvCache,
-  stream: true,
-  tools: [{ name: 'get_weather', description: '...', parameters: weatherSchema }]
-})
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
+});
 
 // Turn 2 — same kvCache, different tools. Free rotation.
 const turn2 = completion({
-  modelId,
-  history,
-  kvCache,
-  stream: true,
-  tools: [{ name: 'get_horoscope', description: '...', parameters: horoscopeSchema }]
-})
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
+});
 ```
 
 ### Tool-call dialect routing
@@ -2803,15 +2821,12 @@ fine-tunes that emit native pythonic headers, which the auto-router defaults to 
 for empirical reasons.
 
 ```typescript
-import { completion, type ToolDialect } from '@qvac/sdk'
+import { completion, type ToolDialect } from "@qvac/sdk";
 
 const result = completion({
-  modelId,
-  history,
-  tools,
-  stream: true,
-  toolDialect: 'pythonic' // "hermes" | "pythonic" | "json"
-})
+  modelId, history, tools, stream: true,
+  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
+});
 ```
 
 ### img2img for diffusion models
@@ -2821,13 +2836,13 @@ SD/SDXL, and in-context conditioning on FLUX.2. `strength` controls how much of 
 source is preserved on SD/SDXL; FLUX.2 ignores it (the path is purely conditional).
 
 ```typescript
-const initImage = new Uint8Array(fs.readFileSync('input.png'))
+const initImage = new Uint8Array(fs.readFileSync("input.png"));
 const { outputs } = diffusion({
   modelId,
-  prompt: 'oil painting style, vibrant colors',
+  prompt: "oil painting style, vibrant colors",
   init_image: initImage,
-  strength: 0.5 // 0 = keep source, 1 = ignore source
-})
+  strength: 0.5, // 0 = keep source, 1 = ignore source
+});
 ```
 
 ### Sentence-level TTS streaming
@@ -2840,22 +2855,22 @@ exposes the int16 PCM samples plus the source sentence and chunk index.
 ```typescript
 const session = await textToSpeechStream({
   modelId: ttsModelId,
-  inputType: 'text',
+  inputType: "text",
   accumulateSentences: true,
-  sentenceDelimiterPreset: 'latin', // "latin" | "cjk" | "multilingual"
-  flushAfterMs: 400
-})
+  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400,
+});
 
-;(async () => {
+(async () => {
   for await (const delta of completion({ modelId: llmModelId /* ... */ }).tokenStream) {
-    session.write(delta)
+    session.write(delta);
   }
-  session.end()
-})()
+  session.end();
+})();
 
 for await (const chunk of session) {
   // chunk.buffer / chunk.chunkIndex / chunk.sentenceChunk
-  if (chunk.done) break
+  if (chunk.done) break;
 }
 ```
 
@@ -2867,9 +2882,9 @@ flag — enabling proper subtitle generation and timeline alignment instead of r
 concatenation.
 
 ```typescript
-const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true })
+const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true });
 for (const s of segments) {
-  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`)
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
 }
 ```
 
@@ -2880,12 +2895,12 @@ suspend/resume races. A new `state()` API reports the current lifecycle phase:
 `active`, `suspending`, `suspended`, or `resuming`.
 
 ```typescript
-import { state, suspend, resume, type LifecycleState } from '@qvac/sdk'
+import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
 
-await suspend()
-const current: LifecycleState = await state()
-if (current !== 'active') {
-  await resume()
+await suspend();
+const current: LifecycleState = await state();
+if (current !== "active") {
+  await resume();
 }
 ```
 
@@ -2896,12 +2911,12 @@ Two new SDK config knobs cover slow/unstable links: `registryDownloadMaxRetries`
 extends the per-block stream timeout beyond the default 60s.
 
 ```typescript
-import { setSDKConfig } from '@qvac/sdk'
+import { setSDKConfig } from "@qvac/sdk";
 
 setSDKConfig({
   registryDownloadMaxRetries: 5,
-  registryStreamTimeoutMs: 180_000
-})
+  registryStreamTimeoutMs: 180_000,
+});
 ```
 
 ### Auto KV-cache: replay the canonical assistant turn
@@ -2913,16 +2928,14 @@ guarantee a cache hit. Tool-call turns aren't auto-cached today and omit the fie
 fall back to `final.contentText` in that case.
 
 ```typescript
-const run = completion({ modelId, history, kvCache: true })
-for await (const _ of run.tokenStream) {
-  /* stream */
-}
-const final = await run.final
+const run = completion({ modelId, history, kvCache: true });
+for await (const _ of run.tokenStream) { /* stream */ }
+const final = await run.final;
 const nextHistory = [
   ...history,
-  { role: 'assistant', content: final.cacheableAssistantContent ?? final.contentText },
-  { role: 'user', content: 'follow-up question' }
-]
+  { role: "assistant", content: final.cacheableAssistantContent ?? final.contentText },
+  { role: "user", content: "follow-up question" },
+];
 ```
 
 ### LLM-addon cache API plumbed through SDK
@@ -3071,22 +3084,22 @@ The `ping()` API has been replaced by `heartbeat()`, which supports both local a
 **Before:**
 
 ```typescript
-import { ping } from '@qvac/sdk'
-const pong = await ping()
+import { ping } from "@qvac/sdk";
+const pong = await ping();
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from '@qvac/sdk'
+import { heartbeat } from "@qvac/sdk";
 
 // Local heartbeat (replaces ping)
-await heartbeat()
+await heartbeat();
 
 // Delegated heartbeat — check if a remote provider is alive
 await heartbeat({
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
-})
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
+});
 ```
 
 ---
@@ -3098,22 +3111,22 @@ await heartbeat({
 The SDK now supports LoRA finetuning of loaded LLM models. Training runs can be started, paused, resumed, cancelled, and inspected — all through a single `finetune()` function. Progress streams provide real-time loss and step metrics.
 
 ```typescript
-import { finetune } from '@qvac/sdk'
+import { finetune } from "@qvac/sdk";
 
 const handle = finetune({
   modelId,
   options: {
-    trainDatasetDir: './dataset/train',
-    validation: { type: 'dataset', path: './dataset/eval' },
-    outputParametersDir: './artifacts/lora',
-    numberOfEpochs: 2
-  }
-})
+    trainDatasetDir: "./dataset/train",
+    validation: { type: "dataset", path: "./dataset/eval" },
+    outputParametersDir: "./artifacts/lora",
+    numberOfEpochs: 2,
+  },
+});
 
 for await (const progress of handle.progressStream) {
-  console.log(progress.global_steps, progress.loss)
+  console.log(progress.global_steps, progress.loss);
 }
-const result = await handle.result
+const result = await handle.result;
 ```
 
 Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` to let the addon auto-detect whether to start fresh or resume.
@@ -3123,26 +3136,26 @@ Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` t
 Stable Diffusion models are now integrated as a first-class SDK capability. Load a diffusion model and generate images with step-by-step progress tracking.
 
 ```typescript
-import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from '@qvac/sdk'
+import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: 'diffusion',
-  modelConfig: { prediction: 'v' }
-})
+  modelType: "diffusion",
+  modelConfig: { prediction: "v" },
+});
 
 const { progressStream, outputs, stats } = diffusion({
   modelId,
-  prompt: 'a cat sitting on a windowsill',
+  prompt: "a cat sitting on a windowsill",
   width: 512,
   height: 512,
-  steps: 20
-})
+  steps: 20,
+});
 
 for await (const { step, totalSteps } of progressStream) {
-  console.log(`${step}/${totalSteps}`)
+  console.log(`${step}/${totalSteps}`);
 }
-const buffers = await outputs
+const buffers = await outputs;
 ```
 
 ### Duplex Streaming Transcription (`transcribeStream`)
@@ -3150,16 +3163,16 @@ const buffers = await outputs
 A new bidirectional streaming API lets you feed audio incrementally and receive transcription segments as speech is detected, enabling real-time voice interfaces.
 
 ```typescript
-import { transcribeStream } from '@qvac/sdk'
+import { transcribeStream } from "@qvac/sdk";
 
-const session = await transcribeStream({ modelId })
-session.write(audioChunk)
-session.end()
+const session = await transcribeStream({ modelId });
+session.write(audioChunk);
+session.end();
 
 for await (const text of session) {
-  console.log(text)
+  console.log(text);
 }
-session.destroy()
+session.destroy();
 ```
 
 The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern still works but logs a deprecation warning — use `transcribe()` for batch transcription.
@@ -3169,10 +3182,10 @@ The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern sti
 Mobile and desktop apps can now cleanly suspend and resume SDK operations when the app enters the background or foreground, preventing resource leaks and stale state.
 
 ```typescript
-import { suspend, resume } from '@qvac/sdk'
+import { suspend, resume } from "@qvac/sdk";
 
-await suspend() // app going to background
-await resume() // app returning to foreground
+await suspend(); // app going to background
+await resume();  // app returning to foreground
 ```
 
 ### Delegated Cancellation
@@ -3180,15 +3193,15 @@ await resume() // app returning to foreground
 Remote inference and downloads running on a delegation provider can now be cancelled from the consumer side.
 
 ```typescript
-import { cancel } from '@qvac/sdk'
+import { cancel } from "@qvac/sdk";
 
-await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
+await cancel({ operation: "inference", modelId: "delegated-model-id" });
 
 await cancel({
-  operation: 'downloadAsset',
-  downloadKey: 'download-key',
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
-})
+  operation: "downloadAsset",
+  downloadKey: "download-key",
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
+});
 ```
 
 ### Delegation Health Check Timeout
@@ -3198,14 +3211,14 @@ A new `healthCheckTimeout` option on the delegate config lets you control how lo
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
+  modelType: "llm",
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000
-  }
-})
+    healthCheckTimeout: 2000,
+  },
+});
 ```
 
 ### Addon Stats Across All Operations
@@ -3213,8 +3226,8 @@ await loadModel({
 All inference operations now return detailed performance stats from the underlying addons. Completion, transcription, translation, TTS, and embedding responses all include stats like `tokensPerSecond`, `timeToFirstToken`, `audioDuration`, and the new `backendDevice` field (`"cpu"` or `"gpu"`).
 
 ```typescript
-const { embedding, stats } = await embed({ modelId, text: 'hello' })
-console.log(stats?.backendDevice) // "cpu" | "gpu"
+const { embedding, stats } = await embed({ modelId, text: "hello" });
+console.log(stats?.backendDevice); // "cpu" | "gpu"
 ```
 
 ---
@@ -3337,22 +3350,22 @@ The `ping()` function has been replaced by `heartbeat()`, which extends health c
 **Before:**
 
 ```typescript
-import { ping } from '@qvac/sdk'
-const pong = await ping()
+import { ping } from "@qvac/sdk";
+const pong = await ping();
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from '@qvac/sdk'
+import { heartbeat } from "@qvac/sdk";
 
 // Local heartbeat (replaces ping)
-await heartbeat()
+await heartbeat();
 
 // Delegated heartbeat — verify a remote provider is reachable
 await heartbeat({
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
-})
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
+});
 ```
 
 ---
@@ -3366,14 +3379,14 @@ Delegated model loading now supports an optional `healthCheckTimeout` parameter.
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
+  modelType: "llm",
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000 // optional, defaults to 1500ms
-  }
-})
+    healthCheckTimeout: 2000, // optional, defaults to 1500ms
+  },
+});
 ```
 
 ### Delegated Cancellation
@@ -3382,14 +3395,14 @@ Cancel operations now route automatically to remote providers when the target mo
 
 ```typescript
 // Cancel delegated inference (routes automatically via model registry)
-await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
+await cancel({ operation: "inference", modelId: "delegated-model-id" });
 
 // Cancel delegated remote download
 await cancel({
-  operation: 'downloadAsset',
-  downloadKey: 'download-key',
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
-})
+  operation: "downloadAsset",
+  downloadKey: "download-key",
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
+});
 ```
 
 ---
@@ -3434,11 +3447,11 @@ The embedding addon no longer accepts the raw tab-delimited config string. Use t
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: 'embeddings',
+  modelType: "embeddings",
   modelConfig: {
-    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
-  }
-})
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
 ```
 
 **After:**
@@ -3446,13 +3459,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: 'embeddings',
+  modelType: "embeddings",
   modelConfig: {
     gpuLayers: 99,
-    device: 'gpu',
-    batchSize: 1024
-  }
-})
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
 ```
 
 ### Companion Model Sources Moved Into `modelConfig`
@@ -3463,76 +3476,76 @@ Top-level companion source fields (`projectionModelSrc`, `vadModelSrc`, `srcVoca
 
 ```typescript
 await loadModel({
-  modelType: 'llm',
-  modelSrc: '.../model.gguf',
-  projectionModelSrc: '.../mmproj.gguf'
-})
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  projectionModelSrc: ".../mmproj.gguf",
+});
 
 await loadModel({
-  modelType: 'whisper',
-  modelSrc: '.../model.bin',
-  vadModelSrc: '.../vad.bin'
-})
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  vadModelSrc: ".../vad.bin",
+});
 
 await loadModel({
-  modelType: 'nmt',
-  modelSrc: '.../model.intgemm.alphas.bin',
-  srcVocabSrc: '.../srcvocab.spm',
-  dstVocabSrc: '.../trgvocab.spm'
-})
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  srcVocabSrc: ".../srcvocab.spm",
+  dstVocabSrc: ".../trgvocab.spm",
+});
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelType: 'llm',
-  modelSrc: '.../model.gguf',
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
   modelConfig: {
-    projectionModelSrc: '.../mmproj.gguf'
-  }
-})
+    projectionModelSrc: ".../mmproj.gguf",
+  },
+});
 
 await loadModel({
-  modelType: 'whisper',
-  modelSrc: '.../model.bin',
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
   modelConfig: {
-    vadModelSrc: '.../vad.bin'
-  }
-})
+    vadModelSrc: ".../vad.bin",
+  },
+});
 
 await loadModel({
-  modelType: 'nmt',
-  modelSrc: '.../model.intgemm.alphas.bin',
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
   modelConfig: {
-    srcVocabSrc: '.../srcvocab.spm',
-    dstVocabSrc: '.../trgvocab.spm'
-  }
-})
+    srcVocabSrc: ".../srcvocab.spm",
+    dstVocabSrc: ".../trgvocab.spm",
+  },
+});
 ```
 
 Additionally, custom plugins must now provide a `loadConfigSchema`. For plugins that accept any config, use a passthrough schema:
 
 ```typescript
 const myPlugin: QvacPlugin = {
-  modelType: 'my-plugin',
-  displayName: 'My Plugin',
-  addonPackage: '@my/addon',
+  modelType: "my-plugin",
+  displayName: "My Plugin",
+  addonPackage: "@my/addon",
   loadConfigSchema: z.object({}).catchall(z.unknown()),
   createModel: (params) => ({ model, loader }),
-  handlers: {}
-}
+  handlers: {},
+};
 ```
 
 ### Parakeet Model Constants Renamed
 
 All existing Parakeet model constants now include a variant prefix (`TDT_`) to distinguish them from the new CTC and Sortformer variants. This is a find-and-replace migration:
 
-| Old Constant              | New Constant                  |
-| ------------------------- | ----------------------------- |
-| `PARAKEET_ENCODER_*`      | `PARAKEET_TDT_ENCODER_*`      |
-| `PARAKEET_DECODER_*`      | `PARAKEET_TDT_DECODER_*`      |
-| `PARAKEET_VOCAB`          | `PARAKEET_TDT_VOCAB`          |
+| Old Constant | New Constant |
+|---|---|
+| `PARAKEET_ENCODER_*` | `PARAKEET_TDT_ENCODER_*` |
+| `PARAKEET_DECODER_*` | `PARAKEET_TDT_DECODER_*` |
+| `PARAKEET_VOCAB` | `PARAKEET_TDT_VOCAB` |
 | `PARAKEET_PREPROCESSOR_*` | `PARAKEET_TDT_PREPROCESSOR_*` |
 
 ---
@@ -3549,24 +3562,24 @@ import {
   PARAKEET_TDT_ENCODER_DATA_FP32,
   PARAKEET_TDT_DECODER_FP32,
   PARAKEET_TDT_VOCAB,
-  PARAKEET_TDT_PREPROCESSOR_FP32
-} from '@qvac/sdk'
+  PARAKEET_TDT_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
 
 const modelId = await loadModel({
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelSrc: PARAKEET_TDT_ENCODER_FP32,
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
     parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32
-  }
-})
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
+  },
+});
 
-const stream = transcribeStream({ modelId, audioInput: './audio.mp3' })
+const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
 for await (const chunk of stream) {
-  process.stdout.write(chunk)
+  process.stdout.write(chunk);
 }
 ```
 
@@ -3579,21 +3592,21 @@ Translate between language pairs that don't have a direct model by chaining thro
 ```typescript
 await loadModel({
   modelSrc: BERGAMOT_ES_EN,
-  modelType: 'nmt',
+  modelType: "nmt",
   modelConfig: {
-    engine: 'Bergamot',
-    from: 'es',
-    to: 'it',
+    engine: "Bergamot",
+    from: "es",
+    to: "it",
     pivotModel: {
       modelSrc: BERGAMOT_EN_IT,
       beamsize: 4,
       temperature: 0.3,
       topk: 100,
       normalize: 1,
-      lengthpenalty: 1.2
-    }
-  }
-})
+      lengthpenalty: 1.2,
+    },
+  },
+});
 ```
 
 ### SDK Profiler
@@ -3601,25 +3614,28 @@ await loadModel({
 A built-in profiler lets you measure SDK operation performance at runtime. Enable it globally or on a per-call basis:
 
 ```typescript
-import { profiler } from '@qvac/sdk'
+import { profiler } from "@qvac/sdk";
 
 profiler.enable({
-  mode: 'verbose',
-  includeServerBreakdown: true
-})
+  mode: "verbose",
+  includeServerBreakdown: true,
+});
 
 // Run operations, then export results
-console.log(profiler.exportSummary())
-console.log(profiler.exportTable())
-console.log(profiler.exportJSON({ includeRecentEvents: true }))
+console.log(profiler.exportSummary());
+console.log(profiler.exportTable());
+console.log(profiler.exportJSON({ includeRecentEvents: true }));
 
-profiler.disable()
+profiler.disable();
 ```
 
 Per-call profiling control is also available on `embed`, `completion`, `transcribe`, `translate`, `ragSearch`, and `invokePlugin`:
 
 ```typescript
-await embed({ modelId, text: 'hello' }, { profiling: { enabled: true } })
+await embed(
+  { modelId, text: "hello" },
+  { profiling: { enabled: true } },
+);
 ```
 
 ---
@@ -3635,15 +3651,15 @@ The SDK now supports two additional Parakeet model variants beyond the existing 
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_CTC_FP32_1,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'ctc',
+    modelType: "ctc",
     parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
     parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
-  }
-})
-const text = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
 ```
 
 **Sortformer diarization** for speaker identification:
@@ -3651,13 +3667,13 @@ const text = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_SORTFORMER_FP32,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'sortformer',
-    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32
-  }
-})
-const diarization = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
+    modelType: "sortformer",
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
+  },
+});
+const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
 // Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
 ```
 
@@ -3686,24 +3702,20 @@ The profiler now captures detailed load/download metrics and stream profiling da
 ### Added Models
 
 **OCR:**
-
 - `OCR_DETECTOR_DB_MOBILENET_V3_LARGE`
 - `OCR_DETECTOR_DB_RESNET50`
 - `OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL`
 - `OCR_RECOGNIZER_PARSEQ`
 
 **Parakeet (CTC):**
-
 - `PARAKEET_CTC_FP32`, `PARAKEET_CTC_DATA_FP32`, `PARAKEET_CTC_VOCAB`, `PARAKEET_CTC_INT8`, `PARAKEET_CTC_CONFIG`
 - `PARAKEET_CTC_FP32_1`, `PARAKEET_CTC_DATA_FP32_1`, `PARAKEET_CTC_TOKENIZER`
 
 **Parakeet (Sortformer / EOU):**
-
 - `PARAKEET_SORTFORMER_FP32`
 - `PARAKEET_EOU_ENCODER_FP32`, `PARAKEET_EOU_DECODER_FP32`, `PARAKEET_EOU_TOKENIZER`
 
 **Parakeet (TDT — renamed from unprefixed):**
-
 - `PARAKEET_TDT_ENCODER_FP32`, `PARAKEET_TDT_ENCODER_DATA_FP32`, `PARAKEET_TDT_DECODER_FP32`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_FP32`
 - `PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_PREPROCESSOR_INT8`
 
@@ -3745,30 +3757,30 @@ Model constant names have been normalized for consistency. If your code referenc
 
 ```typescript
 // Before
-import { BERGAMOT_AREN } from '@qvac/sdk'
+import { BERGAMOT_AREN } from "@qvac/sdk";
 
 // After
-import { BERGAMOT_AR_EN } from '@qvac/sdk'
+import { BERGAMOT_AR_EN } from "@qvac/sdk";
 ```
 
 **Whisper models** have simplified names without author/repo prefixes:
 
 ```typescript
 // Before
-import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from '@qvac/sdk'
+import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from "@qvac/sdk";
 
 // After
-import { WHISPER_EN_BASE_Q0F16 } from '@qvac/sdk'
+import { WHISPER_EN_BASE_Q0F16 } from "@qvac/sdk";
 ```
 
 **LLM models** have normalized version prefixes:
 
 ```typescript
 // Before
-import { QWEN_3_1_7B_INST_Q4 } from '@qvac/sdk'
+import { QWEN_3_1_7B_INST_Q4 } from "@qvac/sdk";
 
 // After
-import { QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
+import { QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
 ```
 
 ### HyperdriveItem Type Renamed to RegistryItem
@@ -3777,10 +3789,10 @@ The model metadata type has been renamed and restructured to support the new reg
 
 ```typescript
 // Before
-import type { HyperdriveItem } from '@qvac/sdk'
+import type { HyperdriveItem } from "@qvac/sdk";
 
 // After
-import type { RegistryItem } from '@qvac/sdk'
+import type { RegistryItem } from "@qvac/sdk";
 ```
 
 The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
@@ -3794,22 +3806,26 @@ The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replace
 Discover and search models directly through the SDK without needing a separate registry client package.
 
 ```typescript
-import { modelRegistryList, modelRegistrySearch, modelRegistryGetModel } from '@qvac/sdk'
+import {
+  modelRegistryList,
+  modelRegistrySearch,
+  modelRegistryGetModel,
+} from "@qvac/sdk";
 
 // List all available models
-const models = await modelRegistryList()
+const models = await modelRegistryList();
 
 // Search by engine type
-const llmModels = await modelRegistrySearch({ engine: '@qvac/llm-llamacpp' })
+const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
 
 // Search by text filter
-const whisperModels = await modelRegistrySearch({ filter: 'whisper' })
+const whisperModels = await modelRegistrySearch({ filter: "whisper" });
 
 // Search by quantization
-const q4Models = await modelRegistrySearch({ quantization: 'q4' })
+const q4Models = await modelRegistrySearch({ quantization: "q4" });
 
 // Get a specific model by path
-const model = await modelRegistryGetModel(registryPath, registrySource)
+const model = await modelRegistryGetModel(registryPath, registrySource);
 ```
 
 ### Plugin System
@@ -3817,22 +3833,22 @@ const model = await modelRegistryGetModel(registryPath, registrySource)
 Build custom model integrations with the new plugin architecture. Plugins support both request/reply and streaming patterns.
 
 ```typescript
-import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from '@qvac/sdk'
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
 
 // Invoke a plugin handler
 const result = await invokePlugin<MyResponse>({
   modelId,
-  handler: 'myHandler',
-  params: { key: 'value' }
-})
+  handler: "myHandler",
+  params: { key: "value" },
+});
 
 // Stream responses from a plugin
 for await (const chunk of invokePluginStream<MyStreamResponse>({
   modelId,
-  handler: 'myStreamHandler',
-  params: { key: 'value' }
+  handler: "myStreamHandler",
+  params: { key: "value" },
 })) {
-  console.log(chunk.result)
+  console.log(chunk.result);
 }
 ```
 
@@ -3843,25 +3859,25 @@ Clone voices from reference audio samples with the new Chatterbox engine.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: 'tts',
+  modelType: "tts",
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'en',
+    ttsEngine: "chatterbox",
+    language: "en",
     ttsTokenizerSrc,
     ttsSpeechEncoderSrc,
     ttsEmbedTokensSrc,
     ttsConditionalDecoderSrc,
     ttsLanguageModelSrc,
-    referenceAudioSrc // Your voice sample
-  }
-})
+    referenceAudioSrc, // Your voice sample
+  },
+});
 
 const audio = await textToSpeech({
   modelId,
-  text: 'Hello in a cloned voice!',
-  inputType: 'text',
-  stream: false
-})
+  text: "Hello in a cloned voice!",
+  inputType: "text",
+  stream: false,
+});
 ```
 
 ### Supertonic TTS Engine (General Purpose)
@@ -3871,19 +3887,19 @@ High-quality text-to-speech with adjustable speed and inference steps.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: 'tts',
+  modelType: "tts",
   modelConfig: {
-    ttsEngine: 'supertonic',
-    language: 'en',
+    ttsEngine: "supertonic",
+    language: "en",
     ttsTokenizerSrc,
     ttsTextEncoderSrc,
     ttsLatentDenoiserSrc,
     ttsVoiceDecoderSrc,
     ttsVoiceSrc,
-    ttsSpeed: 1.0, // Playback speed
-    ttsNumInferenceSteps: 5 // Quality vs speed tradeoff
-  }
-})
+    ttsSpeed: 1.0,           // Playback speed
+    ttsNumInferenceSteps: 5, // Quality vs speed tradeoff
+  },
+});
 ```
 
 ### CLI SDK Path Option
@@ -3907,10 +3923,10 @@ Model downloads now use `downloadBlob` for more efficient direct registry fetchi
 The `close()` function is now properly async and awaitable for clean shutdown:
 
 ```typescript
-import { close } from '@qvac/sdk'
+import { close } from "@qvac/sdk";
 
 // Now returns a Promise
-await close()
+await close();
 ```
 
 ### Engine-Addon Mapping Utilities
@@ -3918,10 +3934,10 @@ await close()
 Map between engine names and addon types:
 
 ```typescript
-import { resolveCanonicalEngine, getAddonFromEngine } from '@qvac/sdk'
+import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
 
-const engine = resolveCanonicalEngine('@qvac/llm-llamacpp') // "llamacpp-completion"
-const addon = getAddonFromEngine('llamacpp-completion') // "llm"
+const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
+const addon = getAddonFromEngine("llamacpp-completion");     // "llm"
 ```
 
 ---
@@ -4000,9 +4016,9 @@ The RAG system has been restructured for better control and flexibility. The mai
 ```typescript
 await ragSaveEmbeddings({
   modelId,
-  documents: ['Doc 1', 'Doc 2'],
-  chunk: false
-})
+  documents: ["Doc 1", "Doc 2"],
+  chunk: false,
+});
 ```
 
 **After:**
@@ -4023,7 +4039,6 @@ await ragSaveEmbeddings({
 ```
 
 Other RAG changes:
-
 - `ragSaveEmbeddings` no longer returns `droppedIndices`
 - `ragDeleteEmbeddings` now returns `void` instead of `boolean` (throws on failure)
 - `ragDeleteEmbeddings` no longer requires `modelId` (uses cached workspace)
@@ -4037,35 +4052,35 @@ No more string-based config! Use typed properties for embedding model configurat
 
 ```typescript
 await loadModel({
-  modelSrc: 'embed-model.gguf',
-  modelType: 'embeddings',
+  modelSrc: "embed-model.gguf",
+  modelType: "embeddings",
   modelConfig: {
-    config: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
-  }
-})
+    config: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelSrc: 'embed-model.gguf',
-  modelType: 'embeddings',
+  modelSrc: "embed-model.gguf",
+  modelType: "embeddings",
   modelConfig: {
     gpuLayers: 99,
-    device: 'gpu',
-    batchSize: 1024
-  }
-})
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
 
 // Escape hatch for advanced CLI control
 await loadModel({
-  modelSrc: 'embed-model.gguf',
-  modelType: 'embeddings',
+  modelSrc: "embed-model.gguf",
+  modelType: "embeddings",
   modelConfig: {
-    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
-  }
-})
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
 ```
 
 ### Translation Engine Must Be Specified
@@ -4077,9 +4092,9 @@ Loading translation models now requires an explicit `engine` field for type-safe
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: 'nmt',
-  modelConfig: { from: 'en', to: 'it' }
-})
+  modelType: "nmt",
+  modelConfig: { from: "en", to: "it" },
+});
 ```
 
 **After:**
@@ -4087,13 +4102,13 @@ const modelId = await loadModel({
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: 'nmt',
+  modelType: "nmt",
   modelConfig: {
-    engine: 'Opus', // Required: "Opus" | "Bergamot" | "IndicTrans"
-    from: 'en',
-    to: 'it'
-  }
-})
+    engine: "Opus",  // Required: "Opus" | "Bergamot" | "IndicTrans"
+    from: "en",
+    to: "it",
+  },
+});
 ```
 
 ---
@@ -4105,28 +4120,28 @@ const modelId = await loadModel({
 A new translation engine option with support for batch translation and automatic vocabulary file derivation.
 
 ```typescript
-import { loadModel, translate, BERGAMOT_ENFR } from '@qvac/sdk'
+import { loadModel, translate, BERGAMOT_ENFR } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: BERGAMOT_ENFR,
-  modelType: 'nmt',
+  modelType: "nmt",
   modelConfig: {
-    engine: 'Bergamot',
-    from: 'en',
-    to: 'fr',
-    normalize: 1 // Bergamot-specific option
-  }
-})
+    engine: "Bergamot",
+    from: "en",
+    to: "fr",
+    normalize: 1,  // Bergamot-specific option
+  },
+});
 
 // Batch translation
 const result = translate({
   modelId,
-  text: ['Hello world', 'How are you?'],
-  modelType: 'nmt',
-  stream: false
-})
+  text: ["Hello world", "How are you?"],
+  modelType: "nmt",
+  stream: false,
+});
 
-const translated = await result.text
+const translated = await result.text;
 // "Bonjour le monde\nComment allez-vous?"
 ```
 
@@ -4143,23 +4158,23 @@ The SDK now uses import maps internally, improving compatibility across Node.js,
 Extract text from images with bounding boxes and confidence scores.
 
 ```typescript
-import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from '@qvac/sdk'
+import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: OCR_CRAFT_LATIN_RECOGNIZER,
-  modelType: 'ocr',
-  modelConfig: { langList: ['en'] }
-})
+  modelType: "ocr",
+  modelConfig: { langList: ["en"] },
+});
 
 // Get all text blocks at once
-const { blocks, done } = ocr({ modelId, image: '/path/to/image.png' })
-const result = await blocks
-await done
+const { blocks, done } = ocr({ modelId, image: "/path/to/image.png" });
+const result = await blocks;
+await done;
 
 // Or stream blocks as they're detected
-const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true })
+const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true });
 for await (const blocks of blockStream) {
-  console.log(blocks)
+  console.log(blocks);
   // [{ text: "Hello", bbox: [10, 20, 100, 50], confidence: 0.95 }]
 }
 ```
@@ -4171,15 +4186,15 @@ Load large models split across multiple files, from URLs or archives.
 ```typescript
 // Pattern-based sharded URLs (auto-detects shard pattern)
 await loadModel({
-  modelSrc: 'https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf',
-  modelType: 'llm'
-})
+  modelSrc: "https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf",
+  modelType: "llm",
+});
 
 // Archive-based shards (.tar.gz, .tar, .tgz)
 await loadModel({
-  modelSrc: 'https://huggingface.co/user/model/resolve/main/model.tar.gz',
-  modelType: 'llm'
-})
+  modelSrc: "https://huggingface.co/user/model/resolve/main/model.tar.gz",
+  modelType: "llm",
+});
 ```
 
 ### Device-Specific Model Configuration
@@ -4256,13 +4271,13 @@ The SDK now uses a config file instead of the `setConfig()` API. This simplifies
 **Before:**
 
 ```typescript
-import { setConfig, loadModel } from '@qvac/sdk'
+import { setConfig, loadModel } from "@qvac/sdk";
 
 await setConfig({
-  cacheDirectory: '/custom/cache/path'
-})
+  cacheDirectory: "/custom/cache/path",
+});
 
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
 ```
 
 **After:**
@@ -4276,10 +4291,10 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
 ```
 
 ```typescript
-import { loadModel } from '@qvac/sdk'
+import { loadModel } from "@qvac/sdk";
 
 // Config automatically loaded at initialization!
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
 ```
 
 #### Config Resolution Order
@@ -4292,31 +4307,31 @@ The SDK searches for configuration in this order:
 
 #### Supported Formats
 
-| Format     | Filename           | Notes                         |
-| ---------- | ------------------ | ----------------------------- |
-| JSON       | `qvac.config.json` | Simplest option               |
-| JavaScript | `qvac.config.js`   | Use `export default`          |
+| Format     | Filename           | Notes                        |
+| ---------- | ------------------ | ---------------------------- |
+| JSON       | `qvac.config.json` | Simplest option              |
+| JavaScript | `qvac.config.js`   | Use `export default`         |
 | TypeScript | `qvac.config.ts`   | Fully typed with `QvacConfig` |
 
 **TypeScript example:**
 
 ```typescript
 // qvac.config.ts
-import type { QvacConfig } from '@qvac/sdk'
+import type { QvacConfig } from "@qvac/sdk";
 
 const config: QvacConfig = {
-  cacheDirectory: '/custom/cache/path',
-  swarmRelays: ['relay-key-1', 'relay-key-2']
-}
+  cacheDirectory: "/custom/cache/path",
+  swarmRelays: ["relay-key-1", "relay-key-2"],
+};
 
-export default config
+export default config;
 ```
 
 #### Migration Steps
 
 1. Remove all `setConfig()` calls from your code
 2. Create a config file in your project root
-3. _(Optional)_ For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
+3. *(Optional)* For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
 
 ---
 
@@ -4326,14 +4341,14 @@ Some model constants have been renamed for clarity, and duplicate constants have
 
 **Changes:**
 
-| Before                     | After                                      |
-| -------------------------- | ------------------------------------------ |
-| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                         |
-| `WHISPER_NORWEGIAN_TINY_1` | _(removed — use `WHISPER_NORWEGIAN_TINY`)_ |
-| `WHISPER_TINY_SILERO`      | _(removed — use `WHISPER_TINY`)_           |
-| `MARIAN_OPUS_EN_FR_Q4_0_1` | _(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)_ |
-| `MARIAN_OPUS_FR_EN_Q4_0_1` | _(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)_ |
-| `MARIAN_OPUS_IT_EN`        | _(removed — use `MARIAN_OPUS_EN_IT`)_      |
+| Before                     | After                                             |
+| -------------------------- | ------------------------------------------------- |
+| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                                |
+| `WHISPER_NORWEGIAN_TINY_1` | *(removed — use `WHISPER_NORWEGIAN_TINY`)*        |
+| `WHISPER_TINY_SILERO`      | *(removed — use `WHISPER_TINY`)*                  |
+| `MARIAN_OPUS_EN_FR_Q4_0_1` | *(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)*        |
+| `MARIAN_OPUS_FR_EN_Q4_0_1` | *(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)*        |
+| `MARIAN_OPUS_IT_EN`        | *(removed — use `MARIAN_OPUS_EN_IT`)*             |
 
 All model metadata and hyperdrive keys remain unchanged—only the constant names were affected.
 
@@ -4349,7 +4364,7 @@ The logging stream API has been simplified with consistent naming.
 
 ```typescript
 for await (const log of loggingStream({ modelId: myModelId })) {
-  console.log(log.message)
+  console.log(log.message);
 }
 ```
 
@@ -4357,7 +4372,7 @@ for await (const log of loggingStream({ modelId: myModelId })) {
 
 ```typescript
 for await (const log of loggingStream({ id: myModelId })) {
-  console.log(log.message)
+  console.log(log.message);
 }
 ```
 
@@ -4388,17 +4403,17 @@ You can now update a model's configuration without unloading it. Pass the existi
 ```typescript
 // Load model with initial config
 const modelId = await loadModel({
-  modelSrc: 'pear://.../whisper.gguf',
-  modelType: 'whisper',
-  modelConfig: { language: 'en' }
-})
+  modelSrc: "pear://.../whisper.gguf",
+  modelType: "whisper",
+  modelConfig: { language: "en" },
+});
 
 // Hot-reload with new config (same modelId, no reload delay)
 await loadModel({
   modelId,
-  modelType: 'whisper',
-  modelConfig: { language: 'es' }
-})
+  modelType: "whisper",
+  modelConfig: { language: "es" },
+});
 ```
 
 ---
@@ -4410,51 +4425,51 @@ The SDK now supports the Model Context Protocol (MCP) for tool integration. Pass
 **Using MCP clients:**
 
 ```typescript
-import { completion } from '@qvac/sdk'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { completion } from "@qvac/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 // Create and connect your MCP client
-const mcpClient = new Client({ name: 'my-app', version: '1.0.0' })
-await mcpClient.connect(transport)
+const mcpClient = new Client({ name: "my-app", version: "1.0.0" });
+await mcpClient.connect(transport);
 
 // Pass MCP clients to completion
 const result = completion({
   modelId,
   history,
-  mcp: [{ client: mcpClient }]
-})
+  mcp: [{ client: mcpClient }],
+});
 
 // Execute tool calls
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call()
+  const response = await toolCall.call();
 }
 
 // Clean up when done
-await mcpClient.close()
+await mcpClient.close();
 ```
 
 **Using inline tools with handlers:**
 
 ```typescript
-import { z } from 'zod'
+import { z } from "zod";
 
 const result = completion({
   modelId,
   history,
   tools: [
     {
-      name: 'get_weather',
-      description: 'Get weather for a city',
+      name: "get_weather",
+      description: "Get weather for a city",
       parameters: z.object({ city: z.string() }),
       handler: async (args) => {
-        return await fetchWeather(args.city)
-      }
-    }
-  ]
-})
+        return await fetchWeather(args.city);
+      },
+    },
+  ],
+});
 
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call() // Executes your handler
+  const response = await toolCall.call(); // Executes your handler
 }
 ```
 
@@ -4466,10 +4481,10 @@ The `embed()` function now accepts arrays, enabling efficient batch processing. 
 
 ```typescript
 // Single text → returns number[]
-const embedding = await embed({ modelId, text: 'hello' })
+const embedding = await embed({ modelId, text: "hello" });
 
 // Batch texts → returns number[][]
-const embeddings = await embed({ modelId, text: ['a', 'b', 'c'] })
+const embeddings = await embed({ modelId, text: ["a", "b", "c"] });
 ```
 
 Batch processing uses a default batch size of 1024 for optimal throughput.

--- a/packages/sdk/changelog/0.18.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.18.1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.18.1
+
+Release Date: 2026-08-21
+
+## 🔌 API
+
+- Describe llamacpp modelConfig fields and export config schemas. (see PR [#3975](https://github.com/tetherto/qvac/pull/3975)) - See [API changes](./api.md)
+

--- a/packages/sdk/changelog/0.18.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.18.1/CHANGELOG.md
@@ -6,3 +6,8 @@ Release Date: 2026-08-21
 
 - Describe llamacpp modelConfig fields and export config schemas. (see PR [#3975](https://github.com/tetherto/qvac/pull/3975)) - See [API changes](./api.md)
 
+## 📦 Models
+
+- Emit CosyVoice3 companion set from update-models. (see PR [#4002](https://github.com/tetherto/qvac/pull/4002)) - See [model changes](./models.md)
+  Updated: TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
+

--- a/packages/sdk/changelog/0.18.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.18.1/CHANGELOG_LLM.md
@@ -1,0 +1,20 @@
+# QVAC SDK v0.18.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1
+
+QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. Load and inference behavior is unchanged.
+
+## New APIs
+
+### Config schemas at `@qvac/sdk/schemas`
+
+`@qvac/sdk/schemas` exports `llamacppCompletionConfigSchema`, `llamacppEmbeddingConfigSchema`, and `modelSourceSchema`. Field `.describe()` text comes from the addon README / `index.d.ts` (or an existing SDK description) and is written into `contract/schema.json`. The same descriptions land on the generated Python pydantic fields.
+
+```typescript
+import { llamacppCompletionConfigSchema } from '@qvac/sdk/schemas'
+
+llamacppCompletionConfigSchema.shape.ctx_size.description
+// "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+```
+
+The internal schema identifiers are unchanged.

--- a/packages/sdk/changelog/0.18.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.18.1/CHANGELOG_LLM.md
@@ -2,7 +2,7 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1
 
-QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. Load and inference behavior is unchanged.
+QVAC SDK 0.18.1 adds human-readable descriptions on every llamacpp `modelConfig` field and exports those schemas from `@qvac/sdk/schemas`. CLI, typed-client, and Python generators can now surface what each completion and embedding option means. The CosyVoice3 companion-set cache key also changes, so the first load after upgrade uses a new companion cache folder. Load APIs are otherwise unchanged.
 
 ## New APIs
 
@@ -18,3 +18,9 @@ llamacppCompletionConfigSchema.shape.ctx_size.description
 ```
 
 The internal schema identifiers are unchanged.
+
+## Bug Fixes
+
+### CosyVoice3 companion cache folder
+
+CosyVoice3 companion files still download with the LLM, as in 0.18.0. The companion-set cache key for `TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0` changed, so the first load after upgrading fills a new cache folder. Later loads reuse that folder. Speech APIs and `pace` / `instruct` rules are unchanged.

--- a/packages/sdk/changelog/0.18.1/api.md
+++ b/packages/sdk/changelog/0.18.1/api.md
@@ -1,0 +1,15 @@
+# 🔌 API Changes v0.18.1
+
+## Describe llamacpp modelConfig fields and export config schemas
+
+PR: [#3975](https://github.com/tetherto/qvac/pull/3975)
+
+```typescript
+import { llamacppCompletionConfigSchema } from '@qvac/sdk/schemas'
+
+llamacppCompletionConfigSchema.shape.ctx_size.description
+// "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+```
+
+---
+

--- a/packages/sdk/changelog/0.18.1/models.md
+++ b/packages/sdk/changelog/0.18.1/models.md
@@ -1,0 +1,13 @@
+# 📦 Model Changes v0.18.1
+
+## Updated Models
+
+```
+TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
+```
+
+---
+
+### Related PRs
+
+- [#4002](https://github.com/tetherto/qvac/pull/4002) - Emit CosyVoice3 companion set from update-models

--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -8057,36 +8057,45 @@
                   "type": "object",
                   "properties": {
                     "ctx_size": {
+                      "description": "Context window size in tokens; `0` uses the model's trained context length. Default 1024.",
                       "type": "number"
                     },
                     "temp": {
+                      "description": "Sampling temperature (0–2). Default 0.8.",
                       "type": "number",
                       "minimum": 0,
                       "maximum": 2
                     },
                     "top_p": {
+                      "description": "Top-p (nucleus) sampling cutoff (0–1). Default 0.9.",
                       "type": "number",
                       "minimum": 0,
                       "maximum": 1
                     },
                     "top_k": {
+                      "description": "Top-k sampling — keep only the top K tokens (0–128). Default 40.",
                       "type": "integer",
                       "minimum": 0,
                       "maximum": 128
                     },
                     "seed": {
+                      "description": "Sampling RNG seed; `-1` (default) picks a random seed.",
                       "type": "number"
                     },
                     "gpu_layers": {
+                      "description": "Number of model layers to offload to the GPU. Default 99 (offload all).",
                       "type": "number"
                     },
                     "lora": {
+                      "description": "Path to a LoRA adapter file to apply on top of the base model.",
                       "type": "string"
                     },
                     "device": {
+                      "description": "Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`.",
                       "type": "string"
                     },
                     "predict": {
+                      "description": "Max tokens to predict. `-1` = until stop token, `-2` = until context filled.",
                       "anyOf": [
                         {
                           "type": "number",
@@ -8104,49 +8113,62 @@
                       ]
                     },
                     "system_prompt": {
+                      "description": "Seeds conversation history on the JS side only; never forwarded to the addon. Default `'You are a helpful assistant.'`",
                       "type": "string"
                     },
                     "no_mmap": {
+                      "description": "Disable memory-mapped model loading. Default false.",
                       "type": "boolean"
                     },
                     "verbosity": {
+                      "description": "Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.",
                       "type": "number",
                       "enum": [0, 1, 2, 3],
                       "title": "LoadModelSrcRequestLlamacppCompletionModelConfigVerbosity"
                     },
                     "presence_penalty": {
+                      "description": "Presence penalty applied to tokens that have already appeared. Default 0.",
                       "type": "number"
                     },
                     "frequency_penalty": {
+                      "description": "Frequency penalty applied to tokens by their frequency so far. Default 0.",
                       "type": "number"
                     },
                     "repeat_penalty": {
+                      "description": "Repetition penalty applied to repeated tokens. Default 1.1.",
                       "type": "number"
                     },
                     "stop_sequences": {
+                      "description": "Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`).",
                       "type": "array",
                       "items": {
                         "type": "string"
                       }
                     },
                     "n_discarded": {
+                      "description": "Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`).",
                       "type": "number"
                     },
                     "parallel": {
+                      "description": "Concurrent sequence slots for continuous batching (1–256). Default 1 (sequential, batching off); `>= 2` enables batched decoding and splits the KV cache evenly across slots.",
                       "type": "integer",
                       "minimum": 1,
                       "maximum": 9007199254740991
                     },
                     "tools": {
+                      "description": "Enable tool calling via the model's jinja chat template. Default false.",
                       "type": "boolean"
                     },
                     "cache-type-k": {
+                      "description": "KV-cache key quantization type (`f16`, `f32`, `bf16`, `q8_0`, `q4_0`, …). Unset selects a backend-safe default.",
                       "type": "string"
                     },
                     "cache-type-v": {
+                      "description": "KV-cache value quantization type; quantizing the value cache requires flash attention. Unset selects a backend-safe default.",
                       "type": "string"
                     },
                     "main-gpu": {
+                      "description": "GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class.",
                       "anyOf": [
                         {
                           "type": "integer",
@@ -8161,22 +8183,27 @@
                       ]
                     },
                     "split-mode": {
+                      "description": "How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism).",
                       "type": "string",
                       "enum": ["none", "layer", "row"],
                       "title": "LoadModelSrcRequestLlamacppCompletionModelConfigSplitMode"
                     },
                     "tensor-split": {
+                      "description": "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25).",
                       "type": "string"
                     },
                     "openclCacheDir": {
+                      "description": "Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.",
                       "type": "string"
                     },
                     "reasoning_budget": {
+                      "description": "Reasoning-channel token budget. `-1` (default) unrestricted, `0` disables it, any positive integer caps the reasoning channel at that many tokens (the closing think tag is force-emitted once the budget is spent).",
                       "type": "integer",
                       "minimum": -1,
                       "maximum": 2147483647
                     },
                     "projectionModelSrc": {
+                      "description": "Multimodal projection (mmproj / vision encoder) model source; multimodal models only.",
                       "anyOf": [
                         {
                           "type": "string"
@@ -8260,16 +8287,19 @@
                       ]
                     },
                     "image_tile_mode": {
+                      "description": "Qwen3.5-VL multi-tile image encoding mode (multimodal models only): `'sequential'` (default) encodes image tiles one at a time, `'batched'` encodes all tiles in a single batched pass, `'disabled'` does no multi-tile encoding (single tile). Ignored by text-only models.",
                       "type": "string",
                       "enum": ["disabled", "batched", "sequential"],
                       "title": "LoadModelSrcRequestLlamacppCompletionModelConfigImageTileMode"
                     },
                     "image_no_upscale": {
+                      "description": "idefics3-style image preprocessing rule (multimodal models only): `'on'` rounds the image's long side up to a whole number of slices and caps it, so an image smaller than the cap keeps its own resolution and becomes far fewer slices; `'off'` always stretches the long side to the cap. When unset, the model's own GGUF value is used; ignored with a warning by models that do not use idefics3-style preprocessing. Changes the number of image tokens (and therefore both accuracy and encode time), so a checkpoint whose GGUF omits the key needs this set to preprocess correctly.",
                       "type": "string",
                       "enum": ["on", "off"],
                       "title": "LoadModelSrcRequestLlamacppCompletionModelConfigImageNoUpscale"
                     },
                     "mmproj-use-gpu": {
+                      "description": "Run the multimodal projector (mmproj / vision encoder) on the GPU (multimodal models only). `true` forces GPU, `false` forces CPU. When unset, the backend is auto-selected per device class: GPU on desktop/iOS and Android Adreno 800+; CPU on every other Android GPU (Arm Mali, Adreno <800, and undetectable Adreno tiers), with the LLM layers still on the GPU. Only honoured when the model itself runs on a GPU backend — ignored with a warning on CPU.",
                       "type": "boolean"
                     }
                   },
@@ -9128,41 +9158,49 @@
                   "type": "object",
                   "properties": {
                     "gpuLayers": {
+                      "description": "Number of model layers to offload to the GPU. Default 99 (offload all).",
                       "type": "integer",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991
                     },
                     "device": {
+                      "description": "Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`.",
                       "type": "string",
                       "enum": ["gpu", "cpu"],
                       "title": "LoadModelSrcRequestLlamacppEmbeddingModelConfigDevice"
                     },
                     "batchSize": {
+                      "description": "Tokens processed per batch (input throughput). Default 1024.",
                       "type": "integer",
                       "minimum": 1,
                       "maximum": 9007199254740991
                     },
                     "pooling": {
+                      "description": "Pooling strategy collapsing token embeddings into one sequence vector: `'none'`, `'mean'`, `'cls'`, `'last'`, or `'rank'`. Unset uses the model default.",
                       "type": "string",
                       "enum": ["none", "mean", "cls", "last", "rank"],
                       "title": "LoadModelSrcRequestLlamacppEmbeddingModelConfigPooling"
                     },
                     "attention": {
+                      "description": "Attention type: `'causal'` or `'non-causal'`. Unset uses the model default.",
                       "type": "string",
                       "enum": ["causal", "non-causal"],
                       "title": "LoadModelSrcRequestLlamacppEmbeddingModelConfigAttention"
                     },
                     "embdNormalize": {
+                      "description": "Embedding normalization: `-1` none, `0` max-abs int16, `1` taxicab, `2` euclidean, `>2` p-norm. Default 2 (euclidean).",
                       "type": "integer",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991
                     },
                     "flashAttention": {
+                      "description": "Flash attention: `'on'`, `'off'`, or `'auto'`. Default `'auto'`.",
                       "type": "string",
                       "enum": ["on", "off", "auto"],
                       "title": "LoadModelSrcRequestLlamacppEmbeddingModelConfigFlashAttention"
                     },
                     "mainGpu": {
+                      "description": "GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class.",
                       "anyOf": [
                         {
                           "type": "integer",
@@ -9177,19 +9215,23 @@
                       ]
                     },
                     "splitMode": {
+                      "description": "How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism).",
                       "type": "string",
                       "enum": ["none", "layer", "row"],
                       "title": "LoadModelSrcRequestLlamacppEmbeddingModelConfigSplitMode"
                     },
                     "tensorSplit": {
+                      "description": "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25).",
                       "type": "string"
                     },
                     "verbosity": {
+                      "description": "Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.",
                       "type": "number",
                       "enum": [0, 1, 2, 3],
                       "title": "LoadModelSrcRequestLlamacppEmbeddingModelConfigVerbosity"
                     },
                     "openclCacheDir": {
+                      "description": "Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.",
                       "type": "string"
                     }
                   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -124,6 +124,11 @@
       "types": "./dist/schemas/plugin.d.ts",
       "import": "./dist/schemas/plugin.js"
     },
+    "./schemas": {
+      "types": "./dist/schemas/public.d.ts",
+      "import": "./dist/schemas/public.js",
+      "require": "./dist/schemas/public.js"
+    },
     "./expo-plugin": "./dist/expo/plugins/index.js",
     "./electron-forge": {
       "require": "./electron-forge/index.cjs",

--- a/packages/sdk/schemas/llamacpp-config.ts
+++ b/packages/sdk/schemas/llamacpp-config.ts
@@ -19,85 +19,161 @@ const verbositySchema = z.enum(VERBOSITY)
 
 // Base schema - validates types, all fields optional (for client-side validation)
 export const llmConfigBaseSchema = z.object({
-  ctx_size: z.number().optional(),
-  temp: z.number().min(0).max(2).optional(),
-  top_p: z.number().min(0).max(1).optional(),
-  top_k: z.number().int().min(0).max(128).optional(),
-  seed: z.number().optional(),
-  gpu_layers: z.number().optional(),
-  lora: z.string().optional(),
-  device: z.string().optional(),
+  ctx_size: z
+    .number()
+    .optional()
+    .describe(
+      "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
+    ),
+  temp: z.number().min(0).max(2).optional().describe('Sampling temperature (0–2). Default 0.8.'),
+  top_p: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe('Top-p (nucleus) sampling cutoff (0–1). Default 0.9.'),
+  top_k: z
+    .number()
+    .int()
+    .min(0)
+    .max(128)
+    .optional()
+    .describe('Top-k sampling — keep only the top K tokens (0–128). Default 40.'),
+  seed: z.number().optional().describe('Sampling RNG seed; `-1` (default) picks a random seed.'),
+  gpu_layers: z
+    .number()
+    .optional()
+    .describe('Number of model layers to offload to the GPU. Default 99 (offload all).'),
+  lora: z
+    .string()
+    .optional()
+    .describe('Path to a LoRA adapter file to apply on top of the base model.'),
+  device: z
+    .string()
+    .optional()
+    .describe("Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`."),
   predict: z
     .union([
       z.literal(-1), // special: until stop token
       z.literal(-2), // special: until context filled
       z.number().int().min(1) // positive integer: fixed token count
     ])
-    .optional(),
-  /** JS-side only: seeds conversation history. Never forwarded to the C++ addon. */
-  system_prompt: z.string().optional(),
-  no_mmap: z.boolean().optional(),
-  verbosity: verbositySchema.optional(),
-  presence_penalty: z.number().optional(),
-  frequency_penalty: z.number().optional(),
-  repeat_penalty: z.number().optional(),
-  stop_sequences: z.array(z.string()).optional(),
-  n_discarded: z.number().optional(),
-  /**
-   * Concurrent sequence slots for continuous batching. Defaults to 1
-   * (sequential, batching disabled); values >= 2 enable batched decoding in
-   * @qvac/llm-llamacpp.
-   */
-  parallel: z.number().int().min(1).optional(),
-  tools: z.boolean().optional(),
-  'cache-type-k': z.string().optional(),
-  'cache-type-v': z.string().optional(),
-  'main-gpu': z.union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])]).optional(),
-  'split-mode': z.enum(['none', 'layer', 'row']).optional(),
-  'tensor-split': z.string().optional(),
-  /**
-   * Writable directory for OpenCL kernel binary cache. Required on Android
-   * for fast GPU startup.
-   */
-  openclCacheDir: z.string().optional(),
-  /**
-   * Reasoning channel token budget. `-1` = unrestricted, `0` = disabled, any
-   * positive integer caps the reasoning channel at that many tokens (the
-   * sampler force-emits the closing think tag once the budget is exhausted).
-   */
-  reasoning_budget: z.number().int().min(-1).max(REASONING_BUDGET_MAX).optional(),
-  projectionModelSrc: modelSrcInputSchema.optional(),
-  /**
-   * Qwen3.5-VL multi-tile image encoding mode (multimodal models only):
-   *   - `"sequential"` (default): encode image tiles one tile at a time.
-   *   - `"batched"`: encode all tiles in a single batched pass.
-   *   - `"disabled"`: no multi-tile encoding (single tile).
-   * Ignored by text-only models. Default is `"sequential"`.
-   */
-  image_tile_mode: z.enum(['disabled', 'batched', 'sequential']).optional(),
-  /**
-   * idefics3-style image preprocessing rule (multimodal models only):
-   *   - `"on"`: round the image's long side up to a whole number of slices and
-   *     cap it, so an image smaller than the cap keeps its own resolution and
-   *     becomes far fewer slices.
-   *   - `"off"`: always stretch the long side to the cap.
-   * When unset, the model's own GGUF value is used. Ignored with a warning by
-   * models that do not use idefics3-style preprocessing. Changes the number of
-   * image tokens, and therefore both accuracy and encode time, so a checkpoint
-   * whose GGUF omits the key needs this set to preprocess correctly.
-   */
-  image_no_upscale: z.enum(['on', 'off']).optional(),
-  /**
-   * Run the multimodal projector (mmproj / vision encoder) on the GPU
-   * (multimodal models only). `true` forces GPU, `false` forces CPU. When
-   * unset, the llm-llamacpp addon auto-selects the backend per device class:
-   * GPU on desktop/iOS and positively-detected Android Adreno 800+ GPUs; CPU on
-   * every other Android GPU — Mali, Adreno <800, and any tier that can't be
-   * detected (only Adreno 800+ is benchmarked to encode the projector faster on
-   * the GPU than the CPU). Only honoured when the model itself runs on a GPU
-   * backend — ignored with a warning on CPU.
-   */
-  'mmproj-use-gpu': z.boolean().optional()
+    .optional()
+    .describe('Max tokens to predict. `-1` = until stop token, `-2` = until context filled.'),
+  system_prompt: z
+    .string()
+    .optional()
+    .describe(
+      "Seeds conversation history on the JS side only; never forwarded to the addon. Default `'You are a helpful assistant.'`"
+    ),
+  no_mmap: z.boolean().optional().describe('Disable memory-mapped model loading. Default false.'),
+  verbosity: verbositySchema
+    .optional()
+    .describe('Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.'),
+  presence_penalty: z
+    .number()
+    .optional()
+    .describe('Presence penalty applied to tokens that have already appeared. Default 0.'),
+  frequency_penalty: z
+    .number()
+    .optional()
+    .describe('Frequency penalty applied to tokens by their frequency so far. Default 0.'),
+  repeat_penalty: z
+    .number()
+    .optional()
+    .describe('Repetition penalty applied to repeated tokens. Default 1.1.'),
+  stop_sequences: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Strings that stop generation when produced (forwarded to the addon as `reverse_prompt`).'
+    ),
+  n_discarded: z
+    .number()
+    .optional()
+    .describe(
+      'Tokens to discard from the front of the context when it fills (sliding window); `0` (default) disables sliding. In batch mode clamped to the per-slot window (`ctx_size / parallel`).'
+    ),
+  parallel: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      'Concurrent sequence slots for continuous batching (1–256). Default 1 (sequential, batching off); `>= 2` enables batched decoding and splits the KV cache evenly across slots.'
+    ),
+  tools: z
+    .boolean()
+    .optional()
+    .describe("Enable tool calling via the model's jinja chat template. Default false."),
+  'cache-type-k': z
+    .string()
+    .optional()
+    .describe(
+      'KV-cache key quantization type (`f16`, `f32`, `bf16`, `q8_0`, `q4_0`, …). Unset selects a backend-safe default.'
+    ),
+  'cache-type-v': z
+    .string()
+    .optional()
+    .describe(
+      'KV-cache value quantization type; quantizing the value cache requires flash attention. Unset selects a backend-safe default.'
+    ),
+  'main-gpu': z
+    .union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])])
+    .optional()
+    .describe(
+      "GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class."
+    ),
+  'split-mode': z
+    .enum(['none', 'layer', 'row'])
+    .optional()
+    .describe(
+      "How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism)."
+    ),
+  'tensor-split': z
+    .string()
+    .optional()
+    .describe(
+      "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25)."
+    ),
+  openclCacheDir: z
+    .string()
+    .optional()
+    .describe(
+      'Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.'
+    ),
+  reasoning_budget: z
+    .number()
+    .int()
+    .min(-1)
+    .max(REASONING_BUDGET_MAX)
+    .optional()
+    .describe(
+      'Reasoning-channel token budget. `-1` (default) unrestricted, `0` disables it, any positive integer caps the reasoning channel at that many tokens (the closing think tag is force-emitted once the budget is spent).'
+    ),
+  projectionModelSrc: modelSrcInputSchema
+    .optional()
+    .describe(
+      'Multimodal projection (mmproj / vision encoder) model source; multimodal models only.'
+    ),
+  image_tile_mode: z
+    .enum(['disabled', 'batched', 'sequential'])
+    .optional()
+    .describe(
+      "Qwen3.5-VL multi-tile image encoding mode (multimodal models only): `'sequential'` (default) encodes image tiles one at a time, `'batched'` encodes all tiles in a single batched pass, `'disabled'` does no multi-tile encoding (single tile). Ignored by text-only models."
+    ),
+  image_no_upscale: z
+    .enum(['on', 'off'])
+    .optional()
+    .describe(
+      "idefics3-style image preprocessing rule (multimodal models only): `'on'` rounds the image's long side up to a whole number of slices and caps it, so an image smaller than the cap keeps its own resolution and becomes far fewer slices; `'off'` always stretches the long side to the cap. When unset, the model's own GGUF value is used; ignored with a warning by models that do not use idefics3-style preprocessing. Changes the number of image tokens (and therefore both accuracy and encode time), so a checkpoint whose GGUF omits the key needs this set to preprocess correctly."
+    ),
+  'mmproj-use-gpu': z
+    .boolean()
+    .optional()
+    .describe(
+      'Run the multimodal projector (mmproj / vision encoder) on the GPU (multimodal models only). `true` forces GPU, `false` forces CPU. When unset, the backend is auto-selected per device class: GPU on desktop/iOS and Android Adreno 800+; CPU on every other Android GPU (Arm Mali, Adreno <800, and undetectable Adreno tiers), with the LLM layers still on the GPU. Only honoured when the model itself runs on a GPU backend — ignored with a warning on CPU.'
+    )
 })
 
 export type LlmConfigInput = z.infer<typeof llmConfigBaseSchema>
@@ -121,22 +197,69 @@ export type LlmConfig = z.infer<typeof llmConfigSchema>
 
 // Base schema - validates types, all fields optional (for client-side validation)
 export const embedConfigBaseSchema = z.object({
-  gpuLayers: z.number().int().optional(),
-  device: z.enum(['gpu', 'cpu']).optional(),
-  batchSize: z.number().int().min(1).optional(),
-  pooling: z.enum(['none', 'mean', 'cls', 'last', 'rank']).optional(),
-  attention: z.enum(['causal', 'non-causal']).optional(),
-  embdNormalize: z.number().int().optional(),
-  flashAttention: z.enum(['on', 'off', 'auto']).optional(),
-  mainGpu: z.union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])]).optional(),
-  splitMode: z.enum(['none', 'layer', 'row']).optional(),
-  tensorSplit: z.string().optional(),
-  verbosity: verbositySchema.optional(),
-  /**
-   * Writable directory for OpenCL kernel binary cache. Required on Android
-   * for fast GPU startup.
-   */
-  openclCacheDir: z.string().optional()
+  gpuLayers: z
+    .number()
+    .int()
+    .optional()
+    .describe('Number of model layers to offload to the GPU. Default 99 (offload all).'),
+  device: z
+    .enum(['gpu', 'cpu'])
+    .optional()
+    .describe("Device to run inference on: `'gpu'` or `'cpu'`. Default `'gpu'`."),
+  batchSize: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Tokens processed per batch (input throughput). Default 1024.'),
+  pooling: z
+    .enum(['none', 'mean', 'cls', 'last', 'rank'])
+    .optional()
+    .describe(
+      "Pooling strategy collapsing token embeddings into one sequence vector: `'none'`, `'mean'`, `'cls'`, `'last'`, or `'rank'`. Unset uses the model default."
+    ),
+  attention: z
+    .enum(['causal', 'non-causal'])
+    .optional()
+    .describe("Attention type: `'causal'` or `'non-causal'`. Unset uses the model default."),
+  embdNormalize: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'Embedding normalization: `-1` none, `0` max-abs int16, `1` taxicab, `2` euclidean, `>2` p-norm. Default 2 (euclidean).'
+    ),
+  flashAttention: z
+    .enum(['on', 'off', 'auto'])
+    .optional()
+    .describe("Flash attention: `'on'`, `'off'`, or `'auto'`. Default `'auto'`."),
+  mainGpu: z
+    .union([z.number().int().min(0), z.enum(['integrated', 'dedicated'])])
+    .optional()
+    .describe(
+      "GPU to use on multi-GPU systems: a device index, or `'integrated'`/`'dedicated'` to restrict selection to that class."
+    ),
+  splitMode: z
+    .enum(['none', 'layer', 'row'])
+    .optional()
+    .describe(
+      "How to split the model across GPUs: `'none'` (default, single GPU), `'layer'` (pipeline parallelism), or `'row'` (tensor parallelism)."
+    ),
+  tensorSplit: z
+    .string()
+    .optional()
+    .describe(
+      "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25)."
+    ),
+  verbosity: verbositySchema
+    .optional()
+    .describe('Native log verbosity: `0`=ERROR, `1`=WARN, `2`=INFO, `3`=DEBUG. Default 0.'),
+  openclCacheDir: z
+    .string()
+    .optional()
+    .describe(
+      'Writable directory for the OpenCL kernel binary cache; required on Android for fast GPU startup.'
+    )
 })
 
 export type EmbedConfigInput = z.infer<typeof embedConfigBaseSchema>

--- a/packages/sdk/schemas/public.ts
+++ b/packages/sdk/schemas/public.ts
@@ -1,0 +1,16 @@
+// Public schema surface for `@qvac/sdk/schemas`. Stable, end-user-facing names
+// (aliased from the internal schemas) so consumers such as the CLI can import a
+// model's `modelConfig` schema and read its field descriptions without
+// depending on internal identifiers.
+
+export {
+  llmConfigBaseSchema as llamacppCompletionConfigSchema,
+  embedConfigBaseSchema as llamacppEmbeddingConfigSchema,
+  type LlmConfigInput as LlamacppCompletionConfig,
+  type EmbedConfigInput as LlamacppEmbeddingConfig
+} from './llamacpp-config'
+
+export {
+  modelSrcInputSchema as modelSourceSchema,
+  type ModelSrcInput as ModelSource
+} from './model-src-utils'


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Lands `@qvac/sdk` / `@qvac/inference` / `@qvac/bare-sdk` / `tetherto-qvac-sdk` 0.18.1 on `release-sdk-0.18.1`.
- Ships [#3975](https://github.com/tetherto/qvac/pull/3975) (`@qvac/sdk/schemas` + llamacpp `modelConfig` field descriptions) and [#4002](https://github.com/tetherto/qvac/pull/4002) (CosyVoice3 companion `setKey`), both on `main` but not on this cut.

## 📝 How does it solve it?

- Cherry-picks the #3975 squash (`c9247f7f`) and the #4002 squash (`4f05cd64`) onto the 0.18.1 cut.
- Stamps the lockstep pod to `0.18.1` and adds the patch changelog, Python `SDK_VERSION`, and docs-site `v0.18.1` release-notes section.
- Changelog records #4002 as a companion-cache-folder fix, not a CosyVoice3 re-announce (that shipped in 0.18.0).

## 🔌 API Changes

New public subpath `@qvac/sdk/schemas` (from #3975; non-breaking addition):

```typescript
import { llamacppCompletionConfigSchema } from '@qvac/sdk/schemas'

llamacppCompletionConfigSchema.shape.ctx_size.description
// "Context window size in tokens; `0` uses the model's trained context length. Default 1024."
```

## 🧪 How was it tested?

- Both cherry-picks applied cleanly onto `release-sdk-0.18.1`.
- Changelog generator (`--base-commit` = 0.18.0 merge `758613aec`) listed PRs #3975 and #4002.
- `bun run check:deps-vs-sdk` passed in `packages/bare-sdk`.
- NOTICE files unchanged: no dependency range edits in this patch.
