### PR TITLE
chore[notask]: pin audiogen-ggml to the minimax-metal branch via a vcpkg overlay port

### DIFF
--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -16,6 +16,12 @@ find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
 
+# TEMPORARY — remove together with vcpkg-overlay-ports/ once feat/minimax-metal
+# is merged and the registry's speech-cpp pin advances. The overlay replaces the
+# registry's speech-cpp port with one pinned to that branch, so this package
+# builds against it. See vcpkg-overlay-ports/speech-cpp/portfile.cmake.
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports;${VCPKG_OVERLAY_PORTS}")
+
 project(audiogen-ggml CXX C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -20,7 +20,12 @@ set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/tri
 # is merged and the registry's speech-cpp pin advances. The overlay replaces the
 # registry's speech-cpp port with one pinned to that branch, so this package
 # builds against it. See vcpkg-overlay-ports/speech-cpp/portfile.cmake.
-set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports;${VCPKG_OVERLAY_PORTS}")
+# NB: list-argument form, not "a;${VAR}" string interpolation. When
+# VCPKG_OVERLAY_PORTS is unset, the string form yields a trailing empty list
+# element, vcpkg.cmake emits a bare `--overlay-ports=`, and vcpkg resolves that
+# empty path to the invocation directory — this package dir — then parses its
+# manifest vcpkg.json as a port and dies on "missing required field 'name'".
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports" ${VCPKG_OVERLAY_PORTS})
 
 project(audiogen-ggml CXX C)
 

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/portfile.cmake
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/portfile.cmake
@@ -1,0 +1,296 @@
+# LOCAL OVERLAY PORT — NOT FOR MERGE.
+#
+# Identical to qvac-registry-vcpkg's ports/speech-cpp at baseline
+# cf1500e91d595db131c41421d4e1455f9143ec6e, except that the REF/SHA512 source
+# pin below points at the qvac-ext-lib-whisper.cpp branch feat/minimax-metal
+# (d73fb6ea1ee39d3d4bff9dab45b6f64202e44701, "feat: Add metal support for
+# minimax") instead of the registry's 792b6892. Its purpose is to let this
+# package build and run against that branch before the registry pin advances.
+#
+# Delete this whole directory (and the VCPKG_OVERLAY_PORTS line in
+# ../../CMakeLists.txt) once the branch is merged and a new speech-cpp port
+# version lands in qvac-registry-vcpkg. Keeping it would silently pin the
+# package to a dead branch commit and mask registry updates.
+#
+# To re-point at a different commit: update REF, then recompute SHA512 over
+# https://github.com/tetherto/qvac-ext-lib-whisper.cpp/archive/<REF>.tar.gz
+# (`shasum -a 512 <file>`).
+#
+# ---------------------------------------------------------------------------
+#
+# speech-cpp: umbrella port over tetherto/qvac-ext-lib-whisper.cpp (QIP #94,
+# Ticket 4). One source pin, per-engine features:
+#
+#   speech-cpp[whisper]   -> third_party/whisper.cpp (package `whisper`)
+#   speech-cpp[parakeet]  -> engines/parakeet        (package `qvac-parakeet`)
+#   speech-cpp[tts]       -> engines/tts             (package `tts-cpp`)
+#   speech-cpp[audiogen]  -> engines/audiogen        (package `audiogen-cpp`)
+#
+# The repo-root CMakeLists.txt is the superbuild this port drives: it resolves
+# ONE system ggml (find_package(ggml) from the ggml-speech port) and hands it
+# to every enabled engine, so the whole stack shares a single ggml pin — the
+# ggml/ tree vendored inside the whisper subtree is never compiled. Backend
+# selection (metal / vulkan / opencl) is therefore expressed purely as
+# ggml-speech features in vcpkg.json; the GGML_* flags passed below only steer
+# engine-side gating (e.g. which GPU paths the engines consider validated).
+#
+# Upstream whisper.cpp v1.9.1+ ships its own C-API `parakeet` (lib/libparakeet.*,
+# lib/cmake/parakeet/, parakeet.pc) which collides with engines/parakeet. The
+# umbrella forces WHISPER_BUILD_PARAKEET=OFF, so with [whisper,parakeet] enabled
+# only OUR parakeet is built and installed — under the qvac-parakeet namespace
+# (find_package(qvac-parakeet) + qvac::parakeet) — and upstream's is neither
+# built nor installed. No file-ownership clash, no wasted build.
+#
+# The REF below is the single source pin for every engine. It replaced the
+# standalone whisper-cpp / parakeet-cpp / tts-cpp / audiogen-cpp ports, which
+# were removed from this registry once every consumer had migrated.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF d73fb6ea1ee39d3d4bff9dab45b6f64202e44701
+    SHA512 a0ae8bb6ae031506a4c9f4252a00ea72f3e7b56e877c49164e0611d47e6b4d01351f75ddccbe9f7f241b7b9095ea4f07cd860b7aa9b3f8e35dbf5aa5ba43f908
+    HEAD_REF feat/minimax-metal
+)
+
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "speech-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the umbrella "
+        "CMakeLists.txt at the qvac-ext-lib-whisper.cpp repo root may have moved.")
+endif()
+
+# Engine features, each mapped to its SPEECH_BUILD_<ENGINE> superbuild gate.
+# The plain variables (not vcpkg_check_features) are needed again below for
+# the per-engine vcpkg_cmake_config_fixup guards. Adding a future engine
+# (e.g. qwen-asr) means extending this list plus its fixup below.
+set(SPEECH_ENGINE_FEATURES whisper parakeet tts audiogen)
+
+set(SPEECH_ENABLED_ENGINES "")
+foreach(SPEECH_ENGINE IN LISTS SPEECH_ENGINE_FEATURES)
+    string(TOUPPER "${SPEECH_ENGINE}" SPEECH_ENGINE_UPPER)
+    set(SPEECH_BUILD_${SPEECH_ENGINE_UPPER} OFF)
+    if("${SPEECH_ENGINE}" IN_LIST FEATURES)
+        set(SPEECH_BUILD_${SPEECH_ENGINE_UPPER} ON)
+        list(APPEND SPEECH_ENABLED_ENGINES "${SPEECH_ENGINE}")
+    endif()
+endforeach()
+
+# Unreachable through a default install (the whisper feature is a default);
+# guards a manifest that sets default-features false and picks only backends.
+if (NOT SPEECH_ENABLED_ENGINES)
+    list(JOIN SPEECH_ENGINE_FEATURES ", " SPEECH_ENGINE_FEATURE_LIST)
+    message(FATAL_ERROR
+        "speech-cpp: no engine selected. Enable at least one of the engine "
+        "features: ${SPEECH_ENGINE_FEATURE_LIST}.")
+endif()
+
+# Engine-side GPU gating (the actual backends are compiled into ggml-speech;
+# see the header comment).
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        opencl  GGML_OPENCL
+        coreml  PARAKEET_COREML
+)
+
+set(PLATFORM_OPTIONS)
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DSPEECH_BUILD_WHISPER=${SPEECH_BUILD_WHISPER}
+        -DSPEECH_BUILD_PARAKEET=${SPEECH_BUILD_PARAKEET}
+        -DSPEECH_BUILD_TTS=${SPEECH_BUILD_TTS}
+        -DSPEECH_BUILD_AUDIOGEN=${SPEECH_BUILD_AUDIOGEN}
+        -DSPEECH_BUILD_TESTS=OFF
+        -DSPEECH_BUILD_EXECUTABLES=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        # One shared system ggml. The superbuild already forces these (whisper
+        # via CACHE FORCE; parakeet via set(); tts / audiogen default ON), but
+        # the whole shared-pin premise rests on them, so pass them defensively
+        # too — harmless when redundant, and a vendored-ggml build can never
+        # slip in silently if an upstream default changes.
+        -DWHISPER_USE_SYSTEM_GGML=ON
+        -DPARAKEET_USE_SYSTEM_GGML=ON
+        -DTTS_CPP_USE_SYSTEM_GGML=ON
+        -DAUDIOGEN_USE_SYSTEM_GGML=ON
+        # whisper-specific (the umbrella owns WHISPER_BUILD_TESTS/EXAMPLES and
+        # WHISPER_BUILD_PARAKEET=OFF itself)
+        -DWHISPER_BUILD_SERVER=OFF
+        # parakeet-specific
+        -DPARAKEET_BUILD_LIBRARY=ON
+        -DPARAKEET_INSTALL=ON
+        -DPARAKEET_OPENMP=OFF
+        -DPARAKEET_CCACHE=OFF
+        # tts-specific
+        -DTTS_CPP_BUILD_LIBRARY=ON
+        -DTTS_CPP_BUILD_SHARED=OFF
+        -DTTS_CPP_INSTALL=ON
+        -DTTS_CPP_OPENMP=OFF
+        -DTTS_CPP_CCACHE=OFF
+        # audiogen-specific
+        -DAUDIOGEN_BUILD_LIBRARY=ON
+        -DAUDIOGEN_INSTALL=ON
+        -DAUDIOGEN_CCACHE=OFF
+        # shared ggml-side knobs the engines forward
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# One config-fixup per enabled engine, each under its own package name. There
+# is no bin/ payload to relocate for any of them (the old standalone
+# parakeet-cpp PARAKEET_BIN_DIR/bin handling is dead and intentionally not
+# carried over): executables are off and every engine builds static.
+if (SPEECH_BUILD_WHISPER)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME whisper CONFIG_PATH share/whisper)
+endif()
+if (SPEECH_BUILD_PARAKEET)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME qvac-parakeet CONFIG_PATH lib/cmake/qvac-parakeet)
+endif()
+if (SPEECH_BUILD_TTS)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME tts-cpp CONFIG_PATH share/tts-cpp)
+    # tts-cpp links mecab (Chatterbox MTL Japanese) and its exported link
+    # interface carries mecab::mecab, but the generated tts-cppConfig.cmake
+    # only declares the ggml dependency — a plain find_package(tts-cpp) fails
+    # with "mecab::mecab ... target was not found". Declare it where the
+    # engine's config generation should (engine follow-up); until then a bare
+    # find_package(tts-cpp CONFIG) would not be consumable, which this port
+    # guarantees.
+    set(SPEECH_TTS_CONFIG "${CURRENT_PACKAGES_DIR}/share/tts-cpp/tts-cppConfig.cmake")
+    file(READ "${SPEECH_TTS_CONFIG}" SPEECH_TTS_CONFIG_CONTENTS)
+    if (SPEECH_TTS_CONFIG_CONTENTS MATCHES "find_dependency\\(ggml CONFIG\\)"
+        AND NOT SPEECH_TTS_CONFIG_CONTENTS MATCHES "find_dependency\\(mecab")
+        string(REPLACE
+            "find_dependency(ggml CONFIG)"
+            "find_dependency(ggml CONFIG)\nfind_dependency(mecab CONFIG)"
+            SPEECH_TTS_CONFIG_CONTENTS "${SPEECH_TTS_CONFIG_CONTENTS}")
+        file(WRITE "${SPEECH_TTS_CONFIG}" "${SPEECH_TTS_CONFIG_CONTENTS}")
+    endif()
+endif()
+if (SPEECH_BUILD_AUDIOGEN)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME audiogen-cpp CONFIG_PATH share/audiogen-cpp)
+endif()
+
+# The engines' generated .pc files carry absolute -L/-I paths derived from the
+# resolved location of the imported ggml target, and CMake's spelling of that
+# path can differ from vcpkg's (macOS: /tmp vs /private/tmp), so
+# vcpkg_fixup_pkgconfig()'s exact-string rewrite can silently miss. Normalise
+# by meaning: rewrite any absolute -L/-I whose realpath lands inside the
+# install prefix to the ${prefix}-relative form. (Same fix as the standalone
+# parakeet-cpp port; see the discussion there.)
+get_filename_component(SPEECH_INSTALLED_REALPATH "${CURRENT_INSTALLED_DIR}" REALPATH)
+
+function(speech_relativize_pc pc_file)
+    if (NOT EXISTS "${pc_file}")
+        return()
+    endif()
+    file(READ "${pc_file}" contents)
+    string(REGEX MATCHALL "-[LI][^ \t\r\n\"]+" tokens "${contents}")
+    foreach (token IN LISTS tokens)
+        string(SUBSTRING "${token}" 0 2 flag)
+        string(SUBSTRING "${token}" 2 -1 dir)
+        if (NOT IS_ABSOLUTE "${dir}")
+            continue()
+        endif()
+        get_filename_component(dir_real "${dir}" REALPATH)
+        # Only touch paths inside our own prefix; a genuinely external dep
+        # (e.g. a system OpenMP runtime) must keep its absolute path.
+        string(FIND "${dir_real}" "${SPEECH_INSTALLED_REALPATH}/" hit)
+        if (NOT hit EQUAL 0)
+            continue()
+        endif()
+        string(LENGTH "${SPEECH_INSTALLED_REALPATH}/" prefix_len)
+        string(SUBSTRING "${dir_real}" ${prefix_len} -1 rel)
+        string(REPLACE "${token}" "${flag}\${prefix}/${rel}" contents "${contents}")
+    endforeach()
+    file(WRITE "${pc_file}" "${contents}")
+endfunction()
+
+file(GLOB SPEECH_PC_FILES
+    "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+foreach (SPEECH_PC_FILE IN LISTS SPEECH_PC_FILES)
+    speech_relativize_pc("${SPEECH_PC_FILE}")
+endforeach()
+
+vcpkg_fixup_pkgconfig()
+
+# Guard the outcome by meaning, not by spelling: after the rewrites no -L/-I in
+# a shipped .pc may still resolve into this machine's install/package/build
+# trees, or the cached binary would not be relocatable.
+file(GLOB SPEECH_PC_FILES "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc")
+foreach (SPEECH_PC_FILE IN LISTS SPEECH_PC_FILES)
+    file(READ "${SPEECH_PC_FILE}" SPEECH_PC_CONTENTS)
+    string(REGEX MATCHALL "-[LI][^ \t\r\n\"]+" SPEECH_PC_TOKENS "${SPEECH_PC_CONTENTS}")
+    foreach (SPEECH_PC_TOKEN IN LISTS SPEECH_PC_TOKENS)
+        string(SUBSTRING "${SPEECH_PC_TOKEN}" 2 -1 SPEECH_PC_DIR)
+        if (NOT IS_ABSOLUTE "${SPEECH_PC_DIR}")
+            continue()
+        endif()
+        get_filename_component(SPEECH_PC_DIR_REAL "${SPEECH_PC_DIR}" REALPATH)
+        foreach (SPEECH_TREE
+                 "${SPEECH_INSTALLED_REALPATH}" "${CURRENT_PACKAGES_DIR}" "${CURRENT_BUILDTREES_DIR}")
+            get_filename_component(SPEECH_TREE_REAL "${SPEECH_TREE}" REALPATH)
+            string(FIND "${SPEECH_PC_DIR_REAL}" "${SPEECH_TREE_REAL}" SPEECH_TREE_HIT)
+            if (SPEECH_TREE_HIT EQUAL 0)
+                message(FATAL_ERROR
+                    "speech-cpp: ${SPEECH_PC_FILE} still contains '${SPEECH_PC_TOKEN}', which "
+                    "resolves inside ${SPEECH_TREE_REAL}. The packaged .pc would not be "
+                    "relocatable and would break consumers restoring this package from the "
+                    "binary cache.")
+            endif()
+        endforeach()
+    endforeach()
+endforeach()
+
+# Post-build guard for acceptance criterion 2: upstream whisper.cpp's bundled
+# parakeet must never ship from this port.
+foreach (SPEECH_FORBIDDEN
+         "lib/cmake/parakeet"
+         "lib/pkgconfig/parakeet.pc"
+         "include/parakeet.h")
+    if (EXISTS "${CURRENT_PACKAGES_DIR}/${SPEECH_FORBIDDEN}")
+        message(FATAL_ERROR
+            "speech-cpp: ${SPEECH_FORBIDDEN} was installed — upstream whisper.cpp's "
+            "bundled parakeet leaked past the WHISPER_BUILD_PARAKEET=OFF gate and "
+            "would collide with engines/parakeet's qvac-parakeet package.")
+    endif()
+endforeach()
+file(GLOB SPEECH_UPSTREAM_PARAKEET_LIBS "${CURRENT_PACKAGES_DIR}/lib/*parakeet*")
+foreach (SPEECH_LIB IN LISTS SPEECH_UPSTREAM_PARAKEET_LIBS)
+    get_filename_component(SPEECH_LIB_NAME "${SPEECH_LIB}" NAME)
+    if (NOT SPEECH_LIB_NAME MATCHES "qvac-parakeet")
+        message(FATAL_ERROR
+            "speech-cpp: unexpected parakeet artifact ${SPEECH_LIB_NAME} in lib/ — "
+            "only libqvac-parakeet.* (from engines/parakeet) may be installed.")
+    endif()
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/usage
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/usage
@@ -1,0 +1,31 @@
+speech-cpp is an umbrella port: enable the engines you need as features and
+consume each enabled engine's own CMake package. The default feature set is
+the whisper engine plus the platform's default GPU backend; set
+default-features to false to pick a different engine mix.
+
+  speech-cpp[whisper]:
+    find_package(whisper CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE whisper::whisper)
+
+  speech-cpp[parakeet]:
+    find_package(qvac-parakeet CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE qvac::parakeet)
+
+  speech-cpp[tts]  (Chatterbox, Supertonic, CosyVoice3, Parler-TTS, LavaSR):
+    find_package(tts-cpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE tts-cpp::tts-cpp)
+
+  speech-cpp[audiogen]  (ACE-Step music generation):
+    find_package(audiogen-cpp CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE audiogen-cpp::audiogen-cpp)
+
+GPU backends (fan out to ggml-speech, shared by all engines):
+  metal  - Metal (macOS/iOS; default on Apple platforms)
+  vulkan - Vulkan (default on Windows/Linux/Android)
+  opencl - OpenCL (default on Android)
+Parakeet extra:
+  coreml - Apple Core ML encoder sidecar (implies the parakeet feature)
+
+Example consumer manifest dependency:
+  { "name": "speech-cpp", "default-features": false,
+    "features": ["whisper", "parakeet", "vulkan"] }

--- a/packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/vcpkg.json
@@ -1,0 +1,110 @@
+{
+  "name": "speech-cpp",
+  "version-date": "2026-08-18",
+  "port-version": 3,
+  "description": "LOCAL OVERLAY, NOT FOR MERGE. Umbrella port over the QVAC speech stack with one shared ggml dependency and selectable whisper, parakeet, TTS, and audiogen engines. This overlay revision moves the source pin off the registry's 792b6892 and onto the qvac-ext-lib-whisper.cpp branch feat/minimax-metal (d73fb6ea) to validate MiniMax Metal support before it merges. Requires ggml-speech 2026-08-18.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "default-features": false,
+      "version>=": "2026-08-18"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    },
+    "whisper"
+  ],
+  "features": {
+    "audiogen": {
+      "description": "Build the audiogen engine (ACE-Step music generation) from engines/audiogen. CMake package: find_package(audiogen-cpp CONFIG) + audiogen-cpp::audiogen-cpp."
+    },
+    "coreml": {
+      "description": "Parakeet only: enable the Apple Core ML (Neural Engine) encoder sidecar (presence-driven at runtime; falls back to the ggml encoder when the .mlmodelc sidecar is absent).",
+      "supports": "osx | ios",
+      "dependencies": [
+        {
+          "name": "speech-cpp",
+          "default-features": false,
+          "features": [
+            "parakeet"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration for all enabled engines (macOS / iOS, via ggml-speech[metal]).",
+      "supports": "osx | ios",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "default-features": false,
+          "features": [
+            "metal"
+          ],
+          "platform": "osx | ios"
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration for all enabled engines (Android / Adreno, via ggml-speech[opencl]).",
+      "supports": "android",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "default-features": false,
+          "features": [
+            "opencl"
+          ],
+          "platform": "android"
+        }
+      ]
+    },
+    "parakeet": {
+      "description": "Build the Parakeet engine (NVIDIA FastConformer ASR: CTC / TDT / EOU, plus Sortformer diarization) from engines/parakeet. CMake package: find_package(qvac-parakeet CONFIG) + qvac::parakeet."
+    },
+    "tts": {
+      "description": "Build the TTS engine collection from engines/tts: Resemble Chatterbox (Turbo + Multilingual), Supertonic, Fun-CosyVoice3, Parler-TTS, Audio8 and LavaSR speech enhancement, as one library. CMake package: find_package(tts-cpp CONFIG) + tts-cpp::tts-cpp.",
+      "dependencies": [
+        "mecab"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration for all enabled engines (Linux / Windows / Android; Apple platforms use the metal feature instead, via ggml-speech[vulkan]).",
+      "supports": "!osx & !ios",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "default-features": false,
+          "features": [
+            "vulkan"
+          ],
+          "platform": "!osx & !ios"
+        }
+      ]
+    },
+    "whisper": {
+      "description": "Build the whisper engine from third_party/whisper.cpp (upstream whisper.cpp with the QVAC delta; upstream's bundled parakeet is gated off). CMake package: find_package(whisper CONFIG) + whisper::whisper."
+    }
+  }
+}


