### PR TITLE
QVAC-24023 chore: release @qvac/audiogen-ggml 0.4.0

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-28
+
 ### Added
 
 - Export `AUDIOGEN_BACKEND_NAMES`, `audiogenBackendName()` and the

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Why

#4098 added `AUDIOGEN_BACKEND_NAMES`, `audiogenBackendName()` and the
`AudiogenBackendName` type, and they are sitting in `[Unreleased]`. Nothing can
consume them until a release carries them: `packages/inference` resolves
`@qvac/audiogen-ggml` from the registry, not from the workspace, so #4099 stays
red until this publishes.

## What

Releases the export as `0.4.0`:

- `package.json` - `0.3.0` -> `0.4.0`
- `CHANGELOG.md` - the `[Unreleased]` block becomes `[0.4.0] - 2026-08-28`

Minor, not patch: the change adds public API and removes nothing.

## Follow-up this enables

`packages/inference` pins `@qvac/audiogen-ggml` at `^0.2.1` in both
`peerDependencies` and `devDependencies`. That range cannot resolve `0.3.x` or
`0.4.x`, so #4099 raises it to `^0.4.0` alongside its own changes. Note the
`^0.2.1` range on `main` today already cannot see the published `0.3.0`.

Context: tetherto/qvac#4060.
