### PR TITLE
QVAC-24269 fix: cancel model load on client disconnect, not request-body end

### DIFF
--- a/packages/cli/src/serve/core/cancel-bridge.ts
+++ b/packages/cli/src/serve/core/cancel-bridge.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { ServerResponse } from 'node:http'
 import { cancel } from '@qvac/sdk'
 import type { Logger } from '../../logger.js'
 
@@ -7,7 +7,11 @@ import type { Logger } from '../../logger.js'
  * disconnect (browser tab closed, `fetch().abort()`, network drop)
  * cancels the underlying SDK call promptly.
  *
- * The bridge listens for the `close` event on the incoming request:
+ * The bridge listens for the `close` event on the response stream. Fastify
+ * consumes the request body before a route handler runs, so by the time this
+ * binds, `req` has already emitted `close` and a listener added then never
+ * fires.
+ *
  *  - If the response has already finished (`res.writableEnded`), the
  *    request completed naturally and we skip the cancel — firing one
  *    would log a spurious "no in-flight request matched" line on the
@@ -16,7 +20,7 @@ import type { Logger } from '../../logger.js'
  *    targeted `cancel({ requestId })` so the SDK handler stops
  *    yielding tokens / running inference / fetching bytes.
  *
- * Fire-and-forget by design. `req.on('close')` is synchronous and
+ * Fire-and-forget by design. `res.on('close')` is synchronous and
  * `cancel(...)` runs over RPC; awaiting it inside the listener
  * would block the Node event loop on every disconnect. The `.catch`
  * swallows cancel-after-end races — by the time `close` fires the
@@ -37,7 +41,6 @@ import type { Logger } from '../../logger.js'
  * point through keeps the test fast and free of module-mock plumbing.
  */
 export function bindClientDisconnectCancel(
-  req: IncomingMessage,
   res: ServerResponse,
   requestId: string,
   logger: Logger,
@@ -50,5 +53,5 @@ export function bindClientDisconnectCancel(
       logger.debug(`  cancel-on-disconnect failed for requestId=${requestId}: ${message}`)
     })
   }
-  req.once('close', onClose)
+  res.once('close', onClose)
 }

