### PR TITLE
DO NOT MERGE - probe: exercise the restore-only vcpkg cache path

### DIFF
--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -57,7 +57,11 @@ jobs:
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
 
     env:
-      WORKDIR: ${{ inputs.workdir }}
+      # PROBE ONLY: the pull_request trigger carries no inputs, so
+      # inputs.workdir is empty and the default on workflow_dispatch /
+      # workflow_call does not apply. Not needed on the real branch, where this
+      # workflow is only ever reached through those two events.
+      WORKDIR: ${{ inputs.workdir || 'packages/llm-llamacpp' }}
       GIT_TERMINAL_PROMPT: "0"
 
     steps:

--- a/.probe-cache-note.md
+++ b/.probe-cache-note.md
@@ -1,0 +1,3 @@
+# probe
+
+Triggers a pull_request run to exercise the restore-only cache path. Delete with the branch.


### PR DESCRIPTION
Throwaway probe for QVAC-24194 / PR #4103. Do not merge, do not review.

The restore-only branch of the vcpkg cache step cannot be reached from `on-pr-llm-llamacpp.yml`, because `pull_request_target` resolves that reusable workflow from the base branch. The base branch of this PR carries a temporary `pull_request` trigger so a real PR event exercises it.

Expected: `cpp-tests-llm.yml` runs under `pull_request`, takes the `actions/cache/restore` step rather than `actions/cache`, restores `cpp-tests-v6-llm-*` from the base branch scope, and skips building qvac-fabric.

Both branches will be deleted once the result is recorded.