### PR TITLE
QVAC-24013 chore[mod]: raise every speech-cpp floor to 2026-08-26

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -57,6 +57,17 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
   was the only GPU backend wired there. Both now accept CUDA (`2`) or Vulkan
   (`3`), because a CUDA-enabled build compiles both in and ggml registers CUDA
   first.
+- Raise the `speech-cpp` floor to 2026-08-26, including the new opt-in `cuda`
+  feature's own floor, which brings in ggml-speech
+  2026-08-26. Sortformer finalization is now deterministic: every non-cancelled
+  finalize ends with exactly one synthetic terminator, where before a real
+  trailing segment could carry the final flag instead. The speaker spans this
+  package emits are unchanged, because it keys off the terminator's negative
+  speaker id rather than the flag. Indic Conformer multilingual CTC also runs on
+  Vulkan now. The Whisper engine sources are unchanged. On the ggml side the
+  update adds Vulkan `im2col`/`col2im` tiling, CUDA kernels and launch guards for
+  the `conv_transpose_1d`, `im2col` and `pad` paths, and Adreno OpenCL launch
+  validation with GEMV work-group limits.
 
 ### Fixed
 

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "whisper",
@@ -24,7 +24,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "whisper",
@@ -36,7 +36,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "whisper",
@@ -61,7 +61,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-24#1",
+          "version>=": "2026-08-26",
           "default-features": false,
           "features": [
             "cuda"

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU fallback, and `stats.backendDevice`/`backendId` report the backend
   actually in use.
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-08-26, which brings in ggml-speech
+  2026-08-26. This is the engine half of the MiniMax-Music3 GPU support above:
+  MiniMax-Music3 now runs on Vulkan, and the Vulkan `im2col_3d` path handles
+  work-group counts past the y-dimension limit. ACE-Step Vulkan generation is
+  over 2x faster on AMD Strix Halo (RADV) through tiled `im2col`/`col2im`
+  pipelines and a large-tile transpose copy, and CUDA transposed copies now
+  cover every type and stay off strided destinations.
+
 ### Fixed
 
 - MiniMax-Music3 produced tonal noise instead of music, and a cancellation

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-24#2",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "audiogen",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-24#2",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "audiogen",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-24#2",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "audiogen",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-24#2",
+          "version>=": "2026-08-26",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-24#2",
+          "version>=": "2026-08-26",
           "default-features": false,
           "features": [
             "vulkan"

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-08-26, which brings in ggml-speech
+  2026-08-26. The Whisper engine sources are unchanged; the ggml update adds
+  Vulkan `im2col`/`col2im` tiling, CUDA kernels and launch guards for the
+  `conv_transpose_1d`, `im2col` and `pad` paths, and Adreno OpenCL launch
+  validation with GEMV work-group limits.
+
 ## [0.7.2] - 2026-08-18
 
 ### Changed

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "whisper",
@@ -23,7 +23,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "whisper",
@@ -33,7 +33,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "whisper",

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-08-26, which brings in ggml-speech
+  2026-08-26. The engine gains CUDA paths for Chatterbox, Supertonic, Parler-TTS,
+  CosyVoice3 and Audio8; this package does not declare a `cuda` feature, so no
+  CUDA backend is built and the runtime behaviour here is unchanged. On the ggml
+  side the update adds Vulkan `im2col`/`col2im` tiling, CUDA kernels and launch
+  guards for the `conv_transpose_1d`, `im2col` and `pad` paths, and Adreno
+  OpenCL launch validation with GEMV work-group limits.
+
 ## [0.7.5] - 2026-08-20
 
 ### Changed

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "tts",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "tts",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-18",
+      "version>=": "2026-08-26",
       "default-features": false,
       "features": [
         "tts",
@@ -52,7 +52,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-18",
+          "version>=": "2026-08-26",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
Follow-up to the merged registry release [qvac-registry-vcpkg#334](https://github.com/tetherto/qvac-registry-vcpkg/pull/334), which published `speech-cpp@2026-08-26` (`ad64f66a`) and `ggml-speech@2026-08-26` (`051de800`). This raises the floor in every consumer so they resolve the pair together.

## Why this one is a breakage fix, not just a bump

The source repo was renamed `qvac-ext-lib-whisper.cpp` -> `qvac-fabric-speech.cpp`. GitHub embeds the repo name in the top-level directory of the source tarball, so the archive bytes changed for **every** pre-rename pin and the published `SHA512` stopped matching. Read straight out of the version database:

| `speech-cpp` version | `REPO` in its portfile | cold fetch |
|---|---|---|
| `2026-08-18#0` | `tetherto/qvac-ext-lib-whisper.cpp` | broken |
| `2026-08-24#2` | `tetherto/qvac-ext-lib-whisper.cpp` | broken |
| `2026-08-25#0` | `tetherto/qvac-fabric-speech.cpp` | ok |
| `2026-08-26#0` | `tetherto/qvac-fabric-speech.cpp` | ok |

All four consumers resolved a broken version, so a cold build fails anywhere the vcpkg asset/binary cache does not already hold the archive. Warm CI hid it, because asset-cache lookup is by the recorded hash.

## What moves

`bci-whispercpp` is included for the same reason the other three are, and as in the two previous floor bumps (#3897, #3931).

| package | `speech-cpp` before -> after | `ggml-speech` before -> after | `version>=` lines |
|---|---|---|---|
| `asr-ggml` | `2026-08-18` -> `2026-08-26` | `2026-08-17` -> `2026-08-26` | 4 (3 deps + `features.cuda`) |
| `tts-ggml` | `2026-08-18` -> `2026-08-26` | `2026-08-17` -> `2026-08-26` | 4 (3 deps + `features.vulkan`) |
| `audiogen-ggml` | `2026-08-24#2` -> `2026-08-26` | `2026-08-21` -> `2026-08-26` | 5 (3 deps + `features.cuda` + `features.vulkan`) |
| `bci-whispercpp` | `2026-08-18` -> `2026-08-26` | `2026-08-17` -> `2026-08-26` | 3 |

16 lines total. Rebased onto #4063, which added `asr-ggml`'s opt-in `cuda` feature after this branch was cut; that feature carried its own `speech-cpp` floor at `2026-08-24#1`, which is one of the rename-broken versions, so it moves to `2026-08-26` with the rest rather than being left behind to fail on any CUDA build. Verified by dry-run: `--x-feature=cuda` on `x64-linux` resolves `speech-cpp[core,cuda,parakeet,vulkan,whisper]@2026-08-26` and `ggml-speech[core,cuda,vulkan]@2026-08-26`. No package declares `ggml-speech` directly — `speech-cpp@2026-08-26` carries `ggml-speech version>= 2026-08-26`, so ggml moves transitively. The before/after columns are **measured** with `vcpkg install --dry-run`, not inferred; note the pre-bump ggml resolution is `2026-08-17`, one notch below what the published `0.3.2` entries assumed, because `speech-cpp@2026-08-18#0` declares a `2026-08-17` ggml floor.

Addon `vcpkg-configuration.json` `default-registry.baseline` values are deliberately untouched. There are no `overrides` blocks in any of the four.

## Change windows

**`asr-ggml`, `bci-whispercpp`, `tts-ggml`** — `speech-cpp` `5f181b9d..ad64f66a`:

* `engines/parakeet`: make the AOSC final event deterministic (#142, @Alok-Ranjan23); run IndicConformer multilingual CTC on Vulkan (#156, @mexxik).
* `engines/tts`: CUDA paths for Chatterbox (#159), Supertonic (#161), Parler-TTS (#163), CosyVoice3 (#167) and Audio8 (#170), all @mexxik. `tts-ggml` declares no `cuda` feature, so no CUDA backend is built and its runtime behaviour is unchanged — the code ships unengaged.
* `third_party/whisper.cpp`: **effectively unchanged** — the only delta is `PATCHES.md` and `examples/addon.node/package.json`, neither of which is compiled into the library. So `bci-whispercpp` and the Whisper half of `asr-ggml` gain the ggml update and the working archive hash, nothing else.
* Outside the engine subtrees: only CI workflow files and the repo `README.md`.

**`audiogen-ggml`** — `speech-cpp` `30cc6c5c..ad64f66a`:

* Run MiniMax-Music3 on Vulkan (#171, @Zbig9000). This is the engine half of the MiniMax GPU support this package already exposes and already claims under `[Unreleased]`; before this bump the Vulkan branch of that claim had no engine behind it.
* ACE-Step 2x+ speedup on AMD Strix Halo, Vulkan RADV (#172, @pratiknarola-t).
* MiniMax CPU/Metal parity regression in audiogen CI (#168, @ishanvohra2) and the ACE-Step engine comparison harness (#166, @ishanvohra2) — tests and benchmarks only.

**`ggml-speech` halves** — `2026-08-17..051de800` for asr/tts/bci, `2026-08-21..051de800` for audiogen: Vulkan `im2col`/`col2im` tiling with a large-tile transpose copy and `im2col_3d` looping past the y work-group limit; CUDA kernels and launch guards for the `conv_transpose_1d`, `im2col` and `pad` paths plus full transposed-copy type coverage; Adreno OpenCL launch validation and GEMV work-group limits.

## No API migration

Only two public headers changed across the windows, `parakeet/diarization.h` and `tts-cpp/supertonic/engine.h`, and **both diffs are comment-only** — no symbol added, removed or renamed. `audiogen-ggml`'s window touches no public header at all.

The parakeet comment does record a contract change: the last Sortformer callback is now always the synthetic terminator, where before a real trailing segment could carry `is_final`. That is inert for `asr-ggml` — both consumption sites (`ParakeetStreamingProcessor.cpp:166`, `ParakeetModel.cpp:813`) key off `seg.speaker_id < 0` and never read `is_final`, so the set of speaker spans reaching JS is identical. The engine-level event stream simply stops being nondeterministic.

## Documentation

Checked both levels, no edit needed, and stating it so a reviewer does not have to re-derive it. The root `README.md` rows for Transcription, Text-to-Speech and Music generation stay accurate — no addon exposes a new feature here. `audiogen-ggml/README.md` already says MiniMax-Music3 "runs on desktop CPUs and GPUs", which this bump makes true on Vulkan rather than changing. `asr-ggml/README.md` documents Vulkan per platform rather than per model, so Indic-on-Vulkan needs no wording change. `tts-ggml` gains no exposed feature.

No `package.json` version bumps — those go in their own release PR, so the entries land under `[Unreleased]`. `bci-whispercpp` had no `[Unreleased]` section and gets one.

## Verification

* **Resolution, measured before and after** for all four packages via `vcpkg install --dry-run --triplet=arm64-osx` on a copy of each manifest pair. After the change every one resolves `speech-cpp@2026-08-26` at git-tree `7968dcff` and `ggml-speech@2026-08-26` at `a79d518b` — exactly the trees recorded in the registry version database — from the registry URL, on untouched baselines.
* **Real local build of `asr-ggml`** against the merged registry: `bare-make generate && bare-make build` on arm64-osx. Both ports built **from source** (`Building ggml-speech…2026-08-26`, `Building speech-cpp[core,coreml,metal,parakeet,whisper]…2026-08-26`), then all 11 addon translation units compiled and linked `qvac__asr-ggml@0.bare` with zero errors. This is also the first build of the `coreml` feature combination against this pin.
* The three registry overlay-CI runs on `speech-cpp@2026-08-26` + `ggml-speech@2026-08-26` (asr, tts, audiogen) validated these exact port trees across the full platform matrix; their per-job verdicts are recorded on qvac-registry-vcpkg#334.
