### PR TITLE
QVAC-20631 bump classification-ggml to 0.21.0

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-08-21
+
+### Changed
+
+- `@qvac/fabric` dependency bumped `^0.6.0` -> `^0.7.0`, which carries `qvac-fabric`
+  `10069.1.1` -> `10069.2.0` (TurboVec CPU support from the fabric runtime).
+  This package consumes the shared runtime via npm rather than building the vcpkg
+  port, so the range bump is what picks up the new fabric. A caret on a `0.x`
+  version locks the minor, so `^0.6.0` would not have resolved `0.7.0` on its
+  own. No API change for this package.
+
+  This addon runs MobileNetV3-Small on CPU and does not expose vector indexing,
+  so the TurboVec addition does not change its own inference API. The bump keeps
+  classification on the current shared runtime build rather than leaving it on a
+  superseded fabric.
+
 ## [0.20.0] - 2026-08-19
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {
@@ -84,7 +84,7 @@
     "typescript-eslint": "^8.63.0"
   },
   "dependencies": {
-    "@qvac/fabric": "^0.6.0",
+    "@qvac/fabric": "^0.7.0",
     "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",
     "bare-env": "^3.0.0",


### PR DESCRIPTION
- Version updated to 0.21.0
- Changelog added for 0.21.0
- `@qvac/fabric` bumped from `^0.6.0` to `^0.7.0`, which points to `qvac-fabric` `10069.2.0`
