### PR TITLE
fix[notask]: skip the inference peer-dependency check when inference is absent

### DIFF
--- a/packages/sdk/scripts/enforce-inference-peer-dependencies.ts
+++ b/packages/sdk/scripts/enforce-inference-peer-dependencies.ts
@@ -5,7 +5,7 @@
 //   - SDK's dependencies.p == inference's peerDependencies.p.
 // That is, inference's devDependencies and SDK's dependencies match inference's peerDependencies.
 
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { join, resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -19,6 +19,14 @@ interface Manifest {
 
 const sdkDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const inferenceDir = resolve(sdkDir, '..', 'inference')
+
+// The SDK e2e build checks out packages/sdk on its own and installs inference
+// as a resolved package, so there is no sibling manifest to compare against.
+// The full-checkout run in pr-checks-sdk-pod is what enforces this.
+if (!existsSync(join(inferenceDir, 'package.json'))) {
+  console.log('Skipping: packages/inference is not present in this checkout.')
+  process.exit(0)
+}
 
 function readManifest(dir: string) {
   return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as Manifest


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The SDK E2E build dies before it runs a single test.

`packages/sdk/scripts/enforce-inference-peer-dependencies.ts` resolves `../inference` and reads its manifest unconditionally:

```ts
const inferenceDir = resolve(sdkDir, '..', 'inference')
return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
```

The E2E jobs check out the SDK package alone:

```
git sparse-checkout set packages/sdk .github/actions/sdk-e2e-fail-on-failures .github/actions/sdk-e2e-prepare-inference
```

`packages/inference` is absent there **by design** — `sdk-e2e-prepare-inference` supplies inference as a resolved package (branch tarball or npm spec) rather than as a sibling directory. So the read throws `ENOENT`, which fails `lint`, which fails `build`, on desktop, Android and iOS alike:

```
ENOENT: no such file or directory, open '.../packages/inference/package.json'
error: script "enforce-inference-peer-dependencies" exited with code 1
error: script "lint" exited with code 1
error: script "build" exited with code 1
```

**Why this went unnoticed.** #4037 wired the check into `lint` at 12:20 on 26 Aug; #3812 dropped that wiring at 13:28, about an hour later, and no E2E ran in between. #4111 restored it at 11:47 on 27 Aug. Only one SDK PR has run E2E since — every other recent SDK run had `run-tests` skipped, because an unlabelled run resolves to `should-run=false`.

It is latent rather than isolated: of six open SDK PRs sampled, five already carry the current `lint` in their branch, and the sixth will once it merges main.

## 📝 How does it solve it?

The check compares the SDK's addon ranges against inference's `peerDependencies`. With no inference manifest on disk there is nothing to compare, so it now skips instead of throwing.

Enforcement is unaffected where it actually gates. `pr-checks-sdk-pod` has no sparse checkout and runs `npm run --if-present lint` over the full tree, and every checkout in `publish-sdk.yml` except the authorize gate is a full checkout, so a release can never silently skip the check.

## 🧪 How was it tested?

Both directions, locally:

- Full checkout: `bun scripts/enforce-inference-peer-dependencies.ts` exits 0 with the comparison performed.
- `packages/sdk`-only replica: prints `Skipping: packages/inference is not present in this checkout.` and exits 0.

CI evidence:

- **Before** — https://github.com/tetherto/qvac/actions/runs/33143307645

  Every build job on every platform, all the same `readManifest` throw. No test executed on any of them:

  | Job | Link |
  | --- | --- |
  | `[desktop] test (qvac-ubuntu2204-x64-gpu)` | https://github.com/tetherto/qvac/actions/runs/33143307645/job/98758990111 |
  | `[desktop] test (qvac-macos26-arm64-gpu)` | https://github.com/tetherto/qvac/actions/runs/33143307645/job/98758990133 |
  | `[desktop] test (qvac-win25-x64-gpu)` | https://github.com/tetherto/qvac/actions/runs/33143307645/job/98758990104 |
  | `[android] build` | https://github.com/tetherto/qvac/actions/runs/33143307645/job/98758990051 |
  | `[ios] build` | https://github.com/tetherto/qvac/actions/runs/33143307645/job/98758990073 |

  The four downstream `report-finalize` / `report-artifacts-refresh` jobs fail as a consequence, which is why the run reports ten failures for one cause.
- **After** — https://github.com/tetherto/qvac/actions/runs/33172594574 (`Build project (root)` succeeds on the same step that previously threw, and the suite proceeds to run)

## 📋 Considered and rejected

- **Add `packages/inference` to the E2E sparse checkout.** Fights the design: `sdk-e2e-prepare-inference` deliberately resolves inference as a package so the run tests the published shape, and a sibling source tree could contradict the installed version.
- **Move the check out of `lint` into its own script called explicitly from `pr-checks-sdk-pod`.** Cleaner in principle, since this is a cross-package check living in a package-level script, but `pr-checks-sdk-pod` invokes scripts generically (`npm run --if-present lint`) so a new name needs a workflow change, and living in `lint` is what gives developers local enforcement. Worth doing deliberately rather than as an unblock.
