### PR TITLE
QVAC-23774 fix: surface preload failure cause and refuse to start when all preloads fail

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -384,6 +384,8 @@ qvac serve openai [options]
 | `--no-cancel-load-on-disconnect` | Keep loading a model even if the client that triggered the load disconnects.                                                        |
 | `-v, --verbose`                  | Detailed output.                                                                                                                    |
 
+With lazy loading on (the default), the server starts even when some preload models fail; a failed model still loads lazily on the next request. With `--no-lazy-load`, preloaded models are the only ones that can serve, so if every preload model fails the server exits non-zero instead of listening — under a supervisor (systemd, Docker) that surfaces the failure rather than a running-but-empty server. The worker stderr behind the failure (for example a missing addon) is logged either way.
+
 `serve.cors.origins` in `qvac.config.*` and repeatable `--cors-origin` flags are combined. Origins must be exact HTTP(S) origins without credentials, paths, queries, or fragments. `--cors` is only a compatibility validation switch and does not enable CORS itself. It fails without an explicit CLI/config origin, including with `--docs`. Existing `--cors` scripts must add every trusted origin explicitly:
 
 ```bash

--- a/packages/cli/src/serve/core/lifecycle.ts
+++ b/packages/cli/src/serve/core/lifecycle.ts
@@ -1,14 +1,44 @@
 import { unloadModel as sdkUnloadModel, close as sdkClose } from '@qvac/sdk'
-import type { ModelRegistry, ServeConfig } from './model-registry.js'
+import type { LoadConfig, ModelRegistry, ServeConfig } from './model-registry.js'
 import type { LoadManager } from './load-manager.js'
 import type { Logger } from '../../logger.js'
+
+export interface PreloadResult {
+  /** Number of models marked `preload` that were attempted. */
+  attempted: number
+  /** How many of them reached READY. */
+  loaded: number
+}
+
+// Render an error and its `cause` chain: RPC-init failures carry the worker's
+// stderr (missing addon, bad `.so`) on `cause`.
+export function formatErrorChain(err: unknown): string {
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  let current: unknown = err
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current)
+    parts.push(current.message)
+    current = (current as { cause?: unknown }).cause
+  }
+  if (current !== undefined && current !== null && !(current instanceof Error)) {
+    parts.push(String(current))
+  }
+  return parts.join('\n  caused by: ')
+}
+
+// Refuse to start only when lazy loading is off and every preload model failed:
+// preloaded models are then the only ones that can serve.
+export function shouldRefuseStart(load: Pick<LoadConfig, 'lazy'>, preload: PreloadResult): boolean {
+  return !load.lazy && preload.attempted > 0 && preload.loaded === 0
+}
 
 export async function preloadModels(
   serveConfig: ServeConfig,
   registry: ModelRegistry,
   logger: Logger,
   loadManager: LoadManager
-): Promise<void> {
+): Promise<PreloadResult> {
   const toPreload: string[] = []
 
   for (const [alias, entry] of serveConfig.models) {
@@ -20,20 +50,23 @@ export async function preloadModels(
 
   if (toPreload.length === 0) {
     logger.info('No models configured for preload.')
-    return
+    return { attempted: 0, loaded: 0 }
   }
 
   logger.info(`Preloading ${toPreload.length} model(s): ${toPreload.join(', ')}`)
 
+  let loaded = 0
   for (const alias of toPreload) {
     try {
       // No signal: a preload is a permanent waiter, never disconnect-cancelled.
       await loadManager.load(alias)
+      loaded++
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      logger.error(`Failed to preload "${alias}": ${message}`)
+      logger.error(`Failed to preload "${alias}": ${formatErrorChain(err)}`)
     }
   }
+
+  return { attempted: toPreload.length, loaded }
 }
 
 export async function unloadModel(

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -24,7 +24,7 @@ import { resolveServeApiKey } from './api-key.js'
 import { checkNetworkExposure, validateServeStartup } from './startup.js'
 import { createModelRegistry } from './core/model-registry.js'
 import { createLoadManager, defaultLoadFn } from './core/load-manager.js'
-import { preloadModels, shutdownSDK } from './core/lifecycle.js'
+import { preloadModels, shouldRefuseStart, shutdownSDK } from './core/lifecycle.js'
 import { createResponsesStore } from './adapters/openai/responses-store.js'
 import { createChunkAttributionStore } from './adapters/openai/chunk-attribution-store.js'
 import { createEphemeralFilesStore } from './adapters/openai/ephemeral-files-store.js'
@@ -254,12 +254,16 @@ export async function startServer(options: StartServerOptions): Promise<FastifyI
   // keeping the port closed until models are ready, matching the pre-Fastify
   // semantics that the e2e suite depends on.
   await app.ready()
-  await preloadModels(
+  const preload = await preloadModels(
     app.qvac.serveConfig,
     app.qvac.registry,
     app.qvac.logger,
     app.qvac.loadManager
   )
+  if (shouldRefuseStart(app.qvac.serveConfig.load, preload)) {
+    await app.close().catch(() => {})
+    throw new Error(`All ${preload.attempted} preload model(s) failed to load; refusing to start.`)
+  }
   app.qvac.logger.warn(app.qvac.responsesStore.bannerLine())
   app.qvac.logger.warn(app.qvac.videoJobsStore.bannerLine())
 

--- a/packages/cli/test/lifecycle.test.ts
+++ b/packages/cli/test/lifecycle.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createModelRegistry } from '../src/serve/core/model-registry.js'
+import type { ResolvedModelEntry, ServeConfig } from '../src/serve/core/model-registry.js'
+import type { LoadManager } from '../src/serve/core/load-manager.js'
+import { preloadModels, formatErrorChain, shouldRefuseStart } from '../src/serve/core/lifecycle.js'
+import { createLogger } from '../src/logger.js'
+
+const logger = createLogger('silent')
+
+function entry(alias: string, preload: boolean): ResolvedModelEntry {
+  return {
+    alias,
+    modelSrc: `hyper://example.invalid/${alias}`,
+    sdkType: 'llamacpp',
+    endpointCategory: 'chat',
+    isDefault: false,
+    preload,
+    config: {}
+  }
+}
+
+function serveConfigWith(entries: ResolvedModelEntry[]): ServeConfig {
+  return { models: new Map(entries.map((e) => [e.alias, e])) } as unknown as ServeConfig
+}
+
+function fakeLoadManager(failing: Set<string>): LoadManager {
+  return {
+    load: (alias: string) =>
+      failing.has(alias) ? Promise.reject(new Error(`load failed: ${alias}`)) : Promise.resolve()
+  } as unknown as LoadManager
+}
+
+describe('preloadModels', () => {
+  it('reports nothing attempted when no model is marked preload', async () => {
+    const cfg = serveConfigWith([entry('a', false)])
+    const res = await preloadModels(cfg, createModelRegistry(), logger, fakeLoadManager(new Set()))
+    assert.deepEqual(res, { attempted: 0, loaded: 0 })
+  })
+
+  it('reports zero loaded when every preload fails', async () => {
+    const cfg = serveConfigWith([entry('a', true), entry('b', true)])
+    const res = await preloadModels(
+      cfg,
+      createModelRegistry(),
+      logger,
+      fakeLoadManager(new Set(['a', 'b']))
+    )
+    assert.deepEqual(res, { attempted: 2, loaded: 0 })
+  })
+
+  it('counts the ones that loaded on a partial failure', async () => {
+    const cfg = serveConfigWith([entry('a', true), entry('b', true)])
+    const res = await preloadModels(
+      cfg,
+      createModelRegistry(),
+      logger,
+      fakeLoadManager(new Set(['a']))
+    )
+    assert.deepEqual(res, { attempted: 2, loaded: 1 })
+  })
+})
+
+describe('shouldRefuseStart', () => {
+  it('refuses when lazy is off and every preload failed', () => {
+    assert.equal(shouldRefuseStart({ lazy: false }, { attempted: 2, loaded: 0 }), true)
+  })
+
+  it('starts when lazy is off but at least one preload loaded', () => {
+    assert.equal(shouldRefuseStart({ lazy: false }, { attempted: 2, loaded: 1 }), false)
+  })
+
+  it('starts when lazy is off and nothing was preloaded', () => {
+    assert.equal(shouldRefuseStart({ lazy: false }, { attempted: 0, loaded: 0 }), false)
+  })
+
+  it('starts when lazy is on even if every preload failed (retries on request)', () => {
+    assert.equal(shouldRefuseStart({ lazy: true }, { attempted: 2, loaded: 0 }), false)
+  })
+})
+
+describe('formatErrorChain', () => {
+  it('joins a nested cause chain', () => {
+    const err = new Error('top', { cause: new Error('mid', { cause: new Error('root') }) })
+    assert.equal(formatErrorChain(err), 'top\n  caused by: mid\n  caused by: root')
+  })
+
+  it('renders a non-Error terminal cause', () => {
+    const err = new Error('top', { cause: 'string root' })
+    assert.equal(formatErrorChain(err), 'top\n  caused by: string root')
+  })
+
+  it('renders a non-Error input', () => {
+    assert.equal(formatErrorChain('boom'), 'boom')
+  })
+
+  it('is cycle-safe', () => {
+    const err = new Error('loop') as Error & { cause?: unknown }
+    err.cause = err
+    assert.equal(formatErrorChain(err), 'loop')
+  })
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- On preload failure, `qvac serve` logged only `err.message` (e.g. "RPC initialization timed out") and dropped `err.cause`, which carries the worker stderr — the real reason (missing addon, bad `.so`).
- With lazy loading off, preloaded models are the only ones that can serve, yet the server still opened its port when every preload failed — healthy-looking, but serving nothing.
- This hits the managed serve path hardest: `@qvac/ai-sdk-provider` synthesizes `preload: true` for every model, so "all preloads failed" genuinely means nothing is serveable — and today a broken addon just makes the provider's health-wait time out after minutes with no useful error.

## 📝 How does it solve it?

- Log the full error `cause` chain on preload failure, surfacing the worker stderr behind "RPC initialization timed out".
- When lazy loading is off (`--no-lazy-load`), exit non-zero if every preload model fails instead of listening. With lazy loading on (the default), the server still starts — a failed preload retries on the next request — so ordinary and mixed configs are unaffected.
- The managed provider opts into fail-fast by running with `lazy: false` (a separate, provider-side change).

## 🧪 How was it tested?

- Unit tests (`test/lifecycle.test.ts`): `shouldRefuseStart` (lazy on/off × loaded/none), `preloadModels` (none / all-fail / partial), and `formatErrorChain` (nested, non-Error cause, non-Error input, cyclic).
- Live run with an emptied addon `.bare`: default (lazy on) logs the `dlopen(... .bare)` worker stderr and still starts (model shows `state: "error"`); `--no-lazy-load` logs the same and exits 1 without opening the port.
- `typecheck`, `lint`, and `prettier` pass.