### PR TITLE
chore[skiplog|notask]: drop TypeScript baseUrl from @qvac/rag

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works — switch to `import`. Named exports are unchanged (#3718).
+- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works. Switch to `import`. Named exports are unchanged (#3718).
 
 ### Fixed
 

--- a/packages/rag/tsconfig.json
+++ b/packages/rag/tsconfig.json
@@ -11,7 +11,6 @@
     "types": [],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "paths": {
       "@qvac/rag": ["./src/index.ts"]
     },


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/rag` 0.7.0 npm publish failed: `prepare` runs `tsc -p tsconfig.build.json`, and TypeScript 7 rejects `baseUrl` (`TS5102`).
- 0.7.0 is not on npm. No `rag-v0.7.0` tag.

## 📝 How does it solve it?

- Remove `baseUrl` from `packages/rag/tsconfig.json`. `paths` already uses `./src/index.ts`.

## 🧪 How was it tested?

- Diff is one compiler option. Publish job on `release-rag-0.7.0` is the verification.
