### PR TITLE
infra[notask]: publish rag/logging/error libs from prebuilt dist

### DIFF
--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -1,6 +1,11 @@
 name: General CI/CD (error)
-# This workflow is used to call the reusable workflows in the qvac repository
-# https://github.com/qvac/blob/main/.github/workflows/public-reusable-npm.yml
+# Publishes @qvac/error. Since the TS/ESM migration the package has a real build
+# step (`prepare` -> `tsc -p tsconfig.build.json`). The old generic path ran that
+# build implicitly during `npm publish` in a job with no `node_modules`, so `tsc`
+# failed and the publish broke. This workflow instead compiles `dist` once in a
+# dedicated `build` job, uploads it, and every publish job downloads that
+# prebuilt `dist` and publishes with NPM_CONFIG_IGNORE_SCRIPTS=true so
+# `npm publish` ships it as-is instead of re-running the `prepare` build.
 
 on:
   push:
@@ -11,20 +16,19 @@ on:
       - tmp-*
     paths:
       - "packages/error/**"
+      - ".github/workflows/trigger-reusable-lib-error.yml"
   workflow_dispatch:
     inputs:
-      custom_input_1:
-        required: false
-        type: string
-      custom_input_2:
-        required: false
-        type: string
-      custom_input_3:
+      npm_tag:
+        description: "Optional npm dist-tag override for release branches"
         required: false
         type: string
 
 permissions:
   contents: read
+
+env:
+  WORKDIR: packages/error
 
 jobs:
   release-merge-guard:
@@ -94,19 +98,66 @@ jobs:
           echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
