### PR TITLE
chore[skiplog|notask]: backmerge release-rag-0.7.0 — drop TypeScript baseUrl

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works — switch to `import`. Named exports are unchanged (#3718).
+- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works. Switch to `import`. Named exports are unchanged (#3718).
 
 ### Fixed
 

--- a/packages/rag/tsconfig.json
+++ b/packages/rag/tsconfig.json
@@ -11,7 +11,6 @@
     "types": [],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "baseUrl": ".",
     "paths": {
       "@qvac/rag": ["./src/index.ts"]
     },


### PR DESCRIPTION
## What this PR does

Lands the `@qvac/rag` tsconfig `baseUrl` drop on `main` so it stays aligned with `release-rag-0.7.0`. `[skiplog]` — compile config only, not a product change.

## Companion release PR

- https://github.com/tetherto/qvac/pull/4049

## Files

- `packages/rag/tsconfig.json` — remove `baseUrl` (TypeScript 7 `TS5102`; unblocks 0.7.0 npm publish)
