### PR TITLE
QVAC-22630 chore: release @qvac/model-fit 0.6.0

### DIFF
--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -1,5 +1,91 @@
 # Changelog
 
+## [0.6.0] - 2026-08-22
+
+### Added
+
+- Disposable-process protocol v2, carrying an explicit
+  `loadKind: 'completion' | 'embedding'` so the runner can select the matching
+  normalization policy internally. `encodeFitLlamaProcessRequest(loadKind,
+  config)` encodes it; `parseFitProcessResponse` answers both versions.
+  Protocol v1 is unchanged and still accepted.
+
+- Fit-relevant completion and embedding load normalization — backend selection,
+  context/batch settings, split policy, flash/KV defaults, SWA and CPU
+  placement — so a raw llama load config can be projected the way the addon
+  that will run it would resolve it. This duplicates `llm-llamacpp` and
+  `embed-llamacpp` for now; shared ownership can be revisited separately.
+
+- `FitLlamaResult` and `FitLlamaReason` in `./process`, adding the
+  `unsupported-config` outcome for a configuration the normalization cannot
+  represent (mobile, streaming, sharded, multimodal, finetune, LoRA, RoPE/YaRN,
+  unknown keys). The result is advisory and must never be used to deny a load.
+
+  Deliberately a separate type: `fitParams()` cannot produce that outcome, so
+  `FitResult` and `FitReason` are unchanged and existing low-level consumers
+  narrow nothing new. Every `FitResult` is assignable to `FitLlamaResult`.
+
+### Changed
+
+- Raw load-parameter normalization stays private to the disposable process
+  runner. `./binding.js`, which is a public export, now re-exports `paramsFit`
+  explicitly rather than the whole addon, and the runner reaches the load-config
+  fitter through the unexported `./binding-internal.js`. The package root
+  continues to expose only the existing low-level `fitParams()` API.
+
+- The C++ unit targets behind `BUILD_TESTING` now run in CI via
+  `cpp-tests-model-fit.yml` and the `test:cpp` scripts, and their translation
+  units are linted, so the normalization above is covered by the PR gate rather
+  than by a local step.
+
+### Fixed
+
+These are all divergences between what this package projected and what the load
+would actually do. Each was found by review of the normalization above and is
+fixed against the behaviour of `llm-llamacpp` / `embed-llamacpp`:
+
+- `llama_model_params::devices` is a NULL-terminated list, and neither list this
+  package built carried the terminator. The single-GPU list read one element
+  past its allocation on every fit; the CPU path passed an empty vector, which
+  is not the same as an empty list — `common_model_params_to_llama` forwards
+  only a non-empty one — so fabric fell back to default device selection,
+  enumerating every GPU and skipping the host-memory check that is the only real
+  constraint on a CPU load.
+
+- The CPU path no longer pins `n_gpu_layers` to 0. The addons leave the field
+  alone, and forcing it made `common_fit_params` abort when the projection
+  needed to adjust it.
+
+- An unset embedding context is pinned to the model's trained context, and an
+  oversized one is capped rather than rejected, matching
+  `embed-llamacpp`. Leaving it at 0 invited the fitter to report a reduced
+  context, and a correspondingly reduced memory figure, for a load that runs at
+  the full trained context.
+
+- `flash-attn` is recognised as enabled on `on` only, as `llm-llamacpp` does.
+  Accepting any truthy spelling fired the q8_0 KV auto-default where the real
+  load keeps f16, under-estimating KV memory by roughly 2x.
+
+- `ctx-size: '0'` no longer becomes a 4096 context floor. Fabric encodes "do not
+  reduce the context" as `UINT32_MAX` in a signed field, and clamping that at
+  zero inverted the one configuration that explicitly forbids reduction.
+
+- Conflicting key aliases (`gpu-layers`/`n-gpu-layers`,
+  `kv-offload`/`no-kv-offload`, `op-offload`/`no-op-offload`) are rejected
+  instead of resolved by hash-bucket order, which made the verdict depend on
+  internal hashing rather than on the request.
+
+- `no-host` is a valueless flag upstream, so `no-host: 'false'` now reports
+  `unsupported-config` instead of projecting the opposite weight placement.
+  `host`, `extra-bufts` and `no-extra-bufts` leave the supported set for the
+  same reason: qvac-fabric registers no such option, so no load can express
+  them.
+
+### Pull Requests
+
+- [#3930](https://github.com/tetherto/qvac/pull/3930) - QVAC-22630 feat[api]:
+  add config normalization to model-fit addon
+
 ## [0.5.0] - 2026-08-20
 
 ### Changed

--- a/packages/model-fit/package.json
+++ b/packages/model-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/model-fit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Memory-fit preflight addon for QVAC — wraps llama.cpp's common_fit_params to project whether a GGUF model fits available device memory before loading it",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/model-fit` 0.5.0 is the published version, and [#3930](https://github.com/tetherto/qvac/pull/3930) has since merged to `main` — the disposable-process protocol v2, the completion/embedding load normalization behind it, and the review fixes that came out of it. None of it is installable yet.

## 📝 How does it solve it?

Bumps `packages/model-fit/package.json` to `0.6.0` and records the release in `packages/model-fit/CHANGELOG.md`. No source change.

A minor bump, not a patch or a breaking one:

- It adds public surface — protocol v2 with an explicit `loadKind`, `encodeFitLlamaProcessRequest`, and the `FitLlamaResult` / `FitLlamaReason` types carrying the `unsupported-config` outcome.
- Nothing published is removed or narrowed. `FitResult` gained `unsupported-config` and then lost it again inside #3930, both before release: `index.d.ts` on `release-model-fit-0.5.0` already declares the status-2 reasons as `'model-unreadable' | 'no-backend-device'`, exactly what 0.6.0 ships. `fitParams()`'s contract is byte-identical to 0.5.0's.
- Protocol v1 is unchanged and still accepted.

## 🧪 How was it tested?

Verified at the merge commit before cutting the branch:

- `ctest --test-dir build --output-on-failure` — 3/3
- `npm run test:process` — `process.test.js` 21/21, `llama-config.test.js` 17/17 (328 asserts)
- `bare test/integration/fit.test.js` — 27/27 against a real GGUF
- `npm run test:node` — 2/2
- `npm run test:types` — typecheck, declaration consumer and `check:generated`
- `npm run lint`, `clang-format`, `clang-tidy` (0 user-code warnings)
- CI on #3930 at its final head: 44 checks pass, including the full seven-runner desktop integration matrix under `run-desktop-addon-tests`.

This PR itself contains no source change, so it inherits that state.

## 🔌 API Changes

Additive. `fitParams()` and `FitResult` are untouched relative to 0.5.0.

```typescript
import {
  encodeFitLlamaProcessRequest,
  parseFitProcessResponse,
  resolveFitProcessRunnerPath
} from '@qvac/model-fit/process'
import type { FitLlamaResult } from '@qvac/model-fit/process'

const request = encodeFitLlamaProcessRequest('completion', {
  modelPath: '/absolute/path/model.gguf',
  params: { device: 'gpu', 'ctx-size': '4096', 'gpu-layers': '40' },
  marginMiB: 1024
})

// Send `request` as the runner's single stdin line, then:
const response = parseFitProcessResponse(JSON.parse(line))
if (response.status === 'completed') {
  const result: FitLlamaResult = response.result
  // `unsupported-config` is advisory — it must never be used to deny a load.
}
```

The raw load-config fitter is deliberately **not** in-process public API: `./binding.js` re-exports `paramsFit` only, and the runner reaches the fitter through the unexported `./binding-internal.js`.

## 📦 Release

- Base branch `release-model-fit-0.6.0`, cut from `main` at `975b36ea3`.
- Merging this triggers the GPR publish; the backmerge into `main` follows and triggers npm.
