### PR TITLE
[SUPERSEDED by the tmp-qvac-23763-cuda stack] QVAC-23763 feat[api]: add CUDA support to the NLP addons

### DIFF
--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -70,5 +70,11 @@ runs:
         echo "ROCM_PATH=$rocm_prefix" >> "$GITHUB_ENV"
         echo "HIP_PATH=$rocm_prefix" >> "$GITHUB_ENV"
         echo "$rocm_prefix/bin" >> "$GITHUB_PATH"
-        echo "VCPKG_KEEP_ENV_VARS=ROCM_PATH;HIP_PATH" >> "$GITHUB_ENV"
+        # Merge rather than assign: setup-cuda sets the same variable, and a job
+        # that ran both would otherwise keep only whichever action ran last.
+        keep="ROCM_PATH;HIP_PATH"
+        if [ -n "${VCPKG_KEEP_ENV_VARS:-}" ]; then
+          keep="${VCPKG_KEEP_ENV_VARS};${keep}"
+        fi
+        echo "VCPKG_KEEP_ENV_VARS=$keep" >> "$GITHUB_ENV"
         echo "LD_LIBRARY_PATH=$rocm_prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"

--- a/.github/workflows/benchmark-embed-llamacpp.yml
+++ b/.github/workflows/benchmark-embed-llamacpp.yml
@@ -236,6 +236,13 @@ jobs:
         if: inputs.addon_version == ''
         uses: tetherto/qvac/.github/actions/setup-llvm@98a6a6b6e8f3866dfdd75052a4071269ce85dc41
 
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, which hard-errors without nvcc. The
+      # action no-ops when this self-hosted GPU runner already has a toolkit.
+      - name: Setup CUDA toolkit for the ggml CUDA backend
+        if: inputs.addon_version == ''
+        uses: ./.github/actions/setup-cuda
+
       - name: Build addon from source (monorepo workdir)
         if: inputs.addon_version == ''
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/benchmark-llm-llamacpp.yml
+++ b/.github/workflows/benchmark-llm-llamacpp.yml
@@ -287,6 +287,12 @@ jobs:
         if: inputs.addon_version == ''
         uses: tetherto/qvac/.github/actions/setup-llvm@98a6a6b6e8f3866dfdd75052a4071269ce85dc41
 
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, which hard-errors without nvcc. The
+      # action no-ops when this self-hosted GPU runner already has a toolkit.
+      - name: Setup CUDA toolkit for the ggml CUDA backend
+        uses: ./.github/actions/setup-cuda
+
       - name: Build addon from source
         if: inputs.addon_version == ''
         working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -42,6 +42,16 @@ on:
         type: boolean
         required: false
         default: false
+      include-cuda-sdk:
+        description: >-
+          Install the NVIDIA CUDA toolkit before generating the build system.
+          Required for packages whose qvac-fabric feature set pulls the
+          cuda-backend: that feature hard-errors without nvcc rather than
+          silently skipping, so configure fails on this linux runner even
+          though linting never builds or runs the CUDA backend.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   cpp-lint:
@@ -104,6 +114,12 @@ jobs:
       - if: ${{ inputs.include-rocm-sdk }}
         name: Setup ROCm SDK for HIP cross-compile
         uses: ./.github/actions/setup-rocm
