### PR TITLE
fix[notask]: adopt tar-stream's first-party types in the SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -250,7 +250,7 @@
     "hyperdrive": "^13.0.1",
     "hyperswarm": "^4.14.0",
     "semver": "^7.8.0",
-    "tar-stream": "3.2.0",
+    "tar-stream": "^3.2.1",
     "which-runtime": "^1.3.2",
     "zod": "^4.3.0"
   },
@@ -263,7 +263,6 @@
     "@types/brittle": "^3.5.0",
     "@types/node": "^24.2.1",
     "@types/semver": "^7.7.1",
-    "@types/tar-stream": "^3.1.4",
     "ajv": "8.20.0",
     "bare-readline": "^1.2.0",
     "bare-stdio": "^1.0.2",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -250,7 +250,7 @@
     "hyperdrive": "^13.0.1",
     "hyperswarm": "^4.14.0",
     "semver": "^7.8.0",
-    "tar-stream": "^3.1.8",
+    "tar-stream": "3.2.0",
     "which-runtime": "^1.3.2",
     "zod": "^4.3.0"
   },

--- a/packages/sdk/src/commands/verify/resource-collectors.ts
+++ b/packages/sdk/src/commands/verify/resource-collectors.ts
@@ -5,6 +5,7 @@ import tarStream, { type Pack } from 'tar-stream'
 import { collectAddonsFromBundle } from '@/commands/verify/bundle-source'
 import { listBarePrebuildFiles } from '@/commands/verify/prebuilds'
 
+// Taken off `pipe` rather than imported from streamx, which nothing here declares.
 type PackSink = Parameters<Pack['pipe']>[0]
 
 export const RESOURCE_COLLECTOR_PACKAGES = ['bare-cpu-info', 'bare-gpu-info'] as const
