### PR TITLE
chore[notask]: release @qvac/sdk 0.18.2

### DIFF
--- a/docs/website/content/docs/reference/release-notes/index.mdx
+++ b/docs/website/content/docs/reference/release-notes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK Release Notes — v0.18.x (latest)
-description: Lists all releases from v0.18.0 to v0.18.1.
+description: Lists all releases from v0.18.0 to v0.18.2.
 ---
 
 ## v0.18.0
@@ -229,6 +229,14 @@ VISIONPSY_NANO_460M_MULTIMODAL_Q8_0_1
 TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
 ```
 
+## v0.18.2
+
+### @qvac/sdk
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.2
+
+QVAC SDK 0.18.2 raises the `@qvac/diffusion-cpp` dependency to `^0.18.0`. That is the addon-cpp / infer-base floor that `^0.17.0` cannot install. Video APIs are unchanged. This patch does not ship ABot-World or LTX Ingredients IC-LoRA; those stay on later addon minors (`0.19` and `0.20`) for the next SDK line.
+
 ## v0.18.1
 
 ### @qvac/sdk
@@ -257,3 +265,4 @@ The internal schema identifiers are unchanged.
 ##### CosyVoice3 companion cache folder
 
 CosyVoice3 companion files still download with the LLM, as in 0.18.0. The companion-set cache key for `TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0` changed, so the first load after upgrading fills a new cache folder. Later loads reuse that folder. Speech APIs and `pace` / `instruct` rules are unchanged.
+

--- a/docs/website/content/docs/reference/release-notes/index.mdx
+++ b/docs/website/content/docs/reference/release-notes/index.mdx
@@ -235,7 +235,7 @@ TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.2
 
-QVAC SDK 0.18.2 raises the `@qvac/diffusion-cpp` dependency to `^0.18.0`. That is the addon-cpp / infer-base floor that `^0.17.0` cannot install. Video APIs are unchanged. This patch does not ship ABot-World or LTX Ingredients IC-LoRA; those stay on later addon minors (`0.19` and `0.20`) for the next SDK line.
+QVAC SDK 0.18.2 bumps `@qvac/diffusion-cpp` to `^0.18.0`.
 
 ## v0.18.1
 

--- a/docs/website/src/lib/versions.ts
+++ b/docs/website/src/lib/versions.ts
@@ -40,7 +40,7 @@ export interface VersionedSection {
 
 export const API_SECTION: VersionedSection = {
   basePath: '/reference/api',
-  latest: 'v0.18.1',
+  latest: 'v0.18.2',
   latestSeries: 'v0.18.x',
   versions: [
     { label: 'v0.18.x (latest)', value: 'v0.18.x', isLatest: true },
@@ -59,7 +59,7 @@ export const API_SECTION: VersionedSection = {
 
 export const RELEASE_NOTES_SECTION: VersionedSection = {
   basePath: '/reference/release-notes',
-  latest: 'v0.18.1',
+  latest: 'v0.18.2',
   latestSeries: 'v0.18.x',
   versions: [
     { label: 'v0.18.x (latest)', value: 'v0.18.x', isLatest: true },

--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/inference",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Bare-only in-process core of the QVAC SDK. Runs inference directly on the Bare runtime with explicit plugin assembly and no RPC, worker, or subprocess layer.",
   "license": "Apache-2.0",
   "repository": {
@@ -190,7 +190,7 @@
     "@qvac/bci-whispercpp": "^0.7.1",
     "@qvac/classification-ggml": "^0.20.0",
     "@qvac/decoder-audio": "^0.5.0",
-    "@qvac/diffusion-cpp": "^0.17.0",
+    "@qvac/diffusion-cpp": "^0.18.0",
     "@qvac/embed-llamacpp": "^0.34.0",
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/llm-llamacpp": "^0.45.0",
@@ -246,7 +246,7 @@
     "@qvac/bci-whispercpp": "^0.7.1",
     "@qvac/classification-ggml": "^0.20.0",
     "@qvac/decoder-audio": "^0.5.0",
-    "@qvac/diffusion-cpp": "^0.17.0",
+    "@qvac/diffusion-cpp": "^0.18.0",
     "@qvac/embed-llamacpp": "^0.34.0",
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/llm-llamacpp": "^0.45.0",

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/sdk_version.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/sdk_version.py
@@ -5,6 +5,6 @@ connects to must be this version. Sourced from packages/sdk/package.json.
 
 from __future__ import annotations
 
-SDK_VERSION = "0.18.1"
+SDK_VERSION = "0.18.2"
 
 __all__ = ["SDK_VERSION"]

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.18.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.2
+
+QVAC SDK 0.18.2 raises the `@qvac/diffusion-cpp` dependency to `^0.18.0`. That is the addon-cpp / infer-base floor that `^0.17.0` cannot install. Video APIs are unchanged. This patch does not ship ABot-World or LTX Ingredients IC-LoRA; those stay on later addon minors (`0.19` and `0.20`) for the next SDK line.
+
 ## [0.18.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.1

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.2
 
-QVAC SDK 0.18.2 raises the `@qvac/diffusion-cpp` dependency to `^0.18.0`. That is the addon-cpp / infer-base floor that `^0.17.0` cannot install. Video APIs are unchanged. This patch does not ship ABot-World or LTX Ingredients IC-LoRA; those stay on later addon minors (`0.19` and `0.20`) for the next SDK line.
+QVAC SDK 0.18.2 bumps `@qvac/diffusion-cpp` to `^0.18.0`.
 
 ## [0.18.1]
 

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -666,7 +666,7 @@ JavaScript Dependencies
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/diffusion-cpp@0.17.0
+  @qvac/diffusion-cpp@0.18.0
     https://github.com/tetherto/qvac
   @qvac/embed-llamacpp@0.34.0
     https://github.com/tetherto/qvac

--- a/packages/sdk/changelog/0.18.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.18.2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.18.2
+
+Release Date: 2026-08-25
+
+## 🧹 Chores
+
+- Bump `@qvac/diffusion-cpp` from `^0.17.0` to `^0.18.0` so the lockstep SDK can install the addon-cpp / infer-base floor published in that addon. This range does not include ABot-World (`0.19`) or LTX Ingredients IC-LoRA (`0.20`).

--- a/packages/sdk/changelog/0.18.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.18.2/CHANGELOG.md
@@ -4,4 +4,4 @@ Release Date: 2026-08-25
 
 ## 🧹 Chores
 
-- Bump `@qvac/diffusion-cpp` from `^0.17.0` to `^0.18.0` so the lockstep SDK can install the addon-cpp / infer-base floor published in that addon. This range does not include ABot-World (`0.19`) or LTX Ingredients IC-LoRA (`0.20`).
+- Bump `@qvac/diffusion-cpp` from `^0.17.0` to `^0.18.0`.

--- a/packages/sdk/changelog/0.18.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.18.2/CHANGELOG_LLM.md
@@ -2,4 +2,4 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.2
 
-QVAC SDK 0.18.2 raises the `@qvac/diffusion-cpp` dependency to `^0.18.0`. That is the addon-cpp / infer-base floor that `^0.17.0` cannot install. Video APIs are unchanged. This patch does not ship ABot-World or LTX Ingredients IC-LoRA; those stay on later addon minors (`0.19` and `0.20`) for the next SDK line.
+QVAC SDK 0.18.2 bumps `@qvac/diffusion-cpp` to `^0.18.0`.

--- a/packages/sdk/changelog/0.18.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.18.2/CHANGELOG_LLM.md
@@ -1,0 +1,5 @@
+# QVAC SDK v0.18.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.18.2
+
+QVAC SDK 0.18.2 raises the `@qvac/diffusion-cpp` dependency to `^0.18.0`. That is the addon-cpp / infer-base floor that `^0.17.0` cannot install. Video APIs are unchanged. This patch does not ship ABot-World or LTX Ingredients IC-LoRA; those stay on later addon minors (`0.19` and `0.20`) for the next SDK line.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -216,7 +216,7 @@
     "@qvac/bci-whispercpp": "^0.7.1",
     "@qvac/classification-ggml": "^0.20.0",
     "@qvac/decoder-audio": "^0.5.0",
-    "@qvac/diffusion-cpp": "^0.17.0",
+    "@qvac/diffusion-cpp": "^0.18.0",
     "@qvac/embed-llamacpp": "^0.34.0",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",


### PR DESCRIPTION
## What problem does this PR solve?

Bump `@qvac/diffusion-cpp` from `^0.17.0` to `^0.18.0` for SDK 0.18.2.

## How does it solve it?

- Pin `@qvac/diffusion-cpp` to `^0.18.0` on `@qvac/sdk` and `@qvac/inference`.
- Lockstep stamp inference / sdk / bare-sdk / python `SDK_VERSION` to 0.18.2.

## How was it tested?

- `packages/bare-sdk` `check:deps-vs-sdk` passes.
- Changelog markdown is prettier-clean.
- Full e2e still to run on the release cut after merge.