+
+      # Same ordering requirement as ROCm above: must run BEFORE vcpkg so nvcc
+      # is on PATH when the qvac-fabric cuda-backend feature is resolved.
+      - if: ${{ inputs.include-cuda-sdk }}
+        name: Setup CUDA toolkit for the ggml CUDA backend
+        uses: ./.github/actions/setup-cuda
 
       - name: Setup vcpkg
         uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -168,6 +168,14 @@ jobs:
           ls -lh "${{ env.WORKDIR }}/models/unit-test/"
           du -sh "${{ env.WORKDIR }}/models/unit-test/test-model.gguf"
 
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, and that feature hard-errors without
+      # nvcc rather than silently skipping, so configure fails here without it.
+      # Compile-only; this runner has no NVIDIA GPU and does not need one.
+      - if: ${{ matrix.platform == 'linux' }}
+        name: Setup CUDA toolkit for the ggml CUDA backend
+        uses: ./.github/actions/setup-cuda
+
       - if: ${{ matrix.platform == 'darwin' }}
         name: Use Apple clang for Apple platform builds
         run: |

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -141,6 +141,14 @@ jobs:
           ls -lh models/unit-test/
           du -sh models/unit-test/*
 
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, and that feature hard-errors without
+      # nvcc rather than silently skipping, so configure fails here without it.
+      # Compile-only; this runner has no NVIDIA GPU and does not need one.
+      - if: ${{ matrix.platform == 'linux' }}
+        name: Setup CUDA toolkit for the ggml CUDA backend
+        uses: ./.github/actions/setup-cuda
+
       - if: ${{ matrix.platform == 'darwin' }}
         name: Use Apple clang for Apple platform builds
         run: |

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -139,6 +139,14 @@ jobs:
         name: Setup ROCm SDK for HIP cross-compile
         uses: ./.github/actions/setup-rocm
 
+      # QVAC-23763: it also requests cuda-backend on linux, which hard-errors
+      # without nvcc rather than silently skipping, so configure fails here
+      # without it. Compile-only; this runner has no NVIDIA GPU and needs none.
+      # setup-cuda MERGES VCPKG_KEEP_ENV_VARS so the ROCm vars above survive.
+      - if: ${{ matrix.platform == 'linux' }}
+        name: Setup CUDA toolkit for the ggml CUDA backend
+        uses: ./.github/actions/setup-cuda
+
       - name: Setup vcpkg
         uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -24,13 +24,21 @@ jobs:
   run-integration-tests:
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
+    # QVAC-23763: the -vulkan suffix only appears on the new Vulkan leg, so
+    # every existing job keeps the exact name any required check refers to.
+    name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.force_vulkan == 'true' && '-vulkan' || '' }}-integration-tests
     permissions:
       contents: read
       packages: read
 
     env:
       WORKDIR: packages/embed-llamacpp
+      # QVAC-23763: marks a leg as the Vulkan half of an NVIDIA runner. NOT set
+      # as CUDA_VISIBLE_DEVICES directly: an unset matrix field evaluates to the
+      # empty string, and an EMPTY CUDA_VISIBLE_DEVICES hides every CUDA device
+      # exactly like -1, which would silently drop CUDA on all the other legs.
+      # The test step exports the real variable only when this is 'true'.
+      FORCE_VULKAN: ${{ matrix.force_vulkan || 'false' }}
 
     strategy:
       fail-fast: false
@@ -45,6 +53,16 @@ jobs:
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
+          # QVAC-23763: the qvac-ubuntu*-x64-gpu runners are NVIDIA, so the same
+          # box covers both GPU backends. This entry is the Vulkan half; the one
+          # above runs CUDA because it is now preferred by default. NVIDIA is
+          # the only GPU kind on the hosted runners, so this is the only way to
+          # exercise both.
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
+            runner: qvac-ubuntu2404-x64-gpu
+            force_vulkan: 'true'
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64
@@ -214,4 +232,12 @@ jobs:
 
       - name: Run integration test
         working-directory: ${{ env.WORKDIR }}
-        run: npm run test:integration ${{ matrix.platform }}-${{ matrix.arch }}
+        run: |
+          # QVAC-23763: export CUDA_VISIBLE_DEVICES only for the Vulkan leg.
+          # Exporting it unconditionally would set it to the empty string
+          # elsewhere, which hides every CUDA device just as -1 does.
+          if [ "${FORCE_VULKAN}" = "true" ]; then
+            echo "FORCE_VULKAN=true: hiding CUDA devices so the addon selects Vulkan"
+            export CUDA_VISIBLE_DEVICES=-1
+          fi
+          npm run test:integration ${{ matrix.platform }}-${{ matrix.arch }}

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -70,6 +70,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WORKDIR: packages/llm-llamacpp
       NO_GPU: ${{ matrix.no_gpu || 'false' }}
+      # QVAC-23763: marks a leg as the Vulkan half of an NVIDIA runner. NOT set
+      # as CUDA_VISIBLE_DEVICES directly: an unset matrix field evaluates to the
+      # empty string, and an EMPTY CUDA_VISIBLE_DEVICES hides every CUDA device
+      # exactly like -1, which would silently drop CUDA on all the other legs.
+      # The test step exports the real variable only when this is 'true'.
+      FORCE_VULKAN: ${{ matrix.force_vulkan || 'false' }}
     permissions:
       contents: read
       packages: read
@@ -96,6 +102,18 @@ jobs:
             runner: qvac-ubuntu2404-x64-gpu
             timeout_minutes: 480
             label: linux-x64-u24-gpu
+          # QVAC-23763: the qvac-ubuntu*-x64-gpu runners are NVIDIA, so the same
+          # box covers both GPU backends. This entry is the Vulkan half; the one
+          # above runs CUDA because it is now preferred by default. NVIDIA is
+          # the only GPU kind on the hosted runners, so this is the only way to
+          # exercise both.
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
+            runner: qvac-ubuntu2404-x64-gpu
+            timeout_minutes: 480
+            force_vulkan: 'true'
+            label: linux-x64-u24-gpu-vulkan
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
@@ -280,6 +298,13 @@ jobs:
         if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         run: |
+          # QVAC-23763: export CUDA_VISIBLE_DEVICES only for the Vulkan leg.
+          # Exporting it unconditionally would set it to the empty string
+          # elsewhere, which hides every CUDA device just as -1 does.
+          if [ "${FORCE_VULKAN}" = "true" ]; then
+            echo "FORCE_VULKAN=true: hiding CUDA devices so the addon selects Vulkan"
+            export CUDA_VISIBLE_DEVICES=-1
+          fi
           if [ "${{ inputs.qvac_perf_only }}" = "true" ]; then
             echo "qvac_perf_only=true: regenerating test/integration/all.js with perf-emitting tests only"
             npx brittle -r test/integration/all.js \

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -28,7 +28,9 @@ jobs:
   run-integration-tests:
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
+    # QVAC-23763: the -vulkan suffix only appears on the new Vulkan leg, so
+    # every existing job keeps the exact name any required check refers to.
+    name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.force_vulkan == 'true' && '-vulkan' || '' }}-integration-tests
     permissions:
       contents: read
       packages: read
@@ -36,6 +38,12 @@ jobs:
 
     env:
       WORKDIR: packages/vla-ggml
+      # QVAC-23763: marks a leg as the Vulkan half of an NVIDIA runner. NOT set
+      # as CUDA_VISIBLE_DEVICES directly: an unset matrix field evaluates to the
+      # empty string, and an EMPTY CUDA_VISIBLE_DEVICES hides every CUDA device
+      # exactly like -1, which would silently drop CUDA on all the other legs.
+      # The test step exports the real variable only when this is 'true'.
+      FORCE_VULKAN: ${{ matrix.force_vulkan || 'false' }}
 
     strategy:
       fail-fast: false
@@ -53,6 +61,14 @@ jobs:
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
+          # QVAC-23763: this runner is NVIDIA, so the same box covers both GPU
+          # backends. This entry is the Vulkan half; the one above runs CUDA
+          # because it is now preferred by default.
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
+            runner: qvac-ubuntu2404-x64-gpu
+            force_vulkan: 'true'
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64
@@ -459,6 +475,13 @@ jobs:
           GROOT_TEST_ACTIVATIONS_V4: ${{ !(matrix.platform == 'darwin' && matrix.arch == 'x64') && format('{0}/{1}/test/groot-oracle/activations_v4.safetensors', github.workspace, env.WORKDIR) || '' }}
         run: |
           set +e
+          # QVAC-23763: export CUDA_VISIBLE_DEVICES only for the Vulkan leg.
+          # Exporting it unconditionally would set it to the empty string
+          # elsewhere, which hides every CUDA device just as -1 does.
+          if [ "${FORCE_VULKAN}" = "true" ]; then
+            echo "FORCE_VULKAN=true: hiding CUDA devices so the addon selects Vulkan"
+            export CUDA_VISIBLE_DEVICES=-1
+          fi
           # Stream test output AND capture it so we can inspect the TAP summary
           # if the process exits with a non-zero code. Some GPU configurations
           # (qvac-ubuntu2404-x64-gpu with NVIDIA RTX 4000 SFF Ada + Vulkan)

--- a/.github/workflows/on-pr-embed-llamacpp.yml
+++ b/.github/workflows/on-pr-embed-llamacpp.yml
@@ -130,6 +130,10 @@ jobs:
       sha: ${{ github.event.pull_request.base.sha }}
       pr_head_sha: ${{ github.event.pull_request.head.sha }}
       workdir: packages/embed-llamacpp
+      # QVAC-23763: cpp-lint configures the package on a linux runner, and the
+      # vcpkg.json requests the qvac-fabric cuda-backend feature there, which
+      # hard-errors without nvcc.
+      include-cuda-sdk: true
 
   cpp-tests:
     permissions:

--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -149,6 +149,10 @@ jobs:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
       pr_head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
       workdir: packages/llm-llamacpp
+      # QVAC-23763: cpp-lint configures the package on a linux runner, and the
+      # vcpkg.json requests the qvac-fabric cuda-backend feature there, which
+      # hard-errors without nvcc.
+      include-cuda-sdk: true
 
   ts-checks:
     needs: [fork-approval, authorize]

--- a/.github/workflows/on-pr-vla.yml
+++ b/.github/workflows/on-pr-vla.yml
@@ -134,6 +134,9 @@ jobs:
       # vla pulls qvac-fabric[hip-backend]; ggml-config find_dependency(hip)
       # needs ROCm on the lint runner at configure time.
       include-rocm-sdk: true
+      # QVAC-23763: it now also pulls cuda-backend on linux, which hard-errors
+      # without nvcc, and cpp-lint configures the package on a linux runner.
+      include-cuda-sdk: true
 
   cpp-tests:
     permissions:

--- a/.github/workflows/prebuilds-embed-llamacpp.yml
+++ b/.github/workflows/prebuilds-embed-llamacpp.yml
@@ -50,5 +50,10 @@ jobs:
       repository: ${{ inputs.repository }}
       artifact-name-prefix: llama-cpp-
       include-vulkan-sdk: true
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, and that feature hard-errors without
+      # nvcc rather than silently skipping, so every linux build needs the
+      # toolkit. Compile-only; the runners need no NVIDIA GPU.
+      include-cuda: true
       extra-cmake-defines: ${{ inputs.vk-profiling && '-D VK_PROFILING=ON' || '' }}
     secrets: inherit

--- a/.github/workflows/prebuilds-llm-llamacpp.yml
+++ b/.github/workflows/prebuilds-llm-llamacpp.yml
@@ -50,5 +50,10 @@ jobs:
       repository: ${{ inputs.repository }}
       artifact-name-prefix: llama-cpp-
       include-vulkan-sdk: true
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, and that feature hard-errors without
+      # nvcc rather than silently skipping, so every linux build needs the
+      # toolkit. Compile-only; the runners need no NVIDIA GPU.
+      include-cuda: true
       extra-cmake-defines: ${{ inputs.vk-profiling && '-D VK_PROFILING=ON' || '' }}
     secrets: inherit

--- a/.github/workflows/prebuilds-vla.yml
+++ b/.github/workflows/prebuilds-vla.yml
@@ -52,4 +52,12 @@ jobs:
       # Cross-compile the ROCm/HIP backend (gfx1151) into the linux-x64 prebuild.
       # No AMD GPU needed on the runner; fail-safe if ROCm install/feature is absent.
       include-rocm: true
+      # QVAC-23763: the package's vcpkg.json requests the qvac-fabric
+      # cuda-backend feature on linux, and that feature hard-errors without
+      # nvcc rather than silently skipping, so every linux build needs the
+      # toolkit. Compile-only; the runners need no NVIDIA GPU. Unlike
+      # include-rocm this also covers linux-arm64, because the Jetson Orin is a
+      # target. setup-cuda MERGES VCPKG_KEEP_ENV_VARS, so it composes with the
+      # ROCm setup above rather than clobbering it.
+      include-cuda: true
     secrets: inherit

--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -30,9 +30,19 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running text e
 |----------|-------------|-------------|--------|-------------|
 | macOS | arm64, x64 | 14.0+ | ✅ Tier 1 | Metal |
 | iOS | arm64 | 17.0+ | ✅ Tier 1 | Metal |
-| Linux | arm64, x64 | Ubuntu-22+ | ✅ Tier 1 | Vulkan |
+| Linux | arm64, x64 | Ubuntu-22+ | ✅ Tier 1 | CUDA (NVIDIA), Vulkan |
 | Android | arm64 | 12+ | ✅ Tier 1 | Vulkan, OpenCL (Adreno 700+) |
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
+
+**Note — CUDA (Linux, NVIDIA):**
+On Linux the CUDA backend ships as a dynamically loaded module alongside Vulkan, and is preferred
+over Vulkan when an NVIDIA device is present. Windows is Vulkan-only because it has no dynamic
+backend loading.
+
+- If the CUDA module or the NVIDIA driver is missing, the device never registers and selection
+  falls through to Vulkan, then CPU. Nothing needs configuring for that.
+- `backend: "vulkan"` forces Vulkan on an NVIDIA machine. Setting `CUDA_VISIBLE_DEVICES=-1` in the
+  environment has the same effect without touching the load config.
 
 **Dependencies:**
 - inference-addon-cpp (≥1.1.2): C++ addon framework
@@ -141,6 +151,7 @@ The `config` is a plain JS object whose keys are forwarded directly to the nativ
 | `embd_normalize` | string of integer                             | `"2"`         | Embedding normalization (`-1` = none, `0` = max abs int16, `1` = taxicab, `2` = euclidean, `>2` = p-norm) |
 | `flash_attn`     | `"on"` \| `"off"` \| `"auto"`                 | `"auto"`      | Enable / disable flash attention                                                         |
 | `main-gpu`       | string of integer \| `"integrated"` \| `"dedicated"` | —      | GPU selection for multi-GPU systems                                                      |
+| `backend`        | comma-separated list of `cuda`, `vulkan`, `metal`, `opencl`, `hip`, `rocm`, `sycl` | — | Overrides which GPU backend is used, in priority order (e.g. `"cuda,vulkan"`). An unrecognised name is rejected; a recognised one with no device present is skipped. Use `device: "cpu"` to run on CPU |
 | `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. The verbosity level is process-global and is updated each time a model is constructed, so the most recently constructed model's `config.verbosity` wins for all subsequent native log dispatch. |
 
 #### Native addon logging

--- a/packages/embed-llamacpp/addon/src/model-interface/BackendSelection.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BackendSelection.cpp
@@ -1,8 +1,10 @@
 #include "BackendSelection.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <optional>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -57,7 +59,8 @@ struct DeviceDescription {
 void emplaceIfValidDevice(
     const BackendInterface& bckI, std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
-    std::vector<std::string>& openClBackends, const ggml_backend_reg_t reg,
+    std::vector<std::string>& openClBackends,
+    std::vector<std::string>& cudaBackends, const ggml_backend_reg_t reg,
     const DeviceDescription& devDescr,
     const enum ggml_backend_dev_type backendTypeEnum) {
   if (bckI.ggml_backend_reg_name(reg) != std::string("RPC")) {
@@ -73,12 +76,17 @@ void emplaceIfValidDevice(
         devDescr.gpuBackend.find("opencl") != std::string::npos;
     const bool isAdreno =
         devDescr.gpuDescription.find("adreno") != std::string::npos;
+    // QVAC-23763: ggml-cuda names its devices "CUDA%d". ggml-hip reports
+    // "ROCm%d" instead, so this cannot collide with an AMD device.
+    const bool isCuda = devDescr.gpuBackend.find("cuda") != std::string::npos;
     if (isOpenCl && isAdreno) {
       logEmplaceGpuBackend(devDescr.gpuBackend);
       openClBackends.emplace_back(devDescr.gpuBackend);
     } else if (!isOpenCl) {
       logEmplaceGpuBackend(devDescr.gpuBackend);
-      if (backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_GPU) {
+      if (isCuda && backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_GPU) {
+        cudaBackends.emplace_back(devDescr.gpuBackend);
+      } else if (backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_GPU) {
         gpuBackends.emplace_back(devDescr.gpuBackend);
       } else if (backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_IGPU) {
         igpuBackends.emplace_back(devDescr.gpuBackend);
@@ -109,7 +117,8 @@ void tryEmplaceDevice(
     std::optional<MainGpuType> mainGpuType,
     std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
-    std::vector<std::string>& openClBackends) {
+    std::vector<std::string>& openClBackends,
+    std::vector<std::string>& cudaBackends) {
   const ggml_backend_dev_t dev = bckI.ggml_backend_dev_get(deviceIndex);
   const ggml_backend_reg_t reg = bckI.ggml_backend_dev_backend_reg(dev);
   const enum ggml_backend_dev_type backendTypeEnum =
@@ -124,6 +133,7 @@ void tryEmplaceDevice(
         gpuBackends,
         igpuBackends,
         openClBackends,
+        cudaBackends,
         reg,
         devDescr,
         backendTypeEnum);
@@ -178,6 +188,80 @@ backend_selection::parseMainGpu(const std::string& mainGpuStr) {
   }
 }
 
+namespace {
+
+// Backend families qvac-fabric can register a GPU device for. Used to tell a
+// mistyped `backend` value (hard error) apart from a correctly-spelled backend
+// that simply has no device on this machine (falls through). Deliberately does
+// NOT include "cpu": the CPU path is `device`, and accepting two spellings for
+// it would make `device: 'gpu', backend: 'cpu'` ambiguous.
+constexpr std::array<std::string_view, 7> KNOWN_GPU_BACKEND_FAMILIES = {
+    "cuda", "vulkan", "metal", "opencl", "hip", "rocm", "sycl"};
+
+/// Whether a ggml device backend name belongs to the requested family.
+/// Substring rather than equality because ggml suffixes the device index
+/// ("CUDA0", "Vulkan1") and OpenCL reports as "GPUOpenCL". Metal is special:
+/// some builds report "mtl..." instead of "Metal", which BertModel already
+/// special-cases the same way.
+bool backendNameMatchesFamily(
+    const std::string& lowercasedBackendName, std::string_view family) {
+  if (lowercasedBackendName.find(family) != std::string::npos) {
+    return true;
+  }
+  return family == "metal" && lowercasedBackendName.rfind("mtl", 0) == 0;
+}
+
+} // namespace
+
+std::vector<std::string>
+backend_selection::parseBackendOverride(const std::string& backendStr) {
+  std::vector<std::string> families;
+  std::string current;
+  auto flush = [&]() {
+    const auto begin = current.find_first_not_of(" \t");
+    if (begin == std::string::npos) {
+      return;
+    }
+    const auto end = current.find_last_not_of(" \t");
+    std::string family = current.substr(begin, end - begin + 1);
+    std::ranges::transform(family, family.begin(), ::tolower);
+    if (std::ranges::find(KNOWN_GPU_BACKEND_FAMILIES, family) ==
+        KNOWN_GPU_BACKEND_FAMILIES.end()) {
+      throw qvac_errors::StatusError(
+          qvac_errors::general_error::InvalidArgument,
+          string_format(
+              "backend: unknown backend '%s'. Expected a comma-separated list "
+              "of cuda/vulkan/metal/opencl/hip/rocm/sycl, for example "
+              "'cuda,vulkan'. To run on CPU use device 'cpu' instead.\n",
+              family.c_str()));
+    }
+    if (std::ranges::find(families, family) == families.end()) {
+      families.emplace_back(std::move(family));
+    }
+  };
+  for (const char c : backendStr) {
+    if (c == ',') {
+      flush();
+      current.clear();
+    } else {
+      current.push_back(c);
+    }
+  }
+  flush();
+  return families;
+}
+
+std::vector<std::string> backend_selection::tryBackendOverrideFromMap(
+    std::unordered_map<std::string, std::string>& configFilemap) {
+  auto it = configFilemap.find("backend");
+  if (it == configFilemap.end()) {
+    return {};
+  }
+  std::vector<std::string> families = parseBackendOverride(it->second);
+  configFilemap.erase(it);
+  return families;
+}
+
 std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
     std::unordered_map<std::string, std::string>& configFilemap) {
   auto hIt = configFilemap.find("main-gpu");
@@ -198,11 +282,13 @@ std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, const BackendInterface& bckI,
-    const std::optional<MainGpu>& mainGpu) {
+    const std::optional<MainGpu>& mainGpu,
+    const std::vector<std::string>& backendOverride) {
 
   std::vector<std::string> gpuBackends;
   std::vector<std::string> igpuBackends;
   std::vector<std::string> openClBackends;
+  std::vector<std::string> cudaBackends;
 
   if (preferredBackendType == BackendType::GPU) {
     bool loopAllDevices = true;
@@ -221,7 +307,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
               std::nullopt,
               gpuBackends,
               igpuBackends,
-              openClBackends);
+              openClBackends,
+              cudaBackends);
           loopAllDevices = false;
         } else {
           std::string errorMsg = string_format(
@@ -237,8 +324,40 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     for (size_t i = 0; loopAllDevices && i < bckI.ggml_backend_dev_count();
          ++i) {
       ::tryEmplaceDevice(
-          bckI, i, gpuType, gpuBackends, igpuBackends, openClBackends);
+          bckI,
+          i,
+          gpuType,
+          gpuBackends,
+          igpuBackends,
+          openClBackends,
+          cudaBackends);
     }
+  }
+
+  // QVAC-23763: an explicit `backend` override wins over the cascade below.
+  //
+  // Skipped entirely for a CPU load. No devices are enumerated in that case, so
+  // the block could only ever reach its "matched no available device" warning,
+  // which would be noise on a deliberate device:'cpu' request.
+  if (!backendOverride.empty() && preferredBackendType == BackendType::GPU) {
+    for (const std::string& family : backendOverride) {
+      for (const std::vector<std::string>* candidates :
+           {&openClBackends, &cudaBackends, &gpuBackends, &igpuBackends}) {
+        for (const std::string& name : *candidates) {
+          if (::backendNameMatchesFamily(name, family)) {
+            std::string text = string_format(
+                "Chosen %s Backend (backend override)", family.c_str());
+            bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, text.c_str(), nullptr);
+            return {BackendType::GPU, name};
+          }
+        }
+      }
+    }
+    bckI.llamaLogCallback(
+        GGML_LOG_LEVEL_WARN,
+        "backend override matched no available device; falling back to the "
+        "default backend order",
+        nullptr);
   }
 
   // check if Adreno GPU is present and force OpenCL backend, otherwise let
@@ -246,6 +365,12 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
   if (!openClBackends.empty()) {
     bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, "Chosen GPU OpenCL", nullptr);
     return {BackendType::GPU, openClBackends.front()};
+  }
+
+  // Before the generic GPU bucket, which is where Vulkan lands.
+  if (!cudaBackends.empty()) {
+    bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, "Chosen GPU CUDA", nullptr);
+    return {BackendType::GPU, cudaBackends.front()};
   }
 
   // Prefer GPU over iGPU when possible
@@ -265,7 +390,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu) {
+    const std::optional<MainGpu>& mainGpu,
+    const std::vector<std::string>& backendOverride) {
   BackendInterface bckI{
       .ggml_backend_dev_count = ggml_backend_dev_count,
       .ggml_backend_dev_backend_reg = ggml_backend_dev_backend_reg,
@@ -276,7 +402,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
       .ggml_backend_dev_type = ggml_backend_dev_type,
       .ggml_backend_reg_get_proc_address = ggml_backend_reg_get_proc_address,
       .llamaLogCallback = llamaLogcallback};
-  return backend_selection::chooseBackend(preferredBackendType, bckI, mainGpu);
+  return backend_selection::chooseBackend(
+      preferredBackendType, bckI, mainGpu, backendOverride);
 }
 
 size_t
@@ -301,10 +428,13 @@ bool backend_selection::gpuBackendSupportsRowSplit(
   // Mirror what qvac-fabric actually checks: llama_model::load_tensors() calls
   // make_gpu_buft_list() for EVERY device it was given and throws "device %s
   // does not support split buffers" on the first one whose backend registry
-  // lacks `ggml_backend_split_buffer_type`. Split mode omits `--device`, so
-  // that set is every GPU device across every registered backend — a single
-  // unsupported backend in the process is enough to fail the load. So require
-  // all of them, not any one, and treat "no GPU devices at all" as unsupported.
+  // lacks `ggml_backend_split_buffer_type`. So require all of them, not any
+  // one, and treat "no GPU devices at all" as unsupported.
+  //
+  // QVAC-23763: split mode now scopes `--device` to one registry (see
+  // splitModeDeviceNames), so qvac-fabric sees a narrower set than is checked
+  // here. Left registry-wide on purpose: that only degrades row to layer sooner
+  // than needed, never the other way, and no shipped backend has split buffers.
   size_t gpuDevices = 0;
   const size_t totalDevices = bckI.ggml_backend_dev_count();
   for (size_t i = 0; i < totalDevices; ++i) {
@@ -337,4 +467,69 @@ bool backend_selection::gpuBackendSupportsRowSplit() {
       .ggml_backend_reg_get_proc_address = ggml_backend_reg_get_proc_address,
       .llamaLogCallback = nullptr};
   return backend_selection::gpuBackendSupportsRowSplit(bckI);
+}
+
+std::vector<std::string> backend_selection::splitModeDeviceNames(
+    const BackendInterface& bckI, const std::string& selectedDeviceName) {
+  // Kept in ggml's enumeration order, so the list matches what qvac-fabric
+  // would have discovered on its own.
+  std::vector<std::pair<std::string, std::string>> devices;
+  std::vector<std::string> registries;
+  std::string selectedRegistry;
+
+  const size_t totalDevices = bckI.ggml_backend_dev_count();
+  for (size_t i = 0; i < totalDevices; ++i) {
+    ggml_backend_dev_t dev = bckI.ggml_backend_dev_get(i);
+    const enum ggml_backend_dev_type devType = bckI.ggml_backend_dev_type(dev);
+    if (devType != GGML_BACKEND_DEVICE_TYPE_GPU &&
+        devType != GGML_BACKEND_DEVICE_TYPE_IGPU) {
+      continue;
+    }
+    ggml_backend_reg_t reg = bckI.ggml_backend_dev_backend_reg(dev);
+    if (reg == nullptr) {
+      continue;
+    }
+    std::string registry = bckI.ggml_backend_reg_name(reg);
+    // RPC is skipped for the same reason emplaceIfValidDevice skips it: those
+    // devices are never candidates for selection in the first place.
+    if (registry == "RPC") {
+      continue;
+    }
+    std::string deviceName = bckI.ggml_backend_dev_name(dev);
+    std::ranges::transform(deviceName, deviceName.begin(), ::tolower);
+    if (deviceName == selectedDeviceName) {
+      selectedRegistry = registry;
+    }
+    if (std::ranges::find(registries, registry) == registries.end()) {
+      registries.push_back(registry);
+    }
+    devices.emplace_back(std::move(registry), std::move(deviceName));
+  }
+
+  if (registries.size() < 2 || selectedRegistry.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> names;
+  for (const auto& [registry, deviceName] : devices) {
+    if (registry == selectedRegistry) {
+      names.push_back(deviceName);
+    }
+  }
+  return names;
+}
+
+std::vector<std::string>
+backend_selection::splitModeDeviceNames(const std::string& selectedDeviceName) {
+  BackendInterface bckI{
+      .ggml_backend_dev_count = ggml_backend_dev_count,
+      .ggml_backend_dev_backend_reg = ggml_backend_dev_backend_reg,
+      .ggml_backend_dev_get = ggml_backend_dev_get,
+      .ggml_backend_reg_name = ggml_backend_reg_name,
+      .ggml_backend_dev_description = ggml_backend_dev_description,
+      .ggml_backend_dev_name = ggml_backend_dev_name,
+      .ggml_backend_dev_type = ggml_backend_dev_type,
+      .ggml_backend_reg_get_proc_address = ggml_backend_reg_get_proc_address,
+      .llamaLogCallback = nullptr};
+  return backend_selection::splitModeDeviceNames(bckI, selectedDeviceName);
 }

--- a/packages/embed-llamacpp/addon/src/model-interface/BackendSelection.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BackendSelection.hpp
@@ -5,9 +5,10 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
-#include <llama.h>
 #include <inference-addon-cpp/Errors.hpp>
+#include <llama.h>
 
 namespace backend_selection {
 
@@ -23,6 +24,20 @@ std::optional<MainGpu> parseMainGpu(const std::string& mainGpuStr);
 
 std::optional<MainGpu>
 tryMainGpuFromMap(std::unordered_map<std::string, std::string>& configFilemap);
+
+/// @brief Parse a `backend` override into a lowercased priority list, e.g.
+/// "CUDA,Vulkan" -> {"cuda", "vulkan"}.
+///
+/// An unknown NAME is a config mistake and throws
+/// StatusError(InvalidArgument); a known name with no device attached is
+/// legitimate, e.g. asking for cuda on a Vulkan-only host, and falls through to
+/// the next entry and then to the normal cascade.
+std::vector<std::string> parseBackendOverride(const std::string& backendStr);
+
+/// @brief Extract and erase the `backend` key from a config map.
+/// Returns an empty vector when the key is absent.
+std::vector<std::string> tryBackendOverrideFromMap(
+    std::unordered_map<std::string, std::string>& configFilemap);
 
 using llamaLogCallbackF =
     void (*)(ggml_log_level level, const char* text, void* userData);
@@ -43,14 +58,27 @@ struct BackendInterface {
 
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, const BackendInterface& bckI,
-    const std::optional<MainGpu>& mainGpu = std::nullopt);
+    const std::optional<MainGpu>& mainGpu = std::nullopt,
+    const std::vector<std::string>& backendOverride = {});
 
 /// @brief Choose the backend to use for the model based on GPU device and
-/// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise Vulkan
-/// backend. Uses CPU if no GPU backends are available.
+/// available backends. Prefer OpenCL backend for Adreno GPUs, then CUDA on
+/// NVIDIA, otherwise Vulkan. Uses CPU if no GPU backends are available.
+///
+/// The CUDA preference is stated here rather than inherited: qvac-fabric loads
+/// cuda before vulkan in ggml_backend_load_all_from_path(), and device
+/// registration is an unsorted push_back, so CUDA already happens to enumerate
+/// first. Relying on that would make backend choice a silent function of two
+/// line numbers in ggml-backend-reg.cpp. QVAC-23763.
+///
+/// @p backendOverride, when non-empty, restricts the choice to those backend
+/// families in priority order (e.g. {"cuda", "vulkan"}). Entries with no device
+/// present are skipped; if none match, selection falls through to the normal
+/// cascade rather than failing, because an absent device is not a config error.
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu = std::nullopt);
+    const std::optional<MainGpu>& mainGpu = std::nullopt,
+    const std::vector<std::string>& backendOverride = {});
 
 /// @brief Count GPU devices available for multi-GPU split mode.
 /// Returns the number of discrete GPUs when any are present; otherwise
@@ -70,4 +98,22 @@ bool gpuBackendSupportsRowSplit(const BackendInterface& bckI);
 /// @brief `gpuBackendSupportsRowSplit()` against the real ggml backend
 /// registry.
 bool gpuBackendSupportsRowSplit();
+
+/// @brief The device names to pass as `--device` in multi-GPU split mode,
+/// namely those sharing @p selectedDeviceName's backend registry.
+///
+/// QVAC-23763: with CUDA loaded next to Vulkan, one physical NVIDIA card
+/// registers twice, as CUDA0 and Vulkan0, so the old unconditional omission of
+/// `--device` would spread a single card across two backends.
+///
+/// Empty when every GPU/iGPU device comes from one registry, which is every
+/// pre-CUDA configuration, and the caller then keeps omitting `--device`. Also
+/// empty when @p selectedDeviceName matches nothing, so an unexpected name
+/// degrades to that same old behaviour rather than to no GPU at all.
+std::vector<std::string> splitModeDeviceNames(
+    const BackendInterface& bckI, const std::string& selectedDeviceName);
+
+/// @brief `splitModeDeviceNames()` against the real ggml backend registry.
+std::vector<std::string>
+splitModeDeviceNames(const std::string& selectedDeviceName);
 } // namespace backend_selection

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -416,8 +416,12 @@ BertModelSetup setupParams(
     const BackendType preferredBackend =
         preferredBackendTypeFromString(deviceIt->second);
     const std::optional<MainGpu> mainGpu = tryMainGpuFromMap(configFilemap);
-    const std::pair<BackendType, std::string> chosenBackend =
-        chooseBackend(preferredBackend, llamaLogCallback, mainGpu);
+    // QVAC-23763: extracted and erased here like main-gpu, so the passthrough
+    // loop never forwards it to llama.cpp's argument parser.
+    const std::vector<std::string> backendOverride =
+        tryBackendOverrideFromMap(configFilemap);
+    const std::pair<BackendType, std::string> chosenBackend = chooseBackend(
+        preferredBackend, llamaLogCallback, mainGpu, backendOverride);
 
     if (chosenBackend.first == BackendType::GPU) {
       result.resolvedBackendDevice = 1;
@@ -472,9 +476,37 @@ BertModelSetup setupParams(
     // In multi-GPU split mode we intentionally omit --device so llama.cpp
     // distributes layers/rows across all available GPUs rather than pinning
     // to the single backend that chooseBackend selected.
+    //
+    // QVAC-23763: that stops being safe once one physical card registers under
+    // two backends, so pass the chosen backend's own devices instead. Empty on
+    // a single-registry host, where --device stays omitted as before.
     if (splitMode == LLAMA_SPLIT_MODE_NONE) {
       configVector.emplace_back("--device");
       configVector.emplace_back(chosenBackend.second);
+    } else if (chosenBackend.first == BackendType::GPU) {
+      const std::vector<std::string> splitDevices =
+          splitModeDeviceNames(chosenBackend.second);
+      if (!splitDevices.empty()) {
+        std::string deviceList;
+        for (const std::string& deviceName : splitDevices) {
+          if (!deviceList.empty()) {
+            deviceList += ',';
+          }
+          deviceList += deviceName;
+        }
+        qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
+            GGML_LOG_LEVEL_INFO,
+            string_format(
+                "[BertModel] split-mode: restricting --device to the %s "
+                "backend's own devices (%s); this host registers GPUs under "
+                "more than one backend\n",
+                chosenBackend.second.c_str(),
+                deviceList.c_str())
+                .c_str(),
+            nullptr);
+        configVector.emplace_back("--device");
+        configVector.emplace_back(std::move(deviceList));
+      }
     }
     configFilemap.erase(deviceIt);
 

--- a/packages/embed-llamacpp/test/unit/test_backend_selection.cpp
+++ b/packages/embed-llamacpp/test/unit/test_backend_selection.cpp
@@ -633,3 +633,245 @@ TEST_F(BackendSelectionTest, RowSplit_AccelAndCpuIgnored_True) {
   BackendInterface bckI = mockBackend.toBackendInterface();
   EXPECT_TRUE(gpuBackendSupportsRowSplit(bckI));
 }
+
+// ---- QVAC-23763: CUDA prioritisation and the `backend` override ----
+
+// GPU backend names as ggml reports them. ggml-cuda uses "CUDA%d"; ggml-hip
+// uses "ROCm%d", which is why CUDA detection cannot pick up an AMD device.
+constexpr const char* CUDA0_BACK = "CUDA0";
+constexpr const char* CUDA1_BACK = "CUDA1";
+constexpr const char* ROCM0_BACK = "ROCm0";
+constexpr const char* NVIDIA_DESC = "NVIDIA GeForce RTX 3090";
+constexpr const char* TESLA_DESC = "Tesla T4";
+
+std::pair<BackendType, std::string> chooseWithOverride(
+    MockBackendInterface& mockBackend,
+    const std::vector<std::string>& backendOverride,
+    BackendType preferred = BackendType::GPU) {
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  return chooseBackend(preferred, bckI, std::nullopt, backendOverride);
+}
+
+// The headline behaviour: on a host where the same physical GPU registers
+// under both backends, CUDA wins.
+TEST_F(BackendSelectionTest, CudaPreferredOverVulkan) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// Registration order must not decide the outcome. This is the whole reason the
+// preference is stated rather than inherited from ggml's load order.
+TEST_F(BackendSelectionTest, CudaPreferredOverVulkanRegardlessOfDeviceOrder) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// No CUDA module or no NVIDIA driver: the device never registers, so the
+// cascade lands on Vulkan with no special handling.
+TEST_F(BackendSelectionTest, VulkanChosenWhenNoCudaDevice) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, VULKAN0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "vulkan0");
+}
+
+// A discrete CUDA GPU must still beat an integrated GPU.
+TEST_F(BackendSelectionTest, CudaPreferredOverIntegratedGpu) {
+  mockBackend.addDevice(createIGPUDevice(INTEL_DESC, VULKAN0_BACK));
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// Adreno OpenCL must keep winning: mobile behaviour is unchanged by CUDA.
+TEST_F(BackendSelectionTest, AdrenoOpenClStillBeatsCuda) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "gpuopencl");
+}
+
+// "ROCm0" must not be mistaken for a CUDA device.
+TEST_F(BackendSelectionTest, RocmIsNotTreatedAsCuda) {
+  mockBackend.addDevice(createGPUDevice("AMD Radeon 8060S", ROCM0_BACK));
+  mockBackend.addDevice(createGPUDevice("AMD Radeon 8060S", VULKAN0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "rocm0");
+}
+
+TEST_F(BackendSelectionTest, OverrideVulkanBeatsPresentCuda) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"vulkan", "cuda"});
+  expectChosen(result, BackendType::GPU, "vulkan0");
+}
+
+TEST_F(BackendSelectionTest, OverrideRespectsListOrder) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda", "vulkan"});
+  expectChosen(result, BackendType::GPU, "cuda0");
+}
+
+// A correctly spelled backend with no device on this machine is not a config
+// error, so selection continues down the list and then the normal cascade.
+TEST_F(BackendSelectionTest, OverrideSkipsAbsentBackend) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda", "vulkan"});
+  expectChosen(result, BackendType::GPU, "vulkan0");
+}
+
+TEST_F(BackendSelectionTest, OverrideFallsThroughWhenNothingMatches) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda"});
+  expectChosen(result, BackendType::GPU, "vulkan0");
+}
+
+// device 'cpu' with a backend override must land on CPU quietly: no devices are
+// enumerated, so the override has nothing to match and must not be an error.
+TEST_F(BackendSelectionTest, OverrideIgnoredWhenPreferredCpu) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, CUDA0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda"}, BackendType::CPU);
+  EXPECT_EQ(result.first, BackendType::CPU);
+  EXPECT_EQ(result.second, "none");
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideLowercasesAndSplits) {
+  EXPECT_EQ(
+      parseBackendOverride("CUDA,Vulkan"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideTrimsSpaces) {
+  EXPECT_EQ(
+      parseBackendOverride(" cuda , vulkan "),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideDropsDuplicates) {
+  EXPECT_EQ(
+      parseBackendOverride("cuda,cuda,vulkan"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideIgnoresEmptyEntries) {
+  EXPECT_EQ(
+      parseBackendOverride("cuda,,vulkan,"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+// A misspelled name IS a config error, unlike an absent device.
+TEST_F(BackendSelectionTest, ParseBackendOverrideThrowsOnUnknownName) {
+  EXPECT_THROW(parseBackendOverride("cudaa"), qvac_errors::StatusError);
+}
+
+// 'cpu' is deliberately not a backend name: the CPU path is `device`.
+TEST_F(BackendSelectionTest, ParseBackendOverrideRejectsCpu) {
+  EXPECT_THROW(parseBackendOverride("cpu"), qvac_errors::StatusError);
+}
+
+TEST_F(BackendSelectionTest, TryBackendOverrideFromMapErasesKey) {
+  std::unordered_map<std::string, std::string> config{
+      {"device", "gpu"}, {"backend", "cuda,vulkan"}};
+  EXPECT_EQ(
+      tryBackendOverrideFromMap(config),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+  EXPECT_EQ(config.count("backend"), 0u);
+  EXPECT_EQ(config.count("device"), 1u);
+}
+
+TEST_F(BackendSelectionTest, TryBackendOverrideFromMapAbsentIsEmpty) {
+  std::unordered_map<std::string, std::string> config{{"device", "gpu"}};
+  EXPECT_TRUE(tryBackendOverrideFromMap(config).empty());
+}
+
+// ---- QVAC-23763: split-mode device scoping ----
+//
+// Grouping is by backend REGISTRY name, not by device name, so these fixtures
+// set it explicitly. createGPUDevice() leaves it at the mock default, which
+// puts every device in one registry.
+
+constexpr const char* CUDA_REG = "CUDA";
+constexpr const char* VULKAN_REG = "Vulkan";
+
+static MockDevice createGPUDeviceInRegistry(
+    std::string&& desc, std::string&& backend, std::string&& registry) {
+  return {
+      std::move(desc),
+      std::move(backend),
+      GGML_BACKEND_DEVICE_TYPE_GPU,
+      std::move(registry)};
+}
+
+static std::vector<std::string> splitDevicesFor(
+    MockBackendInterface& mockBackend, const std::string& selected) {
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  return splitModeDeviceNames(bckI, selected);
+}
+
+// Every pre-CUDA host: one registry, so --device keeps being omitted and
+// qvac-fabric enumerates the GPUs itself exactly as before.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesEmptyOnSingleRegistry) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN1_BACK, VULKAN_REG));
+  EXPECT_TRUE(splitDevicesFor(mockBackend, "vulkan0").empty());
+}
+
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesEmptyWithNoGpuAtAll) {
+  mockBackend.addDevice(createCPUDevice("host", "CPU"));
+  EXPECT_TRUE(splitDevicesFor(mockBackend, "cuda0").empty());
+}
+
+// The case this exists for: two NVIDIA cards, each registered twice. Without
+// scoping, split mode would hand qvac-fabric four devices for two GPUs.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesScopesToSelectedRegistry) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA1_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN1_BACK, VULKAN_REG));
+  EXPECT_EQ(
+      splitDevicesFor(mockBackend, "cuda0"),
+      (std::vector<std::string>{"cuda0", "cuda1"}));
+}
+
+// An explicit backend override lands on Vulkan; the split must follow it rather
+// than the default CUDA preference.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesFollowsTheChosenBackend) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN1_BACK, VULKAN_REG));
+  EXPECT_EQ(
+      splitDevicesFor(mockBackend, "vulkan0"),
+      (std::vector<std::string>{"vulkan0", "vulkan1"}));
+}
+
+// An iGPU on the chosen backend is still part of the split: qvac-fabric would
+// have used it when --device was omitted, so dropping it would be a regression.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesKeepsIgpuOfSameRegistry) {
+  MockDevice igpu(
+      "intel arc", "Vulkan1", GGML_BACKEND_DEVICE_TYPE_IGPU, "Vulkan");
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(std::move(igpu));
+  EXPECT_EQ(
+      splitDevicesFor(mockBackend, "vulkan0"),
+      (std::vector<std::string>{"vulkan0", "vulkan1"}));
+}
+
+// A name that matches nothing degrades to the old omit-everything behaviour
+// rather than to an empty device list, which would strand the load on no GPU.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesEmptyWhenSelectionUnmatched) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  EXPECT_TRUE(splitDevicesFor(mockBackend, "metal0").empty());
+}

--- a/packages/embed-llamacpp/vcpkg-configuration.json
+++ b/packages/embed-llamacpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",

--- a/packages/embed-llamacpp/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg.json
@@ -8,8 +8,12 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10297.0.0",
+      "version>=": "10297.0.0#1",
       "features": [
+        {
+          "name": "cuda-backend",
+          "platform": "linux & x64"
+        },
         "vector-index"
       ]
     },

--- a/packages/fabric/vcpkg-configuration.json
+++ b/packages/fabric/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",

--- a/packages/fabric/vcpkg.json
+++ b/packages/fabric/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10297.0.0"
+      "version>=": "10297.0.0#1"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/llm-llamacpp/README.md
+++ b/packages/llm-llamacpp/README.md
@@ -31,10 +31,25 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running Large 
 |----------|-------------|-------------|--------|-------------|
 | macOS | arm64, x64 | 14.0+ | ✅ Tier 1 | Metal |
 | iOS | arm64 | 17.0+ | ✅ Tier 1 | Metal |
-| Linux | arm64, x64 | Ubuntu-22+ | ✅ Tier 1 | Vulkan |
+| Linux | arm64, x64 | Ubuntu-22+ | ✅ Tier 1 | CUDA (NVIDIA), Vulkan |
 | Android | arm64 | 12+ | ✅ Tier 1 | Vulkan, OpenCL (Adreno 700+) |
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
 
+
+**Note — CUDA (Linux, NVIDIA):**
+On Linux the CUDA backend ships as a dynamically loaded module alongside Vulkan, and is preferred
+over Vulkan when an NVIDIA device is present. Windows is Vulkan-only because it has no dynamic
+backend loading.
+
+- If the CUDA module or the NVIDIA driver is missing, the device never registers and selection
+  falls through to Vulkan, then CPU. Nothing needs configuring for that.
+- `backend: "vulkan"` forces Vulkan on an NVIDIA machine. Setting `CUDA_VISIBLE_DEVICES=-1` in the
+  environment has the same effect without touching the load config.
+- TurboQuant / PolarQuant KV-cache types (`tbq3_0`, `tbq4_0`, `pq3_0`, `pq4_0`) are **not**
+  supported on CUDA and are rejected during model configuration. Use a Vulkan GPU or CPU for those.
+  Standard quantized types (`q4_0`, `q8_0`, …) work normally.
+- BitNet (TQ1_0 / TQ2_0) and some LoRA finetuning kernels are not yet available on CUDA. Use
+  `backend: "vulkan"` for those workloads until the kernels land.
 
 **Note — BitNet models (TQ1_0 / TQ2_0 quantization):**
 BitNet models require special backend handling on Adreno GPUs. When a BitNet model is detected and no explicit `main-gpu` is set:
@@ -177,6 +192,7 @@ const config = {
 | verbosity         | 0 – 3 (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG) | 0                            | Logging verbosity level                               |
 | n_discarded       | integer                                     | 0                            | Tokens to discard in sliding window context. In batch mode the sliding window is the per-sequence slot (`n_ctx / n_parallel`), so `n_discarded` is clamped to that per-slot window, not the full context; a value `>=` the slot cap is clamped and logs a warning |
 | main-gpu          | integer, `"integrated"`, or `"dedicated"`   | —                            | GPU selection for multi-GPU systems                   |
+| backend           | comma-separated list of `cuda`, `vulkan`, `metal`, `opencl`, `hip`, `rocm`, `sycl` | —   | Overrides which GPU backend is used, in priority order (e.g. `"cuda,vulkan"`). An unrecognised name is rejected; a recognised one with no device present is skipped. Use `device: "cpu"` to run on CPU |
 | split-mode        | `"none"`, `"layer"`, or `"row"`             | `"none"`                     | How to split the model across GPUs ([details](./docs/multi-gpu.md)) |
 | tensor-split      | comma-separated proportions (e.g. `"1,1"`)  | —                            | GPU split ratios for layer/row parallelism ([details](./docs/multi-gpu.md)) |
 | parallel          | integer                                     | 1                            | Concurrent sequence slots for continuous batching. Values `>= 2` enable batch `run()` and split the KV cache uniformly across slots ([details](./docs/continuous-batching.md)) |

--- a/packages/llm-llamacpp/addon/src/model-interface/LoadFitNormalization.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LoadFitNormalization.cpp
@@ -151,7 +151,7 @@ void tuneLoadConfigMap(
     std::unordered_map<std::string, std::string>& configFilemap,
     const ModelMetaData& metadata, const std::optional<int>& adrenoVersion,
     const FinetuneConfigOverrides& finetuneOverrides, bool isOpenCl,
-    bool isMetal, bool isGpu) {
+    bool isMetal, bool isGpu, bool isCuda) {
 
   const bool isFinetuning = finetuneOverrides.active;
 
@@ -360,7 +360,7 @@ void tuneLoadConfigMap(
   // 28448086915: S25/S26 crash on a q4_0 sliding shift; Mali Vulkan passes).
   // Only f32/f16/bf16 are safe on OpenCL. Metal: standard quant types are
   // supported; only TurboQuant/PolarQuant is rejected.
-  if (isOpenCl || isMetal) {
+  if (isOpenCl || isMetal || isCuda) {
     auto isTurboQuantKvType = [](const std::string& v) {
       return v == "tbq3_0" || v == "tbq4_0" || v == "pq3_0" || v == "pq4_0";
     };
@@ -411,6 +411,25 @@ void tuneLoadConfigMap(
                 side,
                 it->second.c_str(),
                 side));
+      }
+      // QVAC-23763: CUDA has no TurboQuant/PolarQuant kernels at all. Unlike
+      // the OpenCL case above, standard quantized types are fine, so only
+      // TBQ/PQ is rejected, exactly like Metal. CPU is deliberately still
+      // allowed: ggml-tbq-quants is a core (CPU) implementation and the
+      // existing OpenCL/Metal messages already point users there.
+      if (isCuda) {
+        if (!isTurboQuantKvType(it->second))
+          return;
+        throw qvac_errors::StatusError(
+            qvac_errors::general_error::InvalidArgument,
+            string_format(
+                "[LlamaModel] cache-type-%s=%s is a TurboQuant/PolarQuant "
+                "KV-cache type and is not supported on the CUDA backend. "
+                "Either pick a different cache type "
+                "(f32/f16/bf16/q4_0/q4_1/q5_0/q5_1/q8_0/iq4_nl) or switch "
+                "device to a Vulkan GPU or CPU.\n",
+                side,
+                it->second.c_str()));
       }
       // Metal: only TurboQuant/PolarQuant is unsupported.
       if (!isTurboQuantKvType(it->second))
@@ -474,7 +493,8 @@ productionDependencies(backend_selection::llamaLogCallbackF logCallback) {
               backend_selection::BackendType preferred,
               const std::optional<backend_selection::MainGpu>& mainGpu,
               const ModelMetaData& metadata,
-              bool isFinetuning) {
+              bool isFinetuning,
+              const std::vector<std::string>& backendOverride) {
             std::optional<int> adrenoVersion;
             bool isMaliGpu = false;
             auto [type, name] = backend_selection::chooseBackend(
@@ -484,7 +504,8 @@ productionDependencies(backend_selection::llamaLogCallbackF logCallback) {
                 &metadata,
                 &adrenoVersion,
                 isFinetuning,
-                &isMaliGpu);
+                &isMaliGpu,
+                backendOverride);
             return SelectedBackend{
                 .type = type,
                 .name = std::move(name),
@@ -492,7 +513,11 @@ productionDependencies(backend_selection::llamaLogCallbackF logCallback) {
                 .isMaliGpu = isMaliGpu};
           },
       .gpuBackendSupportsRowSplit =
-          []() { return backend_selection::gpuBackendSupportsRowSplit(); }};
+          []() { return backend_selection::gpuBackendSupportsRowSplit(); },
+      .splitModeDeviceNames =
+          [](const std::string& selectedDeviceName) {
+            return backend_selection::splitModeDeviceNames(selectedDeviceName);
+          }};
 }
 
 NormalizedLoad normalizeLoadForFit(
@@ -664,6 +689,7 @@ NormalizedLoad normalizeLoadForFit(
 
   bool isOpenCl = false;
   bool isMetal = false;
+  bool isCuda = false;
   bool isGpu = false;
   {
     using namespace backend_selection;
@@ -672,8 +698,17 @@ NormalizedLoad normalizeLoadForFit(
 
     const std::optional<MainGpu> mainGpu = tryMainGpuFromMap(configFilemap);
 
+    // QVAC-23763: extracted and erased here like main-gpu, so the passthrough
+    // loop never forwards it to llama.cpp's argument parser.
+    const std::vector<std::string> backendOverride =
+        tryBackendOverrideFromMap(configFilemap);
+
     const SelectedBackend selected = dependencies.resolveBackend(
-        preferredBackend, mainGpu, metadata, finetuneOverrides.active);
+        preferredBackend,
+        mainGpu,
+        metadata,
+        finetuneOverrides.active,
+        backendOverride);
     result.adrenoVersion = selected.adrenoVersion;
 
     // QVAC-21257: optional runtime override for the multimodal projector
@@ -814,9 +849,37 @@ NormalizedLoad normalizeLoadForFit(
     // In multi-GPU split mode we intentionally omit --device so llama.cpp
     // distributes layers/rows across all available GPUs rather than pinning
     // to the single backend that chooseBackend selected.
+    //
+    // QVAC-23763: that stops being safe once one physical card registers under
+    // two backends, so pass the chosen backend's own devices instead. Empty on
+    // a single-registry host, where --device stays omitted as before.
     if (splitMode == LLAMA_SPLIT_MODE_NONE) {
       configVector.emplace_back("--device");
       configVector.emplace_back(selected.name);
+    } else if (
+        selected.type == BackendType::GPU &&
+        dependencies.splitModeDeviceNames) {
+      const std::vector<std::string> splitDevices =
+          dependencies.splitModeDeviceNames(selected.name);
+      if (!splitDevices.empty()) {
+        std::string deviceList;
+        for (const std::string& deviceName : splitDevices) {
+          if (!deviceList.empty()) {
+            deviceList += ',';
+          }
+          deviceList += deviceName;
+        }
+        QLOG_IF(
+            Priority::INFO,
+            string_format(
+                "[LlamaModel] split-mode: restricting --device to the %s "
+                "backend's own devices (%s); this host registers GPUs under "
+                "more than one backend\n",
+                selected.name.c_str(),
+                deviceList.c_str()));
+        configVector.emplace_back("--device");
+        configVector.emplace_back(std::move(deviceList));
+      }
     }
     configFilemap.erase("device");
 
@@ -824,6 +887,7 @@ NormalizedLoad normalizeLoadForFit(
     isOpenCl = isGpu && selected.name.find("opencl") != std::string::npos;
     isMetal = isGpu && (selected.name.find("metal") != std::string::npos ||
                         selected.name.rfind("mtl", 0) == 0);
+    isCuda = isGpu && selected.name.find("cuda") != std::string::npos;
   }
 
   tuneLoadConfigMap(
@@ -833,7 +897,8 @@ NormalizedLoad normalizeLoadForFit(
       finetuneOverrides,
       isOpenCl,
       isMetal,
-      isGpu);
+      isGpu,
+      isCuda);
 
   // Handle both reverse-prompt variants
   for (const std::string& key : {"reverse-prompt", "reverse_prompt"}) {

--- a/packages/llm-llamacpp/addon/src/model-interface/LoadFitNormalization.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LoadFitNormalization.hpp
@@ -76,14 +76,23 @@ struct SelectedBackend {
   bool isMaliGpu = false;
 };
 
+/// Args: preferred type, main-gpu override, model metadata, isFinetuning,
+/// and the parsed `backend` priority list (empty when the caller did not set
+/// one). QVAC-23763.
 using BackendResolver = std::function<SelectedBackend(
     backend_selection::BackendType,
     const std::optional<backend_selection::MainGpu>&, const ModelMetaData&,
-    bool)>;
+    bool, const std::vector<std::string>&)>;
 
 struct NormalizationDependencies {
   BackendResolver resolveBackend;
   std::function<bool()> gpuBackendSupportsRowSplit;
+  /// Args: the chosen backend's device name. Returns the devices to pass as
+  /// `--device` in multi-GPU split mode, or empty to keep omitting it.
+  /// QVAC-23763. Unset is treated as empty, so existing callers that build this
+  /// struct without it keep the pre-CUDA behaviour.
+  std::function<std::vector<std::string>(const std::string&)>
+      splitModeDeviceNames;
 };
 
 struct NormalizedLoad {
@@ -104,7 +113,8 @@ void tuneLoadConfigMap(
     ConfigMap& configFilemap, const ModelMetaData& metadata,
     const std::optional<int>& adrenoVersion,
     const FinetuneConfigOverrides& finetuneOverrides = {},
-    bool isOpenCl = false, bool isMetal = false, bool isGpu = false);
+    bool isOpenCl = false, bool isMetal = false, bool isGpu = false,
+    bool isCuda = false);
 
 NormalizedLoad normalizeLoadForFit(
     const std::string& modelPath, ConfigMap configFilemap,

--- a/packages/llm-llamacpp/addon/src/utils/BackendSelection.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/BackendSelection.cpp
@@ -109,6 +109,7 @@ void emplaceIfValidDevice(
     const BackendInterface& bckI, std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
     std::vector<std::string>& openClBackends,
+    std::vector<std::string>& cudaBackends,
     std::optional<int>& maxAdrenoVersion, bool& sawMaliGpu,
     const ggml_backend_reg_t reg, const DeviceDescription& devDescr,
     const enum ggml_backend_dev_type backendTypeEnum) {
@@ -138,12 +139,17 @@ void emplaceIfValidDevice(
         maxAdrenoVersion = version;
       }
     }
+    // QVAC-23763: ggml-cuda names its devices "CUDA%d". ggml-hip reports
+    // "ROCm%d" instead, so this cannot collide with an AMD device.
+    const bool isCuda = devDescr.gpuBackend.find("cuda") != std::string::npos;
     if (isOpenCl && isAdreno) {
       logEmplaceGpuBackend(devDescr.gpuBackend);
       openClBackends.emplace_back(devDescr.gpuBackend);
     } else if (!isOpenCl) {
       logEmplaceGpuBackend(devDescr.gpuBackend);
-      if (backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_GPU) {
+      if (isCuda && backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_GPU) {
+        cudaBackends.emplace_back(devDescr.gpuBackend);
+      } else if (backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_GPU) {
         gpuBackends.emplace_back(devDescr.gpuBackend);
       } else if (backendTypeEnum == GGML_BACKEND_DEVICE_TYPE_IGPU) {
         igpuBackends.emplace_back(devDescr.gpuBackend);
@@ -175,6 +181,7 @@ void tryEmplaceDevice(
     std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
     std::vector<std::string>& openClBackends,
+    std::vector<std::string>& cudaBackends,
     std::optional<int>& maxAdrenoVersion, bool& sawMaliGpu) {
   const ggml_backend_dev_t dev = bckI.ggml_backend_dev_get(deviceIndex);
   const ggml_backend_reg_t reg = bckI.ggml_backend_dev_backend_reg(dev);
@@ -190,6 +197,7 @@ void tryEmplaceDevice(
         gpuBackends,
         igpuBackends,
         openClBackends,
+        cudaBackends,
         maxAdrenoVersion,
         sawMaliGpu,
         reg,
@@ -246,6 +254,80 @@ backend_selection::parseMainGpu(const std::string& mainGpuStr) {
   }
 }
 
+namespace {
+
+// Backend families qvac-fabric can register a GPU device for. Used to tell a
+// mistyped `backend` value (hard error) apart from a correctly-spelled backend
+// that simply has no device on this machine (falls through). Deliberately does
+// NOT include "cpu": the CPU path is `device`, and accepting two spellings for
+// it would make `device: 'gpu', backend: 'cpu'` ambiguous.
+constexpr std::array<std::string_view, 7> KNOWN_GPU_BACKEND_FAMILIES = {
+    "cuda", "vulkan", "metal", "opencl", "hip", "rocm", "sycl"};
+
+/// Whether a ggml device backend name belongs to the requested family.
+/// Substring rather than equality because ggml suffixes the device index
+/// ("CUDA0", "Vulkan1") and OpenCL reports as "GPUOpenCL". Metal is special:
+/// some builds report "mtl..." instead of "Metal", which LoadFitNormalization
+/// already special-cases the same way.
+bool backendNameMatchesFamily(
+    const std::string& lowercasedBackendName, std::string_view family) {
+  if (lowercasedBackendName.find(family) != std::string::npos) {
+    return true;
+  }
+  return family == "metal" && lowercasedBackendName.rfind("mtl", 0) == 0;
+}
+
+} // namespace
+
+std::vector<std::string>
+backend_selection::parseBackendOverride(const std::string& backendStr) {
+  std::vector<std::string> families;
+  std::string current;
+  auto flush = [&]() {
+    const auto begin = current.find_first_not_of(" \t");
+    if (begin == std::string::npos) {
+      return;
+    }
+    const auto end = current.find_last_not_of(" \t");
+    std::string family = current.substr(begin, end - begin + 1);
+    std::ranges::transform(family, family.begin(), ::tolower);
+    if (std::ranges::find(KNOWN_GPU_BACKEND_FAMILIES, family) ==
+        KNOWN_GPU_BACKEND_FAMILIES.end()) {
+      throw qvac_errors::StatusError(
+          qvac_errors::general_error::InvalidArgument,
+          string_format(
+              "backend: unknown backend '%s'. Expected a comma-separated list "
+              "of cuda/vulkan/metal/opencl/hip/rocm/sycl, for example "
+              "'cuda,vulkan'. To run on CPU use device 'cpu' instead.\n",
+              family.c_str()));
+    }
+    if (std::ranges::find(families, family) == families.end()) {
+      families.emplace_back(std::move(family));
+    }
+  };
+  for (const char c : backendStr) {
+    if (c == ',') {
+      flush();
+      current.clear();
+    } else {
+      current.push_back(c);
+    }
+  }
+  flush();
+  return families;
+}
+
+std::vector<std::string> backend_selection::tryBackendOverrideFromMap(
+    std::unordered_map<std::string, std::string>& configFilemap) {
+  auto it = configFilemap.find("backend");
+  if (it == configFilemap.end()) {
+    return {};
+  }
+  std::vector<std::string> families = parseBackendOverride(it->second);
+  configFilemap.erase(it);
+  return families;
+}
+
 std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
     std::unordered_map<std::string, std::string>& configFilemap) {
   auto hIt = configFilemap.find("main-gpu");
@@ -268,11 +350,12 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, const BackendInterface& bckI,
     const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu,
     std::optional<int>* outAdrenoVersion, const bool isFinetuning,
-    bool* outIsMaliGpu) {
+    bool* outIsMaliGpu, const std::vector<std::string>& backendOverride) {
 
   std::vector<std::string> gpuBackends;
   std::vector<std::string> igpuBackends;
   std::vector<std::string> openClBackends;
+  std::vector<std::string> cudaBackends;
   std::optional<int> maxAdrenoVersion;
   bool sawMaliGpu = false;
 
@@ -293,6 +376,7 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
               gpuBackends,
               igpuBackends,
               openClBackends,
+              cudaBackends,
               maxAdrenoVersion,
               sawMaliGpu);
           loopAllDevices = false;
@@ -316,6 +400,7 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
           gpuBackends,
           igpuBackends,
           openClBackends,
+          cudaBackends,
           maxAdrenoVersion,
           sawMaliGpu);
     }
@@ -323,6 +408,7 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
 
   auto clearAllGpuBackends = [&]() {
     openClBackends.clear();
+    cudaBackends.clear();
     gpuBackends.clear();
     igpuBackends.clear();
   };
@@ -379,9 +465,44 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     *outIsMaliGpu = sawMaliGpu;
   }
 
+  // QVAC-23763: an explicit `backend` override wins over the cascade below,
+  // but only over candidates that survived the guards above: a request for a
+  // backend that was just cleared (BitNet TQ on Adreno <800, finetuning on
+  // Adreno <800) must not resurrect it.
+  //
+  // Skipped entirely for a CPU load. No devices are enumerated in that case, so
+  // the block could only ever reach its "matched no available device" warning,
+  // which would be noise on a deliberate device:'cpu' request.
+  if (!backendOverride.empty() && preferredBackendType == BackendType::GPU) {
+    for (const std::string& family : backendOverride) {
+      for (const std::vector<std::string>* candidates :
+           {&openClBackends, &cudaBackends, &gpuBackends, &igpuBackends}) {
+        for (const std::string& name : *candidates) {
+          if (::backendNameMatchesFamily(name, family)) {
+            std::string text = string_format(
+                "Chosen %s Backend (backend override)", family.c_str());
+            bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, text.c_str(), nullptr);
+            return {BackendType::GPU, name};
+          }
+        }
+      }
+    }
+    bckI.llamaLogCallback(
+        GGML_LOG_LEVEL_WARN,
+        "backend override matched no available device; falling back to the "
+        "default backend order",
+        nullptr);
+  }
+
   if (!openClBackends.empty()) {
     bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, "Chosen GPU OpenCL", nullptr);
     return {BackendType::GPU, openClBackends.front()};
+  }
+
+  // Before the generic GPU bucket, which is where Vulkan lands.
+  if (!cudaBackends.empty()) {
+    bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, "Chosen GPU CUDA", nullptr);
+    return {BackendType::GPU, cudaBackends.front()};
   }
 
   if (!gpuBackends.empty()) {
@@ -402,7 +523,7 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
     const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata,
     std::optional<int>* outAdrenoVersion, const bool isFinetuning,
-    bool* outIsMaliGpu) {
+    bool* outIsMaliGpu, const std::vector<std::string>& backendOverride) {
   BackendInterface bckI{
       ggml_backend_dev_count,
       ggml_backend_dev_backend_reg,
@@ -420,7 +541,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
       mainGpu,
       outAdrenoVersion,
       isFinetuning,
-      outIsMaliGpu);
+      outIsMaliGpu,
+      backendOverride);
 }
 
 size_t
@@ -445,10 +567,13 @@ bool backend_selection::gpuBackendSupportsRowSplit(
   // Mirror what qvac-fabric actually checks: llama_model::load_tensors() calls
   // make_gpu_buft_list() for EVERY device it was given and throws "device %s
   // does not support split buffers" on the first one whose backend registry
-  // lacks `ggml_backend_split_buffer_type`. Split mode omits `--device`, so
-  // that set is every GPU device across every registered backend — a single
-  // unsupported backend in the process is enough to fail the load. So require
-  // all of them, not any one, and treat "no GPU devices at all" as unsupported.
+  // lacks `ggml_backend_split_buffer_type`. So require all of them, not any
+  // one, and treat "no GPU devices at all" as unsupported.
+  //
+  // QVAC-23763: split mode now scopes `--device` to one registry (see
+  // splitModeDeviceNames), so qvac-fabric sees a narrower set than is checked
+  // here. Left registry-wide on purpose: that only degrades row to layer sooner
+  // than needed, never the other way, and no shipped backend has split buffers.
   size_t gpuDevices = 0;
   const size_t totalDevices = bckI.ggml_backend_dev_count();
   for (size_t i = 0; i < totalDevices; ++i) {
@@ -481,4 +606,69 @@ bool backend_selection::gpuBackendSupportsRowSplit() {
       ggml_backend_reg_get_proc_address,
       nullptr};
   return backend_selection::gpuBackendSupportsRowSplit(bckI);
+}
+
+std::vector<std::string> backend_selection::splitModeDeviceNames(
+    const BackendInterface& bckI, const std::string& selectedDeviceName) {
+  // Kept in ggml's enumeration order, so the list matches what qvac-fabric
+  // would have discovered on its own.
+  std::vector<std::pair<std::string, std::string>> devices;
+  std::vector<std::string> registries;
+  std::string selectedRegistry;
+
+  const size_t totalDevices = bckI.ggml_backend_dev_count();
+  for (size_t i = 0; i < totalDevices; ++i) {
+    ggml_backend_dev_t dev = bckI.ggml_backend_dev_get(i);
+    const enum ggml_backend_dev_type devType = bckI.ggml_backend_dev_type(dev);
+    if (devType != GGML_BACKEND_DEVICE_TYPE_GPU &&
+        devType != GGML_BACKEND_DEVICE_TYPE_IGPU) {
+      continue;
+    }
+    ggml_backend_reg_t reg = bckI.ggml_backend_dev_backend_reg(dev);
+    if (reg == nullptr) {
+      continue;
+    }
+    std::string registry = bckI.ggml_backend_reg_name(reg);
+    // RPC is skipped for the same reason emplaceIfValidDevice skips it: those
+    // devices are never candidates for selection in the first place.
+    if (registry == "RPC") {
+      continue;
+    }
+    std::string deviceName = bckI.ggml_backend_dev_name(dev);
+    std::ranges::transform(deviceName, deviceName.begin(), ::tolower);
+    if (deviceName == selectedDeviceName) {
+      selectedRegistry = registry;
+    }
+    if (std::ranges::find(registries, registry) == registries.end()) {
+      registries.push_back(registry);
+    }
+    devices.emplace_back(std::move(registry), std::move(deviceName));
+  }
+
+  if (registries.size() < 2 || selectedRegistry.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> names;
+  for (const auto& [registry, deviceName] : devices) {
+    if (registry == selectedRegistry) {
+      names.push_back(deviceName);
+    }
+  }
+  return names;
+}
+
+std::vector<std::string>
+backend_selection::splitModeDeviceNames(const std::string& selectedDeviceName) {
+  BackendInterface bckI{
+      ggml_backend_dev_count,
+      ggml_backend_dev_backend_reg,
+      ggml_backend_dev_get,
+      ggml_backend_reg_name,
+      ggml_backend_dev_description,
+      ggml_backend_dev_name,
+      ggml_backend_dev_type,
+      ggml_backend_reg_get_proc_address,
+      nullptr};
+  return backend_selection::splitModeDeviceNames(bckI, selectedDeviceName);
 }

--- a/packages/llm-llamacpp/addon/src/utils/BackendSelection.hpp
+++ b/packages/llm-llamacpp/addon/src/utils/BackendSelection.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 #include <inference-addon-cpp/Errors.hpp>
 #include <llama.h>
@@ -31,6 +32,20 @@ std::optional<MainGpu> parseMainGpu(const std::string& mainGpuStr);
 std::optional<MainGpu>
 tryMainGpuFromMap(std::unordered_map<std::string, std::string>& configFilemap);
 
+/// @brief Parse a `backend` override into a lowercased priority list, e.g.
+/// "CUDA,Vulkan" -> {"cuda", "vulkan"}.
+///
+/// An unknown NAME is a config mistake and throws
+/// StatusError(InvalidArgument); a known name with no device attached is
+/// legitimate, e.g. asking for cuda on a Vulkan-only host, and falls through to
+/// the next entry and then to the normal cascade.
+std::vector<std::string> parseBackendOverride(const std::string& backendStr);
+
+/// @brief Extract and erase the `backend` key from a config map.
+/// Returns an empty vector when the key is absent.
+std::vector<std::string> tryBackendOverrideFromMap(
+    std::unordered_map<std::string, std::string>& configFilemap);
+
 using llamaLogCallbackF =
     void (*)(ggml_log_level level, const char* text, void* userData);
 
@@ -53,11 +68,23 @@ std::pair<BackendType, std::string> chooseBackend(
     const ModelMetaData* metadata = nullptr,
     const std::optional<MainGpu>& mainGpu = std::nullopt,
     std::optional<int>* outAdrenoVersion = nullptr, bool isFinetuning = false,
-    bool* outIsMaliGpu = nullptr);
+    bool* outIsMaliGpu = nullptr,
+    const std::vector<std::string>& backendOverride = {});
 
 /// @brief Choose the backend to use for the model based on GPU device and
-/// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise
-/// Vulkan backend. Uses CPU if no GPU backends are available.
+/// available backends. Prefer OpenCL backend for Adreno GPUs, then CUDA on
+/// NVIDIA, otherwise Vulkan. Uses CPU if no GPU backends are available.
+///
+/// The CUDA preference is stated here rather than inherited: qvac-fabric loads
+/// cuda before vulkan in ggml_backend_load_all_from_path(), and device
+/// registration is an unsorted push_back, so CUDA already happens to enumerate
+/// first. Relying on that would make backend choice a silent function of two
+/// line numbers in ggml-backend-reg.cpp. QVAC-23763.
+///
+/// @p backendOverride, when non-empty, restricts the choice to those backend
+/// families in priority order (e.g. {"cuda", "vulkan"}). Entries with no device
+/// present are skipped; if none match, selection falls through to the normal
+/// cascade rather than failing, because an absent device is not a config error.
 ///
 /// For BitNet models with TQ1_0/TQ2_0 quantization on Adreno GPUs:
 ///   - Adreno 800+: prefer Vulkan over OpenCL
@@ -76,7 +103,8 @@ std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
     const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata,
     std::optional<int>* outAdrenoVersion = nullptr, bool isFinetuning = false,
-    bool* outIsMaliGpu = nullptr);
+    bool* outIsMaliGpu = nullptr,
+    const std::vector<std::string>& backendOverride = {});
 
 /// @brief Count GPU devices available for multi-GPU split mode.
 /// Returns the number of discrete GPUs when any are present; otherwise
@@ -96,4 +124,22 @@ bool gpuBackendSupportsRowSplit(const BackendInterface& bckI);
 /// @brief `gpuBackendSupportsRowSplit()` against the real ggml backend
 /// registry.
 bool gpuBackendSupportsRowSplit();
+
+/// @brief The device names to pass as `--device` in multi-GPU split mode,
+/// namely those sharing @p selectedDeviceName's backend registry.
+///
+/// QVAC-23763: with CUDA loaded next to Vulkan, one physical NVIDIA card
+/// registers twice, as CUDA0 and Vulkan0, so the old unconditional omission of
+/// `--device` would spread a single card across two backends.
+///
+/// Empty when every GPU/iGPU device comes from one registry, which is every
+/// pre-CUDA configuration, and the caller then keeps omitting `--device`. Also
+/// empty when @p selectedDeviceName matches nothing, so an unexpected name
+/// degrades to that same old behaviour rather than to no GPU at all.
+std::vector<std::string> splitModeDeviceNames(
+    const BackendInterface& bckI, const std::string& selectedDeviceName);
+
+/// @brief `splitModeDeviceNames()` against the real ggml backend registry.
+std::vector<std::string>
+splitModeDeviceNames(const std::string& selectedDeviceName);
 } // namespace backend_selection

--- a/packages/llm-llamacpp/docs/multi-gpu.md
+++ b/packages/llm-llamacpp/docs/multi-gpu.md
@@ -123,11 +123,21 @@ The `device` parameter is always required and is consumed first. When set to `'g
 After backend selection, the split-mode determines the forwarding strategy:
 
 - **`split-mode: 'none'`** (or omitted): the chosen backend name is passed as `--device <backend>`, pinning inference to that single GPU.
-- **`split-mode: 'layer'` or `'row'`**: `--device` is intentionally **not** passed. This lets qvac-fabric discover all available GPUs and distribute the model according to `tensor-split`.
+- **`split-mode: 'layer'` or `'row'`**: `--device` is either omitted, or set to the list of devices belonging to the chosen backend. See below.
 
-### Why `--device` is omitted in split modes
+### What `--device` does in split modes
 
-When a split mode is active, passing `--device` would pin all computation to the single backend that `chooseBackend()` selected, defeating the purpose of multi-GPU. By omitting it, qvac-fabric's own device enumeration distributes layers or rows across all visible GPU backends.
+Passing a single `--device` would pin all computation to the one device `chooseBackend()` selected, defeating the purpose of multi-GPU. So a split mode never does that. What it passes instead depends on how many GPU backends the host registers.
+
+**One GPU backend**, which is every host without the CUDA module: `--device` is not passed at all. qvac-fabric's own device enumeration distributes layers or rows across all visible GPUs.
+
+**More than one GPU backend**, which on Linux means an NVIDIA machine where CUDA and Vulkan both register: `--device` is passed as the comma-separated list of devices from the chosen backend only, for example `cuda0,cuda1`. The same physical card registers once per backend, as both `CUDA0` and `Vulkan0`, so leaving `--device` off would tell qvac-fabric to spread one GPU across two backends. Scoping the list keeps the split across every GPU while counting each one once.
+
+Use the `backend` config key to choose which backend the split runs on, for example `backend: 'vulkan'` on an NVIDIA host.
+
+### `main-gpu` indices
+
+`main-gpu` as an integer indexes qvac-fabric's device list. On a host with more than one GPU backend that list holds every backend's devices, so adding CUDA shifts the indices an existing config was written against.
 
 ## Usage examples
 

--- a/packages/llm-llamacpp/index.d.ts
+++ b/packages/llm-llamacpp/index.d.ts
@@ -115,6 +115,14 @@ declare namespace LlmLlamacpp {
     }
     interface LlamaConfig {
         device?: string;
+        /**
+         * Comma-separated GPU backend priority list, e.g. `'cuda,vulkan'`.
+         * Accepted names: cuda, vulkan, metal, opencl, hip, rocm, sycl. An
+         * unrecognised name is rejected; a recognised one with no device present is
+         * skipped and selection continues down the normal order. Use
+         * `device: 'cpu'` to run on CPU. QVAC-23763.
+         */
+        backend?: string;
         gpu_layers?: NumericLike;
         ctx_size?: NumericLike;
         system_prompt?: string;

