### PR TITLE
infra[notask]: install pinned LLVM on self-hosted linux C++ jobs

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -97,6 +97,12 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
+      # Pin the LLVM toolchain instead of relying on the runner's system
+      # clang, whose default -stdlib=libc++ headers can drift out of sync
+      # with it on the persistent self-hosted fleet.
+      - name: Setup LLVM
+        uses: tetherto/qvac/.github/actions/setup-llvm@98a6a6b6e8f3866dfdd75052a4071269ce85dc41
+
       # Must run BEFORE vcpkg so ROCM_PATH is set when the qvac-fabric
       # hip-backend feature is installed/resolved (setup-rocm exports
       # VCPKG_KEEP_ENV_VARS=ROCM_PATH;HIP_PATH so the hip package is cache-keyed

--- a/.github/workflows/cpp-test-coverage-asr-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-asr-ggml.yml
@@ -66,6 +66,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           lfs: true
 
+      # Pin the LLVM toolchain instead of relying on the runner's system
+      # clang, whose default -stdlib=libc++ headers can drift out of sync
+      # with it on the persistent self-hosted fleet.
+      - name: Setup LLVM
+        if: runner.os == 'Linux'
+        uses: tetherto/qvac/.github/actions/setup-llvm@98a6a6b6e8f3866dfdd75052a4071269ce85dc41
+
       - name: Setup ccache
         if: matrix.platform == 'linux'
         run: |

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -181,8 +181,13 @@ jobs:
           arch: ${{ matrix.arch }}
           linux-extra-packages: ${{ inputs.linux-extra-packages }}
 
-      - name: Setup LLVM (Linux arm and macOS)
-        if: runner.environment == 'github-hosted'
+      # Self-hosted Linux runners keep an older system clang whose default
+      # -stdlib=libc++ headers can drift out of sync with it (other workflows
+      # install newer libc++ packages fleet-wide), so they need the pinned
+      # LLVM on PATH just like hosted runners. Self-hosted Windows stays on
+      # its preprovisioned toolchain.
+      - name: Setup LLVM (Linux and macOS)
+        if: runner.environment == 'github-hosted' || runner.os == 'Linux'
         uses: tetherto/qvac/.github/actions/setup-llvm@98a6a6b6e8f3866dfdd75052a4071269ce85dc41
 
       - name: Manual Workspace Cleanup


### PR DESCRIPTION
## What problem does this PR solve?
Every C++ build on the self-hosted `qvac-ubuntu2204-x64` fleet fails since 2026-08-26 with libc++ header parse errors:

```
/usr/include/c++/v1/__configuration/compiler.h:37:8: warning: "Libc++ only supports Clang 20 and later"
/usr/include/c++/v1/__type_traits/enable_if.h:18:1: error: expected identifier or '{'
```

Example: `prebuild / linux-x64` and `cpp-lint` on https://github.com/tetherto/qvac/actions/runs/32982171795 (blocking #4088), and the same failure on #4051's runs. The last green ASR run (2026-08-25 14:57 UTC) only passed because it reused prebuild artifacts.

Root cause: the fleet carries apt.llvm.org libc++ headers at `/usr/include/c++/v1` (installed system-wide by workflows that already run `setup-llvm` there, e.g. the benchmark workflows), while `/usr/bin/clang++` is still system clang 14. Jobs that skip `setup-llvm` and rely on unversioned `clang` with `-stdlib=libc++` (via `vcpkg-overlays/triplets/*-linux.cmake` and `qvac-addon.cmake`) now compile clang 14 against LLVM-22-era libc++ headers. The changed compiler environment also changes vcpkg's compiler hash, which is why the binary cache stopped shielding these jobs.

## How does it solve it?
Run `setup-llvm` (the documented single source of truth for the CI LLVM major) on self-hosted Linux in the three C++ jobs that were still relying on the runner's system clang:

- `reusable-prebuilds.yml`: extend the Setup LLVM gate from `runner.environment == 'github-hosted'` to also cover `runner.os == 'Linux'`
- `cpp-lint.yaml`: add the Setup LLVM step before vcpkg/build-system generation
- `cpp-test-coverage-asr-ggml.yml`: add the Setup LLVM step before the ccache/compile steps

`setup-llvm` prepends `/usr/lib/llvm-22/bin` to `PATH`, so unversioned `clang`/`clang++` resolve to the pinned LLVM whose driver uses its own bundled libc++ headers - immune to any future drift of `/usr/include/c++/v1` on the persistent runners. This matches what `benchmark-ocr-ggml.yml` / `benchmark-translation-nmtcpp.yml` already do on the same fleet. Self-hosted Windows keeps its preprovisioned toolchain (no behavior change), macOS stays a no-op.

## Breaking changes
N/A. Linux vcpkg ABI hashes change (clang 14 -> 22), so the first builds repopulate the binary cache.

## Verification
- `node --test .github/scripts/test/ci-trust-policy.test.mjs` passes (73/73) with these changes.
- Dispatch of `Prebuilds (ASR GGML)` on this branch to exercise the fixed reusable workflow on the real runners is pending: GitHub Actions is currently in a major outage (https://www.githubstatus.com, incident started 15:11 UTC); the two attempted runs died to outage errors (startup_failure / "job was not acquired by runner"). Will re-dispatch and link the run here once Actions recovers.

Unblocks #4088 (and #4051).
