### PR TITLE
infra[notask|skiplog]: publish rag from prebuilt dist to unblock release-rag-0.7.0

### DIFF
--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -1,6 +1,12 @@
 name: General CI/CD (rag)
-# This workflow is used to call the reusable workflows in the qvac repository
-# https://github.com/qvac/blob/main/.github/workflows/public-reusable-npm.yml
+# Publishes @qvac/rag. Since the TS/ESM migration the package has a real build
+# step (`prepare` -> `tsc -p tsconfig.build.json` + a Bare hyperspec copy). The
+# old generic path ran that build implicitly during `npm publish` in a job with
+# no `node_modules`, so `tsc` could not resolve `@qvac/*`, `ready-resource`, etc.
+# and the publish failed. This workflow instead compiles `dist` once in a
+# dedicated `build` job, uploads it, and every publish job downloads that
+# prebuilt `dist` and publishes with NPM_CONFIG_IGNORE_SCRIPTS=true so
+# `npm publish` ships it as-is instead of re-running the `prepare` build.
 
 on:
   push:
@@ -11,20 +17,19 @@ on:
       - tmp-*
     paths:
       - "packages/rag/**"
+      - ".github/workflows/trigger-reusable-lib-rag.yml"
   workflow_dispatch:
     inputs:
-      custom_input_1:
-        required: false
-        type: string
-      custom_input_2:
-        required: false
-        type: string
-      custom_input_3:
+      npm_tag:
+        description: "Optional npm dist-tag override for release branches"
         required: false
         type: string
 
 permissions:
   contents: read
+
+env:
+  WORKDIR: packages/rag
 
 jobs:
   release-merge-guard:
@@ -94,19 +99,66 @@ jobs:
           echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