--- a/packages/llm-llamacpp/src/index.ts
+++ b/packages/llm-llamacpp/src/index.ts
@@ -960,6 +960,14 @@ namespace LlmLlamacpp {
 
   export interface LlamaConfig {
     device?: string;
+    /**
+     * Comma-separated GPU backend priority list, e.g. `'cuda,vulkan'`.
+     * Accepted names: cuda, vulkan, metal, opencl, hip, rocm, sycl. An
+     * unrecognised name is rejected; a recognised one with no device present is
+     * skipped and selection continues down the normal order. Use
+     * `device: 'cpu'` to run on CPU. QVAC-23763.
+     */
+    backend?: string;
     gpu_layers?: NumericLike;
     ctx_size?: NumericLike;
     system_prompt?: string;

--- a/packages/llm-llamacpp/test/unit/test_backend_selection.cpp
+++ b/packages/llm-llamacpp/test/unit/test_backend_selection.cpp
@@ -1149,3 +1149,303 @@ TEST_F(BackendSelectionTest, OutIsMaliGpuFalseWhenPreferredCpu) {
   EXPECT_EQ(result.first, BackendType::CPU);
   EXPECT_FALSE(isMaliGpu);
 }
+
+// ---- QVAC-23763: CUDA prioritisation and the `backend` override ----
+
+// GPU backend names as ggml reports them. ggml-cuda uses "CUDA%d"; ggml-hip
+// uses "ROCm%d", which is why CUDA detection cannot pick up an AMD device.
+constexpr const char* CUDA0_BACK = "CUDA0";
+constexpr const char* CUDA1_BACK = "CUDA1";
+constexpr const char* ROCM0_BACK = "ROCm0";
+constexpr const char* NVIDIA_DESC = "NVIDIA GeForce RTX 3090";
+constexpr const char* TESLA_DESC = "Tesla T4";
+
+std::pair<BackendType, std::string> chooseWithOverride(
+    MockBackendInterface& mockBackend,
+    const std::vector<std::string>& backendOverride,
+    BackendType preferred = BackendType::GPU) {
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  return chooseBackend(
+      preferred,
+      bckI,
+      nullptr,
+      std::nullopt,
+      nullptr,
+      false,
+      nullptr,
+      backendOverride);
+}
+
+// The headline behaviour: on a host where the same physical GPU registers
+// under both backends, CUDA wins.
+TEST_F(BackendSelectionTest, CudaPreferredOverVulkan) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// Registration order must not decide the outcome. This is the whole reason the
+// preference is stated rather than inherited from ggml's load order.
+TEST_F(BackendSelectionTest, CudaPreferredOverVulkanRegardlessOfDeviceOrder) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// No CUDA module or no NVIDIA driver: the device never registers, so the
+// cascade lands on Vulkan with no special handling.
+TEST_F(BackendSelectionTest, VulkanChosenWhenNoCudaDevice) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, VULKAN0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "vulkan0");
+}
+
+TEST_F(BackendSelectionTest, CudaAloneIsChosen) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// A discrete CUDA GPU must still beat an integrated GPU.
+TEST_F(BackendSelectionTest, CudaPreferredOverIntegratedGpu) {
+  mockBackend.addDevice(createIGPUDevice("Intel Arc", VULKAN0_BACK));
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "cuda0");
+}
+
+// Adreno OpenCL must keep winning: mobile behaviour is unchanged by CUDA.
+TEST_F(BackendSelectionTest, AdrenoOpenClStillBeatsCuda) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, CUDA0_BACK));
+  expectChosen(mockBackend, BackendType::GPU, "gpuopencl");
+}
+
+// "ROCm0" must not be mistaken for a CUDA device.
+TEST_F(BackendSelectionTest, RocmIsNotTreatedAsCuda) {
+  mockBackend.addDevice(createGPUDevice("AMD Radeon 8060S", ROCM0_BACK));
+  mockBackend.addDevice(createGPUDevice("AMD Radeon 8060S", VULKAN0_BACK));
+  // Both land in the generic GPU bucket, so the first registered one wins and
+  // the CUDA branch is never taken.
+  expectChosen(mockBackend, BackendType::GPU, "rocm0");
+}
+
+// device 'cpu' must not enumerate a CUDA device.
+TEST_F(BackendSelectionTest, CudaIgnoredWhenPreferredCpu) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, CUDA0_BACK));
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  auto result = chooseBackend(BackendType::CPU, bckI);
+  EXPECT_EQ(result.first, BackendType::CPU);
+}
+
+TEST_F(BackendSelectionTest, OverrideForcesVulkanOnACudaHost) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"vulkan"});
+  expectChosen(result, BackendType::GPU, "vulkan0");
+}
+
+TEST_F(BackendSelectionTest, OverrideHonoursPriorityOrder) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, VULKAN0_BACK));
+  auto vulkanFirst = chooseWithOverride(mockBackend, {"vulkan", "cuda"});
+  expectChosen(vulkanFirst, BackendType::GPU, "vulkan0");
+  auto cudaFirst = chooseWithOverride(mockBackend, {"cuda", "vulkan"});
+  expectChosen(cudaFirst, BackendType::GPU, "cuda0");
+}
+
+// First entry absent, second present: skip to the second rather than failing.
+TEST_F(BackendSelectionTest, OverrideSkipsAbsentBackend) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda", "vulkan"});
+  expectChosen(result, BackendType::GPU, "vulkan0");
+}
+
+// Correctly spelled but nothing matches: fall through to the normal cascade
+// instead of failing the load, because an absent device is not a config error.
+TEST_F(BackendSelectionTest, OverrideFallsBackWhenNothingMatches) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, VULKAN0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda"});
+  expectChosen(result, BackendType::GPU, "vulkan0");
+}
+
+TEST_F(BackendSelectionTest, OverrideFallsBackToCpuWhenNoGpuAtAll) {
+  auto result = chooseWithOverride(mockBackend, {"cuda", "vulkan"});
+  EXPECT_EQ(result.first, BackendType::CPU);
+}
+
+// The override selects a family, not a device index: with two CUDA devices the
+// first one still wins.
+TEST_F(BackendSelectionTest, OverridePicksFirstDeviceOfFamily) {
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA0_BACK));
+  mockBackend.addDevice(createGPUDevice(TESLA_DESC, CUDA1_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda"});
+  expectChosen(result, BackendType::GPU, "cuda0");
+}
+
+// ---- parseBackendOverride ----
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideBasic) {
+  EXPECT_EQ(
+      parseBackendOverride("CUDA,Vulkan"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideTrimsAndLowercases) {
+  EXPECT_EQ(
+      parseBackendOverride("  CuDa ,  VULKAN  "),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideDropsDuplicates) {
+  EXPECT_EQ(
+      parseBackendOverride("cuda,cuda,vulkan"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideIgnoresEmptyEntries) {
+  EXPECT_EQ(
+      parseBackendOverride("cuda,,vulkan,"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST_F(BackendSelectionTest, ParseBackendOverrideEmptyStringIsEmptyList) {
+  EXPECT_TRUE(parseBackendOverride("").empty());
+}
+
+// A misspelled name is a config mistake and must be loud, not silently ignored.
+TEST_F(BackendSelectionTest, ParseBackendOverrideRejectsUnknownName) {
+  EXPECT_THROW(parseBackendOverride("cudaa"), qvac_errors::StatusError);
+  EXPECT_THROW(parseBackendOverride("vulcan"), qvac_errors::StatusError);
+  EXPECT_THROW(
+      parseBackendOverride("cuda,notabackend"), qvac_errors::StatusError);
+}
+
+// 'cpu' is spelled via `device`, not `backend`; accepting both would make
+// device:'gpu' + backend:'cpu' ambiguous.
+TEST_F(BackendSelectionTest, ParseBackendOverrideRejectsCpu) {
+  EXPECT_THROW(parseBackendOverride("cpu"), qvac_errors::StatusError);
+}
+
+// ---- tryBackendOverrideFromMap ----
+
+TEST_F(BackendSelectionTest, TryBackendOverrideFromMapErasesKey) {
+  std::unordered_map<std::string, std::string> config{
+      {"backend", "cuda,vulkan"}, {"device", "gpu"}};
+  auto families = tryBackendOverrideFromMap(config);
+  EXPECT_EQ(families, (std::vector<std::string>{"cuda", "vulkan"}));
+  // Must be erased, otherwise it reaches llama.cpp's argument parser.
+  EXPECT_EQ(config.count("backend"), 0u);
+  EXPECT_EQ(config.count("device"), 1u);
+}
+
+TEST_F(BackendSelectionTest, TryBackendOverrideFromMapAbsentIsEmpty) {
+  std::unordered_map<std::string, std::string> config{{"device", "gpu"}};
+  EXPECT_TRUE(tryBackendOverrideFromMap(config).empty());
+}
+
+TEST_F(BackendSelectionTest, TryBackendOverrideFromMapPropagatesThrow) {
+  std::unordered_map<std::string, std::string> config{{"backend", "nope"}};
+  EXPECT_THROW(tryBackendOverrideFromMap(config), qvac_errors::StatusError);
+}
+
+// device 'cpu' with a backend override must land on CPU quietly: no devices are
+// enumerated, so the override has nothing to match and must not be treated as
+// an error.
+TEST_F(BackendSelectionTest, OverrideIgnoredWhenPreferredCpu) {
+  mockBackend.addDevice(createGPUDevice(NVIDIA_DESC, CUDA0_BACK));
+  auto result = chooseWithOverride(mockBackend, {"cuda"}, BackendType::CPU);
+  EXPECT_EQ(result.first, BackendType::CPU);
+  EXPECT_EQ(result.second, "none");
+}
+
+// ---- QVAC-23763: split-mode device scoping ----
+//
+// Grouping is by backend REGISTRY name, not by device name, so these fixtures
+// set it explicitly. createGPUDevice() leaves it at the mock default, which
+// puts every device in one registry.
+
+constexpr const char* CUDA_REG = "CUDA";
+constexpr const char* VULKAN_REG = "Vulkan";
+
+static MockDevice createGPUDeviceInRegistry(
+    std::string&& desc, std::string&& backend, std::string&& registry) {
+  return {
+      std::move(desc),
+      std::move(backend),
+      GGML_BACKEND_DEVICE_TYPE_GPU,
+      std::move(registry)};
+}
+
+static std::vector<std::string> splitDevicesFor(
+    MockBackendInterface& mockBackend, const std::string& selected) {
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  return splitModeDeviceNames(bckI, selected);
+}
+
+// Every pre-CUDA host: one registry, so --device keeps being omitted and
+// qvac-fabric enumerates the GPUs itself exactly as before.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesEmptyOnSingleRegistry) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN1_BACK, VULKAN_REG));
+  EXPECT_TRUE(splitDevicesFor(mockBackend, "vulkan0").empty());
+}
+
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesEmptyWithNoGpuAtAll) {
+  mockBackend.addDevice(createCPUDevice("host", "CPU"));
+  EXPECT_TRUE(splitDevicesFor(mockBackend, "cuda0").empty());
+}
+
+// The case this exists for: two NVIDIA cards, each registered twice. Without
+// scoping, split mode would hand qvac-fabric four devices for two GPUs.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesScopesToSelectedRegistry) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA1_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN1_BACK, VULKAN_REG));
+  EXPECT_EQ(
+      splitDevicesFor(mockBackend, "cuda0"),
+      (std::vector<std::string>{"cuda0", "cuda1"}));
+}
+
+// An explicit backend override lands on Vulkan; the split must follow it rather
+// than the default CUDA preference.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesFollowsTheChosenBackend) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN1_BACK, VULKAN_REG));
+  EXPECT_EQ(
+      splitDevicesFor(mockBackend, "vulkan0"),
+      (std::vector<std::string>{"vulkan0", "vulkan1"}));
+}
+
+// An iGPU on the chosen backend is still part of the split: qvac-fabric would
+// have used it when --device was omitted, so dropping it would be a regression.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesKeepsIgpuOfSameRegistry) {
+  MockDevice igpu(
+      "intel arc", "Vulkan1", GGML_BACKEND_DEVICE_TYPE_IGPU, "Vulkan");
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  mockBackend.addDevice(std::move(igpu));
+  EXPECT_EQ(
+      splitDevicesFor(mockBackend, "vulkan0"),
+      (std::vector<std::string>{"vulkan0", "vulkan1"}));
+}
+
+// A name that matches nothing degrades to the old omit-everything behaviour
+// rather than to an empty device list, which would strand the load on no GPU.
+TEST_F(BackendSelectionTest, SplitModeDeviceNamesEmptyWhenSelectionUnmatched) {
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, CUDA0_BACK, CUDA_REG));
+  mockBackend.addDevice(
+      createGPUDeviceInRegistry(NVIDIA_DESC, VULKAN0_BACK, VULKAN_REG));
+  EXPECT_TRUE(splitDevicesFor(mockBackend, "metal0").empty());
+}

--- a/packages/llm-llamacpp/test/unit/test_load_fit_normalization.cpp
+++ b/packages/llm-llamacpp/test/unit/test_load_fit_normalization.cpp
@@ -329,11 +329,13 @@ protected:
   static lfn::NormalizationDependencies
   backend(lfn::SelectedBackend selected, bool supportsRowSplit = false) {
     return {
-        .resolveBackend = [selected](
-                              backend_selection::BackendType,
-                              const std::optional<backend_selection::MainGpu>&,
-                              const ModelMetaData&,
-                              bool) { return selected; },
+        .resolveBackend =
+            [selected](
+                backend_selection::BackendType,
+                const std::optional<backend_selection::MainGpu>&,
+                const ModelMetaData&,
+                bool,
+                const std::vector<std::string>&) { return selected; },
         .gpuBackendSupportsRowSplit =
             [supportsRowSplit]() { return supportsRowSplit; }};
   }
@@ -426,7 +428,8 @@ TEST_F(LoadFitNormalizationTest, RowSplitProbeRunsOnlyForSelectedGpuRowMode) {
       [](backend_selection::BackendType,
          const std::optional<backend_selection::MainGpu>&,
          const ModelMetaData&,
-         bool) {
+         bool,
+         const std::vector<std::string>&) {
         return lfn::SelectedBackend{
             .type = backend_selection::GPU, .name = "none"};
       };

--- a/packages/llm-llamacpp/test/unit/test_tune_config_map.cpp
+++ b/packages/llm-llamacpp/test/unit/test_tune_config_map.cpp
@@ -1079,3 +1079,99 @@ TEST_F(TuneConfigMapTest, AutoDefault_AdrenoOpenCl_StaysF16) {
   EXPECT_EQ(configFilemap_.count("cache-type-k"), 0);
   EXPECT_EQ(configFilemap_.count("cache-type-v"), 0);
 }
+
+// ---- QVAC-23763: TurboQuant / PolarQuant rejected on CUDA ----
+//
+// ggml-cuda ships no TBQ/PQ kernels at all (`grep -rl tbq ggml/src/ggml-cuda/`
+// is empty, while Vulkan has mul_mat_vec_tbq3_0.comp), so these types would
+// abort natively. Standard quantized types are fine on CUDA, so this mirrors
+// the Metal guard rather than the stricter OpenCL one. CPU stays allowed:
+// ggml-tbq-quants is a core CPU implementation.
+
+TEST_F(TuneConfigMapTest, Cuda_RejectsTurboQuantKCacheType) {
+  MockModelMetaData meta(false, "llama");
+  configFilemap_["cache-type-k"] = "tbq4_0";
+
+  EXPECT_THROW(
+      load_fit_normalization::tuneLoadConfigMap(
+          configFilemap_,
+          meta,
+          std::nullopt,
+          FtOverrides{},
+          /*isOpenCl=*/false,
+          /*isMetal=*/false,
+          /*isGpu=*/true,
+          /*isCuda=*/true),
+      qvac_errors::StatusError);
+}
+
+TEST_F(TuneConfigMapTest, Cuda_RejectsPolarQuantVCacheType) {
+  MockModelMetaData meta(false, "llama");
+  configFilemap_["cache-type-v"] = "pq3_0";
+
+  EXPECT_THROW(
+      load_fit_normalization::tuneLoadConfigMap(
+          configFilemap_,
+          meta,
+          std::nullopt,
+          FtOverrides{},
+          /*isOpenCl=*/false,
+          /*isMetal=*/false,
+          /*isGpu=*/true,
+          /*isCuda=*/true),
+      qvac_errors::StatusError);
+}
+
+TEST_F(TuneConfigMapTest, Cuda_AllowsStandardQuantizedCacheTypes) {
+  MockModelMetaData meta(false, "llama");
+  configFilemap_["cache-type-k"] = "q8_0";
+  configFilemap_["cache-type-v"] = "q4_0";
+
+  EXPECT_NO_THROW(
+      load_fit_normalization::tuneLoadConfigMap(
+          configFilemap_,
+          meta,
+          std::nullopt,
+          FtOverrides{},
+          /*isOpenCl=*/false,
+          /*isMetal=*/false,
+          /*isGpu=*/true,
+          /*isCuda=*/true));
+}
+
+TEST_F(TuneConfigMapTest, Cuda_AllowsF16CacheTypes) {
+  MockModelMetaData meta(false, "llama");
+  configFilemap_["cache-type-k"] = "f16";
+  configFilemap_["cache-type-v"] = "f16";
+
+  EXPECT_NO_THROW(
+      load_fit_normalization::tuneLoadConfigMap(
+          configFilemap_,
+          meta,
+          std::nullopt,
+          FtOverrides{},
+          /*isOpenCl=*/false,
+          /*isMetal=*/false,
+          /*isGpu=*/true,
+          /*isCuda=*/true));
+}
+
+// Guard against over-reach. CPU has TBQ kernels and the existing OpenCL/Metal
+// errors tell users to switch to it, so a non-CUDA non-GPU call must keep
+// accepting TBQ.
+TEST_F(TuneConfigMapTest, Cpu_StillAllowsTurboQuantCacheTypes) {
+  MockModelMetaData meta(false, "llama");
+  configFilemap_["cache-type-k"] = "tbq4_0";
+  configFilemap_["cache-type-v"] = "pq4_0";
+
+  EXPECT_NO_THROW(
+      load_fit_normalization::tuneLoadConfigMap(
+          configFilemap_,
+          meta,
+          std::nullopt,
+          FtOverrides{},
+          /*isOpenCl=*/false,
+          /*isMetal=*/false,
+          /*isGpu=*/false,
+          /*isCuda=*/false));
+}

--- a/packages/llm-llamacpp/vcpkg-configuration.json
+++ b/packages/llm-llamacpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",

--- a/packages/llm-llamacpp/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg.json
@@ -1,15 +1,21 @@
 {
   "dependencies": [
+    "concurrentqueue",
+    "nlohmann-json",
     {
       "name": "opencl",
       "platform": "android"
     },
     "picojson",
-    "nlohmann-json",
-    "concurrentqueue",
     {
       "name": "qvac-fabric",
-      "version>=": "10297.0.0"
+      "features": [
+        {
+          "name": "cuda-backend",
+          "platform": "linux & x64"
+        }
+      ],
+      "version>=": "10297.0.0#1"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/model-fit/vcpkg-configuration.json
+++ b/packages/model-fit/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",

--- a/packages/model-fit/vcpkg.json
+++ b/packages/model-fit/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10297.0.0"
+      "version>=": "10297.0.0#1"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/ocr-ggml/vcpkg-configuration.json
+++ b/packages/ocr-ggml/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "c5955445a221df255d2204be964647c08c82c28f",

--- a/packages/ocr-ggml/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg.json
@@ -20,7 +20,7 @@
     {
       "name": "qvac-fabric",
       "default-features": false,
-      "version>=": "10297.0.0",
+      "version>=": "10297.0.0#1",
       "features": [
         "gpu-backends"
       ]

--- a/packages/translation-nmtcpp/vcpkg-configuration.json
+++ b/packages/translation-nmtcpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "1b499699dc209ed0fbc17649f6174335ce5a2743",

--- a/packages/translation-nmtcpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg.json
@@ -16,7 +16,7 @@
     "ssplit",
     {
       "name": "qvac-fabric",
-      "version>=": "10297.0.0",
+      "version>=": "10297.0.0#1",
       "default-features": false,
       "features": [
         "gpu-backends"

--- a/packages/vla-ggml/README.md
+++ b/packages/vla-ggml/README.md
@@ -199,6 +199,21 @@ Non-Adreno GPUs are accepted. On Adreno hardware:
 When no acceptable GPU is found the addon falls back to CPU; to force CPU
 regardless, pass `backend: 'cpu'` to `load()`.
 
+Among accepted devices the order is CUDA, then HIP/ROCm, then anything else
+(Vulkan or Metal). CUDA is available on Linux only, where it ships as a
+dynamically loaded module alongside Vulkan; Windows has no dynamic backend
+loading. If the CUDA module or the NVIDIA driver is missing, the device never
+registers and selection simply continues down that order.
+
+`backend` also takes a comma-separated GPU priority list, so
+`backend: 'vulkan'` forces Vulkan on an NVIDIA machine and
+`backend: 'cuda,vulkan'` states the default order explicitly. Accepted names
+are `cuda`, `vulkan`, `metal`, `opencl`, `hip`, `rocm` and `sycl`. A name whose
+device is absent is skipped and selection continues; an unrecognised name is
+rejected. The Adreno rules above still apply, so an override can never
+resurrect a device they rejected. Setting `CUDA_VISIBLE_DEVICES=-1` in the
+environment is an equivalent way to force Vulkan without touching the config.
+
 ## Built With
 
 - [qvac-lib-inference-addon-cpp](https://github.com/tetherto/qvac-lib-inference-addon-cpp) — foundational Bare-addon framework.

--- a/packages/vla-ggml/addon/src/addon/AddonCpp.hpp
+++ b/packages/vla-ggml/addon/src/addon/AddonCpp.hpp
@@ -44,11 +44,14 @@ public:
   // `backendsDir`: absolute path to the prebuilds folder; forwarded to the
   // backend implementation so ggml backends are loaded from an absolute
   // path rather than relative to process CWD (required on mobile).
+  // `backendOverride`: GPU backend families in priority order, e.g.
+  // {"cuda", "vulkan"}; empty means the default order. QVAC-23763.
   explicit VlaModel(
       const std::string& ggufPath, bool forceCpu = false,
-      std::string backendsDir = {}, const VlaEmbodimentRequest& embodiment = {})
+      std::string backendsDir = {}, const VlaEmbodimentRequest& embodiment = {},
+      const std::vector<std::string>& backendOverride = {})
       : model_(createVlaModelFromGguf(
-            ggufPath, forceCpu, backendsDir, embodiment)) {
+            ggufPath, forceCpu, backendsDir, embodiment, backendOverride)) {
     // Canonical `backendDevice` encoding used across the inference addons
     // (LlamaModel, BertModel): 0 = CPU, 1 = GPU. Captured at load time so
     // `runtimeStats()` can report it without re-querying ggml.

--- a/packages/vla-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/vla-ggml/addon/src/addon/AddonJs.hpp
@@ -17,6 +17,7 @@
 #include <inference-addon-cpp/handlers/OutputHandler.hpp>
 #include <inference-addon-cpp/queue/OutputCallbackJs.hpp>
 
+#include "../utils/BackendSelection.hpp"
 #include "../utils/LoggingMacros.hpp"
 #include "AddonCpp.hpp"
 
@@ -273,7 +274,11 @@ inline js_value_t* hparamsToJs(js_env_t* env, const VlaHparamsGeneric& hp) {
 // it as a managed instance. `jsHandle` is the JS-side wrapper object that
 // the framework passes back as the first argument of every outputCb call.
 // `backend === 'cpu'` forces the CPU backend even on a runner with a usable
-// GPU; any other value lets the addon pick the best device.
+// GPU. QVAC-23763: any other non-empty value is now a comma-separated GPU
+// backend priority list, e.g. 'cuda' or 'cuda,vulkan', and an unrecognised
+// name is rejected. Empty still means "pick the best device". Before
+// QVAC-23763 every non-'cpu' value meant "pick the best device", so a typo was
+// silently ignored; it now throws InvalidArgument.
 inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   using namespace qvac_lib_inference_addon_cpp;
 
@@ -286,9 +291,16 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   // GGUF's default. index.js always sets them (empty when unconfigured).
   const VlaEmbodimentRequest embodiment = detail::parseEmbodimentRequest(args);
   const bool forceCpu = (backend == "cpu");
+  // 'cpu' is handled by forceCpu above and is not a GPU family name, so it
+  // never reaches parseBackendOverride. 'auto' is the documented default from
+  // index.js and an empty value is an unset key; both mean no preference.
+  const bool noPreference = forceCpu || backend.empty() || backend == "auto";
+  const std::vector<std::string> backendOverride =
+      noPreference ? std::vector<std::string>{}
+                   : vla_backend_selection::parseBackendOverride(backend);
 
-  auto model =
-      std::make_unique<VlaModel>(ggufPath, forceCpu, backendsDir, embodiment);
+  auto model = std::make_unique<VlaModel>(
+      ggufPath, forceCpu, backendsDir, embodiment, backendOverride);
 
   // VLA emits a single Float32Array (the action chunk) per job; runtime
   // stats and errors are added to the handler stack by OutputCallBackJs.

--- a/packages/vla-ggml/addon/src/model-interface/groot.cpp
+++ b/packages/vla-ggml/addon/src/model-interface/groot.cpp
@@ -1403,7 +1403,8 @@ static GrootEmbodimentSelection grootResolveForModel(
 
 static std::unique_ptr<GrootModelInternal> grootLoadModel(
     const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
-    const VlaEmbodimentRequest& embodiment = {}) {
+    const VlaEmbodimentRequest& embodiment = {},
+    const std::vector<std::string>& backendOverride = {}) {
   vla_backend_selection::loadBackendsOnce(backendsDir);
   auto m = std::make_unique<GrootModelInternal>();
 
@@ -1422,7 +1423,8 @@ static std::unique_ptr<GrootModelInternal> grootLoadModel(
   m->has_gpu = false;
 
   if (!forceCpu) {
-    ggml_backend_dev_t gpu = vla_backend_selection::pickBestGpuDevice();
+    ggml_backend_dev_t gpu =
+        vla_backend_selection::pickBestGpuDevice(backendOverride);
     if (gpu != nullptr) {
       ggml_backend_t gpuBackend = ggml_backend_dev_init(gpu, nullptr);
       if (gpuBackend != nullptr) {
@@ -2752,8 +2754,10 @@ struct ggml_tensor* grootBuildVisionBlockGraph(
 
 GrootModel::GrootModel(
     const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
-    const VlaEmbodimentRequest& embodiment)
-    : impl_(grootLoadModel(ggufPath, forceCpu, backendsDir, embodiment)) {
+    const VlaEmbodimentRequest& embodiment,
+    const std::vector<std::string>& backendOverride)
+    : impl_(grootLoadModel(
+          ggufPath, forceCpu, backendsDir, embodiment, backendOverride)) {
   hparams_.chunk_size = impl_->action_horizon;
   hparams_.action_dim = impl_->max_action_dim;
   hparams_.max_action_dim = impl_->max_action_dim;

--- a/packages/vla-ggml/addon/src/model-interface/groot.hpp
+++ b/packages/vla-ggml/addon/src/model-interface/groot.hpp
@@ -570,10 +570,13 @@ public:
   // embodiment is requested; the tag is unknown to the full tag->cat_id map;
   // the resolved cat_id is not in this GGUF's ship set; or the resolved
   // num_cameras is unknown/invalid and no override was supplied.
+  // `backendOverride` lists GPU backend families in priority order, e.g.
+  // {"cuda", "vulkan"}; empty means the default order. QVAC-23763.
   GrootModel(
       const std::string& ggufPath, bool forceCpu,
       const std::string& backendsDir,
-      const VlaEmbodimentRequest& embodiment = {});
+      const VlaEmbodimentRequest& embodiment = {},
+      const std::vector<std::string>& backendOverride = {});
 
   ~GrootModel() override;
 

--- a/packages/vla-ggml/addon/src/model-interface/model_factory.cpp
+++ b/packages/vla-ggml/addon/src/model-interface/model_factory.cpp
@@ -74,7 +74,8 @@ std::string sniffGgufArchitecture(const std::string& ggufPath) {
 
 std::unique_ptr<IVlaModel> createVlaModelFromGguf(
     const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
-    const VlaEmbodimentRequest& embodiment) {
+    const VlaEmbodimentRequest& embodiment,
+    const std::vector<std::string>& backendOverride) {
   const std::string arch = sniffGgufArchitecture(ggufPath);
 
   // Fail closed on an explicit selector the architecture cannot honour. Only
@@ -94,15 +95,16 @@ std::unique_ptr<IVlaModel> createVlaModelFromGguf(
 
   if (arch == "smolvla") {
     return std::make_unique<SmolvlaModelAdapter>(
-        ggufPath, forceCpu, backendsDir);
+        ggufPath, forceCpu, backendsDir, backendOverride);
   }
   if (arch == "pi05") {
-    return std::make_unique<Pi05Model>(ggufPath, forceCpu, backendsDir);
+    return std::make_unique<Pi05Model>(
+        ggufPath, forceCpu, backendsDir, backendOverride);
   }
   if (arch == "groot") {
     // `embodiment` selects the embodiment on multi-embodiment GGUFs.
     return std::make_unique<GrootModel>(
-        ggufPath, forceCpu, backendsDir, embodiment);
+        ggufPath, forceCpu, backendsDir, embodiment, backendOverride);
   }
 
   throw std::runtime_error(

--- a/packages/vla-ggml/addon/src/model-interface/model_factory.hpp
+++ b/packages/vla-ggml/addon/src/model-interface/model_factory.hpp
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "model-interface/vla_model.hpp"
 
@@ -30,8 +31,11 @@ std::string sniffGgufArchitecture(const std::string& ggufPath);
 // `embodiment` selects a multi-embodiment GR00T GGUF's embodiment by tag or
 // numeric cat_id, optionally overriding its camera count (unset = the GGUF's
 // default); ignored by the other architectures.
+// `backendOverride` lists GPU backend families in priority order, e.g.
+// {"cuda", "vulkan"}; empty means the default order. QVAC-23763.
 std::unique_ptr<IVlaModel> createVlaModelFromGguf(
     const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
-    const VlaEmbodimentRequest& embodiment = {});
+    const VlaEmbodimentRequest& embodiment = {},
+    const std::vector<std::string>& backendOverride = {});
 
 } // namespace qvac_lib_infer_vla_ggml

--- a/packages/vla-ggml/addon/src/model-interface/pi05.cpp
+++ b/packages/vla-ggml/addon/src/model-interface/pi05.cpp
@@ -1085,8 +1085,8 @@ static bool pi05LoadWeightsAllocCopy(
 // model struct's tensor pointers. Throws std::runtime_error on any
 // missing tensor or wrong architecture key.
 static std::unique_ptr<Pi05ModelInternal> pi05LoadModel(
-    const std::string& ggufPath, bool forceCpu,
-    const std::string& backendsDir) {
+    const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
+    const std::vector<std::string>& backendOverride = {}) {
   vla_backend_selection::loadBackendsOnce(backendsDir);
   auto m = std::make_unique<Pi05ModelInternal>();
 
@@ -1111,7 +1111,8 @@ static std::unique_ptr<Pi05ModelInternal> pi05LoadModel(
   // devices fall through to CPU rather than crash on
   // ggml_backend_dev_init. Mirrors smolvla.cpp::try_init_gpu_backend.
   if (!forceCpu) {
-    ggml_backend_dev_t gpu = vla_backend_selection::pickBestGpuDevice();
+    ggml_backend_dev_t gpu =
+        vla_backend_selection::pickBestGpuDevice(backendOverride);
     if (gpu != nullptr) {
       ggml_backend_t gpuBackend = ggml_backend_dev_init(gpu, nullptr);
       if (gpuBackend != nullptr) {
@@ -1989,9 +1990,9 @@ static bool pi05Inference(
 }
 
 Pi05Model::Pi05Model(
-    const std::string& ggufPath, bool forceCpu,
-    const std::string& backendsDir) {
-  impl_ = pi05LoadModel(ggufPath, forceCpu, backendsDir);
+    const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
+    const std::vector<std::string>& backendOverride) {
+  impl_ = pi05LoadModel(ggufPath, forceCpu, backendsDir, backendOverride);
   hparams_.chunk_size = impl_->action_horizon;
   hparams_.action_dim = impl_->action_dim;
   hparams_.max_action_dim = impl_->action_dim;

--- a/packages/vla-ggml/addon/src/model-interface/pi05.hpp
+++ b/packages/vla-ggml/addon/src/model-interface/pi05.hpp
@@ -447,9 +447,12 @@ public:
   // GPU device selection (always uses the CPU backend); `backendsDir`
   // is the absolute path to the prebuild directory containing the
   // ggml backend plugin shared libs (.so/.dylib/.dll).
+  // `backendOverride` lists GPU backend families in priority order, e.g.
+  // {"cuda", "vulkan"}; empty means the default order. QVAC-23763.
   Pi05Model(
       const std::string& ggufPath, bool forceCpu,
-      const std::string& backendsDir);
+      const std::string& backendsDir,
+      const std::vector<std::string>& backendOverride = {});
 
   // Out-of-line because `Pi05ModelInternal` is forward-declared above;
   // unique_ptr's destructor needs the complete type, which lives in

--- a/packages/vla-ggml/addon/src/model-interface/smolvla.cpp
+++ b/packages/vla-ggml/addon/src/model-interface/smolvla.cpp
@@ -849,14 +849,17 @@ static bool initCpuBackend(SmolvlaModel& model) {
 // so older Snapdragon devices fall through to CPU rather than crash on
 // `ggml_backend_dev_init`. `force_cpu=true` skips selection entirely so the
 // integration test can run the same hardware both ways.
-static void tryInitGpuBackend(SmolvlaModel& model, bool forceCpu) {
+static void tryInitGpuBackend(
+    SmolvlaModel& model, bool forceCpu,
+    const std::vector<std::string>& backendOverride) {
   if (forceCpu) {
     QLOG_IF(
         Priority::INFO,
         "smolvla_load_model: force_cpu=true — skipping GPU selection");
   }
   ggml_backend_dev_t gpu =
-      forceCpu ? nullptr : vla_backend_selection::pickBestGpuDevice();
+      forceCpu ? nullptr
+               : vla_backend_selection::pickBestGpuDevice(backendOverride);
   if (!gpu) {
     return;
   }
@@ -1509,7 +1512,8 @@ static bool loadWeightsAllocCopy(
 // `gguf_unique_ptr` for the duration of the load.
 bool smolvlaLoadModel(
     const char* path, SmolvlaModel& model, bool forceCpu,
-    const std::string& backendsDir) {
+    const std::string& backendsDir,
+    const std::vector<std::string>& backendOverride) {
   QLOG_IF(
       Priority::INFO,
       std::string("smolvla_load_model: loading model from '") + path +
@@ -1521,7 +1525,7 @@ bool smolvlaLoadModel(
     model.load_error = "failed to initialise the CPU backend";
     return false;
   }
-  tryInitGpuBackend(model, forceCpu);
+  tryInitGpuBackend(model, forceCpu, backendOverride);
   if (!model.has_gpu) {
     QLOG_IF(Priority::INFO, "smolvla_load_model: using CPU backend");
   }

--- a/packages/vla-ggml/addon/src/model-interface/smolvla.hpp
+++ b/packages/vla-ggml/addon/src/model-interface/smolvla.hpp
@@ -294,9 +294,12 @@ bool smolvlaCanMmapWeights(ggml_backend_t backend);
 //
 // On failure `model.load_error` holds a human-readable reason; callers
 // surface it so a load failure is diagnosable from the JS error alone.
+// `backendOverride` lists GPU backend families in priority order, e.g.
+// {"cuda", "vulkan"}; empty means the default order. QVAC-23763.
 bool smolvlaLoadModel(
     const char* path, SmolvlaModel& model, bool forceCpu,
-    const std::string& backendsDir);
+    const std::string& backendsDir,
+    const std::vector<std::string>& backendOverride = {});
 
 // Free model resources. Idempotent — also called from
 // `smolvla_model::~smolvla_model`.

--- a/packages/vla-ggml/addon/src/model-interface/smolvla_adapter.cpp
+++ b/packages/vla-ggml/addon/src/model-interface/smolvla_adapter.cpp
@@ -27,9 +27,11 @@ VlaHparamsGeneric projectHparams(const SmolvlaHparams& hp) {
 } // namespace
 
 SmolvlaModelAdapter::SmolvlaModelAdapter(
-    const std::string& ggufPath, bool forceCpu, const std::string& backendsDir)
+    const std::string& ggufPath, bool forceCpu, const std::string& backendsDir,
+    const std::vector<std::string>& backendOverride)
     : model_(new SmolvlaModel()) {
-  if (!smolvlaLoadModel(ggufPath.c_str(), *model_, forceCpu, backendsDir)) {
+  if (!smolvlaLoadModel(
+          ggufPath.c_str(), *model_, forceCpu, backendsDir, backendOverride)) {
     std::string message = "failed to load SmolVLA model from: " + ggufPath;
     if (!model_->load_error.empty()) {
       message += ": " + model_->load_error;

--- a/packages/vla-ggml/addon/src/model-interface/smolvla_adapter.hpp
+++ b/packages/vla-ggml/addon/src/model-interface/smolvla_adapter.hpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "model-interface/smolvla.hpp"
 #include "model-interface/vla_model.hpp"
@@ -21,9 +22,12 @@ public:
   // Loads the model from `ggufPath`. Throws std::runtime_error on failure
   // (mirrors the previous VlaModel constructor behaviour). `forceCpu` and
   // `backendsDir` are forwarded verbatim to `smolvla_load_model`.
+  // `backendOverride` lists GPU backend families in priority order, e.g.
+  // {"cuda", "vulkan"}; empty means the default order. QVAC-23763.
   SmolvlaModelAdapter(
       const std::string& ggufPath, bool forceCpu,
-      const std::string& backendsDir);
+      const std::string& backendsDir,
+      const std::vector<std::string>& backendOverride = {});
 
   ~SmolvlaModelAdapter() override = default;
 

--- a/packages/vla-ggml/addon/src/utils/BackendSelection.cpp
+++ b/packages/vla-ggml/addon/src/utils/BackendSelection.cpp
@@ -1,16 +1,79 @@
 #include "BackendSelection.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <filesystem>
 #include <mutex>
 #include <string>
+#include <string_view>
 
 #include <ggml-backend.h>
+#include <inference-addon-cpp/Errors.hpp>
 
 #include "LoggingMacros.hpp"
 
 namespace vla_backend_selection {
+
+namespace {
+
+// Backend families qvac-fabric can register a GPU device for. "cpu" is absent
+// on purpose: the addon layer strips `backend: 'cpu'` into forceCpu before this
+// is reached, so it is not a GPU family name here. See the header for why this
+// differs from llm-llamacpp and embed-llamacpp.
+constexpr std::array<std::string_view, 7> KNOWN_GPU_BACKEND_FAMILIES = {
+    "cuda", "vulkan", "metal", "opencl", "hip", "rocm", "sycl"};
+
+// Whether a ggml device backend name belongs to the requested family.
+// Substring rather than equality because ggml suffixes the device index
+// ("CUDA0", "Vulkan1") and OpenCL reports as "GPUOpenCL".
+bool backendNameMatchesFamily(
+    const std::string& lowercasedBackendName, std::string_view family) {
+  return lowercasedBackendName.find(family) != std::string::npos;
+}
+
+} // namespace
+
+std::vector<std::string> parseBackendOverride(const std::string& backendStr) {
+  std::vector<std::string> families;
+  std::string current;
+  auto flush = [&]() {
+    const auto begin = current.find_first_not_of(" \t");
+    if (begin == std::string::npos) {
+      return;
+    }
+    const auto end = current.find_last_not_of(" \t");
+    std::string family = current.substr(begin, end - begin + 1);
+    std::transform(
+        family.begin(), family.end(), family.begin(), [](unsigned char c) {
+          return std::tolower(c);
+        });
+    if (std::find(
+            KNOWN_GPU_BACKEND_FAMILIES.begin(),
+            KNOWN_GPU_BACKEND_FAMILIES.end(),
+            family) == KNOWN_GPU_BACKEND_FAMILIES.end()) {
+      throw qvac_errors::StatusError(
+          qvac_errors::general_error::InvalidArgument,
+          "backend: unknown backend '" + family +
+              "'. Expected 'cpu', or a comma-separated list of "
+              "cuda/vulkan/metal/opencl/hip/rocm/sycl, for example "
+              "'cuda,vulkan'.\n");
+    }
+    if (std::find(families.begin(), families.end(), family) == families.end()) {
+      families.emplace_back(std::move(family));
+    }
+  };
+  for (const char c : backendStr) {
+    if (c == ',') {
+      flush();
+      current.clear();
+    } else {
+      current.push_back(c);
+    }
+  }
+  flush();
+  return families;
+}
 
 void loadBackendsOnce(const std::string& backendsDir) {
   static std::once_flag sFlag;
@@ -52,12 +115,18 @@ int parseAdrenoModel(const std::string& description) {
   return 0;
 }
 
-ggml_backend_dev_t pickBestGpuDevice() {
+ggml_backend_dev_t
+pickBestGpuDevice(const std::vector<std::string>& backendOverride) {
   using Priority = qvac_lib_inference_addon_cpp::logger::Priority;
 
   const size_t n = ggml_backend_dev_count();
   ggml_backend_dev_t fallbackGpu = nullptr;
   ggml_backend_dev_t hipDev = nullptr;
+  ggml_backend_dev_t cudaDev = nullptr;
+  // QVAC-23763: every device that passed the Adreno gate, paired with its
+  // lowercased backend name, so an override can only ever choose among devices
+  // the gate already accepted.
+  std::vector<std::pair<std::string, ggml_backend_dev_t>> accepted;
 
   for (size_t i = 0; i < n; ++i) {
     ggml_backend_dev_t dev = ggml_backend_dev_get(i);
@@ -102,6 +171,10 @@ ggml_backend_dev_t pickBestGpuDevice() {
         // Prefer OpenCL-on-Adreno-800+ over any other candidate iterated
         // later (in particular Vulkan-on-Adreno, which would otherwise be
         // skipped but only after we'd already accepted nothing).
+        //
+        // QVAC-23763: still an early return, and deliberately so. An Adreno
+        // host has no CUDA device, so there is nothing for a backend override
+        // to choose between here.
         return dev;
       }
       QLOG_IF(
@@ -135,9 +208,50 @@ ggml_backend_dev_t pickBestGpuDevice() {
       hipDev = dev;
     }
 
+    // QVAC-23763: ggml-cuda names its devices "CUDA%d". ggml-hip reports
+    // "ROCm%d" instead, so this cannot collide with the AMD device above.
+    const bool isCuda = backendLower.find("cuda") != std::string::npos;
+    if (isCuda && cudaDev == nullptr) {
+      cudaDev = dev;
+    }
+
+    accepted.emplace_back(backendLower, dev);
+
     if (fallbackGpu == nullptr) {
       fallbackGpu = dev;
     }
+  }
+
+  // QVAC-23763: an explicit override wins over the preference order below, but
+  // only among devices the Adreno gate accepted, so it can never resurrect a
+  // device the gate rejected.
+  if (!backendOverride.empty()) {
+    for (const std::string& family : backendOverride) {
+      for (const auto& [backendLower, dev] : accepted) {
+        if (backendNameMatchesFamily(backendLower, family)) {
+          QLOG_IF(
+              Priority::INFO,
+              "vla_backend_selection: " + family +
+                  " GPU selected by backend override");
+          return dev;
+        }
+      }
+    }
+    QLOG_IF(
+        Priority::WARNING,
+        "vla_backend_selection: backend override matched no accepted device; "
+        "falling back to the default backend order");
+  }
+
+  // CUDA ahead of HIP: see the header. A CUDA device only ever appears on a
+  // discrete NVIDIA GPU, which is the mixed-vendor case the HIP comment above
+  // flags as picking the wrong device. AMD-only hosts are unaffected.
+  if (cudaDev != nullptr) {
+    QLOG_IF(
+        Priority::INFO,
+        "vla_backend_selection: preferring CUDA GPU (HIP and Vulkan are "
+        "fallbacks)");
+    return cudaDev;
   }
 
   if (hipDev != nullptr) {

--- a/packages/vla-ggml/addon/src/utils/BackendSelection.hpp
+++ b/packages/vla-ggml/addon/src/utils/BackendSelection.hpp
@@ -1,10 +1,30 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <ggml-backend.h>
 
 namespace vla_backend_selection {
+
+// Parse the GPU half of the `backend` config value into a lowercased priority
+// list, e.g. "CUDA,Vulkan" -> {"cuda", "vulkan"}. QVAC-23763.
+//
+// NOTE the asymmetry with llm-llamacpp and embed-llamacpp, which reject "cpu"
+// here because those addons have a separate `device` key for it. vla has no
+// `device` key: `backend: 'cpu'` has always been how a caller forces CPU, and
+// the addon layer strips that case before calling this, so "cpu" never reaches
+// it and is not a valid family name.
+//
+// Names are matched against the backend families qvac-fabric can register, not
+// against the devices present on this machine: an unknown NAME is a config
+// mistake and throws, while a known name with no device attached is legitimate
+// (e.g. asking for cuda on a Vulkan-only host) and falls through to the next
+// entry, then to the normal preference order.
+//
+// BEHAVIOUR CHANGE: before QVAC-23763 any value other than "cpu" was silently
+// treated as "pick the best device", so a typo went unnoticed. It now throws.
+std::vector<std::string> parseBackendOverride(const std::string& backendStr);
 
 // Extract the Adreno model number from a device description string.
 // Returns 0 for non-Adreno devices.
@@ -37,8 +57,23 @@ void loadBackendsOnce(const std::string& backendsDir);
 //   Non-Adreno GPU         -> accept (Vulkan on desktop / Mali, Metal on
 //                                Apple)
 //
+// Among accepted devices the order is CUDA, then HIP/ROCm, then anything else
+// (Vulkan / Metal). QVAC-23763: CUDA is placed ahead of HIP deliberately. The
+// HIP preference below assumes a single AMD-GPU target, and its own comment
+// flags the mixed-vendor host (discrete NVIDIA + AMD iGPU) as the case where
+// it picks the wrong device. A CUDA device only ever appears on a discrete
+// NVIDIA GPU, so preferring it resolves exactly that case. AMD-only hosts are
+// unaffected: with no CUDA device present, HIP still wins.
+//
+// `backendOverride`, when non-empty, restricts the choice to those backend
+// families in priority order. Entries with no accepted device are skipped; if
+// none match, selection falls through to the normal order rather than failing,
+// because an absent device is not a config error. The Adreno gate above still
+// applies: an override can never resurrect a device the gate rejected.
+//
 // Returns nullptr if no acceptable GPU exists; the caller should then init
 // the CPU backend.
-ggml_backend_dev_t pickBestGpuDevice();
+ggml_backend_dev_t
+pickBestGpuDevice(const std::vector<std::string>& backendOverride = {});
 
 } // namespace vla_backend_selection

--- a/packages/vla-ggml/index.d.ts
+++ b/packages/vla-ggml/index.d.ts
@@ -33,8 +33,8 @@ declare class VlaModel {
     private _connectNativeLogger;
     private _onAddonEvent;
     private _releaseNativeLogger;
-    load({ backend }?: {
-        backend?: "auto" | "cpu";
+    load({ backend, }?: {
+        backend?: VlaModel.VlaBackendSelector;
     }): Promise<void>;
     private _load;
     get hparams(): VlaModel.VlaHparams | null;
@@ -137,6 +137,19 @@ declare namespace VlaModel {
         catId?: number;
         numCameras?: number;
     };
+    /**
+     * Which backend `load()` should use. QVAC-23763.
+     *
+     * - `"auto"` (default): pick the best available device, preferring CUDA, then
+     *   HIP/ROCm, then Vulkan or Metal, then CPU.
+     * - `"cpu"`: skip GPU selection entirely.
+     * - a comma-separated GPU family list, e.g. `"cuda"` or `"cuda,vulkan"`:
+     *   try those families in order, then fall back to the normal order if none
+     *   of them has a device on this machine. Accepted family names are cuda,
+     *   vulkan, metal, opencl, hip, rocm and sycl; an unrecognised name is an
+     *   error. A family whose device the Adreno gate rejected stays rejected.
+     */
+    type VlaBackendSelector = "auto" | "cpu" | (string & {});
     interface VlaRunInput {
         images: Float32Array[];
         imgWidth?: number;

--- a/packages/vla-ggml/index.js
+++ b/packages/vla-ggml/index.js
@@ -467,11 +467,15 @@ class VlaModel {
         catch { }
         this._nativeLoggerActive = false;
     }
-    async load({ backend = "auto" } = {}) {
-        if (backend !== "auto" && backend !== "cpu") {
+    // QVAC-23763: `backend` now also takes a comma-separated GPU priority list,
+    // e.g. "cuda" or "cuda,vulkan". "auto" and "cpu" keep their meaning. The
+    // family names are validated natively so the list stays in one place; this
+    // check only rejects the shapes that never reach the addon.
+    async load({ backend = "auto", } = {}) {
+        if (typeof backend !== "string" || backend.trim() === "") {
             throw new QvacErrorAddonVla({
                 code: ERR_CODES.INVALID_CONFIG,
-                adds: `backend must be 'auto' or 'cpu' (got: ${String(backend)})`,
+                adds: `backend must be 'auto', 'cpu', or a comma-separated GPU backend list such as 'cuda,vulkan' (got: ${String(backend)})`,
             });
         }
         return this._run(async () => {

--- a/packages/vla-ggml/src/index.ts
+++ b/packages/vla-ggml/src/index.ts
@@ -619,11 +619,17 @@ class VlaModel {
     this._nativeLoggerActive = false;
   }
 
-  async load({ backend = "auto" }: { backend?: "auto" | "cpu" } = {}): Promise<void> {
-    if (backend !== "auto" && backend !== "cpu") {
+  // QVAC-23763: `backend` now also takes a comma-separated GPU priority list,
+  // e.g. "cuda" or "cuda,vulkan". "auto" and "cpu" keep their meaning. The
+  // family names are validated natively so the list stays in one place; this
+  // check only rejects the shapes that never reach the addon.
+  async load({
+    backend = "auto",
+  }: { backend?: VlaModel.VlaBackendSelector } = {}): Promise<void> {
+    if (typeof backend !== "string" || backend.trim() === "") {
       throw new QvacErrorAddonVla({
         code: ERR_CODES.INVALID_CONFIG,
-        adds: `backend must be 'auto' or 'cpu' (got: ${String(backend)})`,
+        adds: `backend must be 'auto', 'cpu', or a comma-separated GPU backend list such as 'cuda,vulkan' (got: ${String(backend)})`,
       });
     }
     return this._run(async () => {
@@ -1023,6 +1029,20 @@ namespace VlaModel {
     | string
     | number
     | { tag?: string; catId?: number; numCameras?: number };
+
+  /**
+   * Which backend `load()` should use. QVAC-23763.
+   *
+   * - `"auto"` (default): pick the best available device, preferring CUDA, then
+   *   HIP/ROCm, then Vulkan or Metal, then CPU.
+   * - `"cpu"`: skip GPU selection entirely.
+   * - a comma-separated GPU family list, e.g. `"cuda"` or `"cuda,vulkan"`:
+   *   try those families in order, then fall back to the normal order if none
+   *   of them has a device on this machine. Accepted family names are cuda,
+   *   vulkan, metal, opencl, hip, rocm and sycl; an unrecognised name is an
+   *   error. A family whose device the Adreno gate rejected stays rejected.
+   */
+  export type VlaBackendSelector = "auto" | "cpu" | (string & {});
 
   export interface VlaRunInput {
     images: Float32Array[];

--- a/packages/vla-ggml/test/unit/test_backend_selection.cpp
+++ b/packages/vla-ggml/test/unit/test_backend_selection.cpp
@@ -1,8 +1,13 @@
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
+#include <inference-addon-cpp/Errors.hpp>
 
 #include "utils/BackendSelection.hpp"
 
 using vla_backend_selection::parseAdrenoModel;
+using vla_backend_selection::parseBackendOverride;
 
 TEST(VlaBackendSelection, ParsesAdrenoTrademarkForm) {
   EXPECT_EQ(parseAdrenoModel("Adreno (TM) 830"), 830);
@@ -30,4 +35,54 @@ TEST(VlaBackendSelection, ReturnsZeroForNonAdreno) {
 TEST(VlaBackendSelection, ReturnsZeroWhenAdrenoFollowedByNoDigits) {
   EXPECT_EQ(parseAdrenoModel("Adreno"), 0);
   EXPECT_EQ(parseAdrenoModel("Adreno (TM)"), 0);
+}
+
+// ---- QVAC-23763: the `backend` override ----
+//
+// Only the parsing half is covered here. pickBestGpuDevice() calls the ggml
+// device API directly rather than through an injectable interface, unlike the
+// llm and embed addons, so its preference order has no unit-test seam. That is
+// pre-existing and not introduced by this change.
+
+TEST(VlaBackendSelection, ParseBackendOverrideLowercasesAndSplits) {
+  EXPECT_EQ(
+      parseBackendOverride("CUDA,Vulkan"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST(VlaBackendSelection, ParseBackendOverrideTrimsSpaces) {
+  EXPECT_EQ(
+      parseBackendOverride(" cuda , vulkan "),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST(VlaBackendSelection, ParseBackendOverrideDropsDuplicates) {
+  EXPECT_EQ(
+      parseBackendOverride("cuda,cuda,vulkan"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST(VlaBackendSelection, ParseBackendOverrideIgnoresEmptyEntries) {
+  EXPECT_EQ(
+      parseBackendOverride("cuda,,vulkan,"),
+      (std::vector<std::string>{"cuda", "vulkan"}));
+}
+
+TEST(VlaBackendSelection, ParseBackendOverrideAcceptsHipAndRocm) {
+  EXPECT_EQ(
+      parseBackendOverride("rocm,hip"),
+      (std::vector<std::string>{"rocm", "hip"}));
+}
+
+// BEHAVIOUR CHANGE, QVAC-23763: before this, any value other than "cpu" was
+// silently treated as "pick the best device", so a typo went unnoticed.
+TEST(VlaBackendSelection, ParseBackendOverrideThrowsOnUnknownName) {
+  EXPECT_THROW(parseBackendOverride("cudaa"), qvac_errors::StatusError);
+}
+
+// 'cpu' is stripped by the addon layer into forceCpu before parsing, so it is
+// not a GPU family name here. This differs from llm and embed, where the CPU
+// path is the separate `device` key.
+TEST(VlaBackendSelection, ParseBackendOverrideRejectsCpu) {
+  EXPECT_THROW(parseBackendOverride("cpu"), qvac_errors::StatusError);
 }

--- a/packages/vla-ggml/vcpkg-configuration.json
+++ b/packages/vla-ggml/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",

--- a/packages/vla-ggml/vcpkg.json
+++ b/packages/vla-ggml/vcpkg.json
@@ -6,8 +6,12 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "10297.0.0",
+      "version>=": "10297.0.0#1",
       "features": [
+        {
+          "name": "cuda-backend",
+          "platform": "linux & x64"
+        },
         "hip-backend"
       ]
     },

--- a/vcpkg-overlays/ports/qvac-fabric/patches/0001-ggml-cuda-allow-disabling-pdl.patch
+++ b/vcpkg-overlays/ports/qvac-fabric/patches/0001-ggml-cuda-allow-disabling-pdl.patch
@@ -1,0 +1,60 @@
+From: QVAC-23763
+Subject: [PATCH] ggml-cuda: allow PDL to be disabled via GGML_CUDA_NO_PDL
+
+GGML_CUDA_RESTRICT expands differently depending on the GPU architecture:
+
+    #if (defined(GGML_CUDA_USE_PDL) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_HOPPER)
+    #  define GGML_CUDA_RESTRICT
+    #else
+    #  define GGML_CUDA_RESTRICT __restrict__
+    #endif
+
+Host passes have no __CUDA_ARCH__ and so always see __restrict__, while a
+device pass at Hopper or newer sees nothing. For a template __global__ kernel
+nvcc emits the launch stub as host code, so the stub's signature loses
+__restrict__ while the visible declaration keeps it, and the host compiler
+rejects it:
+
+    error: template-id '__wrapper__device_stub_sigmoid_back_cuda<__half>'
+      for 'void __wrapper__device_stub_sigmoid_back_cuda(const half*&, ...)'
+      does not match any template declaration
+    note: candidate is: template<class T> void __wrapper__device_stub_sigmoid_back_cuda(
+      const T* __restrict__&, ...)
+
+This only bites when architectures from different generations are compiled
+together, which is exactly ggml's own default list. Measured on CUDA 13.3:
+
+    86 alone      ok        86 + 89     ok      (both pre-Hopper)
+    86 + 90       fails     86 + 120a   fails   (crosses into Hopper/Blackwell)
+
+It is not specific to a machine, a GPU, a host compiler or a CUDA release:
+reproduced identically with CUDA 12.8 and 13.3 and with both g++ and clang++
+as the host compiler, and it is a pure compile-time failure with no GPU
+involved. It affects several files, sigmoid-back.cu and gated_delta_net_back.cu
+among them, so excluding individual sources is not a viable workaround.
+
+qvac ships CUDA for the RTX 3090 (sm_86), the Jetson Orin (sm_87) and the
+RTX 5090 (sm_120), which necessarily spans generations, so the whole CUDA
+backend fails to build without this.
+
+Adding the opt-out lets the port pass -DGGML_CUDA_NO_PDL, which makes
+GGML_CUDA_RESTRICT expand to __restrict__ uniformly across every pass. The cost
+is losing Programmatic Dependent Launch on Hopper and newer, which is a
+performance optimisation and not a correctness feature.
+
+This is a workaround carried by the port and every future fabric bump has to
+keep carrying it. The proper fix belongs upstream in fabric, either by making
+GGML_CUDA_RESTRICT architecture-independent or by keeping the PDL and
+__restrict__ split out of template kernel signatures.
+
+--- a/ggml/src/ggml-cuda/common.cuh
++++ b/ggml/src/ggml-cuda/common.cuh
+@@ -115,7 +115,7 @@
+ // However, this has been bugged in CTK < 12.3 for MSVC builds, see
+ // https://github.com/ggml-org/llama.cpp/pull/22522#discussion_r3302393293
+ // __CUDA_ARCH__  is undefined in host passes; GPU arch check happens in device-side code.
+-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && \
++#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && !defined(GGML_CUDA_NO_PDL) && \
+     (CUDART_VERSION >= 12030 || (!(defined(_MSC_VER) && !defined(__clang__)) && CUDART_VERSION >= 11080))
+ #    define GGML_CUDA_USE_PDL
+ #endif  // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && (CUDART_VERSION >= 12030 || (!(defined(_MSC_VER) && !defined(__clang__)) && CUDART_VERSION >= 11080))

--- a/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
+++ b/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,310 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-fabric-llm.cpp
+  REF v${VERSION}
+  SHA512 b61c52278f538c837dd41d44339d503d391199002ab3dfb0e96b6b1a44760fe145c0ac513084fcdb5ca2e07e5005135f8c8ec2bf3f42aa6d62d4d721001f4b9f
+  PATCHES
+    # QVAC-23763: lets the cuda-backend block below pass -DGGML_CUDA_NO_PDL.
+    # Without it GGML_CUDA_RESTRICT expands differently per GPU architecture and
+    # the whole CUDA backend fails to compile whenever architectures from more
+    # than one generation are built together, which is ggml's own default. The
+    # patch header carries the full analysis. Applied unconditionally because
+    # vcpkg keys the package ABI on the source tree, so a conditional patch
+    # would give a CUDA and a non-CUDA build the same cache entry.
+    patches/0001-ggml-cuda-allow-disabling-pdl.patch
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+    vector-index GGML_VECTOR_INDEX
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+    hip-backend BUILD_HIP_BACKEND
+    cuda-backend BUILD_CUDA_BACKEND
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # The Android NDK ships only the C Vulkan headers; the ggml Vulkan backend
+  # additionally needs the C++ bindings (vulkan.hpp) and SPIRV-Headers, which as
+  # of b9840 ggml fetches itself via FetchContent (ggml/src/ggml-vulkan/CMakeLists.txt,
+  # `if (ANDROID)` block). The registry vcpkg-cmake sets FETCHCONTENT_FULLY_DISCONNECTED=ON
+  # globally, so allow the fetch here (same as the kleidiai path below).
+  list(APPEND PLATFORM_OPTIONS -DFETCHCONTENT_FULLY_DISCONNECTED=OFF)
+endif()
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID OR (VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS))
+  # Desktop Linux also needs GGML_BACKEND_DL=ON so that multiple GPU backends
+  # (Vulkan + HIP/ROCm) can coexist as separately-loaded modules, the same way
+  # Android dispatches CPU variants at runtime. Without DL the Linux build links
+  # a single static GPU backend and a second one (HIP) cannot be stacked.
+  # GGML_NATIVE is incompatible with DL, so CPU variants are dispatched via
+  # GGML_CPU_ALL_VARIANTS instead. Consumers must ship the core ggml/llama libs
+  # alongside their backend modules so the dynamically-linked .bare can resolve
+  # them at load time.
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# HIP/ROCm backend — opt-in via the 'hip-backend' feature (Linux + AMD only).
+# Only @qvac/vla-ggml requests it, so every other consumer builds with no HIP
+# and gains no ROCm dependency. Builds libqvac-ggml-hip.so as a standalone DL
+# module alongside Vulkan (GGML_BACKEND_DL is already ON above), so the addon
+# dlopen's whichever GPU backend BackendSelection picks at runtime. The `hip`
+# feature-dependency port forwards the system ROCm's find_package() configs.
+#
+# FAIL-SAFE: enable GGML_HIP only when a ROCm SDK is actually present. On a build
+# host without ROCm we skip HIP and build Vulkan/CPU only — the build never
+# hard-fails, and at runtime a missing HIP module just isn't loaded (the DL
+# loader skips it) so BackendSelection falls back to Vulkan/CPU. Targets gfx1151
+# (Strix Halo / Radeon 8060S); the HIP compiler + ROCM_PATH come from the build env.
+# linux-x64 only: AMD GPU hosts (Strix Halo / gfx1151) are x86_64, and the ROCm
+# dist is x64. On other arches (e.g. linux-arm64) HIP is skipped even if the
+# feature is requested — no ROCm requirement, no build break.
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND BUILD_GPU_BACKENDS AND BUILD_HIP_BACKEND)
+  # DETERMINISTIC: requesting hip-backend REQUIRES a ROCm SDK at build time. We
+  # must NOT silently skip when ROCm is absent — a host-dependent skip yields a
+  # no-HIP package with the SAME vcpkg ABI as a real HIP build, which the binary
+  # cache then conflates (cache poisoning: a no-ROCm build caches a no-HIP
+  # package that ROCm-equipped builds then restore). So ROCm present => HIP;
+  # ROCm absent => hard error (don't request hip-backend on a host without ROCm).
+  # The RUNTIME fail-safe is unchanged: an absent HIP module / non-AMD target is
+  # simply not loaded and BackendSelection falls back to Vulkan/CPU.
+  if(NOT (DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/cmake/hip/hip-config.cmake"))
+    message(FATAL_ERROR "qvac-fabric: hip-backend feature requires a ROCm SDK — set ROCM_PATH to a ROCm/TheRock install containing lib/cmake/hip/hip-config.cmake. Do not request hip-backend on a host without ROCm.")
+  endif()
+  message(STATUS "qvac-fabric: hip-backend ON — building GGML_HIP (gfx1151)")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_HIP=ON
+    -DAMDGPU_TARGETS=gfx1151
+    -DCMAKE_HIP_ARCHITECTURES=gfx1151)
+endif()
+
+# CUDA backend — opt-in via the 'cuda-backend' feature (Linux + NVIDIA only).
+# Mirrors hip-backend: builds libqvac-ggml-cuda.so as a standalone DL module
+# alongside Vulkan, so the addon dlopen's whichever GPU backend it picks at
+# runtime. Both x64 (RTX 30xx/50xx, Tesla) and arm64 (Jetson Orin) are in
+# scope, unlike HIP which is x64-only. Windows is deliberately excluded: it has
+# no GGML_BACKEND_DL support, so a second GPU backend cannot be stacked there.
+#
+# DETERMINISTIC, same reasoning as hip-backend above: requesting cuda-backend
+# REQUIRES nvcc at build time. A host-dependent skip would produce a no-CUDA
+# package with the SAME vcpkg ABI as a real CUDA build, which the binary cache
+# then conflates. So nvcc present => CUDA; nvcc absent => hard error.
+#
+# RUNTIME fail-safe: ggml handles a failed CUDA registration itself. An absent
+# or unloadable module, or a host with no NVIDIA driver, never reaches
+# ggml_backend_dev_count(), so device enumeration falls through to Vulkan and
+# then CPU with no addon involvement (verified on a Tesla T4, QVAC-23763).
+if(VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS AND BUILD_CUDA_BACKEND)
+  if(NOT (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
+    message(FATAL_ERROR "qvac-fabric: cuda-backend supports linux x64 and arm64 only, got ${VCPKG_TARGET_ARCHITECTURE}.")
+  endif()
+
+  # ggml's own CUDA CMake calls enable_language(CUDA), which fails with "No
+  # CMAKE_CUDA_COMPILER could be found" whenever nvcc is off PATH — routine
+  # under vcpkg, which does not inherit an interactive shell. Locate nvcc and
+  # pass it explicitly, the same way ports/ggml-speech does.
+  find_program(NVCC_EXECUTABLE nvcc PATHS /usr/local/cuda/bin NO_DEFAULT_PATH)
+  if(NOT NVCC_EXECUTABLE)
+    find_program(NVCC_EXECUTABLE nvcc)
+  endif()
+  if(NOT NVCC_EXECUTABLE)
+    message(FATAL_ERROR "qvac-fabric: cuda-backend feature requires a CUDA toolkit — install one providing nvcc (checked /usr/local/cuda/bin and PATH). Do not request cuda-backend on a host without nvcc.")
+  endif()
+
+  # CMAKE_CUDA_ARCHITECTURES is deliberately NOT set. ggml only picks its own
+  # list when the variable is undefined (ggml/src/ggml-cuda/CMakeLists.txt), and
+  # that list already covers every device we ship to or test on. Under CUDA 13.x
+  # with GGML_NATIVE=OFF it resolves to:
+  #     75-virtual 80-virtual 86-real 89-real 90-virtual 120a-real 121a-real
+  #   86-real     RTX 3090, the qvac-ubuntu*-x64-gpu CI runners
+  #   120a-real   RTX 5090
+  #   75-virtual  PTX, JITs onto Turing (Tesla T4, the QVAC-23763 dev box)
+  #   80-virtual  PTX, JITs onto sm_87 (Nvidia Jetson Orin, our only arm64 target)
+  # Overriding it would also mean passing a semicolon-separated list through
+  # vcpkg_cmake_configure(OPTIONS ...), where the value is re-expanded as a
+  # CMake argument list and silently truncates to its first element. If a
+  # future target ever needs a real (non-JIT) arch added, add it upstream in
+  # ggml rather than escaping a list through OPTIONS here.
+  message(STATUS "qvac-fabric: cuda-backend ON — building GGML_CUDA (ggml default arch list, nvcc ${NVCC_EXECUTABLE})")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CUDA=ON
+    -DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}
+    # The triplet compiles C++ with clang and -stdlib=libc++. nvcc defaults its
+    # host compiler to g++, which then chokes on the clang-only -stdlib flag it
+    # inherits from the link flags. Point it at clang++ so one toolchain drives
+    # everything. CUDA refuses libc++ outright on x86 ("libc++ is not supported
+    # on x86 system"), but that never bites: CUDA flags do not inherit
+    # CMAKE_CXX_FLAGS, so the .cu compile never sees -stdlib=libc++ and only
+    # the link does, where clang++ handles it.
+    -DCMAKE_CUDA_HOST_COMPILER=clang++
+    # -allow-unsupported-compiler: CUDA 13.x caps the host at clang < 22 and the
+    # monorepo standardises on clang-22 (.github/actions/setup-llvm). Revisit
+    # when a CUDA release accepts clang 22.
+    # -DGGML_CUDA_NO_PDL: see the patch applied above.
+    "-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler -DGGML_CUDA_NO_PDL")
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+# Under GGML_BACKEND_DL the per-microarch backends ship as standalone
+# libqvac-ggml-*.so modules that the consumer dlopen's at runtime. Built with
+# -stdlib=libc++ they otherwise carry a runtime NEEDED dependency on the system
+# libc++.so.1 / libc++abi.so.1, so they silently fail to dlopen on any target
+# without libc++ installed (e.g. stock ubuntu-24.04 — no CPU backend registers,
+# inference aborts). Statically link the C++ runtime into the modules so they
+# are self-contained, matching how the addons link themselves. The module<->addon
+# boundary is the C ggml-backend ABI, so per-module libc++ copies never exchange
+# C++ objects. Linux only: Apple/iOS use Metal frameworks, Android ships
+# libc++_shared via the NDK STL, Windows uses the MSVC runtime.
+if(VCPKG_TARGET_IS_LINUX AND DL_BACKENDS)
+  string(APPEND VCPKG_LINKER_FLAGS " -static-libstdc++")
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_BUILD_APP=OFF
+    -DMTMD_VIDEO=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
+++ b/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,65 @@
+{
+  "name": "qvac-fabric",
+  "version": "10297.0.0",
+  "port-version": 1,
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "cuda-backend": {
+      "description": "Build the NVIDIA CUDA GPU backend (libqvac-ggml-cuda.so) on Linux as a DL module alongside Vulkan. Opt-in, the same way 'hip-backend' is. Linux x64 and arm64 only: Windows has no GGML_BACKEND_DL support, so a second GPU backend cannot be stacked there. Requires a CUDA toolkit (nvcc) at build time and hard-errors without one, for the same binary-cache reason as hip-backend. At runtime an absent or unloadable CUDA module is simply not registered, so device enumeration falls through to Vulkan and then CPU with no addon change."
+    },
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "hip-backend": {
+      "description": "Build the ROCm/HIP GPU backend (libqvac-ggml-hip.so) for AMD GPUs on Linux as a DL module alongside Vulkan. Opt-in (only @qvac/vla-ggml requests it). Fail-safe: if no ROCm SDK is present at build time the HIP backend is skipped (Vulkan/CPU only). Targets gfx1151 (Strix Halo). The 'hip' dependency forwards the system ROCm find_package configs.",
+      "dependencies": [
+        {
+          "name": "hip",
+          "platform": "linux & x64"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    },
+    "vector-index": {
+      "description": "Build and install the ggml vector index library."
+    }
+  }
+}


### PR DESCRIPTION
> **DO NOT MERGE.** The last commit is an overlay port so CI can build against qvac-registry-vcpkg#336. It gets reverted once `qvac-fabric` `10297.0.0#1` is published.

## 🎯 What problem does this PR solve?

- The NLP addons have no CUDA backend. On NVIDIA Linux hosts they run on Vulkan.
- There is no way to choose a GPU backend. It is whatever enumeration order happens to produce.

## 📝 How does it solve it?

Covers llm-llamacpp, embed-llamacpp and vla-ggml. **diffusion-cpp is out of scope**: it builds on stable-diffusion-cpp, not qvac-fabric, so nothing here reaches it, and CUDA there needs an engine version bump first.

- Requests the new `qvac-fabric` `cuda-backend` feature on Linux, so the addons ship `libqvac-ggml-cuda.so` as a DL module beside Vulkan. Windows has no dynamic backend loading.
- Backend order is Adreno OpenCL, then CUDA, then the generic GPU bucket where Vulkan lands, then iGPU, then CPU. ggml already registered cuda first, so this states what was load-order luck. The fallback direction needs no code: an absent module or driver never reaches `ggml_backend_dev_count()`.
- New `backend` config key, a priority list like `"cuda,vulkan"`. An unknown name throws; a known name with no device present is skipped.
- Split mode used to omit `--device`. With CUDA beside Vulkan one physical card registers twice, so it now passes the chosen backend's own devices. Empty, and therefore unchanged, on single-backend hosts.
- TurboQuant/PolarQuant rejected on CUDA in llm, which has no such kernels. CPU stays allowed. No BitNet guard: the next fabric rebase brings it.
- All seven fabric consumers move to `10297.0.0#1` together. `verify-fabric-lockstep` compares that string across every manifest, and `version>=` would otherwise resolve to port-version 0, which has no `cuda-backend` feature.
- CI: new `setup-cuda` action on every linux job that configures these packages, `include-cuda` on prebuilds, and a second leg on the NVIDIA runners that hides the CUDA devices so Vulkan is exercised on the same box.

Full reasoning, including why CUDA sits ahead of HIP in vla and why its existing `backend` key had to be extended rather than duplicated, is in the commit message on `fc2b9bd7c`.

## 🧪 How was it tested?

Unit tests, local: llm 894 (892 pass, 2 skipped), embed 191 (188, 3), vla 100 (70, 30 skipped on absent PyTorch-oracle fixtures). No failures. clang-format, clang-tidy, eslint, typecheck and `check:generated` clean.

The port itself: `vcpkg install qvac-fabric[core,cuda-backend,gpu-backends,llama]:x64-linux` on an Ubuntu 24.04 Tesla T4 with CUDA 13.3, clang 22 and libc++, using the repo's own triplet. 0 errors, both `libqvac-ggml-cuda.so` and `libqvac-ggml-vulkan.so` installed, and a runtime probe reports `reg=CUDA dev_name=CUDA0 desc=Tesla T4`.

**Not tested:**

- **No integration test has ever run on CUDA.** This PR is the first run of the CI legs it adds.
- **Nothing has run on the RTX 5090 or the Jetson Orin**, the sm_120 and sm_87 targets. linux-arm64 has never been built at all.
- The T4 is sm_75 and reaches the kernels through PTX JIT, so no `-real` architecture in the shipped list is exercised.
- **Finetuning is not pinned to Vulkan.** The suite runs as one job per platform, so there is no leg to pin, and the CUDA leg will run those tests on CUDA where the quantized path still lacks `OUT_PROD`. They are covered on Vulkan by the new leg. If they go red, split them out rather than reverting the preference.
- vla's device preference has no unit-test seam, since `pickBestGpuDevice()` calls the ggml device API directly, so the CUDA-over-HIP ordering is uncovered.

## 💥 Breaking Changes

NVIDIA Linux only, both from a second GPU backend appearing in the device list.

- A GPU load that ran on Vulkan now runs on CUDA. `backend: "vulkan"`, or `CUDA_VISIBLE_DEVICES=-1` in the environment, keeps the old behaviour.
- `main-gpu` as an integer indexes a list CUDA now sits at the front of, so an existing numeric value selects a different card. llm and embed only.

**BEFORE:**

```typescript
// NVIDIA Linux: runs on Vulkan, main-gpu 0 is the first Vulkan device
await model.load({ device: 'gpu', 'main-gpu': '0' })
```

**AFTER:**

```typescript
// same call now runs on CUDA, and main-gpu 0 is the first CUDA device
await model.load({ device: 'gpu', 'main-gpu': '0' })

// to keep the previous backend
await model.load({ device: 'gpu', backend: 'vulkan', 'main-gpu': '0' })
```

In vla, `backend` already existed meaning `'auto'` or `'cpu'`, and the JS wrapper threw on anything else. Those two keep their exact meaning; any other value is now the GPU priority list, validated natively. Anything that worked before still works.

## 🔌 API Changes

New optional `backend` key in llm-llamacpp and embed-llamacpp; in vla-ggml the existing key is extended to take the same list. `cpu` is rejected in llm and embed because the CPU path is `device`; in vla it stays valid because vla has no `device` key.

```typescript
await model.load({ device: 'gpu', backend: 'cuda,vulkan' })  // priority list
await model.load({ device: 'gpu', backend: 'vulkan' })       // force Vulkan
```

The SDK surface is not in scope here.

CHANGELOG entries and package version bumps follow in a separate PR.

## 🔗 Depends on

qvac-registry-vcpkg#336, which publishes `qvac-fabric` `10297.0.0#1`. It has to merge before the overlay commit here can be reverted.