### PR DESCRIPTION
> **NOT FOR MERGE as-is.** This branch is a pre-merge validation vehicle: it pins `audiogen-ggml` to an unmerged `qvac-ext-lib-whisper.cpp` branch via a local vcpkg overlay port. Both added artifacts carry `NOT FOR MERGE` headers and removal instructions.

## 🎯 What problem does this PR solve?

- MiniMax Metal support lives on the unmerged `qvac-ext-lib-whisper.cpp` branch `feat/minimax-metal` (`d73fb6ea`). There is no way to build `audiogen-ggml` against it, because the `speech-cpp` source pin is owned by `qvac-registry-vcpkg` and still points at `792b6892`.
- This blocks pre-merge validation: we can't confirm the branch compiles and links in the monorepo's actual vcpkg superbuild config, or that it doesn't regress ACE-Step, until the registry pin advances.

## 📝 How does it solve it?

- Adds `packages/audiogen-ggml/vcpkg-overlay-ports/speech-cpp/` — a verbatim copy of `qvac-registry-vcpkg`'s `ports/speech-cpp` at the baseline this package already pins (`cf1500e9`), with the source pin moved to the branch: `REF d73fb6ea`, matching `SHA512`, `HEAD_REF feat/minimax-metal`. `port-version` bumped `2 → 3` so it satisfies the manifest's `version>=: 2026-08-18#2`; `usage` is unchanged.
- Wires it in via `VCPKG_OVERLAY_PORTS` in `CMakeLists.txt`, placed after `find_package(cmake-vcpkg)` and before `project()` — the same position as the existing `VCPKG_OVERLAY_TRIPLETS` line.
- Both artifacts carry `NOT FOR MERGE` headers with removal instructions, since leaving them in would pin the package to a branch commit and mask registry updates.

