### PR TITLE
QVAC-23953 chore: prepare @qvac/rag 0.8.0 release

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -1,81 +1,227 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## [0.8.0]
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.0
+
+This release adds `TurboVecAdapter`, which uses an injected native vector index for candidate search while keeping HyperDB as the durable source of truth. It also strengthens HyperDB writes so invalid or partially failed batches cannot leave inconsistent document and vector records.
+
+## TurboVec-backed search
+
+`TurboVecAdapter` accepts a `TurboVecIndexProvider`, so applications can supply a compatible native index without making `@qvac/rag` depend directly on an embedding addon. The adapter uses the native index to find candidates, then reads and scores the matching records from HyperDB.
+
+```typescript
+import { TurboVecAdapter, type TurboVecIndexProvider } from '@qvac/rag'
+import IdMapIndex from '@qvac/embed-llamacpp/idMapIndex'
+
+const indexProvider: TurboVecIndexProvider = {
+  create: (options) => new IdMapIndex(options),
+  load: (snapshotPath) => IdMapIndex.load(snapshotPath)
+}
+
+const adapter = new TurboVecAdapter({
+  store,
+  dbName: 'workspace',
+  indexProvider,
+  checkpointDir: '/path/to/index'
+})
+```
+
+## Recovery and writer safety
+
+Mutation records and revisioned checkpoints let the adapter rebuild or refresh its native index from HyperDB after an interrupted write or stale checkpoint. A heartbeat-based writer lock prevents two adapter instances from changing the same index at the same time. If the native index is unavailable, HyperDB remains available as the authoritative data store.
+
+## Consistent HyperDB writes
+
+`HyperDBAdapter` now rejects batches that mix embedding dimensions with `EMBEDDING_DIMENSION_MISMATCH`. If a batch write fails partway through, it discards the transaction and retries complete document and vector pairs instead of committing partial rows. Search snapshots are also closed after each operation.
 
 ## [0.7.0]
 
-### Changed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.7.0
 
