### PR TITLE
QVAC-24010 fix[mod]: emit CosyVoice3 companion set from update-models

### DIFF
--- a/packages/inference/src/models/registry/models.ts
+++ b/packages/inference/src/models/registry/models.ts
@@ -16998,7 +16998,7 @@ export const models = [
     quantization: 'q8_0',
     params: '0.5B',
     companionSet: {
-      setKey: '377f9721d0592b7c',
+      setKey: 'b75e001ce19bae4c',
       primaryKey: 'modelPath',
       files: [
         {

--- a/packages/inference/src/models/update-models/companions.ts
+++ b/packages/inference/src/models/update-models/companions.ts
@@ -28,6 +28,13 @@ import { BERGAMOT_MODEL_RE } from '../../surface'
  *     Primary: `char.bin`
  *     Companions in same directory: dicrc, matrix.bin, mecabrc, sys.dic, unk.dic
  *     The TTS addon receives the containing directory for Japanese tokenization.
+ *
+ *   CosyVoice3 TTS sets (directory-based):
+ *     Primary: `cosyvoice3-llm-*.gguf` under a `/cosy_voice/` path
+ *     Companions in same directory: flow, HiFT, vocab.json, merges.txt, voice-en.gguf
+ *     `voice-en.gguf` is written as `voice.gguf` so the addon finds it next to the LLM.
+ *     Companion files stay as standalone catalog entries (same as the original
+ *     hand-patch); only the LLM primary carries `companionSet` for directory load.
  */
 export function groupCompanionSets(models: ProcessedModel[]): ProcessedModel[] {
   const bySourcePath = new Map<string, ProcessedModel>()
@@ -41,6 +48,7 @@ export function groupCompanionSets(models: ProcessedModel[]): ProcessedModel[] {
   groupBergamotCompanions(models, bySourcePath, companionKeys)
   groupBciCompanions(models, bySourcePath, companionKeys)
   groupMecabCompanions(models, bySourcePath, companionKeys)
+  groupCosyvoiceCompanions(models, bySourcePath)
 
   return models.map((model) => {
     const key = sourceKey(model.registrySource, model.registryPath)
@@ -281,6 +289,91 @@ function groupMecabCompanions(
       files: [primaryEntry, ...companionEntries]
     }
   }
+}
+
+const COSYVOICE_DIR_MARKER = '/cosy_voice/'
+const COSYVOICE_COMPANIONS = [
+  { filename: 'cosyvoice3-flow-f32.gguf', key: 'flowPath', targetName: 'cosyvoice3-flow-f32.gguf' },
+  { filename: 'cosyvoice3-hift-f32.gguf', key: 'hiftPath', targetName: 'cosyvoice3-hift-f32.gguf' },
+  { filename: 'vocab.json', key: 'vocabPath', targetName: 'vocab.json' },
+  { filename: 'merges.txt', key: 'mergesPath', targetName: 'merges.txt' },
+  { filename: 'voice-en.gguf', key: 'voicePath', targetName: 'voice.gguf' }
+] as const
+
+function isCosyvoiceLlmFilename(filename: string): boolean {
+  return filename.startsWith('cosyvoice3-llm-') && filename.endsWith('.gguf')
+}
+
+function groupCosyvoiceCompanions(
+  models: ProcessedModel[],
+  bySourcePath: Map<string, ProcessedModel>
+): void {
+  for (const model of models) {
+    if (!model.registryPath.includes(COSYVOICE_DIR_MARKER)) continue
+
+    const lastSep = model.registryPath.lastIndexOf('/')
+    const filename = lastSep >= 0 ? model.registryPath.slice(lastSep + 1) : model.registryPath
+    if (!isCosyvoiceLlmFilename(filename)) continue
+
+    const dirPrefix = lastSep >= 0 ? model.registryPath.slice(0, lastSep + 1) : ''
+    const source = model.registrySource
+    const companions = findCosyvoiceCompanions(source, dirPrefix, bySourcePath)
+    if (companions.length !== COSYVOICE_COMPANIONS.length) continue
+
+    const setKey = shortHash(`${source}:${model.registryPath}`)
+    const primaryEntry: CompanionSetMetadataEntry = {
+      key: 'modelPath',
+      registryPath: model.registryPath,
+      registrySource: source,
+      targetName: filename,
+      expectedSize: model.expectedSize,
+      sha256Checksum: model.sha256Checksum,
+      blobCoreKey: model.blobCoreKey,
+      blobBlockOffset: model.blobBlockOffset,
+      blobBlockLength: model.blobBlockLength,
+      blobByteOffset: model.blobByteOffset,
+      primary: true
+    }
+
+    const companionEntries = companions.map(({ key, targetName, model: comp }) => ({
+      key,
+      registryPath: comp.registryPath,
+      registrySource: comp.registrySource,
+      targetName,
+      expectedSize: comp.expectedSize,
+      sha256Checksum: comp.sha256Checksum,
+      blobCoreKey: comp.blobCoreKey,
+      blobBlockOffset: comp.blobBlockOffset,
+      blobBlockLength: comp.blobBlockLength,
+      blobByteOffset: comp.blobByteOffset
+    }))
+
+    model.companionSet = {
+      setKey,
+      primaryKey: 'modelPath',
+      files: [primaryEntry, ...companionEntries]
+    }
+  }
+}
+
+function findCosyvoiceCompanions(
+  source: string,
+  dirPrefix: string,
+  bySourcePath: Map<string, ProcessedModel>
+): { key: string; targetName: string; model: ProcessedModel }[] {
+  const found: { key: string; targetName: string; model: ProcessedModel }[] = []
+
+  for (const companion of COSYVOICE_COMPANIONS) {
+    const model = bySourcePath.get(sourceKey(source, `${dirPrefix}${companion.filename}`))
+    if (!model) return []
+    found.push({
+      key: companion.key,
+      targetName: companion.targetName,
+      model
+    })
+  }
+
+  return found
 }
 
 function findBergamotCompanions(

--- a/packages/inference/test/companion-detection.test.ts
+++ b/packages/inference/test/companion-detection.test.ts
@@ -246,3 +246,133 @@ test('groupCompanionSets: bergamot cross-source not paired', (t) => {
 
   t.absent(result[0]!.companionSet)
 })
+
+// --- CosyVoice3 companion detection ---
+
+const COSYVOICE_DIR = 'qvac_models_compiled/ggml/cosy_voice/2026-07-23/'
+
+function makeCosyvoiceSet() {
+  return {
+    llm: makeModel({
+      registryPath: `${COSYVOICE_DIR}cosyvoice3-llm-q8_0.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    flow: makeModel({
+      registryPath: `${COSYVOICE_DIR}cosyvoice3-flow-f32.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    hift: makeModel({
+      registryPath: `${COSYVOICE_DIR}cosyvoice3-hift-f32.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    vocab: makeModel({
+      registryPath: `${COSYVOICE_DIR}vocab.json`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    merges: makeModel({
+      registryPath: `${COSYVOICE_DIR}merges.txt`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    voiceEn: makeModel({
+      registryPath: `${COSYVOICE_DIR}voice-en.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    }),
+    voiceZh: makeModel({
+      registryPath: `${COSYVOICE_DIR}voice-zh-female.gguf`,
+      registrySource: 's3',
+      addon: 'tts',
+      engine: 'tts-ggml'
+    })
+  }
+}
+
+test('groupCompanionSets: cosyvoice llm + directory companions (6-file set)', (t) => {
+  const files = makeCosyvoiceSet()
+  const result = groupCompanionSets([
+    files.llm,
+    files.flow,
+    files.hift,
+    files.vocab,
+    files.merges,
+    files.voiceEn,
+    files.voiceZh
+  ])
+
+  t.ok(result[0]!.companionSet, 'primary has companionSet')
+  t.is(result[0]!.companionSet!.primaryKey, 'modelPath')
+  t.is(result[0]!.companionSet!.files.length, 6)
+  t.is(result[0]!.companionSet!.files[0]!.primary, true)
+  t.is(result[0]!.companionSet!.files[0]!.key, 'modelPath')
+  t.is(result[0]!.companionSet!.files[0]!.targetName, 'cosyvoice3-llm-q8_0.gguf')
+  t.absent(result[0]!.isCompanionOnly)
+
+  const keys = result[0]!.companionSet!.files.map((f) => f.key)
+  t.alike(keys, ['modelPath', 'flowPath', 'hiftPath', 'vocabPath', 'mergesPath', 'voicePath'])
+  t.is(result[0]!.companionSet!.files[5]!.targetName, 'voice.gguf')
+  t.is(result[0]!.companionSet!.files[5]!.registryPath, `${COSYVOICE_DIR}voice-en.gguf`)
+
+  t.absent(result[1]!.isCompanionOnly, 'flow stays a standalone catalog entry')
+  t.absent(result[6]!.companionSet, 'extra voices are not pulled into the set')
+  t.absent(result[6]!.isCompanionOnly)
+})
+
+test('groupCompanionSets: cosyvoice llm without companions gets no set', (t) => {
+  const llm = makeModel({
+    registryPath: `${COSYVOICE_DIR}cosyvoice3-llm-q8_0.gguf`,
+    registrySource: 's3'
+  })
+
+  const result = groupCompanionSets([llm])
+
+  t.absent(result[0]!.companionSet)
+  t.absent(result[0]!.isCompanionOnly)
+})
+
+test('groupCompanionSets: cosyvoice cross-source not paired', (t) => {
+  const files = makeCosyvoiceSet()
+  files.flow.registrySource = 'github'
+
+  const result = groupCompanionSets([
+    files.llm,
+    files.flow,
+    files.hift,
+    files.vocab,
+    files.merges,
+    files.voiceEn
+  ])
+
+  t.absent(result[0]!.companionSet)
+})
+
+test('groupCompanionSets: cosyvoice llm outside /cosy_voice/ is skipped', (t) => {
+  const files = makeCosyvoiceSet()
+  files.llm.registryPath = 'other/cosyvoice3-llm-q8_0.gguf'
+  files.flow.registryPath = 'other/cosyvoice3-flow-f32.gguf'
+  files.hift.registryPath = 'other/cosyvoice3-hift-f32.gguf'
+  files.vocab.registryPath = 'other/vocab.json'
+  files.merges.registryPath = 'other/merges.txt'
+  files.voiceEn.registryPath = 'other/voice-en.gguf'
+
+  const result = groupCompanionSets([
+    files.llm,
+    files.flow,
+    files.hift,
+    files.vocab,
+    files.merges,
+    files.voiceEn
+  ])
+
+  t.absent(result[0]!.companionSet)
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- CosyVoice3 `loadModel` expects the LLM GGUF's companion set to co-locate flow, HiFT, vocab, merges, and `voice.gguf` in one directory.
- That grouping was hand-patched in #3857. `update-models` does not emit it, so the next catalog regen drops it and registry loads of `TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0` break.

## 📝 How does it solve it?

- Adds a CosyVoice3 companion family in inference `update-models` (same directory grouping as BCI/MeCab).
- Regenerated `models.ts` now writes the companion set from the live registry. `voice-en.gguf` still caches as `voice.gguf`.
- `setKey` changes from the hand-patched hash (`377f9721d0592b7c`) to the same `source:path` hash other families use (`b75e001ce19bae4c`). First load after this lands uses a new companion-set cache folder.

## 🧪 How was it tested?

- Unit tests in `packages/inference/test/companion-detection.test.ts` (full set, missing companions, cross-source, path guard). 18/18 companion-detection tests pass.
- Ran `bun run update-models` in `packages/inference` against the live registry; CosyVoice companion files/keys match the #3857 hand-patch aside from `setKey`.

## 📦 Models

### Updated models

```
TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
```
