### PR TITLE
QVAC-23467 infra: drop @qvac/bare-sdk from sdk-pod-checks

### DIFF
--- a/.github/sdk-pod-checks.json
+++ b/.github/sdk-pod-checks.json
@@ -10,15 +10,6 @@
     "depends_on": ["packages/inference"]
   },
   {
-    "package": "bare-sdk",
-    "path": "packages/bare-sdk",
-    "pkg_manager": "bun",
-    "needs_bare": true,
-    "tests_bare": true,
-    "sdk_sources": ["workspace"],
-    "depends_on": ["packages/inference"]
-  },
-  {
     "package": "inference",
     "path": "packages/inference",
     "pkg_manager": "bun",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- [#4019](https://github.com/tetherto/qvac/pull/4019) deletes `packages/bare-sdk`, but SDK Pod Checks read `.github/sdk-pod-checks.json` from **base**, not the PR. Main still lists `bare-sdk`, so that PR `cd`s into a directory that no longer exists.

## 📝 How does it solve it?

- Drop the `bare-sdk` entry from `sdk-pod-checks.json` while the package is still in the tree.

## 🧪 How was it tested?

- No new tests. `pr-checks-sdk-pod.yml` checks out the PR base and filters this json by changed paths. A json-only change does not match `packages/bare-sdk/`, so this PR will not `cd` into that package.
