### PR TITLE
fix: bump Device Farm mobile to Node 22 + Appium 3, and fail runs clearly on test failure

### DIFF
--- a/.github/actions/run-mobile-integration-tests/upload-to-devicefarm/generate-testspec.sh
+++ b/.github/actions/run-mobile-integration-tests/upload-to-devicefarm/generate-testspec.sh
@@ -65,11 +65,17 @@ ${HOST_LINE}
 phases:
   install:
     commands:
-      - export NVM_DIR=\$HOME/.nvm
-      - . \$NVM_DIR/nvm.sh 2>/dev/null || true
-      - nvm install 18 2>/dev/null || true
-      - nvm use 18 2>/dev/null || true
-      - node --version || echo "Using system node"
+      # Device Farm ships Node + Appium via devicefarm-cli on both the
+      # amazon_linux_2 (Android) and macos_sequoia (iOS) hosts. The addon
+      # e2e harness pins the Appium 3 stack (appium-xcuitest-driver@12,
+      # appium-uiautomator2-driver@8, @appium/support@7), which requires
+      # Node ^20.19 || ^22.12 || >=24 and refuses to load under the host's
+      # default Appium 2.x runtime. Select Node 22 + Appium 3 so the host
+      # runtime matches the drivers the harness installs.
+      - devicefarm-cli use node 22
+      - devicefarm-cli use appium 3
+      - node --version
+      - appium --version
 
   pre_test:
     commands:

--- a/.github/workflows/integration-mobile-test-asr-ggml.yml
+++ b/.github/workflows/integration-mobile-test-asr-ggml.yml
@@ -162,10 +162,10 @@ jobs:
           test-groups-path: validation-data/packages/asr-ggml/test/mobile/test-groups.json
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
-  # NOTE: continue-on-error: true matches the parent families' workflows.
-  # on-pr-asr-ggml.yml's merge-guard treats `success || skipped` as a pass, so
-  # a hard Device Farm failure does not gate merge today. Tighten once the
-  # Device Farm provisioning + signing + runner pool is stable.
+  # A Device Farm test failure fails this run on every trigger (no
+  # continue-on-error). Mobile is on-demand for this addon (not part of
+  # on-pr-asr-ggml.yml's PR lane), so this does not gate PR merges — it makes
+  # manual/scheduled runs trustworthy instead of silently green.
   build-and-test:
     name: Build ${{ matrix.platform }} (${{ matrix.engine && format('{0} {1} {2}', matrix.engine, matrix.model || matrix.model_type, matrix.use_gpu && 'gpu' || 'cpu') || 'functional' }}) and Run E2E Tests
     # workflow_call: validate-devices is skipped; the `skipped` branch of the
@@ -179,7 +179,6 @@ jobs:
     # 120 for benchmarks. Reserve another hour for checkout, dependency setup,
     # app build, upload, scheduling, log collection, and cancellation cleanup.
     timeout-minutes: ${{ !inputs.run_rtf_benchmarks && 210 || 180 }}
-    continue-on-error: true
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-audiogen-ggml.yml
+++ b/.github/workflows/integration-mobile-test-audiogen-ggml.yml
@@ -164,11 +164,10 @@ jobs:
           test-groups-path: validation-data/packages/audiogen-ggml/test/mobile/test-groups.json
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
-  # NOTE: continue-on-error: true matches the sibling mobile addons
-  # (tts-ggml / parakeet). on-pr-audiogen-ggml.yml's merge-guard treats
-  # `success || skipped` as a pass, so a hard Device Farm failure does not
-  # gate merge today. Tighten once the on-device provisioning + Device Farm
-  # pool is stable (and the ~3 GB on-device model download is proven feasible).
+  # A Device Farm test failure fails this run on every trigger (no
+  # continue-on-error). Mobile is on-demand for this addon (not part of
+  # on-pr-audiogen-ggml.yml's PR lane), so this does not gate PR merges — it
+  # makes manual/scheduled runs trustworthy instead of silently green.
   build-and-test:
     name: Build ${{ matrix.platform }}${{ inputs.run_rtf_benchmarks && format(' ({0} {1})', matrix.dit_variant, matrix.use_gpu && 'gpu' || 'cpu') || '' }} and Run E2E Tests
     # validate-devices is skipped on workflow_call (its `skipped` result keeps
@@ -179,7 +178,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
     permissions:
       contents: read
       packages: read
@@ -191,8 +189,8 @@ jobs:
       # device. The engine loads the ACE-Step stages sequentially, so the
       # load-time peak is a single stage instead of all six at once and create()
       # does not jetsam-OOM on a non-entitled iPhone during the ~3 GB load.