+  # Install deps + compile dist ONCE, then hand the built dist to every publish
+  # job so `npm publish` never has to rebuild in a node_modules-less job.
+  build:
+    name: Build @qvac/rag
+    needs: [publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true'
+      || needs.publish-logic.outputs.publish_feature == 'true'
+      || needs.publish-logic.outputs.publish_tmp == 'true'
+      || needs.publish-logic.outputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: bun install
+
+      - name: Build (compile + copy hyperspec)
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run build
+
+      - name: Upload package dist
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: rag-dist
+          path: packages/rag/dist
+          if-no-files-found: error
+          retention-days: 30
+
   publish-main-gpr-dev:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_main == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    # dist is prebuilt in the `build` job; skip lifecycle scripts so `npm publish`
+    # ships it as-is instead of re-running the `prepare` build with no node_modules.
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
 
       - name: Publish to GitHub Packages (dev)
         uses: ./.github/actions/publish-library-to-gpr
@@ -121,17 +173,43 @@ jobs:
     needs:
       - publish-logic
       - release-merge-guard
+      - build
     permissions:
       contents: write
       packages: write
       id-token: write
     if: |-
       (always() && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
-    uses: ./.github/workflows/public-reusable-npm.yml
-    secrets: inherit
-    with:
-      workdir: packages/rag
-      caller_event_name: ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    environment: npm
+    outputs:
+      published_version: ${{ steps.publish-npm.outputs.npm_published_version }}
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
+
+      - name: Determine dist-tag
+        id: dist-tag
+        uses: tetherto/qvac-actions/npm-dist-tag-determination@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          workdir: packages/rag
+          tag: ${{ inputs.npm_tag }}
+
+      - name: Publish to NPM
+        id: publish-npm
+        uses: tetherto/qvac-actions/publish-library-to-npm@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0
+        with:
+          tag: ${{ steps.dist-tag.outputs.tag }}
+          workdir: packages/rag
 
   # Tag the published version (no GitHub Release; SDK-only releases policy)
   create-tag:
@@ -147,16 +225,25 @@ jobs:
   publish-feature-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_feature == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
 
       - name: Publish to GitHub Packages (feature)
         uses: ./.github/actions/publish-library-to-gpr
@@ -170,16 +257,25 @@ jobs:
   publish-tmp-gpr:
     needs:
       - publish-logic
+      - build
     if: (needs.publish-logic.outputs.publish_tmp == 'true')
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
       packages: write
+    env:
+      NPM_CONFIG_IGNORE_SCRIPTS: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0
+
+      - name: Download prebuilt dist
+        uses: ./.github/actions/download-release-artifact
+        with:
+          name: rag-dist
+          path: packages/rag/dist
 
       - name: Publish to GitHub Packages (tmp)
         uses: ./.github/actions/publish-library-to-gpr

--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate `search` and `infer` queries before logging so a non-string or blank query throws `QvacErrorRAG { code: INVALID_INPUT }` instead of a raw `TypeError` (#3729).
+- Fix the npm/GPR publish pipeline for the TypeScript/ESM build: `dist/` is now compiled once and published as a prebuilt artifact. The previous flow ran the `prepare` (`tsc`) build during `npm publish` in a job without `node_modules`, which blocked the `0.7.0` release (#4056).
 
 ## [0.6.4]
 

--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works. Switch to `import`. Named exports are unchanged (#3718).
+- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works; switch to `import`. Named exports are unchanged (#3718).
 
 ### Fixed
 
 - Validate `search` and `infer` queries before logging so a non-string or blank query throws `QvacErrorRAG { code: INVALID_INPUT }` instead of a raw `TypeError` (#3729).
-- Fix the npm/GPR publish pipeline for the TypeScript/ESM build: `dist/` is now compiled once and published as a prebuilt artifact. The previous flow ran the `prepare` (`tsc`) build during `npm publish` in a job without `node_modules`, which blocked the `0.7.0` release (#4056).
 
 ## [0.6.4]
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `release-rag-0.7.0` publish is blocked: the "Publish to npm" step fails with `tsc` errors (`Cannot find module '@qvac/logging'`, `Cannot find module 'ready-resource'`, `Expected 0 arguments, but got 1`). Since the TS/ESM migration, `@qvac/rag` has a `"prepare": "npm run build"` step, and the generic publish path runs `npm publish` in a job with no `node_modules`, so the implicit `prepare` → `tsc` build fails.
- This is the release-line counterpart of the durable fix on `main` (tetherto/qvac#4055); it carries only the rag workflow change so the stuck `0.7.0` publish can proceed.

## 📝 How does it solve it?

- Reworks `trigger-reusable-lib-rag.yml` to the build-first pattern used by the `ai-sdk-provider` / `cli` lib workflows: a dedicated `build` job installs deps (`bun install`) and compiles once (`npm run build`), uploads `dist/`, and every publish job downloads the prebuilt `dist` and publishes with `NPM_CONFIG_IGNORE_SCRIPTS: "true"` so `npm publish` ships the artifact instead of re-running `prepare` → `tsc`.
- `publish-release-npm` becomes an inline job that downloads the dist and publishes via the SHA-pinned `npm-dist-tag-determination` / `publish-library-to-npm` actions, feeding `published_version` to the existing `create-tag` job.
- Adds the workflow's own path to `on.push.paths`, so merging this change to `release-rag-0.7.0` re-triggers the release publish with the fixed workflow.

## 🧪 How was it tested?

- `actionlint` structural gate clean (only the pre-existing, gate-ignored dead `npm-token` inputs remain).
- Reproduced locally: `bun install && npm run build` for `@qvac/rag` emits the full compiled `dist/` tree via `tsc`, confirming the failure was solely `tsc` running without `node_modules`. The `bare copy-hyperspec` step's source (`src/adapters/database/hyperspec/**`) is committed, so the copy succeeds on the `ubuntu-latest` build runner.
- Byte-identical to the rag workflow in tetherto/qvac#4055 (the rag workflow / `package.json` / `tsconfig.build.json` are identical on `main` and `release-rag-0.7.0`).

## 🔐 Action pinning

New action references added (all SHA-pinned with `# <version>`, matching the versions already used by the lib workflows on `main`):

- `oven-sh/setup-bun`: added `@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0`
- `actions/upload-artifact`: added `@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0`
- `tetherto/qvac-actions/npm-dist-tag-determination`: added `@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0`
- `tetherto/qvac-actions/publish-library-to-npm`: added `@096b1cfbd1d95399ae64d37f55cc16fd7a43314e # 0.4.0`

First-party composite actions are referenced by relative path per repo convention. Permissions scopes are unchanged.
