### PR TITLE
QVAC-24136 doc: update SDK pod references for the post-split layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,9 @@ npx standard <file>        # JS lint (standardjs)
 npm run lint               # lint all JS (excludes addon/)
 ```
 
-### SDK (packages/qvac-sdk)
+### SDK (packages/sdk)
 ```bash
-cd packages/qvac-sdk
+cd packages/sdk
 bun install
 bun run build       # lint + typecheck + compile
 bun run lint        # eslint + typecheck

--- a/packages/ocr-ggml/.agent/agents/consistency-reviewer.md
+++ b/packages/ocr-ggml/.agent/agents/consistency-reviewer.md
@@ -40,7 +40,7 @@ cat packages/translation-nmtcpp/index.js
 
 Also check `package.json` scripts and structure of both reference packages.
 
-If the changed package is a different type (SDK/TypeScript vs addon/C++), read the appropriate reference instead (e.g., `packages/qvac-sdk` for TypeScript packages).
+If the changed package is a different type (SDK/TypeScript vs addon/C++), read the appropriate reference instead (e.g., `packages/sdk` for TypeScript packages).
 
 ### Step 4: Consistency review checklist
 

--- a/packages/ocr-ggml/.agent/knowledge/ci-validation.md
+++ b/packages/ocr-ggml/.agent/knowledge/ci-validation.md
@@ -31,14 +31,14 @@ Each addon has a full suite of per-package workflows:
 
 ### SDK Pod (TypeScript packages)
 
-Packages: `qvac-sdk`, `qvac-cli`, `rag`, `logging`, `error-base`, `docs`
+Packages: `sdk`, `bare-sdk`, `inference`, `cli`, `rag`, `logging`, `error`, `ai-sdk-provider`
 
 | Workflow | File | Purpose |
 |----------|------|---------|
 | PR validation | `pr-validation-sdk-pod.yml` | Validate PR title/body format |
 | PR checks | `pr-checks-sdk-pod.yml` | Lint, typecheck, build, unit tests (dynamic matrix of changed packages) |
-| Publish | `publish-qvac-sdk.yml` | Build + publish SDK to GPR/npm |
-| Desktop tests | `test-qvac-sdk.yml` | GPU integration tests (currently workflow_dispatch only) |
+| Publish | `publish-sdk.yml` | Build + publish SDK to GPR/npm |
+| Desktop tests | `test-sdk.yml` | GPU integration tests (currently workflow_dispatch only) |
 | Release notes | `release-notes-check-<pkg>.yml` | Verify CHANGELOG matches version bumps |
 | GitHub release | `create-github-release-<pkg>.yml` | Create GitHub release on npm publish |
 
@@ -303,8 +303,8 @@ Replace `<pkg>` with the package directory name (e.g., `llm-llamacpp`):
 |------|------|
 | PR format validation | `pr-validation-sdk-pod.yml` |
 | PR checks (lint, build, test) | `pr-checks-sdk-pod.yml` |
-| Publish | `publish-qvac-sdk.yml` |
-| Desktop GPU tests | `test-qvac-sdk.yml` |
+| Publish | `publish-sdk.yml` |
+| Desktop GPU tests | `test-sdk.yml` |
 
 ### Simple libraries
 

--- a/packages/ocr-ggml/.agent/skills/orchestrate/SKILL.md
+++ b/packages/ocr-ggml/.agent/skills/orchestrate/SKILL.md
@@ -83,7 +83,7 @@ Run `git diff --name-only main...HEAD` and apply these rules:
 
 1. **Native addon packages** — if changed files match a package in the **CI Package Mapping** table in `.agent/knowledge/ci-validation.md`, CI is needed. Use the short name from that table. If multiple addon packages changed, run CI for each.
 
-2. **SDK / TS packages** (`packages/qvac-sdk/**`, `packages/rag/**`, `packages/cli/**`) — SDK CI runs automatically via `pr-checks-sdk-pod` on PR creation. No manual trigger needed.
+2. **SDK / TS packages** (`packages/sdk/**`, `packages/rag/**`, `packages/cli/**`) — SDK CI runs automatically via `pr-checks-sdk-pod` on PR creation. No manual trigger needed.
 
 3. **Everything else** (simple libraries, docs, workflows, config, markdown) — no CI needed.
 
@@ -153,7 +153,7 @@ If no CI needed or no reviewer fixes, proceed to reporting.
    ```
 
 2. **Determine PR type** from the changed files:
-   - If changes are in `packages/qvac-sdk/` or other TS packages → SDK PR
+   - If changes are in `packages/sdk/` or other TS packages → SDK PR
    - If changes are in native addon packages → Addon PR
    - If mixed → use addon format (more detailed)
 

--- a/packages/ocr-ggml/.agent/skills/release/SKILL.md
+++ b/packages/ocr-ggml/.agent/skills/release/SKILL.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 
 Release a package to NPM. Ensures version bump, changelog, release branch, CI pipeline, and npm publish.
 
-The package is identified by the `<package-name>` argument, which is the directory name under `packages/` (e.g., `ocr-ggml`, `qvac-sdk`, `tts-onnx`). The skill reads `packages/<package-name>/package.json` to determine the package type and npm scope.
+The package is identified by the `<package-name>` argument, which is the directory name under `packages/` (e.g., `ocr-ggml`, `sdk`, `tts-ggml`). The skill reads `packages/<package-name>/package.json` to determine the package type and npm scope.
 
 ## Usage
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Repo and agent config still referred to the old `packages/qvac-sdk` directory and the renamed `publish-qvac-sdk.yml` / `test-qvac-sdk.yml` workflows.
- The SDK pod package list was stale (`error-base`, `docs`, missing `inference` / `bare-sdk`).

## 📝 How does it solve it?

- `CLAUDE.md`: SDK build section now points at `packages/sdk`.
- `.agent/knowledge/ci-validation.md`: pod list corrected to the real dirs (`sdk`, `bare-sdk`, `inference`, `cli`, `rag`, `logging`, `error`, `ai-sdk-provider`); workflow names updated to `publish-sdk.yml` / `test-sdk.yml`.
- `.agent/agents/consistency-reviewer.md`, `.agent/skills/orchestrate/SKILL.md`, `.agent/skills/release/SKILL.md`: `packages/qvac-sdk` → `packages/sdk` and the dead `tts-onnx` example → `tts-ggml`.
- Docs-only text changes; the generated `.claude/` / `.cursor/` copies refresh on the next `/setup`.