**Scope note:** this validates that the branch builds and that ACE-Step still works. It does **not** exercise MiniMax — the addon implements only `acestep/AcestepModel.cpp`, and the port sets `-DSPEECH_BUILD_TESTS=OFF`, so the branch's own `test_minimax_metal_ops.cpp` (CPU-vs-Metal parity for `mm3_cond_conv1d` / `mm3_voc_convt`) does not build through this path. Run `ctest -L gpu` in `qvac-ext-lib-whisper.cpp` for that.

No `CHANGELOG.md` entry, per `.claude/rules/qvac-packages.md`: nothing here reaches consumers of the published package. `package.json` version is intentionally unchanged — `vcpkg-overlay-ports/` is not in the `files` array, and the `CMakeLists.txt` change is build-time only, so nothing ships in the npm tarball.

## 🧪 How was it tested?

- Full `On PR Trigger (AudioGen GGML)` matrix green — [run 32725089538](https://github.com/tetherto/qvac/actions/runs/32725089538): all 9 prebuild platforms, `cpp-lint`, `sanity-checks`, and all 7 integration-test legs, including `macos-26-darwin-arm64-gpu-integration-tests` (the Metal leg, where `gpu-smoke.test.js` asserts `backendDevice === 1` rather than accepting a silent CPU fallback).
- Confirms the branch pin resolves, the SHA512 is correct, and the superbuild links on every target.

<details>
<summary>Fixed en route: the first run failed on every platform at <code>bare-make generate</code></summary>

The overlay path was initially written as `"...;${VCPKG_OVERLAY_PORTS}"`. With that variable unset, the string form yields a **trailing empty list element**; `vcpkg.cmake` emits one flag per element, so that produced a bare `--overlay-ports=`. vcpkg resolved the empty path against the invocation directory (`packages/audiogen-ggml`), found its `vcpkg.json`, treated the directory as a single port, and parsed the project manifest as a port manifest:

```
packages/audiogen-ggml/vcpkg.json: error: $ (a manifest): missing required field 'name' (a package name)
packages/audiogen-ggml/vcpkg.json: error: $ (a manifest): expected a versioning field
```

Fixed by using the list-argument form, where an empty variable expands to nothing:

```cmake
set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports" ${VCPKG_OVERLAY_PORTS})
```

Note that the pre-existing `VCPKG_OVERLAY_TRIPLETS` line has the identical latent bug — silent only because an empty `--overlay-triplets=` finds no triplet files and falls through, whereas an empty `--overlay-ports=` hits a `vcpkg.json` and hard-errors. Not touched here; same one-token fix if wanted.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