-      # Non-blocking (continue-on-error) on both platforms until the Device Farm
-      # pool is stable.
+      # A Device Farm failure on either platform fails the run (see the
+      # build-and-test comment above — no continue-on-error).
       #
       # The benchmark matrix (run_rtf_benchmarks=true) sweeps the three DiT
       # variants on CPU and GPU (Vulkan on Android, Metal on iOS) — one Device

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -152,7 +152,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-classification-ggml.yml
+++ b/.github/workflows/integration-mobile-test-classification-ggml.yml
@@ -150,7 +150,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -151,7 +151,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -209,7 +209,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -204,7 +204,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: ${{ inputs.job_timeout_minutes || 120 }}
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-inference-addon-cpp.yml
+++ b/.github/workflows/integration-mobile-test-inference-addon-cpp.yml
@@ -538,7 +538,9 @@ jobs:
     # Exceeds the 30m default: waits on the AWS Device Farm run (queue + device
     # provisioning + on-device execution), which routinely takes >30m.
     timeout-minutes: 120
-    continue-on-error: true # advisory until on-device flake is characterised
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger. NOTE: this workflow IS called by on-pr-inference-addon-cpp.yml,
+    # so a failing on-device test now blocks the PR (intended — no silent green).
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -102,7 +102,8 @@ on:
         required: false
         default: ""
     # Additive outputs (QVAC weekend job): surface the monitor verdict so a
-    # caller can read real pass/fail past the job's `continue-on-error: true`.
+    # caller can aggregate per-platform pass/fail for reporting. The job itself
+    # also fails the run directly on any test failure (no continue-on-error).
     # When a caller runs both platforms in one call the matrix overwrites these
     # nondeterministically — single-platform callers (the weekend workflow uses
     # `platforms:` to run one platform per call) get a well-defined value.
@@ -314,9 +315,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: ${{ inputs.job_timeout_minutes || 150 }}
-    continue-on-error: true
-    # Surfaced as workflow_call outputs above so schedule-driven callers can
-    # report a verdict (the job itself never fails — continue-on-error).
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger. The test-result outputs below remain for callers that
+    # aggregate per-platform verdicts (weekend report, benchmarks).
     outputs:
       test-result: ${{ steps.monitor.outputs.test-result }}
       test-total: ${{ steps.monitor.outputs.test-total }}

--- a/.github/workflows/integration-mobile-test-model-fit.yml
+++ b/.github/workflows/integration-mobile-test-model-fit.yml
@@ -154,7 +154,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: ${{ inputs.job_timeout_minutes || 120 }}
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-ocr-ggml.yml
+++ b/.github/workflows/integration-mobile-test-ocr-ggml.yml
@@ -155,7 +155,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -157,7 +157,9 @@ jobs:
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -151,11 +151,10 @@ jobs:
           test-groups-path: validation-data/packages/tts-ggml/test/mobile/test-groups.json
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
-  # NOTE: continue-on-error: true matches the previous monolithic
-  # workflow.  on-pr-tts-ggml.yml's merge-guard treats `success ||
-  # skipped` as a pass, so a hard Device Farm failure does not gate
-  # merge today.  Tighten once the Device Farm provisioning + signing
-  # + runner pool is stable.
+  # A Device Farm test failure fails this run on every trigger (no
+  # continue-on-error). Mobile is on-demand for this addon (not part of
+  # on-pr-tts-ggml.yml's PR lane), so this does not gate PR merges — it makes
+  # manual/scheduled runs trustworthy instead of silently green.
   build-and-test:
     name: Build ${{ matrix.platform }} (${{ matrix.engine || 'chatterbox' }} ${{ matrix.variant }} ${{ matrix.use_gpu && 'gpu' || 'cpu' }}${{ matrix.enhancer == 'lavasr' && ' enh' || '' }}${{ matrix.denoiser == 'lavasr' && ' den' || '' }}) and Run E2E Tests
     # workflow_call: validate-devices is skipped; the `skipped` branch of the
@@ -169,7 +168,6 @@ jobs:
     # Functional shards can spend up to 120 minutes in Device Farm plus queue
     # time; retain enough budget for build, scheduling, and log collection.
     timeout-minutes: ${{ !inputs.run_rtf_benchmarks && 180 || 150 }}
-    continue-on-error: true
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -185,7 +185,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: release
     timeout-minutes: 120
-    continue-on-error: true  # Don't block PR merges if tests fail
+    # No continue-on-error: a Device Farm test failure must fail this run on
+    # every trigger (workflow_dispatch, workflow_call, schedule). Re-adding it
+    # silently turns failed runs green.
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary

Two fixes that together make all addon **mobile Device Farm** CI trustworthy again after the `qvac-test-addon-mobile` e2e harness was bumped to the **Appium 3** stack (to remediate critical Socket alerts — malicious `fs`, `form-data`/`shell-quote` CVEs):

1. **Make the runtime match the harness** — the host was on Node 18 / Appium 2.x, so every Appium-3 run failed to create a session.
2. **Make failures fail the run** — a job-level `continue-on-error: true` was hiding those failures behind a green checkmark on every addon.

---

## Fix 1 — Node 22 + Appium 3 on Device Farm

