### PR TITLE
QVAC-23802 feat[audiogen-ggml]: add an opt-in cuda feature

### DIFF
--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 option(BUILD_TESTING "Build tests" OFF)
 option(ENABLE_VULKAN "Enable Vulkan GPU acceleration" OFF)
+option(ENABLE_CUDA "Enable CUDA GPU acceleration (needs nvcc on the build host)" OFF)
 
 if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
@@ -9,6 +10,10 @@ endif()
 
 if(ENABLE_VULKAN)
   list(APPEND VCPKG_MANIFEST_FEATURES "vulkan")
+endif()
+
+if(ENABLE_CUDA)
+  list(APPEND VCPKG_MANIFEST_FEATURES "cuda")
 endif()
 
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -41,6 +41,20 @@
     }
   ],
   "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "speech-cpp",
+          "version>=": "2026-08-24#2",
+          "default-features": false,
+          "features": [
+            "cuda"
+          ],
+          "platform": "!(osx | ios | android)"
+        }
+      ]
+    },
     "tests": {
       "description": "Build C++ unit tests",
       "dependencies": [


### PR DESCRIPTION
## Status
Ready. Final link of QVAC-23802 (AudioGen CUDA for ACE-Step and MiniMax). One commit, 19 added lines, no behaviour change to any existing build.

## Why
The engine work merged in tetherto/qvac-ext-lib-whisper.cpp#162 and the ports in tetherto/qvac-registry-vcpkg#326 (which added `speech-cpp`'s `cuda` feature — it previously exposed only metal / vulkan / opencl). This addon was the remaining gap: its manifest hardcoded `speech-cpp[audiogen,vulkan]` for desktop and exposed only `ENABLE_VULKAN`, so a CUDA build was not selectable from here and the merged CUDA support stayed unreachable for consumers.

## What changes
Mirrors the existing vulkan plumbing exactly:
- `CMakeLists.txt`: `option(ENABLE_CUDA ...)` appending the `cuda` manifest feature.
- `vcpkg.json`: a `cuda` feature depending on `speech-cpp[cuda]`, which in turn pulls `ggml-speech[cuda]`.

Off by default, and excluded on Apple and Android to match `speech-cpp`'s own `supports: "!osx & !ios & !android"`, so **every current build resolves exactly as before**. `nvcc` is needed only on the build host; the runtime needs just the driver. No CUDA-specific staging was required — the backend install plumbing already iterates `GGML_AVAILABLE_BACKENDS`, so a CUDA-enabled ggml is picked up by the existing code.

## Verification
`vcpkg install --dry-run --x-feature=cuda --triplet=x64-linux` against this manifest resolves the whole chain:

```
ggml-speech[core,cuda,vulkan]:x64-linux@2026-08-21
speech-cpp[audiogen,core,cuda,vulkan]:x64-linux@2026-08-24#2
```

CUDA is additive alongside Vulkan, and the engine's validated-GPU preference selects CUDA when both backends are compiled in. A control run with a deliberately bogus `--x-feature=cudaXX` warns `not a feature supported`, which the `cuda` run does not — confirming the feature is recognised rather than silently ignored.

Engine-level CUDA behaviour behind this feature was validated on an RTX 5090 (CUDA 12.9, sm_120) while landing #162 / #326: ACE-Step `test-acestep-integration` passes on CUDA and CPU, MiniMax `test-minimax-quality` passes with `MM3_DEVICE=gpu`, and the full speech superbuild compiles with `GGML_CUDA=ON` (661/661 targets, `ctest -L unit` 62/62).

## Out of scope
Prebuilds stay Vulkan-only. The reusable prebuild workflow provisions a Vulkan SDK (`include-vulkan-sdk: true`) and has no CUDA equivalent, so shipping CUDA artifacts needs nvcc on the builders — shared-CI-infra work rather than a change to this package. This PR only makes a CUDA build selectable.

Note this is the first `ENABLE_CUDA` lane in the monorepo; `tts-ggml` merged three CUDA engine tickets (Chatterbox, Supertonic, Parler-TTS) and would want the identical two-hunk change if the platform owners want to generalise it.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217591858523925