--- a/packages/cli/src/serve/plugins/cancel-bridge.ts
+++ b/packages/cli/src/serve/plugins/cancel-bridge.ts
@@ -6,7 +6,7 @@ import { bindClientDisconnectCancel } from '../core/cancel-bridge.js'
 const plugin: FastifyPluginAsync = async (app) => {
   app.addHook('onRequest', (req, reply, done) => {
     req.bindCancel = (requestId: string) => {
-      bindClientDisconnectCancel(req.raw, reply.raw, requestId, app.qvac.logger)
+      bindClientDisconnectCancel(reply.raw, requestId, app.qvac.logger)
     }
     done()
   })

--- a/packages/cli/src/serve/plugins/require-model.ts
+++ b/packages/cli/src/serve/plugins/require-model.ts
@@ -1,4 +1,4 @@
-import type { FastifyRequest, preHandlerAsyncHookHandler } from 'fastify'
+import type { FastifyReply, FastifyRequest, preHandlerAsyncHookHandler } from 'fastify'
 import { HttpError } from '../lib/http-error.js'
 import { resolveModelAlias } from '../config.js'
 import { ModelLoadTimeoutError } from '../core/load-manager.js'
@@ -6,15 +6,16 @@ import type { ModelEntry, ResolvedModelEntry } from '../core/model-registry.js'
 import type { QvacContext, QvacRequestModel } from '../lib/types.js'
 
 export function requireModel(category: string): preHandlerAsyncHookHandler {
-  return async function (req) {
+  return async function (req, reply) {
     const body = req.body as Record<string, unknown> | undefined
     const modelName = typeof body?.['model'] === 'string' ? (body['model'] as string).trim() : ''
-    req.qvacModel = await resolveAndCheckModel(req, modelName, category)
+    req.qvacModel = await resolveAndCheckModel(req, reply, modelName, category)
   }
 }
 
 export async function resolveAndCheckModel(
   req: FastifyRequest,
+  reply: FastifyReply,
   modelName: string,
   category: string
 ): Promise<QvacRequestModel> {
@@ -44,7 +45,7 @@ export async function resolveAndCheckModel(
   }
 
   const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
-  const registryEntry = await ensureReady(ctx, alias, modelEntry, modelName, req)
+  const registryEntry = await ensureReady(ctx, alias, modelEntry, modelName, reply)
 
   return {
     alias,
@@ -62,7 +63,7 @@ export async function ensureReady(
   alias: string,
   configEntry: ResolvedModelEntry | ModelEntry,
   modelName: string,
-  req?: FastifyRequest
+  reply?: FastifyReply
 ): Promise<ModelEntry> {
   let entry = ctx.registry.getEntry(alias)
   if (!entry) {
@@ -79,7 +80,7 @@ export async function ensureReady(
   }
 
   const disconnect =
-    ctx.serveConfig.load.cancelOnDisconnect && req ? disconnectSignal(req) : undefined
+    ctx.serveConfig.load.cancelOnDisconnect && reply ? disconnectSignal(reply) : undefined
   try {
     await ctx.loadManager.load(alias, disconnect?.signal)
   } catch (err) {
@@ -99,12 +100,12 @@ export async function ensureReady(
   return entry
 }
 
-// A load-scoped abort signal that fires if the client disconnects during the
-// load. Bound only for the load window (disposed right after), so a normal
-// end-of-response close never trips it.
-function disconnectSignal(req: FastifyRequest): { signal: AbortSignal; dispose: () => void } {
+// Aborts if the client disconnects before the load finishes: `reply.raw` closes
+// when the connection drops. Disposed after the load, so a completed response
+// never trips it.
+function disconnectSignal(reply: FastifyReply): { signal: AbortSignal; dispose: () => void } {
   const controller = new AbortController()
   const onClose = (): void => controller.abort()
-  req.raw.once('close', onClose)
-  return { signal: controller.signal, dispose: () => req.raw.removeListener('close', onClose) }
+  reply.raw.once('close', onClose)
+  return { signal: controller.signal, dispose: () => reply.raw.removeListener('close', onClose) }
 }

--- a/packages/cli/src/serve/routes/audio.ts
+++ b/packages/cli/src/serve/routes/audio.ts
@@ -154,6 +154,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
 
       const { sdkModelId, alias, entry } = await resolveAndCheckModel(
         req,
+        reply,
         String(body.model),
         'transcription'
       )
@@ -231,6 +232,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
 
       const { sdkModelId, alias, entry } = await resolveAndCheckModel(
         req,
+        reply,
         String(body.model),
         'audio-translation'
       )
@@ -385,7 +387,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
       }
 
       const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
-      const registryEntry = await ensureReady(ctx, alias, modelEntry, modelName, req)
+      const registryEntry = await ensureReady(ctx, alias, modelEntry, modelName, reply)
 
       const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
       const sampleRate = resolveSampleRate(registryEntry.config)

--- a/packages/cli/src/serve/routes/vector-stores.ts
+++ b/packages/cli/src/serve/routes/vector-stores.ts
@@ -1,4 +1,4 @@
-import type { FastifyRequest } from 'fastify'
+import type { FastifyReply } from 'fastify'
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import {
   ragListWorkspaces,
@@ -290,7 +290,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
         description: descriptions.search
       }
     },
-    async (req) => {
+    async (req, reply) => {
       const ctx = app.qvac
       const id = decodeId(req.params.id)
       const body = req.body
@@ -307,7 +307,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
         throw new HttpError(404, 'vector_store_not_found', `Vector store "${id}" not found.`)
       }
 
-      const embedding = await resolveEmbeddingModel(ctx, req)
+      const embedding = await resolveEmbeddingModel(ctx, reply)
       if (!embedding.ok) throw new HttpError(embedding.status, embedding.code, embedding.message)
       if (meta.embeddingAlias !== null && meta.embeddingAlias !== embedding.entry.alias) {
         throw new HttpError(
@@ -359,7 +359,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
         description: descriptions.attachFile
       }
     },
-    async (req) => {
+    async (req, reply) => {
       const ctx = app.qvac
       const id = decodeId(req.params.id)
       const fileId = req.body.file_id
@@ -386,7 +386,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
         }
       }
 
-      const embedding = await resolveEmbeddingModel(ctx, req)
+      const embedding = await resolveEmbeddingModel(ctx, reply)
       if (!embedding.ok) throw new HttpError(embedding.status, embedding.code, embedding.message)
       if (meta.embeddingAlias !== null && meta.embeddingAlias !== embedding.entry.alias) {
         throw new HttpError(
@@ -631,7 +631,7 @@ interface EmbeddingResolutionErr {
 
 async function resolveEmbeddingModel(
   ctx: QvacContext,
-  req: FastifyRequest
+  reply: FastifyReply
 ): Promise<EmbeddingResolutionOk | EmbeddingResolutionErr> {
   const picked = pickDefaultEmbedding(ctx.serveConfig)
   if (picked.kind === 'none') {
@@ -654,7 +654,7 @@ async function resolveEmbeddingModel(
   const entry = picked.entry
   let registryEntry
   try {
-    registryEntry = await ensureReady(ctx, entry.alias, entry, entry.alias, req)
+    registryEntry = await ensureReady(ctx, entry.alias, entry, entry.alias, reply)
   } catch (err) {
     if (err instanceof HttpError) {
       return { ok: false, status: err.status, code: err.code, message: err.message }

--- a/packages/cli/test/cancel-bridge.test.ts
+++ b/packages/cli/test/cancel-bridge.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
-import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { ServerResponse } from 'node:http'
 import type { Logger } from '../src/logger.js'
 import { bindClientDisconnectCancel } from '../src/serve/core/cancel-bridge.js'
 
@@ -18,25 +18,22 @@ function makeLogger(): Logger & { debugs: string[] } {
   } as unknown as Logger & { debugs: string[] }
 }
 
-function makeReq(): IncomingMessage {
-  return new EventEmitter() as unknown as IncomingMessage
-}
-
 function makeRes(initial: { writableEnded?: boolean } = {}): ServerResponse {
-  return { writableEnded: initial.writableEnded ?? false } as unknown as ServerResponse
+  const res = new EventEmitter() as unknown as ServerResponse
+  Object.assign(res, { writableEnded: initial.writableEnded ?? false })
+  return res
 }
 
 describe('bindClientDisconnectCancel', () => {
-  it('fires cancel with the bound requestId on req close', async () => {
-    const req = makeReq()
+  it('fires cancel with the bound requestId on response close', async () => {
     const res = makeRes()
     const cancels: { requestId: string }[] = []
     // lunte-disable-next-line require-await
-    bindClientDisconnectCancel(req, res, 'rid-1', makeLogger(), async (opts) => {
+    bindClientDisconnectCancel(res, 'rid-1', makeLogger(), async (opts) => {
       cancels.push(opts)
     })
 
-    req.emit('close')
+    res.emit('close')
     // cancel is awaited inside the .catch; let the microtask queue drain
     await Promise.resolve()
     await Promise.resolve()
@@ -46,30 +43,28 @@ describe('bindClientDisconnectCancel', () => {
   })
 
   it('skips cancel when the response already finished', async () => {
-    const req = makeReq()
     const res = makeRes({ writableEnded: true })
     let called = 0
     // lunte-disable-next-line require-await
-    bindClientDisconnectCancel(req, res, 'rid-2', makeLogger(), async () => {
+    bindClientDisconnectCancel(res, 'rid-2', makeLogger(), async () => {
       called++
     })
 
-    req.emit('close')
+    res.emit('close')
     await Promise.resolve()
 
     assert.equal(called, 0, 'natural completion should not log a benign no-op cancel')
   })
 
   it('swallows cancel rejections without propagating', async () => {
-    const req = makeReq()
     const res = makeRes()
     const logger = makeLogger()
     // lunte-disable-next-line require-await
-    bindClientDisconnectCancel(req, res, 'rid-3', logger, async () => {
+    bindClientDisconnectCancel(res, 'rid-3', logger, async () => {
       throw new Error('cancel race lost')
     })
 
-    req.emit('close')
+    res.emit('close')
     await Promise.resolve()
     await Promise.resolve()
 
@@ -78,17 +73,16 @@ describe('bindClientDisconnectCancel', () => {
     assert.match(logger.debugs[0]!, /cancel race lost/)
   })
 
-  it('binds via req.once so a second close event does not fire cancel twice', async () => {
-    const req = makeReq()
+  it('binds via res.once so a second close event does not fire cancel twice', async () => {
     const res = makeRes()
     let called = 0
     // lunte-disable-next-line require-await
-    bindClientDisconnectCancel(req, res, 'rid-4', makeLogger(), async () => {
+    bindClientDisconnectCancel(res, 'rid-4', makeLogger(), async () => {
       called++
     })
 
-    req.emit('close')
-    req.emit('close')
+    res.emit('close')
+    res.emit('close')
     await Promise.resolve()
     await Promise.resolve()
 

--- a/packages/cli/test/require-model.test.ts
+++ b/packages/cli/test/require-model.test.ts
@@ -1,14 +1,14 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
-import type { FastifyRequest } from 'fastify'
+import type { FastifyReply, FastifyRequest } from 'fastify'
 import { createModelRegistry } from '../src/serve/core/model-registry.js'
 import {
   createLoadManager,
   type LoadManagerDeps,
   type LoadModelFn
 } from '../src/serve/core/load-manager.js'
-import { ensureReady } from '../src/serve/plugins/require-model.js'
+import { ensureReady, resolveAndCheckModel } from '../src/serve/plugins/require-model.js'
 import { createLogger } from '../src/logger.js'
 import type { QvacContext } from '../src/serve/lib/types.js'
 import { HttpError } from '../src/serve/lib/http-error.js'
@@ -43,14 +43,28 @@ function makeCtx(loadFn: LoadModelFn, deps: LoadManagerDeps, cancelOnDisconnect:
     deps
   )
   const serveConfig = {
+    models: new Map([['m', CONFIG_ENTRY]]),
     load: { lazy: true, concurrency: 4, timeoutMs: null, cancelOnDisconnect }
   }
   return { registry, loadManager, serveConfig, logger } as unknown as QvacContext
 }
 
-function fakeReq() {
+function fakeReply() {
   const raw = new EventEmitter()
-  return { req: { raw } as unknown as FastifyRequest, raw }
+  return { reply: { raw } as unknown as FastifyReply, raw }
+}
+
+// A request and a reply backed by separate streams, so a test can tell which
+// one the disconnect signal is bound to.
+function fakeExchange(ctx: QvacContext) {
+  const reqRaw = new EventEmitter()
+  const replyRaw = new EventEmitter()
+  return {
+    req: { raw: reqRaw, server: { qvac: ctx } } as unknown as FastifyRequest,
+    reply: { raw: replyRaw } as unknown as FastifyReply,
+    reqRaw,
+    replyRaw
+  }
 }
 
 describe('ensureReady disconnect handling', () => {
@@ -73,9 +87,9 @@ describe('ensureReady disconnect handling', () => {
       },
       true
     )
-    const { req, raw } = fakeReq()
+    const { reply, raw } = fakeReply()
 
-    const settled = ensureReady(ctx, 'm', CONFIG_ENTRY, 'm', req).catch((e) => e)
+    const settled = ensureReady(ctx, 'm', CONFIG_ENTRY, 'm', reply).catch((e) => e)
     await new Promise((r) => setTimeout(r, 0))
     raw.emit('close') // client disconnects
 
@@ -105,9 +119,9 @@ describe('ensureReady disconnect handling', () => {
       },
       false
     )
-    const { req, raw } = fakeReq()
+    const { reply, raw } = fakeReply()
 
-    const settled = ensureReady(ctx, 'm', CONFIG_ENTRY, 'm', req)
+    const settled = ensureReady(ctx, 'm', CONFIG_ENTRY, 'm', reply)
     await new Promise((r) => setTimeout(r, 0))
     raw.emit('close') // disconnect ignored — load continues
     gate.resolve('sdk-ok')
@@ -115,5 +129,63 @@ describe('ensureReady disconnect handling', () => {
     const entry = await settled
     assert.equal(cancelCalled, false)
     assert.equal(entry.state, ctx.registry.STATES.READY)
+  })
+})
+
+// `ensureReady` aborts on whatever stream it is handed; which one that is gets
+// decided here. These cases pass a distinct request and reply stream so the
+// choice is observable.
+describe('resolveAndCheckModel disconnect wiring', () => {
+  function gatedCtx(requestId: string, cancelOnDisconnect = true) {
+    const gate = deferred<string>()
+    const loadFn: LoadModelFn = () => {
+      const p = gate.promise as Promise<string> & { requestId?: string }
+      p.requestId = requestId
+      return p
+    }
+    const cancelled: { rid: string | null } = { rid: null }
+    const ctx = makeCtx(
+      loadFn,
+      {
+        cancel: (rid) => {
+          cancelled.rid = rid
+          return Promise.resolve()
+        },
+        unload: () => Promise.resolve()
+      },
+      cancelOnDisconnect
+    )
+    return { ctx, gate, cancelled }
+  }
+
+  it('ignores request-stream close, which Fastify fires once the body is read', async () => {
+    const { ctx, gate, cancelled } = gatedCtx('req-body')
+    const { req, reply, reqRaw } = fakeExchange(ctx)
+
+    const settled = resolveAndCheckModel(req, reply, 'm', 'chat')
+    await new Promise((r) => setTimeout(r, 0))
+    reqRaw.emit('close')
+
+    assert.equal(cancelled.rid, null, 'end of the request body must not cancel the load')
+    gate.resolve('sdk-ok')
+
+    const model = await settled
+    assert.equal(model.entry.state, ctx.registry.STATES.READY)
+  })
+
+  it('cancels on reply-stream close, which marks a real client disconnect', async () => {
+    const { ctx, gate, cancelled } = gatedCtx('reply-drop')
+    const { req, reply, replyRaw } = fakeExchange(ctx)
+
+    const settled = resolveAndCheckModel(req, reply, 'm', 'chat').catch((e) => e)
+    await new Promise((r) => setTimeout(r, 0))
+    replyRaw.emit('close')
+
+    assert.equal(cancelled.rid, 'reply-drop')
+    gate.resolve('sdk-late')
+
+    const err = await settled
+    assert.ok(err instanceof HttpError)
+    assert.equal(err.code, 'model_load_failed')
   })
 })

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,6 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "test/chat-agent-shapes.test.ts", "test/require-model.test.ts"],
+  "include": [
+    "src/**/*",
+    "test/chat-agent-shapes.test.ts",
+    "test/require-model.test.ts",
+    "test/cancel-bridge.test.ts"
+  ],
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "test/chat-agent-shapes.test.ts"],
+  "include": ["src/**/*", "test/chat-agent-shapes.test.ts", "test/require-model.test.ts"],
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- With `cancelOnDisconnect` (the default), the first request that lazy-loads a model over a POST body was cancelled before the load started, returning `503 model_load_failed` ("cancelled before start"). Because the load leaves the model unloaded, retries hit the same path, so a POST-lazy-loaded model could never load.
- Cause: the disconnect check watched `req.raw` (the request stream), which closes as soon as the body is read — Fastify reads the body before the load starts, so the abort fired immediately.

## 📝 How does it solve it?

- Watch `reply.raw` (the response stream) instead. It closes only when the client actually disconnects during the load, not when the request body finishes.
- `reply` is threaded through `requireModel` / `resolveAndCheckModel` / `ensureReady` and the vector-store embedding resolver.

## 🧪 How was it tested?

- `/v1/embeddings` with a lazy model: `503` "cancelled before start" before the fix, `200` with a real embedding after.
- A real client disconnect mid-load still cancels the in-flight load (`Load … cancelled (client disconnected)`).
- `typecheck`, `lint`, `prettier`, and the `require-model` / embeddings / audio validation tests pass.