### PR TITLE
QVAC-23799 feat[asr-ggml]: add opt-in CUDA GPU backend for whisper and parakeet

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -14,6 +14,20 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ## [Unreleased]
 
+### Added
+
+- **CUDA GPU backend for both engines on Linux / Windows (NVIDIA).** The
+  addon already resolved and reported CUDA at runtime (`BackendId.CUDA`, `2`),
+  but no build ever compiled the backend in. `asr-ggml[cuda]` now forwards to
+  `speech-cpp[cuda]` → `ggml-speech[cuda]` (`GGML_CUDA=ON`), gated behind the
+  new `ASR_CUDA` CMake option and the `npm run build:cuda` /
+  `build:native:cuda` scripts. It is opt-in rather than default because it
+  needs `nvcc` on the build host, which the published prebuilds do not carry;
+  only the NVIDIA driver is needed at runtime. CUDA is compiled alongside
+  Vulkan, and ggml registers CUDA first, so a `use_gpu` / `useGPU` request
+  prefers CUDA and falls back to Vulkan when no supported device is present.
+  Apple and Android are excluded (`supports: !(osx | ios | android)`).
+
 ### Fixed
 
 - **Parakeet duplex streaming no longer drops the tail of the transcript when

--- a/packages/asr-ggml/CMakeLists.txt
+++ b/packages/asr-ggml/CMakeLists.txt
@@ -3,8 +3,18 @@ cmake_minimum_required(VERSION 3.25)
 option(BUILD_TESTING "Build tests" OFF)
 option(ENABLE_COVERAGE "Enable coverage" OFF)
 
+# Vulkan / Metal / OpenCL are wired per-platform by the unconditional
+# speech-cpp dependencies in vcpkg.json. CUDA stays opt-in because it needs
+# nvcc on the build host, which the default build and the prebuild runners do
+# not carry (diffusion-cpp's SD_CUDA precedent).
+option(ASR_CUDA "Enable the CUDA GPU backend (requires nvcc on the build host)" OFF)
+
 if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+
+if(ASR_CUDA)
+  list(APPEND VCPKG_MANIFEST_FEATURES "cuda")
 endif()
 
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)

--- a/packages/asr-ggml/README.md
+++ b/packages/asr-ggml/README.md
@@ -507,6 +507,17 @@ GPU backends are selected per platform via `vcpkg.json` features; no
 - **Android** — Vulkan + OpenCL (Adreno) as dynamically-loaded `.so` backends shipped beside the prebuild
 - **macOS / iOS** — Metal, statically linked
 
+**CUDA (Linux / Windows on NVIDIA)** is the one exception: it is opt-in,
+because it needs `nvcc` on the build host, which the published prebuilds are
+not built with. Build it yourself with `npm run build:cuda` (or
+`bare-make generate -D ASR_CUDA=ON`), which adds the `cuda` feature to the
+`speech-cpp` dependency and turns on `GGML_CUDA`. Only the NVIDIA driver is
+needed at runtime. CUDA is compiled *alongside* Vulkan rather than replacing
+it; ggml registers CUDA ahead of Vulkan, so a `use_gpu` / `useGPU` request
+lands on CUDA when a supported device is present and falls back to Vulkan
+otherwise. Both engines report the winner through `getBackendInfo()` as
+`backendId: 2` (`BackendId.CUDA`).
+
 Both engines default to CPU: whisper needs `contextParams.use_gpu: true`,
 parakeet needs `parakeetConfig.useGPU: true`.
 
