### PR TITLE
QVAC-24076 doc: inline Bare quickstart to unblock website build

### DIFF
--- a/docs/website/content/docs/js-ts-sdk.mdx
+++ b/docs/website/content/docs/js-ts-sdk.mdx
@@ -275,7 +275,32 @@ To run an example on Bare:
 
 Here is the quickstart adapted for Bare:
 
-```ts file=<rootDir>/packages/sdk/examples/quickstart.bare.ts title="quickstart.bare.ts" lineNumbers
+```ts title="quickstart.bare.ts" lineNumbers
+// The Bare quickstart. Bare has no `process` global and does not spawn a worker,
+// so two setup steps come first: install bare-process as the `process` global,
+// then register the plugins this example uses via `plugins([...])`.
+
+import bareProcess from "bare-process";
+import { plugins, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+import { llmPlugin } from "@qvac/sdk/llamacpp-completion/plugin";
+
+(globalThis as unknown as { process: typeof bareProcess }).process =
+  bareProcess;
+
+const { loadModel, completion, unloadModel } = plugins([llmPlugin]);
+
+// From here it is the same as the Node quickstart.
+const modelId = await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
+
+const history = [
+  { role: "user", content: "Explain quantum computing in one sentence" },
+];
+const result = completion({ modelId, history, stream: true });
+for await (const token of result.tokenStream) {
+  process.stdout.write(token);
+}
+
+await unloadModel({ modelId, autoClose: true });
 ```
 
 For running QVAC on Bare in production, we recommend **[@qvac/bare-sdk](https://github.com/tetherto/qvac/tree/main/packages/bare-sdk)** — a slim, Bare-only assembly where you select addons and register plugins explicitly. It also sets up the bare module shims that examples using `fs` and similar modules rely on.


### PR DESCRIPTION
## What problem does this PR solve?

The `docs/website` build breaks because `js-ts-sdk.mdx` embeds `packages/sdk/examples/quickstart.bare.ts`, which was removed on `main` by the `@qvac/inference` split ([#3595](https://github.com/tetherto/qvac/pull/3595)) — a change not yet released, so the docs must still teach the pre-split pattern.

## How does it solve it?

Inline the removed file's contents in the "Running on Bare" section, keeping `title` and `lineNumbers` for identical rendering; when the split ships, this section will be rewritten to point at `@qvac/bare-sdk`.