### PR TITLE
QVAC-24264 fix: drop removed isDelegated check in serve tool-dialect

### DIFF
--- a/packages/cli/src/serve/lib/tool-dialect.ts
+++ b/packages/cli/src/serve/lib/tool-dialect.ts
@@ -12,7 +12,7 @@ export async function resolveToolDialect(sdkModelId: string): Promise<ToolDialec
 
   try {
     const info = await getLoadedModelInfo({ modelId: sdkModelId })
-    if (!info.isDelegated && info.toolDialect !== undefined) {
+    if (info.toolDialect !== undefined) {
       // Only cache a real resolution: caching the fallback would pin the model
       // to hermes for the process even after a transient RPC failure recovers,
       // re-leaking markup for a native-dialect model on every later turn.


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `qvac serve` failed to typecheck/build: `serve/lib/tool-dialect.ts` still read `getLoadedModelInfo().isDelegated`, a field removed when delegated inference was dropped from the SDK.

## 📝 How does it solve it?

- Removed the `!info.isDelegated` guard, keeping the `info.toolDialect !== undefined` check.

## 🧪 How was it tested?

- `bun run typecheck`, `bun run build`, and `bun run lint` all pass in `packages/cli`.