### PR TITLE
QVAC-24181 infra: resolve @qvac/inference from the workspace in the SDK peer-resolution check

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -350,11 +350,6 @@ jobs:
             cd "$WS/$P_PATH"
             if [ -f "$WS/.npmrc" ]; then cp "$WS/.npmrc" .npmrc; fi
 
-            if [ "$PKG" = "sdk" ]; then
-              run "npm install (peer resolution)" sdk_npm_install_check
-              run "npm install cleanup" rm -rf node_modules package-lock.json
-            fi
-
             # Disallowed dependencies: no git URLs or dev/tmp versions on public
             # npm deps. @tetherto/* GPR mono prerelease pins (e.g. inference-mono
             # 0.16.0-tmp.runid-*) are allowed — coordinated SDK+inference PRs
@@ -403,6 +398,11 @@ jobs:
 
               # Per-source setup (no-op if the script is absent).
               run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+
+              # Peer-resolution drift against this source's resolved @qvac/inference.
+              if [ "$PKG" = "sdk" ]; then
+                run "npm install (peer resolution) $src" sdk_npm_install_check
+              fi
 
               run "format $src" npm run --if-present format
               run "lint $src" npm run --if-present lint


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`sdk_npm_install_check` in `pr-checks-sdk-pod.yml` ran before the `sdk_sources` loop, on the committed manifest, so its `npm install` resolved `@qvac/inference` from the registry. `sdk` and `inference` publish lockstep, so the range `@qvac/inference@^0.18.0` resolved the latest already-published inference instead of the in-repo engine the SDK ships with. Whenever the SDK's addon deps are ahead of that published inference's peers, the check failed with `ERESOLVE` on a pairing (new SDK + old inference) that a lockstep release never produces.

Example: the SDK depends on `@qvac/diffusion-cpp@^0.20.0`, but published `@qvac/inference@0.18.2` peers `@qvac/diffusion-cpp@^0.18.0`, so the install could not resolve.

## 📝 How does it solve it?

Move the check into the `sdk_sources` loop, right after `sdk-source:$SRC`. That step (`link-workspace-inference.ts` for the workspace source) already points `@qvac/inference` at the in-repo copy, so the check's `npm install` resolves the co-published engine with no manual linking. It now runs per source and validates each source's actual resolution.

The check function is unchanged (plain `npm install` + peer/`ERESOLVE` grep); only its placement moved.

## 🧪 How was it tested?

- Reproduced the `ERESOLVE` from the failing run and confirmed via `npm view` that no published `inference@^0.18.0` carries the SDK's current addon peer (diffusion-cpp `^0.20.0` as the example).
- Confirmed that after `sdk-source:workspace` the manifest resolves the in-repo `inference`, whose peers match the SDK's addon deps.
- Scanned all workflows: only `pr-checks-sdk-pod.yml` has `ERESOLVE`/peer failure gates (`sdk_npm_install_check`, now inside the loop, and `consumer_install_check`, which already overrides `@qvac/inference` to the in-repo tarball); no other workflow does a blind registry install of the in-repo SDK tree.