@@ -606,7 +617,10 @@ rationale.
   `VCPKG_ROOT=/path/to/vcpkg`
 - Optional GPU SDKs: [Vulkan SDK](https://vulkan.lunarg.com/) on
   Linux/Windows (`vulkan-tools libvulkan-dev vulkan-utility-libraries-dev
-  spirv-tools` on Ubuntu/Debian); Metal needs nothing on macOS/iOS
+  spirv-tools` on Ubuntu/Debian); Metal needs nothing on macOS/iOS; the
+  opt-in CUDA build additionally needs the
+  [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (`nvcc`) on
+  Linux/Windows
 
 ### Build
 
@@ -616,10 +630,12 @@ cd qvac/packages/asr-ggml
 git submodule update --init --recursive
 npm install
 npm run build          # build:ts (TypeScript) + build:native (bare-make)
+npm run build:cuda     # same, with the CUDA backend compiled in (needs nvcc)
 ```
 
 `build:native` runs `bare-make generate` → `bare-make build` →
-`bare-make install`.
+`bare-make install`. `build:native:cuda` is the same chain with
+`-D ASR_CUDA=ON` on the generate step.
 
 ### Test
 

--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -14,6 +14,8 @@
     "format": "prettier --write \"examples/**/*.js\" \"scripts/**/*.{js,mjs}\" \"test/**/*.js\" \"binding.js\"",
     "build": "npm run build:ts && npm run build:native",
     "build:native": "bare-make generate && bare-make build && bare-make install",
+    "build:native:cuda": "bare-make generate -D ASR_CUDA=ON && bare-make build && bare-make install",
+    "build:cuda": "npm run build:ts && npm run build:native:cuda",
     "build:ts": "tsc -p tsconfig.build.json",
     "build:pack": "npm run build:ts && mkdir -p dist && npm pack --pack-destination dist",
     "clean": "rm -rf build/ prebuilds/",

--- a/packages/asr-ggml/scripts/__tests__/build-backends.test.js
+++ b/packages/asr-ggml/scripts/__tests__/build-backends.test.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const packageRoot = path.resolve(__dirname, '..', '..')
+const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'))
+const vcpkgManifest = JSON.parse(fs.readFileSync(path.join(packageRoot, 'vcpkg.json'), 'utf8'))
+const cmakeSource = fs.readFileSync(path.join(packageRoot, 'CMakeLists.txt'), 'utf8')
+
+const CUDA_CMAKE_OPTION = 'ASR_CUDA'
+const CUDA_MANIFEST_FEATURE = 'cuda'
+const SPEECH_PORT = 'speech-cpp'
+const DESKTOP_PLATFORM = '!(osx | ios | android)'
+
+function speechDependencies(dependencies) {
+  return dependencies.filter((dependency) => dependency.name === SPEECH_PORT)
+}
+
+function desktopSpeechDependency() {
+  return speechDependencies(vcpkgManifest.dependencies).find(
+    (dependency) => dependency.platform === DESKTOP_PLATFORM
+  )
+}
+
+function cudaFeature() {
+  return vcpkgManifest.features[CUDA_MANIFEST_FEATURE]
+}
+
+function cudaSpeechDependency() {
+  return speechDependencies(cudaFeature().dependencies)[0]
+}
+
+function versionFloorOf(dependency) {
+  return dependency['version>=']
+}
+
+test('the CUDA build is opt-in behind a dedicated CMake option', () => {
+  assert.match(cmakeSource, new RegExp(`option\\(${CUDA_CMAKE_OPTION} "[^"]+" OFF\\)`))
+  assert.equal(packageJson.scripts['build:native'].includes(CUDA_CMAKE_OPTION), false)
+})
+
+test('the CUDA CMake option selects the cuda vcpkg manifest feature', () => {
+  assert.match(
+    cmakeSource,
+    new RegExp(
+      `if\\(${CUDA_CMAKE_OPTION}\\)\\s*\\n\\s*list\\(APPEND VCPKG_MANIFEST_FEATURES "${CUDA_MANIFEST_FEATURE}"\\)`
+    )
+  )
+})
+
+test('the CUDA build scripts turn the CMake option on', () => {
+  assert.match(packageJson.scripts['build:native:cuda'], /bare-make generate -D ASR_CUDA=ON/)
+  assert.equal(packageJson.scripts['build:cuda'], 'npm run build:ts && npm run build:native:cuda')
+})
+
+test('the cuda feature forwards to the speech-cpp CUDA backend', () => {
+  assert.deepEqual(cudaSpeechDependency().features, [CUDA_MANIFEST_FEATURE])
+  assert.equal(cudaSpeechDependency()['default-features'], false)
+})
+
+test('the cuda feature is confined to the platforms that have NVIDIA GPUs', () => {
+  assert.equal(cudaFeature().supports, DESKTOP_PLATFORM)
+  assert.equal(cudaSpeechDependency().platform, DESKTOP_PLATFORM)
+})
+
+test('the cuda feature requires a speech-cpp that declares it', () => {
+  assert.ok(versionFloorOf(cudaSpeechDependency()) >= versionFloorOf(desktopSpeechDependency()))
+})

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -55,6 +55,21 @@
     }
   ],
   "features": {
+    "cuda": {
+      "description": "Enable the CUDA GPU backend for both engines (Linux / Windows on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ASR_CUDA=ON`. The runtime needs only the NVIDIA driver.",
+      "supports": "!(osx | ios | android)",
+      "dependencies": [
+        {
+          "name": "speech-cpp",
+          "version>=": "2026-08-24#1",
+          "default-features": false,
+          "features": [
+            "cuda"
+          ],
+          "platform": "!(osx | ios | android)"
+        }
+      ]
+    },
     "tests": {
       "description": "Build C++ unit tests",
       "dependencies": [


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `asr-ggml` could never run on CUDA. Both engines already *resolved and reported* CUDA at runtime — `WhisperModel.cpp` and `ParakeetModel.cpp` map ggml's `CUDA*` backend name to `BackendId.CUDA` (`2`), and `gpu.test.js` / `parakeet-gpu-smoke.test.js` already had `cuda` branches — but no build ever compiled the backend in.
- The cause was purely dependency wiring: `vcpkg.json` requested `speech-cpp` with `vulkan` (desktop/Android), `metal` (Apple) and `opencl` (Android), never `cuda`. On NVIDIA hosts a `use_gpu` / `useGPU` request therefore always landed on Vulkan.

## 📝 How does it solve it?

- New `cuda` feature in `vcpkg.json` forwarding to `speech-cpp[cuda]` → `ggml-speech[cuda]` (`GGML_CUDA=ON`, nvcc resolved by the port).
- New `ASR_CUDA` CMake option appending `"cuda"` to `VCPKG_MANIFEST_FEATURES`, following the `SD_CUDA` precedent in `diffusion-cpp`.
- New `build:cuda` / `build:native:cuda` scripts (`bare-make generate -D ASR_CUDA=ON`).
- **Opt-in, not default**, because it needs `nvcc` on the build host, which the prebuild runners do not carry. Only the NVIDIA driver is needed at runtime.
- CUDA is compiled *alongside* Vulkan rather than replacing it. ggml registers CUDA ahead of Vulkan, so a GPU request prefers CUDA and falls back to Vulkan when no supported device is present.
- Apple and Android are excluded via `"supports": "!(osx | ios | android)"`.
- The `cuda` feature carries its own `speech-cpp` floor, `2026-08-24#1` — the version that introduced the feature. Feature dependencies only apply when the feature is selected, so **default builds keep resolving at `2026-08-18`** and are unaffected.
- No C++ changes.

### No companion PRs needed

- **Registry**: `speech-cpp[cuda]` → `ggml-speech[cuda]` already shipped in `tetherto/qvac-registry-vcpkg@cc90801` (QVAC-23802, speech-cpp `2026-08-24#1`). Nothing to add there.
- **`vcpkg-configuration.json` baseline**: unchanged. The pinned baseline `dca20a94` carries only speech-cpp `2026-08-10` / `2026-08-07`, yet `main` already requires `>= 2026-08-18` and builds green — version constraints resolve against fetched registry HEAD, not the baseline commit. `2026-08-24#1` resolves the same way.
- **Version bump**: none, matching the established flow — #3950 added an `Unreleased` entry without touching `version`, and bumps land in dedicated release PRs (e.g. `chore[mod]: release asr-ggml 0.3.1, ...`). This PR adds to `## [Unreleased]`.

## 🧪 How was it tested?

- New `scripts/__tests__/build-backends.test.js` (6 tests) pins the wiring: the option defaults to `OFF`, `build:native` does not enable it, `ASR_CUDA` maps to the `cuda` manifest feature, the feature forwards to `speech-cpp[cuda]` with `default-features: false`, the platform guards match, and the CUDA floor is not below the base floor.
- `node --test "scripts/__tests__/*.test.js"` → **46/46 pass**.
- Mutation-checked the two CMake regex assertions (option renamed, feature renamed, default flipped to `ON`) — each correctly fails, so the assertions are not vacuous.
- `vcpkg format-manifest` accepts the manifest. It also wants to canonically reorder the pre-existing dependency blocks, which the committed file does not follow, so that churn was left out to keep the diff reviewable.
- Prettier clean on the new test file.

**Not covered:** an actual `-D ASR_CUDA=ON` compile and a CUDA-vs-Vulkan runtime check. Both need a host with the CUDA toolkit; by design this PR adds no CI job, so the first real CUDA build is manual. The claim that ggml prefers CUDA over Vulkan is documented but unmeasured.

## 🔌 API Changes

No API changes. `BackendId.CUDA` (`2`) was already exported and already returned by `getBackendInfo()`; this PR only makes it reachable.

```bash
# opt into CUDA at build time
npm run build:cuda      # or: bare-make generate -D ASR_CUDA=ON
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217592019459441