### PR TITLE
test[notask]: preflight addon Fabric compatibility

### DIFF
--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -332,6 +332,10 @@ jobs:
         working-directory: ${{ inputs.project-directory }}
         run: bun install
 
+      - name: Verify addon Fabric compatibility
+        working-directory: ${{ inputs.project-directory }}
+        run: bun run check:addon-fabric-compatibility
+
       - name: Build project
         working-directory: ${{ inputs.project-directory }}
         shell: node {0}

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -402,6 +402,10 @@ jobs:
         working-directory: ${{ inputs.project-directory }}
         run: bun install
 
+      - name: Verify addon Fabric compatibility
+        working-directory: ${{ inputs.project-directory }}
+        run: bun run check:addon-fabric-compatibility
+
       - name: Build project
         working-directory: ${{ inputs.project-directory }}
         shell: node {0}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -208,6 +208,7 @@
     "contract:export": "tsx ./scripts/export-contract.ts",
     "contract:check": "tsx ./scripts/export-contract.ts --check",
     "check:resource-collectors": "tsx ./scripts/check-resource-collectors-packaging.ts",
+    "check:addon-fabric-compatibility": "tsx ./scripts/check-addon-fabric-compatibility.ts",
     "changelog:generate": "node ../../scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk && prettier --write changelog"
   },
   "dependencies": {

--- a/packages/sdk/scripts/check-addon-fabric-compatibility.ts
+++ b/packages/sdk/scripts/check-addon-fabric-compatibility.ts
@@ -1,0 +1,253 @@
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const FABRIC_PACKAGE = '@qvac/fabric'
+const QVAC_SCOPE = '@qvac/'
+
+type PackageDependencies = Record<string, string>
+
+type PackageManifest = {
+  addon?: boolean
+  dependencies?: PackageDependencies
+  name?: string
+  optionalDependencies?: PackageDependencies
+  peerDependencies?: PackageDependencies
+  version?: string
+}
+
+type InstalledPackage = {
+  dir: string
+  manifest: PackageManifest
+}
+
+export type FabricConsumer = {
+  addonName: string
+  addonVersion: string
+  fabricPackageDir: string | null
+  fabricSpec: string
+  fabricVersion: string | null
+  packageDir: string
+}
+
+export type FabricCompatibilityReport = {
+  consumers: FabricConsumer[]
+  legacyAddons: Array<{ name: string; packageDir: string; version: string }>
+  unresolvedConsumers: FabricConsumer[]
+  versions: string[]
+}
+
+function readManifest(packageDir: string): PackageManifest | null {
+  try {
+    const value: unknown = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'))
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return null
+    return value as PackageManifest
+  } catch {
+    return null
+  }
+}
+
+function packagePath(nodeModulesDir: string, packageName: string): string {
+  return join(nodeModulesDir, ...packageName.split('/'))
+}
+
+function fabricSpec(manifest: PackageManifest): string | undefined {
+  for (const dependencies of [
+    manifest.dependencies,
+    manifest.optionalDependencies,
+    manifest.peerDependencies
+  ]) {
+    const spec = dependencies?.[FABRIC_PACKAGE]
+    if (typeof spec === 'string') return spec
+  }
+  return undefined
+}
+
+function collectQvacPackages(rootNodeModules: string): InstalledPackage[] {
+  const packages: InstalledPackage[] = []
+  const visited = new Set<string>()
+  const pending = [join(rootNodeModules, '@qvac')]
+
+  while (pending.length > 0) {
+    const scopeDir = pending.pop()!
+    if (!existsSync(scopeDir)) continue
+
+    let realScopeDir: string
+    try {
+      realScopeDir = realpathSync(scopeDir)
+    } catch {
+      continue
+    }
+    if (visited.has(realScopeDir)) continue
+    visited.add(realScopeDir)
+
+    for (const entry of readdirSync(scopeDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+
+      const dir = join(scopeDir, entry.name)
+      const manifest = readManifest(dir)
+      if (manifest?.name?.startsWith(QVAC_SCOPE)) {
+        packages.push({ dir, manifest })
+        pending.push(join(dir, 'node_modules', '@qvac'))
+      }
+    }
+  }
+
+  return packages
+}
+
+function resolveInstalledPackage(fromDir: string, packageName: string): string | null {
+  let dir = resolve(fromDir)
+
+  while (true) {
+    const candidate = packagePath(join(dir, 'node_modules'), packageName)
+    if (readManifest(candidate) !== null) return candidate
+
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+function dependencyVersion(packageDir: string | null): string | null {
+  if (!packageDir) return null
+  return readManifest(packageDir)?.version ?? null
+}
+
+export function inspectFabricCompatibility(rootDir: string): FabricCompatibilityReport {
+  const installed = collectQvacPackages(join(resolve(rootDir), 'node_modules'))
+  const addonPackages = installed.filter(
+    ({ manifest }) => manifest.addon === true && manifest.name !== FABRIC_PACKAGE
+  )
+
+  const consumers: FabricConsumer[] = []
+  const legacyAddons: FabricCompatibilityReport['legacyAddons'] = []
+
+  for (const { dir, manifest } of addonPackages) {
+    const name = manifest.name ?? '(unnamed addon)'
+    const version = manifest.version ?? '(unknown)'
+    const spec = fabricSpec(manifest)
+    if (spec === undefined) {
+      legacyAddons.push({ name, packageDir: dir, version })
+      continue
+    }
+
+    const fabricPackageDir = resolveInstalledPackage(dir, FABRIC_PACKAGE)
+    consumers.push({
+      addonName: name,
+      addonVersion: version,
+      fabricPackageDir,
+      fabricSpec: spec,
+      fabricVersion: dependencyVersion(fabricPackageDir),
+      packageDir: dir
+    })
+  }
+
+  return {
+    consumers,
+    legacyAddons,
+    unresolvedConsumers: consumers.filter((consumer) => consumer.fabricVersion === null),
+    versions: [
+      ...new Set(
+        consumers.flatMap((consumer) => (consumer.fabricVersion ? [consumer.fabricVersion] : []))
+      )
+    ].sort()
+  }
+}
+
+export function formatFabricCompatibilityReport(report: FabricCompatibilityReport): string {
+  const lines = [
+    `Fabric compatibility consumers: ${report.consumers.length}`,
+    `Resolved Fabric versions: ${report.versions.length > 0 ? report.versions.join(', ') : '(none)'}`
+  ]
+
+  for (const consumer of report.consumers) {
+    lines.push(
+      `  - ${consumer.addonName}@${consumer.addonVersion}: ` +
+        `@qvac/fabric ${consumer.fabricVersion ?? '(unresolved)'} ` +
+        `(declared ${consumer.fabricSpec})`
+    )
+  }
+
+  if (report.legacyAddons.length > 0) {
+    lines.push(
+      `Legacy addon metadata not checked yet (${report.legacyAddons.length}): ` +
+        report.legacyAddons.map(({ name, version }) => `${name}@${version}`).join(', ')
+    )
+  }
+
+  return lines.join('\n')
+}
+
+export function assertFabricCompatibility(
+  report: FabricCompatibilityReport,
+  options: { requireCompleteMetadata?: boolean } = {}
+): void {
+  const problems: string[] = []
+
+  if (report.unresolvedConsumers.length > 0) {
+    problems.push(
+      'could not resolve @qvac/fabric for: ' +
+        report.unresolvedConsumers
+          .map(({ addonName, addonVersion }) => `${addonName}@${addonVersion}`)
+          .join(', ')
+    )
+  }
+
+  if (report.versions.length > 1) {
+    problems.push(`mixed @qvac/fabric versions detected: ${report.versions.join(', ')}`)
+  }
+
+  if (options.requireCompleteMetadata && report.legacyAddons.length > 0) {
+    problems.push(
+      'addon metadata is incomplete; migrate these packages to declare @qvac/fabric: ' +
+        report.legacyAddons.map(({ name, version }) => `${name}@${version}`).join(', ')
+    )
+  }
+
+  if (problems.length > 0) {
+    throw new Error(`${problems.join('; ')}\n\n${formatFabricCompatibilityReport(report)}`)
+  }
+}
+
+function parseArgs(args: string[]): { requireCompleteMetadata: boolean; rootDir: string } {
+  const rootIndex = args.indexOf('--root')
+  const rootDir = rootIndex >= 0 && args[rootIndex + 1] ? args[rootIndex + 1] : process.cwd()
+  return {
+    requireCompleteMetadata: args.includes('--require-complete-metadata'),
+    rootDir
+  }
+}
+
+function isEntryPoint(): boolean {
+  if (!process.argv[1]) return false
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2))
+  const report = inspectFabricCompatibility(options.rootDir)
+  console.log(formatFabricCompatibilityReport(report))
+
+  if (report.consumers.length === 0) {
+    console.log(
+      'No @qvac/fabric-consuming addons were found; the check remains advisory while addon migration is in progress.'
+    )
+  }
+
+  try {
+    assertFabricCompatibility(report, options)
+    console.log('Fabric compatibility preflight passed.')
+  } catch (error) {
+    console.error(
+      `Fabric compatibility preflight failed: ${error instanceof Error ? error.message : error}`
+    )
+    process.exitCode = 1
+  }
+}
+
+if (isEntryPoint()) main()

--- a/packages/sdk/test/check-addon-fabric-compatibility.test.ts
+++ b/packages/sdk/test/check-addon-fabric-compatibility.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  assertFabricCompatibility,
+  inspectFabricCompatibility
+} from '../scripts/check-addon-fabric-compatibility'
+
+function writePackage(
+  nodeModulesDir: string,
+  name: string,
+  manifest: Record<string, unknown>
+): string {
+  const packageDir = join(nodeModulesDir, ...name.split('/'))
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ name, ...manifest }))
+  return packageDir
+}
+
+function withFixture(run: (rootDir: string, nodeModulesDir: string) => void): void {
+  const rootDir = mkdtempSync(join(tmpdir(), 'qvac-fabric-preflight-'))
+  const nodeModulesDir = join(rootDir, 'node_modules')
+  mkdirSync(nodeModulesDir, { recursive: true })
+  try {
+    run(rootDir, nodeModulesDir)
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true })
+  }
+}
+
+test('aligned Fabric versions pass while legacy packages are reported', () => {
+  withFixture((rootDir, nodeModulesDir) => {
+    writePackage(nodeModulesDir, '@qvac/fabric', { version: '0.8.0', addon: true })
+    writePackage(nodeModulesDir, '@qvac/embed-llamacpp', {
+      addon: true,
+      version: '0.36.0',
+      dependencies: { '@qvac/fabric': '^0.8.0' }
+    })
+    writePackage(nodeModulesDir, '@qvac/classification-ggml', {
+      addon: true,
+      version: '0.22.0',
+      dependencies: { '@qvac/fabric': '^0.8.0' }
+    })
+    writePackage(nodeModulesDir, '@qvac/legacy-addon', { addon: true, version: '0.1.0' })
+
+    const report = inspectFabricCompatibility(rootDir)
+    assert.deepEqual(report.versions, ['0.8.0'])
+    assert.equal(report.consumers.length, 2)
+    assert.equal(report.legacyAddons.length, 1)
+    assert.doesNotThrow(() => assertFabricCompatibility(report))
+    assert.throws(
+      () => assertFabricCompatibility(report, { requireCompleteMetadata: true }),
+      /metadata is incomplete/
+    )
+  })
+})
+
+test('nested incompatible Fabric versions fail the preflight', () => {
+  withFixture((rootDir, nodeModulesDir) => {
+    writePackage(nodeModulesDir, '@qvac/fabric', { version: '0.8.0', addon: true })
+    const nestedNodeModulesDir = writePackage(nodeModulesDir, '@qvac/embed-llamacpp', {
+      addon: true,
+      version: '0.36.0',
+      dependencies: { '@qvac/fabric': '^0.8.0' }
+    })
+    writePackage(join(nestedNodeModulesDir, 'node_modules'), '@qvac/fabric', {
+      version: '0.7.0',
+      addon: true
+    })
+    writePackage(nodeModulesDir, '@qvac/classification-ggml', {
+      addon: true,
+      version: '0.22.0',
+      dependencies: { '@qvac/fabric': '^0.8.0' }
+    })
+
+    const report = inspectFabricCompatibility(rootDir)
+    assert.deepEqual(report.versions, ['0.7.0', '0.8.0'])
+    assert.throws(() => assertFabricCompatibility(report), /mixed @qvac\/fabric versions/)
+  })
+})
+
+test('missing Fabric packages fail closed for migrated consumers', () => {
+  withFixture((rootDir, nodeModulesDir) => {
+    writePackage(nodeModulesDir, '@qvac/embed-llamacpp', {
+      addon: true,
+      version: '0.36.0',
+      dependencies: { '@qvac/fabric': '^0.8.0' }
+    })
+
+    const report = inspectFabricCompatibility(rootDir)
+    assert.equal(report.unresolvedConsumers.length, 1)
+    assert.throws(() => assertFabricCompatibility(report), /could not resolve @qvac\/fabric/)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the published-package Fabric compatibility preflight proposed in #3655.

- scans the installed `@qvac/*` addon package manifests selected by the SDK;
- resolves each migrated add-on's actual `@qvac/fabric` package version;
- fails before the SDK Android/iOS mobile build when versions are mixed or a declared Fabric dependency cannot be resolved;
- reports legacy addons that have not migrated to the npm Fabric dependency yet;
- runs after project dependency installation in both SDK Device Farm workflows.

The check is intentionally non-blocking for legacy metadata during the ongoing addon migration. `--require-complete-metadata` is available for the point when all selected addons expose the npm contract.

## Verification

- 3 fixture tests pass, including nested mixed-version detection and unresolved-dependency failure.
- Prettier check passes.
- Targeted TypeScript check passes.
- Both modified workflow files parse as YAML.
- Current local published-package tree reports one migrated consumer and ten legacy addons, as expected.

Refs #3655