@@ -260,10 +261,9 @@ export async function measureTarget(
   const pack = tarStream.pack()
   const gzip = createGzip({ level: 9 })
   const compressedBytesPromise = countStreamBytes(gzip)
-  // tar-stream 3.2.1's types make `pipe` take a streamx Writable, whose nominal
-  // private brand a node Gzip cannot satisfy even though the two interoperate at
-  // runtime. Read the sink type off `pipe` rather than importing it from streamx,
-  // which no package here declares, so it follows tar-stream if that type widens.
+  // tar-stream types `pipe` for a streamx Writable, which a node Gzip is missing
+  // members of (_open, _predestroy, destroying, addOnceListener) though the two
+  // interoperate at runtime.
   pack.pipe(gzip as unknown as PackSink)
 
   try {

--- a/packages/sdk/src/commands/verify/resource-collectors.ts
+++ b/packages/sdk/src/commands/verify/resource-collectors.ts
@@ -258,7 +258,10 @@ export async function measureTarget(
   const pack = tarStream.pack()
   const gzip = createGzip({ level: 9 })
   const compressedBytesPromise = countStreamBytes(gzip)
-  pack.pipe(gzip)
+  // tar-stream 3.2.1 ships first-party types that pipe into a streamx Writable.
+  // A node Gzip is compatible at runtime but cannot satisfy streamx's nominal
+  // private brand, so the destination type is taken from `pipe` itself.
+  pack.pipe(gzip as unknown as Parameters<Pack['pipe']>[0])
 
   try {
     for (const entry of entries) {

--- a/packages/sdk/src/commands/verify/resource-collectors.ts
+++ b/packages/sdk/src/commands/verify/resource-collectors.ts
@@ -5,7 +5,6 @@ import tarStream, { type Pack } from 'tar-stream'
 import { collectAddonsFromBundle } from '@/commands/verify/bundle-source'
 import { listBarePrebuildFiles } from '@/commands/verify/prebuilds'
 
-// Taken off `pipe` rather than imported from streamx, which nothing here declares.
 type PackSink = Parameters<Pack['pipe']>[0]
 
 export const RESOURCE_COLLECTOR_PACKAGES = ['bare-cpu-info', 'bare-gpu-info'] as const
@@ -261,9 +260,7 @@ export async function measureTarget(
   const pack = tarStream.pack()
   const gzip = createGzip({ level: 9 })
   const compressedBytesPromise = countStreamBytes(gzip)
-  // tar-stream types `pipe` for a streamx Writable, which a node Gzip is missing
-  // members of (_open, _predestroy, destroying, addOnceListener) though the two
-  // interoperate at runtime.
+  // A node Gzip pipes to streamx at runtime but does not type as one.
   pack.pipe(gzip as unknown as PackSink)
 
   try {

--- a/packages/sdk/src/commands/verify/resource-collectors.ts
+++ b/packages/sdk/src/commands/verify/resource-collectors.ts
@@ -260,7 +260,8 @@ export async function measureTarget(
   const pack = tarStream.pack()
   const gzip = createGzip({ level: 9 })
   const compressedBytesPromise = countStreamBytes(gzip)
-  // A node Gzip pipes to streamx at runtime but does not type as one.
+  // tar-stream types `pipe` for a streamx Writable, which a node Gzip is missing
+  // members of, though the two interoperate at runtime.
   pack.pipe(gzip as unknown as PackSink)
 
   try {

--- a/packages/sdk/src/commands/verify/resource-collectors.ts
+++ b/packages/sdk/src/commands/verify/resource-collectors.ts
@@ -5,6 +5,8 @@ import tarStream, { type Pack } from 'tar-stream'
 import { collectAddonsFromBundle } from '@/commands/verify/bundle-source'
 import { listBarePrebuildFiles } from '@/commands/verify/prebuilds'
 
+type PackSink = Parameters<Pack['pipe']>[0]
+
 export const RESOURCE_COLLECTOR_PACKAGES = ['bare-cpu-info', 'bare-gpu-info'] as const
 export const RESOURCE_COLLECTOR_SIZE_BUDGETS = {
   compressedBytes: 2 * 1024 * 1024,
@@ -258,10 +260,11 @@ export async function measureTarget(
   const pack = tarStream.pack()
   const gzip = createGzip({ level: 9 })
   const compressedBytesPromise = countStreamBytes(gzip)
-  // tar-stream 3.2.1 ships first-party types that pipe into a streamx Writable.
-  // A node Gzip is compatible at runtime but cannot satisfy streamx's nominal
-  // private brand, so the destination type is taken from `pipe` itself.
-  pack.pipe(gzip as unknown as Parameters<Pack['pipe']>[0])
+  // tar-stream 3.2.1's types make `pipe` take a streamx Writable, whose nominal
+  // private brand a node Gzip cannot satisfy even though the two interoperate at
+  // runtime. Read the sink type off `pipe` rather than importing it from streamx,
+  // which no package here declares, so it follows tar-stream if that type widens.
+  pack.pipe(gzip as unknown as PackSink)
 
   try {
     for (const entry of entries) {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`bun run build` fails in `packages/sdk` on **every branch**:

```
src/commands/verify/resource-collectors.ts(261,13): error TS2345: Argument of type 'Gzip'
is not assignable to parameter of type 'Writable<WritableEvents>'.
```

`tar-stream@3.2.1` published **2026-08-25T15:35:24Z**. Diffing the two tarballs, it is the first release to ship type declarations at all:

```
$ diff -rq tar-stream-3.2.0/package tar-stream-3.2.1/package
Only in tar-stream-3.2.1/package: index.d.ts
```

Until then the package carried none, so consumers used `@types/tar-stream` from DefinitelyTyped, which types `pipe()` against node streams. First-party types take precedence over `@types/*`, so the SDK silently switched to declarations written against **streamx**, and `pack.pipe(gzip)` with a node `Gzip` stopped compiling.

`packages/sdk/bun.lock` is gitignored (`.gitignore:15`), so nothing held the resolution. The caret range took the new version on the next CI install.

**Isolated, not inferred.** Two runs of the *same commit* (`6dc99b069`) on the *same runner*, either side of the publish:

| | started | tar-stream | result |
|---|---|---|---|
| [attempt 1](https://github.com/tetherto/qvac/actions/runs/32838463976/job/97772817819) | 11:08Z | 3.2.0 | ✅ success |
| [attempt 2](https://github.com/tetherto/qvac/actions/runs/32838463976/job/97870129516) | 16:07Z | 3.2.1 | ❌ TS2345 |

Diffing the two install manifests, 77 packages each, gives exactly one difference:

```
$ diff before.pkgs after.pkgs
67c67
< tar-stream@3.2.0
---
> tar-stream@3.2.1
```

Same runner (`qvac-ubuntu2204-x64-gpu`), same `typescript@5.9.3`, `bare-stream@2.13.3`, `@types/node@24.13.3`, same 1185 packages.

Not branch-specific — [`chore/sdk-0.18.2-changelog`](https://github.com/tetherto/qvac/actions/runs/32869699643) fails the same way, with two more of the same family (`Extract<ExtractEvents>`, `WriteStream`), all node streams handed to tar-stream.

## 📝 How does it solve it?

Takes the real types rather than holding the old version:

- `tar-stream` → `^3.2.1`
- drops `@types/tar-stream`, now redundant and shadowed by the first-party declarations
- casts the pipe destination, which a node `Gzip` cannot satisfy structurally (missing `_open`, `_predestroy`, `destroying`, `addOnceListener`)

The cast reads its target from `Parameters<Pack['pipe']>[0]` so it follows the declaration rather than naming a stream package the SDK does not depend on.

**Why not pin to 3.2.0.** That was the first version of this PR. It holds, but it keeps the SDK on a release with no types, keeps a redundant `@types/tar-stream` shadowing them, and blocks every future tar-stream update. The typings are not wrong here, they are simply new.

**Why not copy inference's shim.** `packages/inference` casts at its pipe sites for the same reason, and this change copies that. It also has `src/types/tar-stream/index.d.ts`, which is not copied: that shim opens with *"tar-stream ships no type declarations"*, which is precisely what 3.2.1 fixed. Writing a fresh one now would shadow upstream's real types with our guess. Inference builds clean on 3.2.1 because its shim overrides them; retiring it there is a follow-up.

## 🧪 How was it tested?

**Before** — branch base, fresh install, caret floats to 3.2.1:

```
$ bun install && grep version node_modules/tar-stream/package.json
  "version": "3.2.1",

$ bun run build
src/commands/verify/resource-collectors.ts(261,13): error TS2345: Argument of type 'Gzip'
is not assignable to parameter of type 'Writable<WritableEvents>'.
exit=2
```

**After** — this branch, lock deleted, fresh install:

```
$ rm -f bun.lock && bun install && grep version node_modules/tar-stream/package.json
  "version": "3.2.1",

$ bun run build
$ eslint . --max-warnings=0
$ tsc-alias -p tsconfig.alias.json
exit=0
```

**Smoke test on the affected path** — `check:resource-collectors` is what actually builds the tar+gzip archive:

| | 3.2.0 | 3.2.1 before | 3.2.1 after |
|---|---|---|---|
| `bun run build` | ✅ exit 0 | ❌ TS2345 | ✅ exit 0 |
| `check:resource-collectors --host linux-x64` | ✅ PASS | ✅ PASS | ✅ PASS |
| archive bytes | 18293 / 49136 | 18293 / 49136 | 18293 / 49136 |

Byte-identical archives in all three, so the regression was **typings-only** and this changes no runtime behaviour. That is also why it stayed invisible until a typecheck ran.

Also run: `eslint --max-warnings=0` clean, prettier clean. `bun run test:unit` exits non-zero locally on the untouched branch base too, so that is pre-existing and unrelated; CI reports `ok [sdk] test:unit [workspace]`.

## ⏭️ Superseded upstream

The root cause is not in tar-stream. It declares no `pipe` at all; `Pack extends Readable` from **streamx**, and streamx typed it `pipe<S extends Writable>(dest: S, cb?): S` against its own `Writable` class, which no Node.js stream extends. tar-stream 3.2.1 only surfaced it by shipping types for the first time.

[mafintosh/streamx#125](https://github.com/mafintosh/streamx/pull/125) fixes it at source by relaxing the constraint to `pipe<S>`. Merged 2026-08-25, **not yet published** (npm `latest` is still 2.28.0 from June).

streamx reaches us transitively through tar-stream's `"streamx": "^2.15.0"`, so the fix lands on the next fresh install once it releases, with no manifest change here.

This PR stays as the unblock while CI is red on every branch. **When streamx publishes, the `PackSink` cast should be deleted** and `pack.pipe(gzip)` restored as-is; only the `@types/tar-stream` removal needs to stay.

## 📋 Notes

- `packages/sdk/bun.lock` being gitignored is what turned an upstream patch release into a repo-wide build break with no commit of ours involved. Whether the SDK should commit its lock is worth a separate conversation; out of scope here.
- `packages/inference` is untouched and unaffected, verified by forcing the version: `bun add tar-stream@3.2.1 && bun run build` → exit 0.
