### PR TITLE
QVAC-23716 feat[api]: serve text translation on /v1/text/translations

### DIFF
--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -38,6 +38,7 @@ For the broader coding-agent stack — `@qvac/ai-sdk-provider`, managed `qvac se
 | `GET`    | `/v1/models/catalog/{id}`        | A single catalog entry                                                                                      |
 | `POST`   | `/v1/chat/completions`           | Chat                                                                                                        |
 | `POST`   | `/v1/completions`                | Legacy text completions (single + multi-prompt; blocking + SSE)                                             |
+| `POST`   | `/v1/text/translations`          | Text-to-text translation (single + batch, blocking + SSE)                                                   |
 | `POST`   | `/v1/responses`                  | Responses API (blocking + SSE streaming); volatile, see below                                               |
 | `GET`    | `/v1/responses/{id}`             | Retrieve a stored response                                                                                  |
 | `DELETE` | `/v1/responses/{id}`             | Delete a stored response                                                                                    |
@@ -869,3 +870,80 @@ Two generation modes:
 | 404  | `video_not_found`         | Unknown job id                                                                                                                                                                     |
 | 501  | `unsupported_variant`     | `GET …/content?variant=` other than `video`                                                                                                                                        |
 | 503  | `model_not_ready`         | Model not loaded yet                                                                                                                                                               |
+
+## `POST /v1/text/translations`
+
+Translates text with a translation model, backed by the SDK's `translate()`.
+`model` names a `serve.models` alias whose endpoint category is `translation`.
+
+### Request
+
+- **Content-Type:** `application/json`
+- **Fields:**
+  - `model` (required) — a `serve.models` alias whose endpoint category is `translation`
+  - `input` (required) — a string, or an array of strings for batch
+  - `stream` (optional) — `true` streams Server-Sent Events (single input only)
+
+### Response
+
+`{ object: "list", data: [...], model }`, one `translation` entry per input,
+matched by `index`:
+
+```json
+{
+  "object": "list",
+  "data": [{ "object": "translation", "index": 0, "text": "Hello, world." }],
+  "model": "ta-en"
+}
+```
+
+Streaming emits `text_translation.chunk` events
+(`{ object, id, created, model, delta }`) and ends with `data: [DONE]`.
+
+### Examples
+
+```bash
+# Blocking, single input
+curl -sS http://127.0.0.1:11434/v1/text/translations \
+  -H "Content-Type: application/json" \
+  -d '{"model":"ta-en","input":"வணக்கம் உலகம்"}'
+
+# Batch (blocking only)
+curl -sS http://127.0.0.1:11434/v1/text/translations \
+  -H "Content-Type: application/json" \
+  -d '{"model":"ta-en","input":["வணக்கம்","நன்றி"]}'
+```
+
+### Errors
+
+| HTTP | `error.code`            | When                                                  |
+| ---- | ----------------------- | ----------------------------------------------------- |
+| 400  | `invalid_json`          | Body is not valid JSON                                |
+| 400  | `missing_model`         | `model` is missing                                    |
+| 400  | `missing_input`         | `input` is missing or empty                           |
+| 400  | `unsupported_streaming` | `stream: true` combined with an array (batch) `input` |
+| 400  | `invalid_model_type`    | Alias is not a `translation` model                    |
+| 404  | `model_not_found`       | Unknown alias                                         |
+| 503  | `model_not_loaded`      | Model not loaded and lazy loading is disabled         |
+| 503  | `model_load_failed`     | Lazy load of the model failed                         |
+| 503  | `model_load_timeout`    | Lazy load exceeded `serve.load.timeoutMs`             |
+| 503  | `model_not_ready`       | Model not loaded yet                                  |
+
+### Model configuration
+
+A translation model is configured under `serve.models` with a `config` block.
+The SDK `translate()` requires the language direction, so `config` must carry
+the `engine` and the `from` / `to` languages. For a Bergamot Tamil→English model:
+
+```json
+{
+  "serve": {
+    "models": {
+      "ta-en": {
+        "model": "BERGAMOT_TA_EN",
+        "config": { "engine": "Bergamot", "from": "ta", "to": "en" }
+      }
+    }
+  }
+}
+```

--- a/packages/cli/src/openai/coverage/extensions.ts
+++ b/packages/cli/src/openai/coverage/extensions.ts
@@ -8,5 +8,6 @@ export const QVAC_EXTENSION_ENDPOINTS = new Set<string>([
   'GET /v1/audio/models',
   'GET /v1/audio/voices',
   'GET /v1/models/catalog',
-  'GET /v1/models/catalog/{id}'
+  'GET /v1/models/catalog/{id}',
+  'POST /v1/text/translations'
 ])

--- a/packages/cli/src/serve/lib/types.ts
+++ b/packages/cli/src/serve/lib/types.ts
@@ -27,6 +27,8 @@ export interface QvacContext {
   ) => Promise<string | sdk.TranscribeSegment[]> & { requestId: string }
   /** Test seam — overrides `video()` from `@qvac/sdk` when set. */
   videoOverride?: typeof sdk.video
+  /** Test seam — overrides `translate()` from `@qvac/sdk` when set. */
+  translateOverride?: typeof sdk.translate
   /** Test seam — overrides `cancel()` from `@qvac/sdk` when set. */
   cancelOverride?: typeof sdk.cancel
   /** Test seam — overrides the SDK model load when set, so lazy-load and preload

--- a/packages/cli/src/serve/route-meta.ts
+++ b/packages/cli/src/serve/route-meta.ts
@@ -23,5 +23,7 @@ export const TAG_DESCRIPTIONS: Record<string, string> = {
   Models:
     'Lifecycle for models configured under `serve.models`. GET lists every configured model; each loads on first request unless `preload: true` warmed it at startup. DELETE unloads a model but keeps the alias reloadable — the next request loads it again.',
   'Model Catalog':
-    'Discovery listing of models the SDK provides, filterable by capability (role, addon, quantization, engine, text). Rows are catalog entries, not callable endpoints — a `not_configured` model must be added to `serve.models` before it can be used.'
+    'Discovery listing of models the SDK provides, filterable by capability (role, addon, quantization, engine, text). Rows are catalog entries, not callable endpoints — a `not_configured` model must be added to `serve.models` before it can be used.',
+  Translation:
+    'QVAC extension (not an OpenAI route): text-to-text translation via SDK `translate()`.'
 }

--- a/packages/cli/src/serve/routes/text.ts
+++ b/packages/cli/src/serve/routes/text.ts
@@ -1,0 +1,110 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { translate } from '@qvac/sdk'
+import { requireModel } from '../plugins/require-model.js'
+import { HttpError } from '../lib/http-error.js'
+import { initSSE, sendSSE, endSSE } from '../lib/sse.js'
+import { textTranslationsBody } from '../schemas/text.js'
+
+type TranslateFn = typeof translate
+
+const NMT_MODEL_TYPE = 'nmtcpp-translation'
+
+function randomId(): string {
+  return Math.random().toString(36).slice(2, 12)
+}
+
+const descriptions = {
+  translate: `
+Translate text with a configured translation model. \`input\` is a single string
+or an array of strings (batch). \`model\` names a \`serve.models\` alias whose
+endpoint category is \`translation\`. Pass \`stream: true\` (single input only) for
+Server-Sent Events; the stream ends with \`data: [DONE]\`.
+`.trim()
+}
+
+// lunte-disable-next-line require-await
+const plugin: FastifyPluginAsyncZod = async (app) => {
+  app.post(
+    '/v1/text/translations',
+    {
+      schema: {
+        body: textTranslationsBody,
+        tags: ['Translation'],
+        summary: 'Translate text',
+        description: descriptions.translate
+      },
+      preHandler: [requireModel('translation')]
+    },
+    async (req, reply) => {
+      const { input, stream } = req.body
+      const inputs = Array.isArray(input) ? input : [input]
+      const { sdkModelId, alias } = req.qvacModel!
+
+      if (stream && inputs.length > 1) {
+        throw new HttpError(
+          400,
+          'unsupported_streaming',
+          'Streaming is not supported for multiple inputs; send a single string or set stream:false.'
+        )
+      }
+
+      const translateFn = app.qvac.translateOverride ?? translate
+
+      app.qvac.logger.info(
+        `  translate model=${alias} inputs=${inputs.length} stream=${Boolean(stream)}`
+      )
+
+      if (stream) {
+        await runStreaming(req, reply, translateFn, sdkModelId, inputs[0]!, alias)
+        return
+      }
+      return await runBlocking(req, translateFn, sdkModelId, inputs, alias)
+    }
+  )
+}
+
+async function runBlocking(
+  req: FastifyRequest,
+  translateFn: TranslateFn,
+  modelId: string,
+  inputs: string[],
+  model: string
+): Promise<{
+  object: 'list'
+  data: Array<{ object: 'translation'; index: number; text: string }>
+  model: string
+}> {
+  const data = await Promise.all(
+    inputs.map(async (text, index) => {
+      const result = translateFn({ modelId, text, stream: false, modelType: NMT_MODEL_TYPE })
+      req.bindCancel(result.requestId)
+      return { object: 'translation' as const, index, text: await result.text }
+    })
+  )
+  return { object: 'list', data, model }
+}
+
+async function runStreaming(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  translateFn: TranslateFn,
+  modelId: string,
+  input: string,
+  model: string
+): Promise<void> {
+  const result = translateFn({ modelId, text: input, stream: true, modelType: NMT_MODEL_TYPE })
+  req.bindCancel(result.requestId)
+
+  initSSE(reply)
+  const raw = reply.raw
+  const id = `textxlt-${randomId()}`
+  const created = Math.floor(Date.now() / 1000)
+
+  for await (const token of result.tokenStream) {
+    sendSSE(raw, { object: 'text_translation.chunk', id, created, model, delta: token })
+  }
+  endSSE(raw)
+}
+
+export default plugin

