### PR TITLE
QVAC-24023 fix[audiogen-ggml]: do not delay cancellation, and pin the mid-generation cancel contract

### DIFF
--- a/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/acestep/AcestepModel.cpp
@@ -148,8 +148,14 @@ void AcestepModel::reload() {
 
 void AcestepModel::cancel() const {
   cancelRequested_.store(true);
-  std::lock_guard lk(engineMu_);
-  if (engine_)
+  // generate() loads the engine under engineMu_ on first use, holding it for
+  // the whole multi-gigabyte load. Blocking here would hold the cancel until
+  // that finished, so a Stop pressed while the models are loading only reached
+  // the engine minutes later. The flag above is the guaranteed path -- the
+  // progress callback returns it on every checkpoint -- so a contended mutex
+  // can be skipped rather than waited on.
+  std::unique_lock lk(engineMu_, std::try_to_lock);
+  if (lk.owns_lock() && engine_)
     engine_->cancel();
 }
 

--- a/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxModel.cpp
+++ b/packages/audiogen-ggml/addon/src/model-interface/minimax/MinimaxModel.cpp
@@ -169,8 +169,11 @@ void MinimaxModel::reload(MinimaxConfig config) {
 
 void MinimaxModel::cancel() const {
   cancelRequested_.store(true);
-  std::lock_guard lock(engineMutex_);
-  if (engine_)
+  // Same reasoning as AcestepModel::cancel(): engineMutex_ is held for the
+  // whole load, and the atomic flag is the guaranteed cancellation path, so a
+  // contended mutex is skipped rather than waited on.
+  std::unique_lock lock(engineMutex_, std::try_to_lock);
+  if (lock.owns_lock() && engine_)
     engine_->cancel();
 }
 

--- a/packages/audiogen-ggml/test/integration/cancel-latency.test.js
+++ b/packages/audiogen-ggml/test/integration/cancel-latency.test.js
@@ -1,0 +1,98 @@
+'use strict'
+
+// Cancellation contract for a generation that is already computing.
+//
+// addon.test.js covers the immediate case: cancel() straight after run(), which
+// aborts before the engine is far in. This file covers the case a user actually
+// hits, pressing Stop mid-generation, and pins two properties that the
+// immediate case cannot observe: cancel() has to settle in bounded time, and a
+// cancelled run must not produce audio.
+//
+// The measured latency is emitted as a comment so CI runs carry the number: a
+// cancel is only honoured at the engine's next progress checkpoint, so the wall
+// time between cancel() and the run unwinding scales with how long one
+// checkpoint takes. On a CPU-bound run that window is where the machine keeps
+// burning cores after the user asked to stop.
+
+const test = require('brittle')
+const path = require('bare-path')
+const { ensureAudiogenModels, getBaseDir } = require('../utils/downloadModel')
+const { loadAudioGen, NO_GPU, INTEGRATION_TIMEOUT_MS } = require('../utils/runAudioGen')
+const { ERR_CODES } = require('@qvac/audiogen-ggml')
+
+const VARIANT = 'turbo-q4'
+// long enough that the LM stage is still running when the cancel lands
+const DURATION_SECONDS = 30
+const SEED = 4231
+// Generous ceiling: this is a regression net, not a performance target. A run
+// that ignores the cancel entirely renders the whole track and blows past it.
+const CANCEL_SETTLE_LIMIT_MS = 180_000
+
+function modelsDir() {
+  return path.join(getBaseDir(), 'models')
+}
+
+test(
+  'AudioGen (ggml): a mid-generation cancel settles and yields no audio',
+  { timeout: INTEGRATION_TIMEOUT_MS },
+  async (t) => {
+    const download = await ensureAudiogenModels({ targetDir: modelsDir(), variant: VARIANT })
+    if (!download.success) {
+      t.fail('ACE-Step models unavailable')
+      return
+    }
+
+    const gen = await loadAudioGen({
+      modelDir: download.modelDir,
+      ditVariant: VARIANT,
+      useGPU: !NO_GPU
+    })
+    t.teardown(() => gen.destroy())
+
+    const response = await gen.run('A long orchestral build.', {
+      duration: DURATION_SECONDS,
+      seed: SEED
+    })
+
+    // Cancel once the engine reports real sampling progress, so the run is
+    // genuinely mid-flight rather than still setting up.
+    let cancelStartedAt = 0
+    let cancelSettledAt = 0
+    let pcmSamples = 0
+    let ticksAfterCancel = 0
+
+    for await (const item of response.iterate()) {
+      if (item && item.progress) {
+        if (cancelStartedAt) {
+          ticksAfterCancel += 1
+          continue
+        }
+        if (item.progress.stage === 'lm' && item.progress.step > 0) {
+          cancelStartedAt = Date.now()
+          await gen.cancel()
+          cancelSettledAt = Date.now()
+        }
+        continue
+      }
+      if (item && item.outputArray) pcmSamples += item.outputArray.length
+    }
+
+    t.ok(cancelStartedAt > 0, 'the run reached the sampling stage before being cancelled')
+
+    const settleMs = cancelSettledAt - cancelStartedAt
+    t.comment(`cancel() settled in ${settleMs}ms, ${ticksAfterCancel} progress ticks followed`)
+    t.ok(
+      settleMs < CANCEL_SETTLE_LIMIT_MS,
+      `cancel() settles within ${CANCEL_SETTLE_LIMIT_MS}ms (took ${settleMs}ms)`
+    )
+
+    t.is(pcmSamples, 0, 'a cancelled run emits no audio')
+
+    try {
+      await response.await()
+      t.fail('a cancelled response must reject')
+    } catch (error) {
+      t.is(error.code, ERR_CODES.CANCELLED, 'the cancelled run rejects as cancelled')
+    }
+  }
+)


### PR DESCRIPTION
## What

Two narrow changes to `audiogen-ggml` cancellation, from investigating QVAC-24023 ("Stop does not stop music generation"):

1. `AcestepModel::cancel()` and `MinimaxModel::cancel()` no longer block on `engineMu_` / `engineMutex_`.
2. A new integration test that pins the cancellation contract for a run that is already computing.

## Why

QVAC-24023 reports that pressing Stop during music generation ends the chat response while the generation keeps saturating the CPU. Measuring the addon directly (same shipped build, matched parameters on macOS arm64 and Linux x86-64) shows cancellation is honoured on both platforms - no audio is produced and the run ends early - but it is not prompt:

| | macOS arm64 (native) | Linux x86-64 (emulated) |
|---|---|---|
| `cancel()` settled after | 17.1 s | 182 s |
| audio produced | none | none |
| LM stage reached | ~65 of 200 steps | ~65 of 200 steps |

The run is only abandoned at the engine's next progress checkpoint, so the machine keeps computing for tens of steps after the user asked to stop. Both platforms stop at the same step, so this is the engine's checkpoint granularity rather than anything platform specific. That granularity lives in `speech-cpp`, not here, so this PR does not claim to fix it - it stops the SDK from adding avoidable delay on top, and adds the regression net that makes the latency visible.

<details>
<summary>Measurement runs (same script, both platforms, <code>useGPU:false</code>, 20 s track, cancel at LM step 10)</summary>

macOS arm64, native:

```
[    337ms] loaded (useGPU=false, duration=20s, cancel at lm step 10)
[  11768ms] tick lm 1/200
[  13961ms] tick lm 17/200
[  13961ms] >>> calling cancel()
[  31025ms] >>> cancel() returned (+17064ms)
[  31025ms] tick AFTER cancel: lm 65/200
[  31025ms] stream ended (+17064ms after cancel)

ticks after cancel:  11
time cancel->end:    17102ms
pcm bytes produced:  0
stats: {"audioDurationMs":0,"totalTimeMs":30686.9,"realTimeFactor":0,"backendDevice":0,"backendId":0}
VERDICT: cancel HONORED - generation stopped early
```

Linux x86-64, emulated CPU (so per-step time is roughly 16x the macOS run):

```
[   2804ms] loaded (useGPU=false, duration=20s, cancel at lm step 10)
[ 473441ms] tick lm 1/200
[ 510836ms] tick lm 17/200
[ 510840ms] >>> calling cancel()
[ 692980ms] >>> cancel() returned (+182139ms)
[ 692981ms] tick AFTER cancel: lm 65/200
[ 692994ms] stream ended (+182154ms after cancel)

ticks after cancel:  10
time cancel->end:    182647ms
pcm bytes produced:  0
VERDICT: cancel HONORED - generation stopped early
```

Both runs stop at the same LM step (65 of 200) despite a ~16x difference in per-step time, which is what points at a fixed checkpoint interval rather than a time-based or platform-specific effect. The standalone probe used here is available on request; the new integration test in this PR measures the same thing inside the suite.

</details>

### 1. Cancel held behind an in-flight load

`generate()` calls `loadLocked()` on first use while holding the engine mutex for the whole multi-gigabyte load. `cancel()` took the same mutex, so a Stop pressed while the models were still loading could not reach `engine_->cancel()` until the load finished.

`cancelRequested_` is set before the lock and the progress callback returns it at every checkpoint, so the atomic flag is the guaranteed cancellation path. The lock is now `try_to_lock`: uncontended (the normal case) behaviour is unchanged, and a contended lock is skipped instead of waited on. `MinimaxModel` had the identical pattern and gets the identical change.

### 2. Missing coverage for a mid-flight cancel

`addon.test.js` already covers "immediate ACE-Step cancellation is terminal", but it cancels straight after `run()`, before the engine is far in, and asserts only that the response rejects. It cannot observe how long a cancel takes or whether a partially rendered track leaks out.

The new test lets the run reach the sampling stage, cancels there, and asserts:

- `cancel()` settles within a bounded time (180 s, chosen as a generous regression net rather than a performance target: a run that ignored the cancel would render the whole 30 s track and blow past it),
- a cancelled run emits no PCM at all,
- the response still rejects with `CANCELLED`.

It also emits the measured settle time and the number of progress ticks that followed as a `t.comment`, so every CI run carries the current number. That is the data needed to decide whether the checkpoint granularity in `speech-cpp` is worth tightening.

## Testing

- `prettier` clean on the new test; `node --check` passes.
- **Not compiled or run here**: the addon needs vcpkg plus `speech-cpp`, and the integration test needs the multi-GB ACE-Step models, neither of which I have in this environment. The C++ change is small and local, but it wants a real CI build, and the new test wants a runner with the models provisioned. Flagging that explicitly rather than implying more verification than was done.

## Follow-up, not in this PR

`SingleJobScheduler::cancelImpl()` waits on `processingSync_.waitInactive()` with no timeout and no logging, so a slow cancel is invisible in logs. A bounded wait that logs a warning would make the reported symptom diagnosable from a user's log bundle. It sits in the shared `inference-addon-cpp` package and affects every addon, so it seemed worth raising separately rather than folding in here.
