### PR TITLE
fix[notask]: assemble CLI workspace SDK against local inference

### DIFF
--- a/packages/cli/scripts/preinstall-build-local-sdk.cjs
+++ b/packages/cli/scripts/preinstall-build-local-sdk.cjs
@@ -83,34 +83,15 @@ if (!isMonorepoSibling()) {
   process.exit(0)
 }
 
-if (alreadyBuilt()) {
+const skipCompile = alreadyBuilt()
+run('bun', ['run', './scripts/link-workspace-inference.ts'])
+
+if (skipCompile) {
   console.log('[@qvac/cli preinstall] @qvac/sdk dist is up to date, skipping rebuild')
   process.exit(0)
 }
 
 console.log('[@qvac/cli preinstall] Building local @qvac/sdk at', SDK_DIR)
-
-// Install the SDK's deps under npm. This is fine for the build step despite
-// the SDK's own scripts being bun-flavored — we drive tsc + the alias
-// resolver directly below, so we don't invoke the bun-only `build` script.
-run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=warn'])
-
-// `@qvac/infer-base` and `@qvac/response` pin `bare-events` to 2.4.2 exact,
-// and 2.4.2 ships no .d.ts files — so tsc sees `Stream extends EventEmitter`
-// resolve to an untyped EventEmitter and bails out on `.on`/`.off`/`.once`
-// calls throughout the SDK. Bun's resolver hoists a newer typed bare-events
-// (>=2.8.0) to top level alongside the nested 2.4.2 copies; npm hoists the
-// pinned 2.4.2 itself. Force-install a recent typed bare-events at top
-// level (no package.json mutation — purely a node_modules tweak) so tsc
-// sees the same shape bun does.
-run('npm', [
-  'install',
-  'bare-events@^2.8.0',
-  '--no-save',
-  '--no-audit',
-  '--no-fund',
-  '--loglevel=warn'
-])
 
 try {
   fs.rmSync(path.join(SDK_DIR, 'dist'), { recursive: true, force: true })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- CLI PRs into `main` run SDK Pod Checks against the in-repo SDK so unreleased SDK APIs can land before an npm publish.
- That workspace leg `npm install`ed `packages/sdk` as a store package, which pulled published `@qvac/inference`. Lab addon pins on `main` (e.g. `@qvac/diffusion-cpp@^0.20.0`) then ERESOLVE against the published engine's older peerOptional ranges. CLI-only PRs (including version backmerges) could not merge.

## 📝 How does it solve it?

- Reuse `packages/sdk/scripts/link-workspace-inference.ts` (already used by SDK's own workspace source) so the CLI garage assemble pins `@qvac/inference` to `file:../inference` before `tsc`.
- Skip-compile still skips only `tsc`; the helper always runs so a later `npm install ../sdk` does not re-fetch store inference.
- Drop the `bare-events@^2.8.0 --no-save` npm workaround. That existed because npm hoisted untyped `2.4.2`. The helper `bun install`s the SDK, which already hoists typed `bare-events` (>=2.8.0), same as SDK CI.

## 🧪 How was it tested?

- Confirmed the failing job was `[cli] sdk-source [workspace]` with `peerOptional @qvac/diffusion-cpp@"^0.17.0"` from published `@qvac/inference@0.18.1` vs found `0.20.0`.
- After merge: SDK Pod Checks on a CLI-touching PR should get past that install (no ERESOLVE) and `tsc` the local SDK.
- Committed `@qvac/sdk` range in `packages/cli/package.json` is unchanged.