The generated Device Farm testspec still forced **Node 18** via `nvm` and left the host's **default Appium 2.x** runtime in place. The Appium-3 drivers the harness installs (`appium-xcuitest-driver@12`, `appium-uiautomator2-driver@8`, `@appium/support@7`) require Node `^20.19 || ^22.12 || >=24` and an Appium-3 core, so every run failed:

```
npm warn EBADENGINE appium@3.6.0 required: node ^20.19.0 || ^22.12.0 || >=24 ; current: v18.20.8
WARN Appium ... appium-xcuitest-driver ... may be incompatible with Appium v2.11.5 (peer ^3.0.0-rc.2)
Could not load driver 'xcuitest' ... require() of ES Module .../p-limit/index.js not supported (ERR_REQUIRE_ESM)
✖ Failed to create a session: Unable to connect to "http://127.0.0.1:4723/wd/hub"
```

Example failing run: https://github.com/tetherto/qvac/actions/runs/32504926599

`generate-testspec.sh` install phase: replace the legacy `nvm install 18` block with `devicefarm-cli`, which ships **Node 22 + Appium 3** pre-installed on both `amazon_linux_2` (Android) and `macos_sequoia` (iOS):

```yaml
install:
  commands:
    - devicefarm-cli use node 22
    - devicefarm-cli use appium 3
    - node --version
    - appium --version
```

This matches the drivers the harness installs, and mirrors the mechanism the SDK's own `packages/sdk/e2e/device-farm/test-spec-ios.yml` already uses (`devicefarm-cli use node/appium`). The AWS `amazon_linux_2` glibc constraint on Node 20+ is a non-issue because these are AWS's pre-installed, host-compatible builds selected via `devicefarm-cli` (not raw nodejs.org binaries).

---

## Fix 2 — Device Farm failures now fail the run (all 14 addon workflows)

While validating Fix 1 I hit a worse problem: a manually-dispatched iOS run reported **`0 passed / 1 failed`** on-device, the monitor step correctly `exit 1`'d, the **job** conclusion was `failure` — and the **run** was still green ✅.

Root cause: the `build-and-test` job in every `integration-mobile-test-*.yml` was marked **`continue-on-error: true`**, so the job's real failure never propagated to the run. The pass/fail verdict only lived in a job *output* that a `workflow_call` caller was expected to read — but mobile is **on-demand only** now, so a plain `workflow_dispatch` run had nothing consuming that output and always went green.

Evidence — same run, two different truths:

| Source | Result |
| --- | --- |
| Run conclusion (the green check everyone trusts) | `success` |
| `build-and-test` job conclusion | `failure` |
| Monitor step | `❌ Device Farm tests failed`, `exit 1` |

This affected **every addon** on the manual/on-demand path.

**Change:** removed `continue-on-error: true` from the `build-and-test` (device-farm) job in all 14 `integration-mobile-test-*.yml` workflows and replaced it with a guard comment so it can't be silently re-added. `fail-fast: false` is already set on every matrix, so both platform legs still run and any failing leg turns the whole run **red** — on `workflow_dispatch`, `workflow_call`, and `schedule` alike.

Note: `integration-mobile-test-inference-addon-cpp.yml` **is** called by `on-pr-inference-addon-cpp.yml`, so a failing on-device test there now blocks that PR (intended — no silent green).

Workflows touched: `asr-ggml, audiogen-ggml, bci-whispercpp, classification-ggml, decoder-audio, diffusion-cpp, embed-llamacpp, inference-addon-cpp, llm-llamacpp, model-fit, ocr-ggml, translation-nmtcpp, tts-ggml, vla`.

## Evidence — Device Farm runs on this branch (`fix/devicefarm-node22-appium3`)

Both verified by reading the **actual on-device counters** in the monitor log, not just the green check:

| Platform | Device | Run | Result |
| --- | --- | --- | --- |
| iOS | Apple iPhone 16 Pro (iOS 26.0) | [32532182052](https://github.com/tetherto/qvac/actions/runs/32532182052) | ✅ `PASSED (3/3 passed)` — session created, 750s on-device execution (was the failing platform) |
| Android | Google Pixel 9 | [32534882261](https://github.com/tetherto/qvac/actions/runs/32534882261) | ✅ `PASSED (3/3 passed)` — 330s on-device execution |

Both verdicts confirmed by reading `Device Farm totals: 3 | Passed: 3 | Failed: 0` in the monitor log (real test cases executed, not a vacuous 0-test "pass").

## Test plan

- [x] `generate-testspec.sh` renders valid YAML for both Android (`amazon_linux_2`) and iOS (`macos_sequoia`)
- [x] `actionlint` clean on all 14 edited workflows; YAML parses
- [x] Device Farm **iOS** run drives the addon end-to-end (session created, `3/3 passed`) — was the failing platform
- [x] Device Farm **Android** run on this branch (Pixel 9, `3/3 passed`)
- [x] False-green root cause reproduced: run `32450983156` had job `failure` + monitor `exit 1` while the run stayed green — closed by removing `continue-on-error`