+  # Install deps + compile dist ONCE, then hand the built dist to every publish
+  # job so `npm publish` never has to rebuild in a node_modules-less job.
+  build:
+    name: Build @qvac/error
+    needs: [publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true'
+      || needs.publish-logic.outputs.publish_feature == 'true'
+      || needs.publish-logic.outputs.publish_tmp == 'true'
+      || needs.publish-logic.outputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: bun install
+
+      - name: Build
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run build
+
+      - name: Upload package dist
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: error-dist
+          path: packages/error/dist
+          if-no-files-found: error
+          retention-days: 30
+
   publish-main-gpr-dev:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_main == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    # dist is prebuilt in the `build` job; skip lifecycle scripts so `npm publish`
+    # ships it as-is instead of re-running the `prepare` build with no node_modules.
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: error-dist
+          path: packages/error/dist
 
       - name: Publish to GitHub Packages (dev)
         uses: ./.github/actions/publish-library-to-gpr
@@ -121,17 +172,43 @@ jobs:
     needs:
       - publish-logic
       - release-merge-guard
+      - build
     permissions:
       contents: write
       packages: write
       id-token: write
     if: |-
       (always() && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
-    uses: ./.github/workflows/public-reusable-npm.yml
-    secrets: inherit
-    with:
-      workdir: packages/error
-      caller_event_name: ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    environment: npm
+    outputs:
+      published_version: ${{ steps.publish-npm.outputs.npm_published_version }}
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: error-dist
+          path: packages/error/dist
+
+      - name: Determine dist-tag
+        id: dist-tag
+        uses: tetherto/qvac-actions/npm-dist-tag-determination@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          workdir: packages/error
+          tag: ${{ inputs.npm_tag }}
+
+      - name: Publish to NPM
+        id: publish-npm
+        uses: tetherto/qvac-actions/publish-library-to-npm@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          tag: ${{ steps.dist-tag.outputs.tag }}
+          workdir: packages/error
 
   # Tag the published version (no GitHub Release; SDK-only releases policy)
   create-tag:
@@ -147,16 +224,25 @@ jobs:
   publish-feature-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_feature == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: error-dist
+          path: packages/error/dist
 
       - name: Publish to GitHub Packages (feature)
         uses: ./.github/actions/publish-library-to-gpr
@@ -170,16 +256,25 @@ jobs:
   publish-tmp-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_tmp == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: error-dist
+          path: packages/error/dist
 
       - name: Publish to GitHub Packages (tmp)
         uses: ./.github/actions/publish-library-to-gpr

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -1,6 +1,11 @@
 name: General CI/CD (logging)
-# This workflow is used to call the reusable workflows in the qvac repository
-# https://github.com/qvac/blob/main/.github/workflows/public-reusable-npm.yml
+# Publishes @qvac/logging. Since the TS/ESM migration the package has a real
+# build step (`prepare` -> `tsc -p tsconfig.build.json`). The old generic path
+# ran that build implicitly during `npm publish` in a job with no `node_modules`,
+# so `tsc` failed and the publish broke. This workflow instead compiles `dist`
+# once in a dedicated `build` job, uploads it, and every publish job downloads
+# that prebuilt `dist` and publishes with NPM_CONFIG_IGNORE_SCRIPTS=true so
+# `npm publish` ships it as-is instead of re-running the `prepare` build.
 
 on:
   push:
@@ -11,20 +16,19 @@ on:
       - tmp-*
     paths:
       - "packages/logging/**"
+      - ".github/workflows/trigger-reusable-lib-logging.yml"
   workflow_dispatch:
     inputs:
-      custom_input_1:
-        required: false
-        type: string
-      custom_input_2:
-        required: false
-        type: string
-      custom_input_3:
+      npm_tag:
+        description: "Optional npm dist-tag override for release branches"
         required: false
         type: string
 
 permissions:
   contents: read
+
+env:
+  WORKDIR: packages/logging
 
 jobs:
   release-merge-guard:
@@ -94,19 +98,66 @@ jobs:
           echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
+  # Install deps + compile dist ONCE, then hand the built dist to every publish
+  # job so `npm publish` never has to rebuild in a node_modules-less job.
+  build:
+    name: Build @qvac/logging
+    needs: [publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true'
+      || needs.publish-logic.outputs.publish_feature == 'true'
+      || needs.publish-logic.outputs.publish_tmp == 'true'
+      || needs.publish-logic.outputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: bun install
+
+      - name: Build
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run build
+
+      - name: Upload package dist
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: logging-dist
+          path: packages/logging/dist
+          if-no-files-found: error
+          retention-days: 30
+
   publish-main-gpr-dev:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_main == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    # dist is prebuilt in the `build` job; skip lifecycle scripts so `npm publish`
+    # ships it as-is instead of re-running the `prepare` build with no node_modules.
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: logging-dist
+          path: packages/logging/dist
 
       - name: Publish to GitHub Packages (dev)
         uses: ./.github/actions/publish-library-to-gpr
@@ -121,17 +172,43 @@ jobs:
     needs:
       - publish-logic
       - release-merge-guard
+      - build
     permissions:
       contents: write
       packages: write
       id-token: write
     if: |-
       (always() && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
-    uses: ./.github/workflows/public-reusable-npm.yml
-    secrets: inherit
-    with:
-      workdir: packages/logging
-      caller_event_name: ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    environment: npm
+    outputs:
+      published_version: ${{ steps.publish-npm.outputs.npm_published_version }}
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: logging-dist
+          path: packages/logging/dist
+
+      - name: Determine dist-tag
+        id: dist-tag
+        uses: tetherto/qvac-actions/npm-dist-tag-determination@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          workdir: packages/logging
+          tag: ${{ inputs.npm_tag }}
+
+      - name: Publish to NPM
+        id: publish-npm
+        uses: tetherto/qvac-actions/publish-library-to-npm@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          tag: ${{ steps.dist-tag.outputs.tag }}
+          workdir: packages/logging
 
   # Tag the published version (no GitHub Release; SDK-only releases policy)
   create-tag:
@@ -147,16 +224,25 @@ jobs:
   publish-feature-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_feature == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: logging-dist
+          path: packages/logging/dist
 
       - name: Publish to GitHub Packages (feature)
         uses: ./.github/actions/publish-library-to-gpr
@@ -170,16 +256,25 @@ jobs:
   publish-tmp-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_tmp == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: logging-dist
+          path: packages/logging/dist
 
       - name: Publish to GitHub Packages (tmp)
         uses: ./.github/actions/publish-library-to-gpr

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -1,6 +1,12 @@
 name: General CI/CD (rag)
-# This workflow is used to call the reusable workflows in the qvac repository
-# https://github.com/qvac/blob/main/.github/workflows/public-reusable-npm.yml
+# Publishes @qvac/rag. Since the TS/ESM migration the package has a real build
+# step (`prepare` -> `tsc -p tsconfig.build.json` + a Bare hyperspec copy). The
+# old generic path ran that build implicitly during `npm publish` in a job with
+# no `node_modules`, so `tsc` could not resolve `@qvac/*`, `ready-resource`, etc.
+# and the publish failed. This workflow instead compiles `dist` once in a
+# dedicated `build` job, uploads it, and every publish job downloads that
+# prebuilt `dist` and publishes with NPM_CONFIG_IGNORE_SCRIPTS=true so
+# `npm publish` ships it as-is instead of re-running the `prepare` build.
 
 on:
   push:
@@ -11,20 +17,19 @@ on:
       - tmp-*
     paths:
       - "packages/rag/**"
+      - ".github/workflows/trigger-reusable-lib-rag.yml"
   workflow_dispatch:
     inputs:
-      custom_input_1:
-        required: false
-        type: string
-      custom_input_2:
-        required: false
-        type: string
-      custom_input_3:
+      npm_tag:
+        description: "Optional npm dist-tag override for release branches"
         required: false
         type: string
 
 permissions:
   contents: read
+
+env:
+  WORKDIR: packages/rag
 
 jobs:
   release-merge-guard:
@@ -94,19 +99,66 @@ jobs:
           echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
+  # Install deps + compile dist ONCE, then hand the built dist to every publish
+  # job so `npm publish` never has to rebuild in a node_modules-less job.
+  build:
+    name: Build @qvac/rag
+    needs: [publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true'
+      || needs.publish-logic.outputs.publish_feature == 'true'
+      || needs.publish-logic.outputs.publish_tmp == 'true'
+      || needs.publish-logic.outputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: bun install
+
+      - name: Build (compile + copy hyperspec)
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run build
+
+      - name: Upload package dist
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: rag-dist
+          path: packages/rag/dist
+          if-no-files-found: error
+          retention-days: 30
+
   publish-main-gpr-dev:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_main == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    # dist is prebuilt in the `build` job; skip lifecycle scripts so `npm publish`
+    # ships it as-is instead of re-running the `prepare` build with no node_modules.
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
 
       - name: Publish to GitHub Packages (dev)
         uses: ./.github/actions/publish-library-to-gpr
@@ -121,17 +173,43 @@ jobs:
     needs:
       - publish-logic
       - release-merge-guard
+      - build
     permissions:
       contents: write
       packages: write
       id-token: write
     if: |-
       (always() && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
-    uses: ./.github/workflows/public-reusable-npm.yml
-    secrets: inherit
-    with:
-      workdir: packages/rag
-      caller_event_name: ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    environment: npm
+    outputs:
+      published_version: ${{ steps.publish-npm.outputs.npm_published_version }}
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
+
+      - name: Determine dist-tag
+        id: dist-tag
+        uses: tetherto/qvac-actions/npm-dist-tag-determination@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          workdir: packages/rag
+          tag: ${{ inputs.npm_tag }}
+
+      - name: Publish to NPM
+        id: publish-npm
+        uses: tetherto/qvac-actions/publish-library-to-npm@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          tag: ${{ steps.dist-tag.outputs.tag }}
+          workdir: packages/rag
 
   # Tag the published version (no GitHub Release; SDK-only releases policy)
   create-tag:
@@ -147,16 +225,25 @@ jobs:
   publish-feature-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_feature == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
 
       - name: Publish to GitHub Packages (feature)
         uses: ./.github/actions/publish-library-to-gpr
@@ -170,16 +257,25 @@ jobs:
   publish-tmp-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_tmp == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
 
       - name: Publish to GitHub Packages (tmp)
         uses: ./.github/actions/publish-library-to-gpr


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Publishing `@qvac/rag`, `@qvac/logging`, and `@qvac/error` to npm/GPR is broken. Since these libraries were migrated to TypeScript/ESM they gained a real build step (`"prepare": "npm run build"` → `tsc -p tsconfig.build.json`). The generic publish path runs `npm publish` in a job with no `node_modules`, so the implicit `prepare` build fails.
- Concretely, the `release-rag-0.7.0` publish run failed at "Publish to npm" with `tsc` errors: `Cannot find module '@qvac/logging'`, `Cannot find module 'ready-resource'`, and `Expected 0 arguments, but got 1` — all symptoms of `tsc` running without installed dependencies. `logging` and `error` have the same latent break on their next release.

## 📝 How does it solve it?

- Reworks the three `trigger-reusable-lib-{rag,logging,error}.yml` workflows to the build-first pattern already used by `trigger-reusable-lib-ai-sdk-provider.yml` / `-cli.yml` on `main`:
  - A dedicated `build` job installs dependencies (`bun install`) and compiles once (`npm run build`), then uploads `dist/` as an artifact (`if-no-files-found: error`).
  - Every publish job (`publish-main-gpr-dev`, `publish-feature-gpr`, `publish-tmp-gpr`, `publish-release-npm`) now `needs: build`, downloads the prebuilt `dist`, and runs with `NPM_CONFIG_IGNORE_SCRIPTS: "true"` so `npm publish` ships the artifact instead of re-firing the `prepare` → `tsc` build. (The env guard is needed here because — unlike `ai-sdk-provider` — these packages keep a `prepare` script for local dev.)
  - `publish-release-npm` is converted from the `public-reusable-npm.yml` reusable-workflow call to an inline job that downloads the dist and publishes via the SHA-pinned `npm-dist-tag-determination` / `publish-library-to-npm` actions, exposing `published_version` for the existing `create-tag` job.
- Also replaces the unused `custom_input_1/2/3` dispatch inputs with the `npm_tag` override and adds the workflow's own path to `on.push.paths` (both matching the canonical lib workflows), and keeps the inline `publish-logic` job and GPR jobs otherwise intact.

## 🧪 How was it tested?

- `actionlint` structural gate (the CI check via `.github/scripts/lint-workflows.mjs`) is clean on all three files. The only remaining `actionlint` findings are pre-existing dead `npm-token` inputs on the GPR publish step (already present on `main`, explicitly ignored by the gate).
- Reproduced the fix locally with `bun install && npm run build` for each package: `@qvac/error` and `@qvac/logging` compile and emit `dist/` (`index.js` + `.d.ts`); `@qvac/rag` emits its full compiled `dist/` tree via `tsc` — confirming the CI failures were solely `tsc` running without `node_modules`.
- Verified the RAG `bare scripts/copy-hyperspec.ts` step's source (`src/adapters/database/hyperspec/**`) is committed, so the copy succeeds on the `ubuntu-latest` build runner (it only trips a Windows-local path quirk during local dev).

## 🔐 Action pinning

New action references added (all SHA-pinned with `# <version>`, matching the versions already used by the `ai-sdk-provider` / `cli` lib workflows on `main`):

- `oven-sh/setup-bun`: added `@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0`
- `actions/upload-artifact`: added `@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0`
- `tetherto/qvac-actions/npm-dist-tag-determination`: added `@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0`
- `tetherto/qvac-actions/publish-library-to-npm`: added `@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0`

First-party composite actions (`download-release-artifact`, `publish-library-to-gpr`, `release-merge-guard`) are referenced by relative path per repo convention. Permissions scopes are unchanged from the prior workflows.
