### PR TITLE
QVAC-23467 infra: skip publish-sdk compile on pull_request_target

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -164,12 +164,17 @@ jobs:
           fi
           echo "OK: @qvac/inference, @qvac/sdk, @qvac/bare-sdk, and tetherto-qvac-sdk all at $INF_VER (verified at ${REF})"
 
+      # pull_request_target checks out base.sha, then bun install resolves
+      # @qvac/inference from npm. That cannot typecheck main's SDK source
+      # (workspace-link is SDK Pod Checks). Keep lockstep verify; skip compile.
       - name: Setup Bun
+        if: github.event_name != 'pull_request_target'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:
           bun-version: latest
 
       - name: Configure scoped registry for @tetherto and @qvac packages
+        if: github.event_name != 'pull_request_target'
         env:
           GIT_PAT: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -203,10 +208,12 @@ jobs:
           EOF
 
       - name: Install dependencies
+        if: github.event_name != 'pull_request_target'
         run: bun install
         working-directory: ${{ env.WORKDIR }}
 
       - name: Modify package name for branch-based builds
+        if: github.event_name != 'pull_request_target'
         working-directory: ${{ env.WORKDIR }}
         run: |
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
@@ -266,10 +273,12 @@ jobs:
           fi
 
       - name: Build (includes lint, typecheck, compile)
+        if: github.event_name != 'pull_request_target'
         run: bun run build
         working-directory: ${{ env.WORKDIR }}
 
       - name: Upload build artifacts
+        if: github.event_name != 'pull_request_target'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:
           name: dist
@@ -277,6 +286,7 @@ jobs:
           retention-days: 30
 
       - name: Determine version and tag
+        if: github.event_name != 'pull_request_target'
         id: version
         working-directory: ${{ env.WORKDIR }}
         run: |
@@ -307,6 +317,7 @@ jobs:
   build-bare-sdk:
     name: Build @qvac/bare-sdk (from sdk dist)
     needs: [build]
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -346,6 +357,7 @@ jobs:
   build-inference:
     name: Build @qvac/inference
     needs: [build]
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `publish-sdk.yml` runs on `pull_request_target` and checks out **base.sha** (`main`), then `bun install` + `bun run build` typecheck `@qvac/sdk` against **npm** `@qvac/inference`. Main's SDK source already uses types that published inference does not export, so the job is red on any PR that touches `packages/sdk/**`, `packages/inference/**`, `packages/bare-sdk/**`, or `packages/sdk-python/**`.
- That compile is not a PR-head check. SDK Pod Checks workspace-link in-repo inference. Editing this workflow in the failing PR cannot green the current run, because `pull_request_target` always uses the YAML from `main`.
- Blocks merge for PRs such as #4018 / #4019 when the merge flow rejects any red CI.

## 📝 How does it solve it?

- On `pull_request_target`, keep checkout + lockstep version verify. Skip bun install/compile/artifact upload in `build`, and skip `build-bare-sdk` / `build-inference` (they need the skipped dist).
- Push and `workflow_dispatch` still compile and publish as before.

## 🧪 How was it tested?

- YAML review only. This PR does not match `publish-sdk.yml` path filters, so the broken compile job should not run here.
- After merge: empty-commit or synchronize #4018 so `pull_request_target` picks up this workflow from `main`; `Build and Publish QVAC SDK / build` should pass on lockstep verify alone.