--- a/packages/cli/src/serve/schemas/text.ts
+++ b/packages/cli/src/serve/schemas/text.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const textTranslationsBody = z
+  .object({
+    model: z.string().min(1),
+    input: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
+    stream: z.boolean().optional()
+  })
+  .passthrough()

--- a/packages/cli/test/e2e/http/text-translation.test.ts
+++ b/packages/cli/test/e2e/http/text-translation.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import type { TestContext } from 'node:test'
+import type { translate } from '@qvac/sdk'
+import { createServer, useServer } from '../helpers/server.js'
+import { JSON_HEADERS, assertStatusAndError, collectSSE } from '../helpers/http.js'
+
+type TranslateParams = Parameters<typeof translate>[0]
+type TranslateResult = ReturnType<typeof translate>
+
+const TEXT_CONFIG = {
+  serve: {
+    models: {
+      'ta-en': { type: 'nmtcpp-translation', src: 'hyper://example.invalid/ta-en', preload: false },
+      'chat-model': {
+        type: 'llamacpp-completion',
+        src: 'hyper://example.invalid/chat',
+        preload: false
+      }
+    }
+  }
+} as const
+
+function makeTranslateOverride(calls: TranslateParams[]) {
+  function translateOverride(params: TranslateParams): TranslateResult {
+    calls.push(params)
+    const single = Array.isArray(params.text) ? params.text.join(' ') : params.text
+    const out = `[${single}]`
+    return {
+      requestId: `req-${calls.length}`,
+      text: Promise.resolve(out),
+      stats: Promise.resolve(undefined),
+      tokenStream: (async function* () {
+        yield out
+      })()
+    }
+  }
+  return translateOverride
+}
+
+async function createReadyTextServer(t: TestContext) {
+  const calls: TranslateParams[] = []
+  const app = await createServer(t, { config: TEXT_CONFIG })
+  app.qvac.translateOverride = makeTranslateOverride(calls)
+  await app.ready()
+  for (const [alias, entry] of app.qvac.serveConfig.models) {
+    app.qvac.registry.register(alias, entry)
+  }
+  app.qvac.registry.setReady('ta-en', 'sdk-ta-en')
+  return { app, calls }
+}
+
+describe('serve: text translation validation', () => {
+  const server = useServer({ config: TEXT_CONFIG })
+
+  it('invalid JSON returns 400', async () => {
+    const res = await server().inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      headers: JSON_HEADERS,
+      payload: '{{bad'
+    })
+    assertStatusAndError(res, 400, 'invalid_json')
+  })
+
+  it('missing model returns 400', async () => {
+    const res = await server().inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { input: 'வணக்கம்' }
+    })
+    assertStatusAndError(res, 400, 'missing_model')
+  })
+
+  it('missing input returns 400', async () => {
+    const res = await server().inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'ta-en' }
+    })
+    assertStatusAndError(res, 400, 'missing_input')
+  })
+
+  it('unknown model returns 404', async () => {
+    const res = await server().inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'nope', input: 'வணக்கம்' }
+    })
+    assertStatusAndError(res, 404, 'model_not_found')
+  })
+
+  it('non-translation model returns invalid_model_type', async () => {
+    const res = await server().inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'chat-model', input: 'வணக்கம்' }
+    })
+    assertStatusAndError(res, 400, 'invalid_model_type')
+  })
+})
+
+describe('serve: text translation', () => {
+  it('translates a single input', async (t) => {
+    const { app, calls } = await createReadyTextServer(t)
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'ta-en', input: 'வணக்கம்' }
+    })
+    assert.equal(res.statusCode, 200)
+    assert.deepEqual(res.json(), {
+      object: 'list',
+      data: [{ object: 'translation', index: 0, text: '[வணக்கம்]' }],
+      model: 'ta-en'
+    })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0]?.stream, false)
+  })
+
+  it('translates a batch with one call per input', async (t) => {
+    const { app, calls } = await createReadyTextServer(t)
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'ta-en', input: ['a', 'b'] }
+    })
+    assert.equal(res.statusCode, 200)
+    assert.deepEqual(res.json(), {
+      object: 'list',
+      data: [
+        { object: 'translation', index: 0, text: '[a]' },
+        { object: 'translation', index: 1, text: '[b]' }
+      ],
+      model: 'ta-en'
+    })
+    assert.equal(calls.length, 2)
+  })
+
+  it('streams a single input as SSE ending with [DONE]', async (t) => {
+    const { app } = await createReadyTextServer(t)
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'ta-en', input: 'வணக்கம்', stream: true }
+    })
+    assert.equal(res.statusCode, 200)
+    assert.match(String(res.headers['content-type']), /text\/event-stream/)
+    const events = collectSSE(res.body)
+    const chunk = events[0]?.data as { object: string; delta: string }
+    assert.equal(chunk.object, 'text_translation.chunk')
+    assert.equal(chunk.delta, '[வணக்கம்]')
+    assert.equal(events.at(-1)?.data, '[DONE]')
+  })
+
+  it('rejects streaming a batch before any translate call', async (t) => {
+    const { app, calls } = await createReadyTextServer(t)
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/text/translations',
+      payload: { model: 'ta-en', input: ['a', 'b'], stream: true }
+    })
+    assertStatusAndError(res, 400, 'unsupported_streaming')
+    assert.equal(calls.length, 0)
+  })
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- We want to expose more of QVAC's capabilities through the OpenAI-compatible serve API. Text translation is a first step, to see how such extensions fit the surface.

