### PR TITLE
QVAC-23975 test[api]: guard that every modelConfig field is described

### DIFF
--- a/packages/inference/src/schemas/text-to-speech.ts
+++ b/packages/inference/src/schemas/text-to-speech.ts
@@ -391,9 +391,18 @@ const ttsCosyvoice3InstructSchema = z.union([
   z.string().trim().min(1),
   z
     .object({
-      dialect: z.enum(TTS_COSYVOICE3_INSTRUCT_DIALECTS).optional(),
-      volume: z.enum(TTS_COSYVOICE3_INSTRUCT_VOLUMES).optional(),
-      style: z.enum(TTS_COSYVOICE3_INSTRUCT_STYLES).optional()
+      dialect: z
+        .enum(TTS_COSYVOICE3_INSTRUCT_DIALECTS)
+        .optional()
+        .describe('Chinese dialect to render (e.g. `cantonese`, `sichuan`).'),
+      volume: z
+        .enum(TTS_COSYVOICE3_INSTRUCT_VOLUMES)
+        .optional()
+        .describe('Speaking volume: `loud` or `soft`.'),
+      style: z
+        .enum(TTS_COSYVOICE3_INSTRUCT_STYLES)
+        .optional()
+        .describe('Speaking style: `peppa` or `robot`.')
     })
     .strict()
     .refine(

--- a/packages/inference/test/config-description-guard.test.ts
+++ b/packages/inference/test/config-description-guard.test.ts
@@ -1,0 +1,108 @@
+import test from 'brittle'
+import { z } from 'zod'
+import { llmConfigBaseSchema, embedConfigBaseSchema } from '@/schemas/llamacpp-config'
+import { whisperConfigSchema, parakeetRuntimeConfigSchema } from '@/schemas/transcription-config'
+import { bciConfigSchema } from '@/schemas/bci-config'
+import { nmtConfigBaseSchema } from '@/schemas/translation-config'
+import {
+  ttsChatterboxLoadConfigSchema,
+  ttsSupertonicLoadConfigSchema,
+  ttsParlerLoadConfigSchema,
+  ttsCosyvoice3LoadConfigSchema,
+  ttsAudio8LoadConfigSchema
+} from '@/schemas/text-to-speech'
+import { ocrConfigSchema } from '@/schemas/ocr'
+import { sdcppConfigSchema } from '@/schemas/sdcpp-config'
+import { audioGenConfigSchema } from '@/schemas/audio-gen'
+import { vlaConfigSchema } from '@/schemas/vla'
+import { classificationConfigSchema } from '@/schemas/classification'
+import { ModelType } from '@/schemas/model-types'
+
+// Contract guard: every load-time `modelConfig` field a model type exposes
+// must carry a `.describe()`, so the language-neutral contract
+// (contract/schema.json) and the generated clients document what each knob
+// means. z.toJSONSchema surfaces `.describe()` text as `description`, so a
+// field missing one shows up as a property without `description` here.
+//
+// This intentionally checks the describable knob surface — the runtime/base
+// config schemas and the TTS union arms — not the frozen legacy-ONNX
+// deprecation placeholders (LEGACY_*_ONNX_MODEL_CONFIG_FIELDS), which are
+// `z.unknown()` shims that only exist to raise a structured migration error.
+
+type JsonSchemaNode = {
+  type?: string
+  description?: string
+  properties?: Record<string, JsonSchemaNode>
+  anyOf?: JsonSchemaNode[]
+  oneOf?: JsonSchemaNode[]
+  allOf?: JsonSchemaNode[]
+}
+
+function collectUndescribed(node: JsonSchemaNode, path: string, out: string[]): void {
+  for (const branch of [node.anyOf, node.oneOf, node.allOf]) {
+    if (branch) for (const child of branch) collectUndescribed(child, path, out)
+  }
+  for (const [name, field] of Object.entries(node.properties ?? {})) {
+    const childPath = `${path}.${name}`
+    // A nested config object (e.g. whisper `vad_params`) needs no description of
+    // its own; every other field (leaf or union, e.g. CosyVoice3 `instruct`) does.
+    // Recurse regardless, so nested fields and union object arms are covered.
+    const isContainer =
+      field.type === 'object' && !!field.properties && Object.keys(field.properties).length > 0
+    if (!isContainer && !field.description) out.push(childPath)
+    collectUndescribed(field, childPath, out)
+  }
+}
+
+const CONFIG_SCHEMAS: ReadonlyArray<readonly [string, z.ZodType]> = [
+  ['llamacpp-completion', llmConfigBaseSchema],
+  ['llamacpp-embedding', embedConfigBaseSchema],
+  ['whispercpp-transcription', whisperConfigSchema],
+  ['parakeet-transcription', parakeetRuntimeConfigSchema],
+  ['bci-whispercpp-transcription', bciConfigSchema],
+  ['nmtcpp-translation', nmtConfigBaseSchema],
+  ['tts-ggml/chatterbox', ttsChatterboxLoadConfigSchema],
+  ['tts-ggml/supertonic', ttsSupertonicLoadConfigSchema],
+  ['tts-ggml/parler', ttsParlerLoadConfigSchema],
+  ['tts-ggml/cosyvoice3', ttsCosyvoice3LoadConfigSchema],
+  ['tts-ggml/audio8', ttsAudio8LoadConfigSchema],
+  ['ggml-ocr', ocrConfigSchema],
+  ['sdcpp-generation', sdcppConfigSchema],
+  ['audiogen-ggml', audioGenConfigSchema],
+  ['ggml-vla', vlaConfigSchema],
+  ['ggml-classification', classificationConfigSchema]
+]
+
+for (const [label, schema] of CONFIG_SCHEMAS) {
+  test(`modelConfig fields are described: ${label}`, (t) => {
+    const jsonSchema = z.toJSONSchema(schema, { unrepresentable: 'any' }) as JsonSchemaNode
+    const undescribed: string[] = []
+    collectUndescribed(jsonSchema, label, undescribed)
+    t.is(
+      undescribed.length,
+      0,
+      undescribed.length === 0
+        ? 'all fields carry a description'
+        : `add .describe() to: ${undescribed.join(', ')}`
+    )
+  })
+}
+
+// Guard against CONFIG_SCHEMAS drifting: every model type must have an entry
+// above (or be explicitly exempt), so a newly added model type can't skip the
+// description check. `onnx-tts` is a legacy alias that routes to `tts-ggml`.
+const EXEMPT_MODEL_TYPES = new Set<string>([ModelType.onnxTts])
+
+test('every model type is covered by a describe guard', (t) => {
+  const covered = new Set(CONFIG_SCHEMAS.map(([label]) => label.split('/')[0]))
+  const missing = Object.values(ModelType).filter(
+    (type) => !EXEMPT_MODEL_TYPES.has(type) && !covered.has(type)
+  )
+  t.is(
+    missing.length,
+    0,
+    missing.length === 0
+      ? 'all model types covered'
+      : `add a guard entry for: ${missing.join(', ')}`
+  )
+})

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
@@ -10770,15 +10770,24 @@ class LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3Instruct(GeneratedBaseModel
     )
     dialect: Annotated[
         LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructDialect | None,
-        Field(title="LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructDialect"),
+        Field(
+            description="Chinese dialect to render (e.g. `cantonese`, `sichuan`).",
+            title="LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructDialect",
+        ),
     ] = None
     volume: Annotated[
         LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructVolume | None,
-        Field(title="LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructVolume"),
+        Field(
+            description="Speaking volume: `loud` or `soft`.",
+            title="LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructVolume",
+        ),
     ] = None
     style: Annotated[
         LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructStyle | None,
-        Field(title="LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructStyle"),
+        Field(
+            description="Speaking style: `peppa` or `robot`.",
+            title="LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructStyle",
+        ),
     ] = None
 
 

--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -11452,6 +11452,7 @@
                               "type": "object",
                               "properties": {
                                 "dialect": {
+                                  "description": "Chinese dialect to render (e.g. `cantonese`, `sichuan`).",
                                   "type": "string",
                                   "enum": [
                                     "cantonese",
@@ -11475,11 +11476,13 @@
                                   "title": "LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructDialect"
                                 },
                                 "volume": {
+                                  "description": "Speaking volume: `loud` or `soft`.",
                                   "type": "string",
                                   "enum": ["loud", "soft"],
                                   "title": "LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructVolume"
                                 },
                                 "style": {
+                                  "description": "Speaking style: `peppa` or `robot`.",
                                   "type": "string",
                                   "enum": ["peppa", "robot"],
                                   "title": "LoadModelSrcRequestTtsGgmlModelConfigCosyvoice3InstructStyle"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The QVAC-23933 pass added `.describe()` text to every model type's `modelConfig`, but nothing stops a **new** field from shipping without a description — which would silently leave a blank in the generated contract (`contract/schema.json`), `qvac configure`, and the typed clients.

## 📝 How does it solve it?

- Adds `packages/inference/test/config-description-guard.test.ts`: for each model type's load-time config schema (llamacpp, whisper, parakeet, BCI, NMT, the five TTS arms, OCR, diffusion, audiogen, VLA, classification), it runs `z.toJSONSchema()` and asserts **every field carries a non-empty `description`**, recursing into nested config objects (e.g. whisper `vad_params`) and union arms (e.g. CosyVoice3 `instruct`). A missing `.describe()` fails the test with the offending field path.
- Fills the one gap the guard surfaced: the CosyVoice3 `instruct` sub-fields (`dialect`, `volume`, `style`).
- Frozen legacy-ONNX deprecation placeholders (`LEGACY_*_ONNX_MODEL_CONFIG_FIELDS`) are intentionally out of scope — they are `z.unknown()` shims that only raise a structured migration error.
- Regenerates `contract/schema.json` and the Python generated models for the CosyVoice3 additions.

Completes QVAC-23933 (the enforcement subtask). **Stacked on #4052** (the shared-modelSrc descriptions) — base will retarget to `main` once #4052 merges.

## 🧪 How was it tested?

- The new guard test passes for all 16 config surfaces; the same walker logic (prototyped) demonstrably flags fields that lack a description, so it's not a tautology.
- `contract:check`, `typecheck`, `lint`, `format`, and `test:unit` pass; `packages/inference` `typecheck` + `lint` pass; `packages/sdk-python` `generate.py --check` passes.

## 🔌 API Changes

Additive only (CosyVoice3 instruct sub-field descriptions):

```typescript
ttsCosyvoice3LoadConfigSchema // instruct: { dialect, volume, style } now each carry a description
```
