### PR TITLE
QVAC-23802 chore[audiogen-ggml]: run the ACE-Step LM on CUDA (speech stack 2026-08-26#1)

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   over 2x faster on AMD Strix Halo (RADV) through tiled `im2col`/`col2im`
   pipelines and a large-tile transpose copy, and CUDA transposed copies now
   cover every type and stay off strided destinations.
+- On CUDA the ACE-Step language model now runs on the GPU instead of the CPU,
+  by raising the `speech-cpp` floor further to 2026-08-26#1: the bundled ggml
+  computes explicit-f32-precision matmuls in true f32 on CUDA, which removes
+  the NaN risk for the LM's large activations and lifts its CPU-only
+  placement.
 
 ### Fixed
 

--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "cf1500e91d595db131c41421d4e1455f9143ec6e",
+    "baseline": "48f5fefe0d4ae67fa410107d3d5912a60b71ddef",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26",
+      "version>=": "2026-08-26#1",
       "default-features": false,
       "features": [
         "audiogen",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26",
+      "version>=": "2026-08-26#1",
       "default-features": false,
       "features": [
         "audiogen",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26",
+      "version>=": "2026-08-26#1",
       "default-features": false,
       "features": [
         "audiogen",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26",
+          "version>=": "2026-08-26#1",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26",
+          "version>=": "2026-08-26#1",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## What

Raises `@qvac/audiogen-ggml`'s registry baseline to `48f5fefe` (qvac-registry-vcpkg tetherto/qvac-registry-vcpkg#335) and the `speech-cpp` floor to `2026-08-26#1` on every platform pin. The opt-in `cuda` feature shipped in #4041; this bump is what moves its prebuilds from `lm=CPU` to `lm=CUDA` and removes the NaN risk for the LM's large activations.

That registry cut pairs:

- **ggml-speech `b30fb103`** — CUDA MUL_MAT honours `GGML_PREC_F32` (explicit-precision matmuls take the f32 cuBLAS path with TF32 disabled, instead of the q8_1 kernels whose fp16 block sums overflow past +-65504 for the ACE-Step LM activations; tetherto/qvac-ext-ggml#68), plus CONCAT support for all scalar and quantized types (tetherto/qvac-ext-ggml#67). `test-backend-ops` passes 12313/12313 on an RTX 5090 (sm_120, CUDA 12.9).
- **speech-cpp `e308515f`** — the engine stage-placement allowlist runs the ACE-Step LM on CUDA (tetherto/qvac-fabric-speech.cpp#173), measured against the F32-dequantized reference on an RTX 5090: Q8_0 LM logit cosine 0.999918 with an identical greedy trajectory, where the CPU Q8_0 path measures 0.9943; batched-CFG regression passes; end to end the engine reports `enc/lm/detok/dit/vae=CUDA0` and produces full-duration finite audio.

The baseline move is required, not optional: `2026-08-26#1` does not exist in the previous baseline, so the floor bump alone would fail resolution.

## Validation

- `vcpkg install --dry-run --x-feature=cuda` resolves `speech-cpp[audiogen,core,cuda,vulkan]@2026-08-26#1` with `ggml-speech@2026-08-26#1` from the new baseline.
- `npm run lint` (prettier, lunte, eslint, type tests) passes; no C++ or JS sources change.
- CHANGELOG entry added under Unreleased; no version bump (per packaging rules, that goes in its own PR).