## 📝 How does it solve it?

- Adds `POST /v1/text/translations`, backed by the SDK's `translate()`. `input` is a single string or an array (batch); `stream: true` streams SSE (single input only).
- The request/response shape uses OpenAI's conventions as the baseline — a `model` field, a `{ object: "list", data: [...] }` envelope, and `[DONE]`-terminated SSE — so it sits consistently beside the existing routes.
- Registered in the OpenAI-coverage check as a QVAC extension, so it reads as an intentional addition rather than a spec deviation.

## 🧪 How was it tested?

- e2e HTTP tests over the route: validation (`missing_model`, `missing_input`, `model_not_found`, `invalid_model_type`), single, batch, SSE, and the batch-plus-stream rejection.
- Ran the built server against a real Bergamot Tamil→English model and confirmed single, batch, and streaming responses.

## 🔌 API Changes

A translation model is configured under `serve.models` with a `config` carrying the engine and direction:

```json
{ "serve": { "models": {
  "ta-en": { "model": "BERGAMOT_TA_EN", "config": { "engine": "Bergamot", "from": "ta", "to": "en" } }
} } }
```

```bash
curl -sS http://127.0.0.1:11434/v1/text/translations \
  -H 'Content-Type: application/json' \
  -d '{"model":"ta-en","input":"வணக்கம் உலகம்"}'
# {"object":"list","data":[{"object":"translation","index":0,"text":"Hello the World"}],"model":"ta-en"}
```