### PR TITLE
QVAC-24232 chore: bump speech package versions

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -14,6 +14,8 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-27
+
 ### Added
 
 - **CUDA GPU backend for both engines on Linux / Windows (NVIDIA).** The

--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/asr-ggml",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Multi-engine ASR (Whisper + NVIDIA Parakeet) inference addon for qvac on the Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-27
+
 ### Added
 
 - Add desktop CPU support for MiniMax-Music3 through local LM and synthesis
@@ -16,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pair runs on the first usable ggml GPU backend (CUDA, Vulkan, Metal) with
   CPU fallback, and `stats.backendDevice`/`backendId` report the backend
   actually in use.
+- Opt-in CUDA GPU backend on Linux / Windows (NVIDIA). The new `ENABLE_CUDA`
+  CMake option appends the `cuda` manifest feature, which pulls
+  `speech-cpp[cuda]` and hence `ggml-speech[cuda]`. Off by default because it
+  needs `nvcc` on the build host; at runtime only the NVIDIA driver is needed.
+  CUDA is additive next to Vulkan, and the engine's validated-GPU preference
+  selects CUDA when both backends are compiled in. Apple and Android are
+  excluded, matching `speech-cpp`'s own `supports` expression, so every
+  existing build resolves exactly as before.
 
 ### Changed
 
@@ -43,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   event. Both are fixed by requiring `speech-cpp` `2026-08-24#2`.
 - `cancel()` no longer hangs forever when the job it targets fails before
   the native engine starts; it now settles as soon as the run settles.
+- Expose `binding.js` through the package `exports` map
+  (`@qvac/audiogen-ggml/binding.js`), so mobile bundlers that resolve the
+  native binding through exports can load the addon.
 
 ## [0.2.4] - 2026-08-20
 

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-27
+
 ### Added
 
 - Opt-in CUDA GPU backend on Linux / Windows (NVIDIA). `bci-whispercpp[cuda]`

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-27
+
 ### Added
 
 - CUDA GPU acceleration on linux x64: the prebuild now bundles the CUDA
@@ -34,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   launch guards for the `conv_transpose_1d`, `im2col` and `pad` paths, the
   CUDA transpose-copy strided-destination fix, and Adreno OpenCL launch
   validation with GEMV work-group limits.
+
+### Fixed
+
+- Expose `binding.js` through the package `exports` map
+  (`@qvac/tts-ggml/binding.js`), so mobile bundlers that resolve the native
+  binding through exports can load the addon.
 
 ## [0.7.5] - 2026-08-20
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Problem

The four speech addons carry released features on `main` that no version bump has made publishable: the opt-in CUDA GPU backends, the speech-cpp floor alignment at 2026-08-26#1 (QVAC-24231, #4107), MiniMax-Music3 desktop support, and the parakeet duplex-streaming drain fix all sit under `[Unreleased]` with `package.json` still at the last released version. Kept separate from the QVAC-24231 alignment PR, which only moved dependency floors.

## How

- Bump `package.json` versions: `asr-ggml` 0.3.3 -> 0.4.0, `tts-ggml` 0.7.5 -> 0.8.0, `audiogen-ggml` 0.2.4 -> 0.3.0, `bci-whispercpp` 0.7.2 -> 0.8.0 (all minor; new capability on every package).
- Release each package's accumulated `[Unreleased]` changelog content under a dated `## [x.y.z] - 2026-08-27` heading, leaving the `[Unreleased]` block empty.
- Add the two entries that were missing from the changelogs: the opt-in `ENABLE_CUDA` build feature on `audiogen-ggml` (#4041) and the `binding.js` package-exports fix for mobile bundlers on `tts-ggml` + `audiogen-ggml` (#4087).

## Tested

- All four new headings match the release extractor regex (`^## \[version\]`) used by `verify-changelog-notes`, with non-empty bodies.
- `package.json` version equals the changelog heading version in each package.
- npm `dist-tags.latest` equals the pre-bump version for all four packages, so no bump was already pending.
- Every `vcpkg.json` floors `speech-cpp` at `2026-08-26#1`, consistent with what the changelogs state; `vcpkg-configuration.json` untouched.
- Diff touches exactly 8 files: the four `package.json` + four `CHANGELOG.md`.

## Breaking changes

None in this PR itself (version metadata and changelog only). The 0.x minor bumps signal the behavior changes already merged on `main` per the repo's SemVer usage.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217869696249887