### PR TITLE
QVAC-23575 chore: release @qvac/test-suite 0.11.0

### DIFF
--- a/packages/test-suite/changelog/0.11.0/CHANGELOG.md
+++ b/packages/test-suite/changelog/0.11.0/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog v0.11.0
+
+Release Date: 2026-08-26
+
+## 🔌 API
+
+- Rename the package from `@qvac/qvac-test-suite` to `@qvac/test-suite`; the GitHub Packages dev build is renamed from `@tetherto/qvac-test-suite` to `@tetherto/test-suite-mono`. (see PR [#4082](https://github.com/tetherto/qvac/pull/4082))
+
+## ⚙️ Infrastructure
+
+- Move the framework out of `tetherto/qvac-test-suite` into the monorepo at `packages/test-suite` and register it as an SDK-pod package. (see PR [#4082](https://github.com/tetherto/qvac/pull/4082))
+- Publish from the monorepo using the prebuilt-dist pattern: `dist` is compiled once in a dedicated build job and downloaded by every publish job. (see PR [#4082](https://github.com/tetherto/qvac/pull/4082))
+
+## 🧹 Chores
+
+- Port the framework docs and Cursor rules into the monorepo conventions. (see PR [#4082](https://github.com/tetherto/qvac/pull/4082))

--- a/packages/test-suite/changelog/0.11.0/CHANGELOG_LLM.md
+++ b/packages/test-suite/changelog/0.11.0/CHANGELOG_LLM.md
@@ -1,6 +1,4 @@
-# Changelog
-
-## [0.11.0]
+# QVAC Test Suite v0.11.0 Release Notes
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.0
 

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/test-suite",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Generic distributed testing framework for multi-platform execution",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 🎯 What problem does this solve?

First release of the test-orchestration framework from the monorepo. `@qvac/test-suite` does not exist on public npm yet — the package's releases up to `0.10.2` were cut from the standalone `tetherto/qvac-test-suite` repository, which was folded in by #4082.

Publishing this unblocks #4083, which then depends on a published range (`^0.11.0`) instead of the interim `file:` link.

## 📝 How is it solved?

- `packages/test-suite/package.json` → `0.11.0`
- `packages/test-suite/changelog/0.11.0/` with `CHANGELOG.md` and `CHANGELOG_LLM.md`
- Root `CHANGELOG.md` rebuilt from the version folder via `generate-changelog-sdk-pod.cjs --update-root-changelog`

Why `0.11.0` and not `0.10.3`: the package name changed, and the old `@qvac/qvac-test-suite` is already at `0.10.3` on npm. A minor bump keeps the version line moving forward across the rename instead of appearing to go backwards.

The package has no prior tag in this repository, so the changelog was generated with the documented migration flags (`--base-commit=0359b82a8 --base-version=0.10.2`). No PRs fall in that range, which is expected — the fold itself is the only change and its notes are authored by hand in `CHANGELOG_LLM.md`.

`NOTICE` is unchanged; the dependency set did not move.

## 🧪 How was this verified?

Locally on the release branch, at `0.11.0`:

- `npm run check` (lunte + eslint + prettier) — clean
- `npm run typecheck` — clean
- `npm run build` — clean, and `node dist/cli/index.js --version` reports `0.11.0`
- The publish workflow's own heading gate: `grep -qE "^## \[0.11.0\]" packages/test-suite/CHANGELOG.md` — passes
- `npm view @qvac/test-suite version` — 404, so this is genuinely the first publish under the new name

## 💥 Breaking Changes

None in this PR — it only bumps the version and adds changelog surfaces. The rename that this version carries was declared and reviewed in #4082.

For consumers, the shape of that rename is:

BEFORE:

```json
{ "dependencies": { "@qvac/qvac-test-suite": "^0.10.3" } }
```

AFTER:

```json
{ "dependencies": { "@qvac/test-suite": "^0.11.0" } }
```

## 🚀 Workflow / Publish Changes

None. Publishing runs through `trigger-reusable-lib-test-suite.yml`, added in #4082.

Note for reviewers: `publish-release-npm` uses `environment: npm`, which has a required-reviewer protection rule — the publish job waits for approval and does not fire on push.

## 🔄 Migration Notes

**Prerequisite for the publish job to succeed:** an npm Trusted Publisher must exist for `@qvac/test-suite` — organization `tetherto`, repository `qvac`, workflow `trigger-reusable-lib-test-suite.yml`, environment `npm`. Publishing uses OIDC with no long-lived token, so without it the job fails when approved.

After this merges:

1. Backmerge this branch into `main` so the version bump and changelog land there.
2. Switch `packages/sdk/e2e` in #4083 from the `file:` link to `^0.11.0` and drop the interim manifest-link handling, then merge #4083.
3. `npm deprecate @qvac/qvac-test-suite` pointing at the new name — not unpublish, so anything pinned to `0.10.x` keeps resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