-- Convert `@qvac/rag` to TypeScript compiled ESM (`"type": "module"`). CommonJS `require('@qvac/rag')` no longer works. Switch to `import`. Named exports are unchanged (#3718).
+`@qvac/rag` is now TypeScript compiled to ESM. CommonJS `require('@qvac/rag')` no longer works — switch to `import`. Invalid `search` and `infer` queries throw `QvacErrorRAG` with `INVALID_INPUT` instead of a raw `TypeError`. Named exports are unchanged.
 
-### Fixed
+## Breaking Changes
 
-- Validate `search` and `infer` queries before logging so a non-string or blank query throws `QvacErrorRAG { code: INVALID_INPUT }` instead of a raw `TypeError` (#3729).
+### ESM only
+
+The package is `"type": "module"`. Node rejects `require()` of ESM. Use `import`. Named exports (`RAG`, `HyperDBAdapter`, adapters, `ERR_CODES`, `QvacErrorRAG`) are the same. `@qvac/rag/errors` still exports the error class and codes without loading the full package.
+
+**Before:**
+
+```js
+const { RAG, HyperDBAdapter } = require('@qvac/rag')
+```
+
+**After:**
+
+```ts
+import { RAG, HyperDBAdapter } from '@qvac/rag'
+```
+
+The 0.6.1 Pear/CJS `require()` path for hard dependencies is gone with this conversion. Pear consumers need an ESM-capable loader.
+
+## Bug Fixes
+
+### Query validated before logging
+
+`rag.search()` and `rag.infer()` reject a non-string or blank query with `QvacErrorRAG { code: INVALID_INPUT }` before any debug log reads `query.substring`. Valid queries are unchanged. Previously a non-string hit `TypeError` at the log line and never reached the existing search guard.
 
 ## [0.6.4]
 
-### Changed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.4
 
-- Drop the unused `crypto-browserify` hard dependency. The package never imported it — `#crypto` resolves to `bare-crypto` (Bare) or `node:crypto` (Node), and the browser / React Native shim reads `globalThis.crypto`. Consumers needing Node-style `crypto.createHash` (e.g. HyperDB document hashing in a browser/RN runtime) should install `crypto-browserify` themselves and assign it to `globalThis.crypto`, as documented in the README.
+This patch drops the unused `crypto-browserify` hard dependency. The package never imported it.
+
+## Changed
+
+### Unused `crypto-browserify` dependency removed
+
+`#crypto` still resolves to `bare-crypto` on Bare, `node:crypto` on Node, and `globalThis.crypto` on browser / React Native. Consumers that need Node-style `crypto.createHash` (for example HyperDB document hashing in a browser or React Native runtime) should install `crypto-browserify` themselves and assign it to `globalThis.crypto`, as documented in the README.
 
 ## [0.6.3]
 
-### Changed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.3
 
-- Bump `bare-fetch` to `^3.0.1` (adopt the 3.x major; public fetch API unchanged).
+This patch bumps the production `bare-fetch` dependency across the 2→3 major to `^3.0.1`.
+
+---
+
+## 🔧 Changed
+
+### `bare-fetch` bumped to `^3.0.1`
+
+The 2→3 transition is transitive-only — the public fetch API is unchanged. The only behavioral change in 3.x is the header validation added in 3.0.1, and RAG only constructs RFC-valid headers, so no code change is required. The bare-tls trust-store change already shipped within the 2.x line via `bun.lock`.
 
 ## [0.6.2]
 
-### Fixed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.2
 
-- Add `./errors.js` export alias so TypeScript ESM emit (`@qvac/rag/errors.js`) resolves under Node package exports.
+This patch fixes a package exports gap that broke SDK consumer installs when TypeScript compiled `@qvac/rag/errors` imports to `@qvac/rag/errors.js`.
+
+---
+
+## 🔌 API
+
+### `./errors.js` export alias
+
+TypeScript ESM output appends `.js` to subpath imports. Node enforces `package.json#exports` strictly, so `@qvac/rag/errors.js` failed even though `@qvac/rag/errors` worked. This release adds a matching `./errors.js` export entry pointing at the same module as `./errors`.
+
+No API surface change — existing `@qvac/rag/errors` imports continue to work unchanged.
 
 ## [0.6.1]
 
-### Added
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.1
 
-- Published `@qvac/rag/errors` subpath for importing `ERR_CODES` and `QvacErrorRAG` without loading the full package entry (#2303).
+This patch restores Pear/CJS compatibility for RAG adapters and adds a lightweight `./errors` subpath so SDK consumers can import error codes without pulling in the full package entry.
 
-### Fixed
+---
 
-- Load RAG hard dependencies (`hyperdb`, `hyperschema`, `llm-splitter`, `#fetch`) via synchronous `require()` instead of dynamic `await import()` for Pear/CJS compatibility (#2284).
+## 🐞 Fixes
+
+### Pear/CJS compatibility (#2284)
+
+RAG adapters now load hard dependencies (`hyperdb`, `hyperschema`, `llm-splitter`, `#fetch`) via synchronous `require()` instead of dynamic `await import()`. This fixes `MODULE_NOT_FOUND` failures when running RAG under Pear, where ESM dynamic imports are unavailable in the CJS module graph.
+
+---
+
+## 🔌 API
+
+### `@qvac/rag/errors` subpath (#2303)
+
+Consumers can now import RAG error codes and the error class from a dedicated subpath that does not transitively load `HyperDBAdapter` or other heavy runtime deps:
+
+```typescript
+import { ERR_CODES, QvacErrorRAG } from '@qvac/rag/errors'
+
+if (err instanceof QvacErrorRAG && err.code === ERR_CODES.OPERATION_CANCELLED) {
+  // handle cancellation
+}
+```
+
+Existing `import { ERR_CODES } from "@qvac/rag"` continues to work unchanged.
 
 ## [0.6.0]
 
-### Changed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.0
 
-- Upgrade to HyperDB 6 (`hyperdb@^6.7.0`), regenerate RAG HyperDB specs for the v6 toolchain, and move runtime Holepunch libraries from `peerDependencies` to direct `dependencies` (#2255).
-- Bump `@qvac/registry-client` dev dependency to `^0.6.0`.
+This release completes the HyperDB 6 migration for `@qvac/rag`, aligning with the published `@qvac/registry-schema@0.3.0` and `@qvac/registry-client@0.6.0` stack. RAG now owns the Holepunch libraries it imports at runtime as direct dependencies instead of optional peers. The public RAG API is unchanged.
+
+---
+
+## 🔧 Changed
+
+### HyperDB 6 and regenerated specs (#2255)
+
+`hyperdb` is bumped from the HyperDB 4 peer range to `^6.7.0` as a direct dependency. The autogenerated HyperDB spec under `src/adapters/database/hyperspec/` is rebuilt with the HyperDB 6 compiler output.
+
+### Dependency graph cleanup
+
+Runtime imports (`bare-crypto`, `bare-fetch`, `hyperdb`, `hyperdht`, `hyperschema`, `llm-splitter`) move from `peerDependencies` back to direct `dependencies` — matching the registry hyperdb v6 cascade and avoiding peer-range drift when installed alongside `@qvac/sdk`. The `@qvac/registry-client` dev dependency is bumped to `^0.6.0` for examples and integration tests.
 
 ## [0.5.0]
 
-### Fixed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.5.0
 
-- React Native / Expo bundling: routed `bare-crypto` and `bare-fetch` through `package.json#imports` (`#crypto`, `#fetch`) with lazy shims, so non-Bare bundlers no longer corrupt the package output (e.g. `SyntaxError: 'LLMChunkAdapter' not exported`). Missing capabilities now throw `QvacErrorRAG { DEPENDENCY_REQUIRED }` only when invoked.
-- `generateId()` no longer mutates a global `crypto` or depends on `uuid-random`; UUID v4s are generated locally using secure randomness from `globalThis.crypto.getRandomValues` or `#crypto.randomBytes` / `getRandomValues`.
-- `QvacErrorRAG` construction in RAG crypto fallbacks now uses the canonical `{ code, adds }` options object so the documented `DEPENDENCY_REQUIRED` (14015) error code is actually thrown (previously degraded to code `0` / `"Unknown QVAC error"`).
+This release makes `@qvac/rag` a first-class citizen in non-Bare runtimes — React Native and Expo bundlers no longer choke on Bare-specific imports — and tightens the package's place in the SDK install graph so Holepunch singletons (DHT, Corestore, HyperDB) are no longer duplicated in consumer trees. It also lands a small but real bug fix in RAG's crypto-fallback error path so consumers can finally catch missing-dependency errors by code.
 
-### Changed
+---
 
-- Holepunch singletons (`hyperdb`, `hyperdht`, `hyperschema`, `bare-crypto`, `bare-fetch`, `llm-splitter`) moved from `dependencies` to `peerDependencies` so consumer trees install a single copy aligned with `@qvac/sdk`'s ranges. `hyperdht` is marked optional (reserved for the unwired `replicateWith` path).
-- Examples and integration tests migrated off `@qvac/dl-hyperdrive` to `@qvac/registry-client` (files-based addon construction). `devDependencies` updated accordingly: removed `@qvac/dl-hyperdrive`, added `@qvac/registry-client@^0.4.1`, bumped `@qvac/embed-llamacpp` `^0.7.6 → ^0.14.0` and `@qvac/llm-llamacpp` `^0.5.7 → ^0.16.0`.
+## 🐞 Fixes
 
-### Added
+### React Native / Expo bundling: `LLMChunkAdapter` is exported again
 
-- `crypto-browserify` as an optional peer dependency for browser / React Native consumers that need Node-style `crypto.createHash` (notably for HyperDB document hashing).
+Previously, importing `@qvac/rag` from a React Native or Expo project failed with `SyntaxError: 'LLMChunkAdapter' not exported` even though the export was present in the source — the bundler was getting corrupted output because RAG's source had hard `bare-crypto` and `bare-fetch` imports that non-Bare bundlers tried (and failed) to resolve.
+
+Bare-specific dependencies are now routed through Node.js `package.json#imports` so the right module is selected per runtime:
+
+- `#crypto` resolves to `bare-crypto` on Bare, `node:crypto` on Node, and a lazy shim on React Native and other targets.
+- `#fetch` resolves to `bare-fetch` on Bare and a lazy shim on Node, React Native, and other targets.
+
+The shims allow bundling to succeed and only throw `QvacErrorRAG { DEPENDENCY_REQUIRED }` if the missing capability is actually invoked at runtime. Consumers on browsers, React Native, or Node who need Node-style `crypto.createHash` (notably for HyperDB document hashing) can install `crypto-browserify`, which is now declared as an **optional peer dependency**.
+
+`generateId()` no longer mutates a global `crypto` or depends on `uuid-random`. It generates UUID v4 IDs locally using secure randomness from `globalThis.crypto.getRandomValues` or `#crypto.randomBytes` / `getRandomValues`, and throws a clear error if neither is available.
+
+### `QvacErrorRAG` in crypto fallbacks now reports the correct error code
+
+Two RAG crypto-fallback call sites were constructing `QvacErrorRAG` with positional arguments `(code, message)` instead of the canonical `{ code, adds }` options object. Because `QvacErrorBase` destructures its single options argument, the thrown error silently degraded to code `0` / `"Unknown QVAC error"` instead of the intended `DEPENDENCY_REQUIRED` (14015) — so consumers catching by code never matched. Both call sites in `helper.js` and `HyperDBAdapter.js` now use the canonical form, and the documented error code is what's actually thrown.
+
+---
+
+## 🧹 Maintenance
+
+### Holepunch singletons moved to `peerDependencies`
+
+`@qvac/rag` previously declared `hyperdb`, `hyperdht`, `hyperschema`, `bare-crypto`, `bare-fetch`, and `llm-splitter` as hard dependencies. When the SDK declared its own (drifting) ranges for these as peers, npm could end up installing duplicate copies of stateful singletons in a consumer's tree — separate DHT nodes, separate Corestores, broken P2P connectivity. These libraries are now `peerDependencies` (mirrored in `devDependencies` so the package still builds and tests in isolation), and `@qvac/sdk` is the single source of truth for the actual installed range. `hyperdht` is marked optional in RAG since it is reserved for the not-yet-wired `replicateWith` path.
+
+Consumers using `@qvac/sdk` or any tooling that auto-installs required peers (npm 7+, pnpm, bun) are unaffected — the peers resolve transparently. Direct standalone consumers of `@qvac/rag` using `yarn` or `legacy-peer-deps=true` may now see missing-peer warnings and should add `hyperdb`, `hyperschema`, and `bare-crypto` (and `bare-fetch` if used in a Bare runtime) to their own dependencies.
+
+### DataLoader cleanup: examples and integration tests off `@qvac/dl-hyperdrive`
+
+The RAG examples and integration test no longer depend on `@qvac/dl-hyperdrive`. Model fetching now goes through `@qvac/registry-client` (mirroring how the SDK and OCR addons consume the QVAC registry), and the addon construction has migrated from the old `HyperDriveDL` + loader-based shape to the current files-based shape (`{ files, config, logger, opts }`).
+
+To support this, `devDependencies` were updated:
+
+- Removed: `@qvac/dl-hyperdrive`
+- Added: `@qvac/registry-client@^0.4.1`
+- Bumped: `@qvac/embed-llamacpp` `^0.7.6 → ^0.14.0`, `@qvac/llm-llamacpp` `^0.5.7 → ^0.16.0` (versions that ship the files-based API).
+
+This is purely a developer-facing change — runtime behavior of `@qvac/rag` is unchanged. The SDK-side `overrides: { @qvac/dl-hyperdrive: ^0.2.0 }` is intentionally retained until the addons-side cleanup of `@qvac/infer-base`'s `dl-hyperdrive` peer dep lands.
 
 ## [0.4.4]
 
-### Changed
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.4.4
 
-- README: replaced `@tetherto` npm references with `@qvac` namespace references.
-- Dependencies: bumped `bare-crypto` to `^1.13.4` and cleaned up RAG package dependency declarations.
+This release focuses on dependency hygiene and package namespace consistency for the RAG library. It aligns documentation with the `@qvac` npm scope and updates core crypto dependency declarations to match current runtime expectations.
 
-## [0.4.3]
+---
 
-### Changed
+## 📘 Documentation
 
-- README: removed outdated npm Personal Access Token / `.npmrc` setup instructions for installing `@qvac/rag`.
+README references have been updated from the legacy `@tetherto` namespace to `@qvac`, reducing installation confusion and ensuring examples match currently published package names.
+
+---
+
+## 🧹 Maintenance
+
+`bare-crypto` dependency declarations were updated to `^1.13.4`, and related `package.json` cleanup was applied in the RAG package. This keeps dependency metadata aligned with the current SDK pod ecosystem and reduces drift across package manifests.

--- a/packages/rag/NOTICE
+++ b/packages/rag/NOTICE
@@ -16,69 +16,74 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperswarm-secret-stream
   @qvac/error@0.1.1
   @qvac/logging@0.1.1
+    https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
   b4a@1.8.1
     https://github.com/holepunchto/b4a
-  bare-addon-resolve@1.10.0
+  bare-abort-controller@1.1.2
+    https://github.com/holepunchto/bare-abort-controller
+  bare-addon-resolve@1.10.1
     https://github.com/holepunchto/bare-addon-resolve
   bare-ansi-escapes@2.2.3
     https://github.com/holepunchto/bare-ansi-escapes
   bare-assert@1.2.0
     https://github.com/holepunchto/bare-assert
-  bare-buffer@3.6.0
+  bare-buffer@3.7.0
     https://github.com/holepunchto/bare-buffer
-  bare-crypto@1.13.7
+  bare-crypto@1.15.3
     https://github.com/holepunchto/bare-crypto
   bare-dns@2.1.4
     https://github.com/holepunchto/bare-dns
-  bare-events@2.4.2
+  bare-env@3.0.1
+    https://github.com/holepunchto/bare-env
+  bare-events@2.9.1
     https://github.com/holepunchto/bare-events
-  bare-events@2.8.3
-    https://github.com/holepunchto/bare-events
-  bare-fetch@3.0.1
+  bare-fetch@3.2.0
     https://github.com/holepunchto/bare-fetch
   bare-form-data@1.2.2
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.7.1
+  bare-fs@4.8.0
     https://github.com/holepunchto/bare-fs
-  bare-http-parser@1.1.4
+  bare-http-parser@1.1.5
     https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.5.6
+  bare-http1@4.5.8
     https://github.com/holepunchto/bare-http1
   bare-https@3.0.0
     https://github.com/holepunchto/bare-https
-  bare-inspect@3.1.4
+  bare-inspect@3.1.5
     https://github.com/holepunchto/bare-inspect
   bare-mime@1.0.0
     https://github.com/holepunchto/bare-mime
-  bare-module-resolve@1.12.2
+  bare-module-resolve@1.12.4
     https://github.com/holepunchto/bare-module-resolve
-  bare-net@2.3.1
+  bare-net@2.3.3
     https://github.com/holepunchto/bare-net
-  bare-os@3.9.1
+  bare-os@3.9.3
     https://github.com/holepunchto/bare-os
-  bare-path@3.0.0
+  bare-path@3.1.1
     https://github.com/holepunchto/bare-path
-  bare-pipe@4.1.5
+  bare-performance@2.1.1
+    https://github.com/holepunchto/bare-performance
+  bare-pipe@4.2.3
     https://github.com/holepunchto/bare-pipe
-  bare-semver@1.0.3
+  bare-semver@1.1.0
     https://github.com/holepunchto/bare-semver
-  bare-stream@2.13.1
+  bare-stream@2.13.3
     https://github.com/holepunchto/bare-stream
-  bare-tcp@2.2.13
+  bare-tcp@2.5.4
     https://github.com/holepunchto/bare-tcp
-  bare-tls@3.1.5
+  bare-tls@3.1.8
     https://github.com/holepunchto/bare-tls
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.3
+  bare-url@2.5.2
     https://github.com/holepunchto/bare-url
-  bare-zlib@1.3.3
+  bare-zlib@1.4.1
     https://github.com/holepunchto/bare-zlib
   blind-relay@1.6.1
     https://github.com/holepunchto/blind-relay
-  compact-encoding@3.1.0
+  compact-encoding@3.3.2
     https://github.com/holepunchto/compact-encoding
   compact-encoding-bitfield@1.1.0
     https://github.com/compact-encoding/compact-encoding-bitfield
@@ -88,7 +93,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/device-file
   events-universal@1.0.1
     https://github.com/holepunchto/events-universal
-  fd-lock@2.1.1
+  fd-lock@2.2.0
     https://github.com/holepunchto/fd-lock
   fs-native-extensions@1.5.0
     https://github.com/holepunchto/fs-native-extensions
@@ -96,13 +101,13 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-errors
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
-  hypercore-storage@2.9.0
+  hypercore-storage@3.2.1
     https://github.com/holepunchto/hypercore-storage
   hyperdb@6.7.0
     https://github.com/holepunchto/hyperdb
   hyperdht-address@1.1.1
     https://github.com/holepunchto/hyperdht-address
-  hyperschema@1.21.0
+  hyperschema@1.22.0
     https://github.com/holepunchto/hyperschema
   index-encoder@3.5.0
     https://github.com/holepunchto/index-encoder
@@ -118,7 +123,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/require-addon
   resource-on-exit@1.0.0
     https://github.com/holepunchto/bare-teardown
-  rocksdb-native@3.15.1
+  rocksdb-native@3.17.4
     https://github.com/holepunchto/rocksdb-native
   scope-lock@1.2.4
     https://github.com/holepunchto/scope-lock
@@ -126,7 +131,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/simdle-native
   text-decoder@1.2.7
     https://github.com/holepunchto/text-decoder
-  udx-native@1.19.2
+  udx-native@1.21.1
     https://github.com/holepunchto/udx-native
   unslab@1.3.0
     https://github.com/holepunchto/unslab
@@ -168,11 +173,11 @@ JavaScript Dependencies
     https://github.com/mafintosh/generate-string
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.30.2
+  hypercore@11.35.2
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.32.0
+  hyperdht@6.33.2
     https://github.com/holepunchto/hyperdht
   is-options@1.0.2
     https://github.com/mafintosh/is-options
@@ -212,7 +217,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/sodium-secretstream
   sodium-universal@5.0.1
     https://github.com/holepunchto/sodium-universal
-  streamx@2.25.0
+  streamx@2.28.0
     https://github.com/mafintosh/streamx
   teex@1.0.1
     https://github.com/mafintosh/teex
@@ -222,7 +227,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/timeout-refresh
   varint@5.0.0
     https://github.com/chrisdickinson/varint
-  xache@1.2.1
+  xache@1.3.0
     https://github.com/mafintosh/xache
   z32@1.1.0
     https://github.com/mafintosh/z32

--- a/packages/rag/changelog/0.8.0/CHANGELOG.md
+++ b/packages/rag/changelog/0.8.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.8.0
+
+Release Date: 2026-08-26
+
+## 🔌 API
+
+- Add TurboVec adapter with journaled HyperDB recovery. (see PR [#4073](https://github.com/tetherto/qvac/pull/4073)) - See [API changes](./api.md)

--- a/packages/rag/changelog/0.8.0/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.8.0/CHANGELOG_LLM.md
@@ -1,0 +1,34 @@
+# QVAC RAG v0.8.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.0
+
+This release adds `TurboVecAdapter`, which uses an injected native vector index for candidate search while keeping HyperDB as the durable source of truth. It also strengthens HyperDB writes so invalid or partially failed batches cannot leave inconsistent document and vector records.
+
+## TurboVec-backed search
+
+`TurboVecAdapter` accepts a `TurboVecIndexProvider`, so applications can supply a compatible native index without making `@qvac/rag` depend directly on an embedding addon. The adapter uses the native index to find candidates, then reads and scores the matching records from HyperDB.
+
+```typescript
+import { TurboVecAdapter, type TurboVecIndexProvider } from '@qvac/rag'
+import IdMapIndex from '@qvac/embed-llamacpp/idMapIndex'
+
+const indexProvider: TurboVecIndexProvider = {
+  create: (options) => new IdMapIndex(options),
+  load: (snapshotPath) => IdMapIndex.load(snapshotPath)
+}
+
+const adapter = new TurboVecAdapter({
+  store,
+  dbName: 'workspace',
+  indexProvider,
+  checkpointDir: '/path/to/index'
+})
+```
+
+## Recovery and writer safety
+
+Mutation records and revisioned checkpoints let the adapter rebuild or refresh its native index from HyperDB after an interrupted write or stale checkpoint. A heartbeat-based writer lock prevents two adapter instances from changing the same index at the same time. If the native index is unavailable, HyperDB remains available as the authoritative data store.
+
+## Consistent HyperDB writes
+
+`HyperDBAdapter` now rejects batches that mix embedding dimensions with `EMBEDDING_DIMENSION_MISMATCH`. If a batch write fails partway through, it discards the transaction and retries complete document and vector pairs instead of committing partial rows. Search snapshots are also closed after each operation.

--- a/packages/rag/changelog/0.8.0/api.md
+++ b/packages/rag/changelog/0.8.0/api.md
@@ -1,0 +1,24 @@
+# 🔌 API Changes v0.8.0
+
+## Add TurboVec adapter with journaled HyperDB recovery
+
+PR: [#4073](https://github.com/tetherto/qvac/pull/4073)
+
+```typescript
+import { TurboVecAdapter, type TurboVecIndexProvider } from '@qvac/rag'
+import IdMapIndex from '@qvac/embed-llamacpp/idMapIndex'
+
+const indexProvider: TurboVecIndexProvider = {
+  create: (options) => new IdMapIndex(options),
+  load: (snapshotPath) => IdMapIndex.load(snapshotPath)
+}
+
+const adapter = new TurboVecAdapter({
+  store,
+  dbName: 'workspace',
+  indexProvider,
+  checkpointDir: '/path/to/index'
+})
+```
+
+---

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rag/src/errors.ts
+++ b/packages/rag/src/errors.ts
@@ -98,4 +98,4 @@ const definitions: ErrorCodesMap = {
   }
 }
 
-addCodes(definitions, { name: '@qvac/rag', version: '0.7.0' })
+addCodes(definitions, { name: '@qvac/rag', version: '0.8.0' })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `@qvac/rag` release branch still reports version 0.7.0, so version 0.8.0 cannot be published with the correct package and error metadata.
- Consumers need release notes for the TurboVec adapter and HyperDB write-safety changes delivered in [#4073](https://github.com/tetherto/qvac/pull/4073).

## 📝 How does it solve it?

- Bumps the package and error-code registry versions to 0.8.0.
- Adds the generated release changelog and API notes, then refreshes the aggregate changelog and NOTICE file.

## 🧪 How was it tested?

- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` — 159/159 tests and 844/844 assertions passed
