### PR TITLE
fix[notask]: declare the speech addons' cuda feature Linux-only

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -35,6 +35,11 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
   compiler comes from the shared linux toolchain. A CUDA build now loads on
   hosts without the CUDA runtime instead of failing with unresolved cudart
   symbols.
+- Declare the `cuda` feature Linux-only (`supports: linux`). A Windows CUDA
+  build never worked: ggml-cuda links statically there and the addon carries
+  no CUDA runtime link, so the build failed with unresolved CUDA runtime
+  symbols. Selecting the feature on Windows now fails fast at manifest
+  resolution instead of at link time.
 
 ## [0.4.0] - 2026-08-27
 

--- a/packages/asr-ggml/README.md
+++ b/packages/asr-ggml/README.md
@@ -507,12 +507,16 @@ GPU backends are selected per platform via `vcpkg.json` features; no
 - **Android** — Vulkan + OpenCL (Adreno) as dynamically-loaded `.so` backends shipped beside the prebuild
 - **macOS / iOS** — Metal, statically linked
 
-**CUDA (Linux / Windows on NVIDIA)** needs `nvcc` on the build host, so it is
+**CUDA (Linux on NVIDIA)** needs `nvcc` on the build host, so it is
 gated behind the `ASR_CUDA` CMake option. The published linux-x64 prebuild
-turns it on (the prebuild workflow installs the CUDA toolkit); elsewhere build
-it yourself with `npm run build:cuda` (or
+turns it on (the prebuild workflow installs the CUDA toolkit); on other Linux
+hosts build it yourself with `npm run build:cuda` (or
 `bare-make generate -D ASR_CUDA=ON`), which adds the `cuda` feature to the
-`speech-cpp` dependency and turns on `GGML_CUDA`. On linux-x64 the cuda
+`speech-cpp` dependency and turns on `GGML_CUDA`. Windows is not supported:
+there the port links ggml-cuda statically and the addon carries no CUDA
+runtime link, so the build cannot resolve the CUDA runtime symbols (the
+`cuda` feature declares `"supports": "linux"` and fails fast). On linux-x64
+the cuda
 feature flips ggml into hybrid dynamically-loaded backend mode: the
 CPU-variant, Vulkan, and CUDA backends ship as `.so` modules next to the
 addon, and only the CUDA module depends on the CUDA runtime. Engaging CUDA
@@ -634,7 +638,7 @@ rationale.
   spirv-tools` on Ubuntu/Debian); Metal needs nothing on macOS/iOS; the
   opt-in CUDA build additionally needs the
   [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (`nvcc`) on
-  Linux/Windows
+  Linux
 
 ### Build
 

--- a/packages/asr-ggml/scripts/__tests__/build-backends.test.js
+++ b/packages/asr-ggml/scripts/__tests__/build-backends.test.js
@@ -18,6 +18,7 @@ const CUDA_CMAKE_OPTION = 'ASR_CUDA'
 const CUDA_MANIFEST_FEATURE = 'cuda'
 const SPEECH_PORT = 'speech-cpp'
 const DESKTOP_PLATFORM = '!(osx | ios | android)'
+const CUDA_PLATFORM = 'linux'
 const GPU_TEST_FILES = [
   'test/integration/gpu.test.js',
   'test/integration/parakeet-gpu-smoke.test.js'
@@ -69,9 +70,9 @@ test('the cuda feature forwards to the speech-cpp CUDA backend', () => {
   assert.equal(cudaSpeechDependency()['default-features'], false)
 })
 
-test('the cuda feature is confined to the platforms that have NVIDIA GPUs', () => {
-  assert.equal(cudaFeature().supports, DESKTOP_PLATFORM)
-  assert.equal(cudaSpeechDependency().platform, DESKTOP_PLATFORM)
+test('the cuda feature is confined to Linux, the one supported CUDA build platform', () => {
+  assert.equal(cudaFeature().supports, CUDA_PLATFORM)
+  assert.equal(cudaSpeechDependency().platform, CUDA_PLATFORM)
 })
 
 test('the cuda feature requires a speech-cpp that declares it', () => {

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -56,8 +56,8 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable the CUDA GPU backend for both engines (Linux / Windows on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ASR_CUDA=ON`. The runtime needs only the NVIDIA driver.",
-      "supports": "!(osx | ios | android)",
+      "description": "Enable the CUDA GPU backend for both engines (Linux on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ASR_CUDA=ON`. The runtime needs the NVIDIA driver plus the CUDA 13 runtime libraries; hosts without them fall back to Vulkan or CPU. Not supported on Windows, where ggml-cuda links statically and the addon carries no CUDA runtime link.",
+      "supports": "linux",
       "dependencies": [
         {
           "name": "speech-cpp",
@@ -66,7 +66,7 @@
           "features": [
             "cuda"
           ],
-          "platform": "!(osx | ios | android)"
+          "platform": "linux"
         }
       ]
     },

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AudiogenBackendName` type, so a consumer can name a `stats.backendId`
   without copying the code table out of this README.
 
+### Changed
+
+- Declare the `cuda` feature Linux-only (`supports: linux`). A Windows CUDA
+  build never worked: ggml-cuda links statically there and the addon carries
+  no CUDA runtime link, so the build failed with unresolved CUDA runtime
+  symbols. Selecting the feature on Windows now fails fast at manifest
+  resolution instead of at link time.
+
 ## [0.3.0] - 2026-08-27
 
 ### Added

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -46,9 +46,10 @@ backends ship as `.so` modules beside the addon, and only the CUDA module
 depends on the CUDA runtime. Engaging CUDA needs the NVIDIA driver plus the
 CUDA 13 runtime libraries (cudart and cuBLAS) resolvable at load time; hosts that
 cannot resolve them skip the module and fall back to Vulkan or CPU. The engine
-prefers CUDA when both GPU backends are usable. Elsewhere the CUDA backend is
-opt-in at build time via `bare-make generate -D ENABLE_CUDA=ON` (needs `nvcc`
-on the build host).
+prefers CUDA when both GPU backends are usable. On other Linux hosts the CUDA
+backend is opt-in at build time via `bare-make generate -D ENABLE_CUDA=ON`
+(needs `nvcc` on the build host); Windows is not supported — there ggml-cuda
+links statically and the addon carries no CUDA runtime link.
 
 To build the native addon from source in a repository checkout:
 

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -42,7 +42,8 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable CUDA GPU acceleration",
+      "description": "Enable CUDA GPU acceleration (Linux on NVIDIA). Not supported on Windows, where ggml-cuda links statically and the addon carries no CUDA runtime link.",
+      "supports": "linux",
       "dependencies": [
         {
           "name": "speech-cpp",
@@ -51,7 +52,7 @@
           "features": [
             "cuda"
           ],
-          "platform": "!(osx | ios | android)"
+          "platform": "linux"
         }
       ]
     },

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime libraries (cudart, cuBLAS) are present; on every other host the
   CUDA module is skipped and the addon behaves as before (Vulkan or CPU).
 
+### Changed
+
+- Declare the `cuda` feature Linux-only (`supports: linux`). A Windows CUDA
+  build never worked: ggml-cuda links statically there and the addon carries
+  no CUDA runtime link, so the build failed with unresolved CUDA runtime
+  symbols. Selecting the feature on Windows now fails fast at manifest
+  resolution instead of at link time.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/packages/bci-whispercpp/README.md
+++ b/packages/bci-whispercpp/README.md
@@ -81,12 +81,15 @@ npm install
 VCPKG_ROOT=/path/to/vcpkg npm run build
 ```
 
-**CUDA (Linux / Windows on NVIDIA)** needs `nvcc` on the build host, so it is
+**CUDA (Linux on NVIDIA)** needs `nvcc` on the build host, so it is
 gated behind the `ENABLE_CUDA` CMake option. The published linux-x64 prebuild
-turns it on (the prebuild workflow installs the CUDA toolkit); elsewhere
-build it yourself with `npm run build:cuda` (or
+turns it on (the prebuild workflow installs the CUDA toolkit); on other Linux
+hosts build it yourself with `npm run build:cuda` (or
 `bare-make generate -D ENABLE_CUDA=ON`), which adds the `cuda` feature to
-the `speech-cpp` dependency. On linux-x64 that
+the `speech-cpp` dependency. Windows is not supported: there the port links
+ggml-cuda statically and the addon carries no CUDA runtime link, so the
+build cannot resolve the CUDA runtime symbols (the `cuda` feature declares
+`"supports": "linux"` and fails fast). On linux-x64 that
 flips ggml into hybrid dynamically-loaded backend mode: the CPU-variant,
 Vulkan, and CUDA backends ship as `.so` modules next to the addon, only the
 CUDA module depends on the CUDA runtime, and hosts that cannot resolve it
@@ -101,7 +104,7 @@ present.
 - **CMake** >= 3.25
 - **vcpkg** with `VCPKG_ROOT` environment variable set
 - Optional: the [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads)
-  (`nvcc`) for the opt-in `build:cuda` build on Linux/Windows
+  (`nvcc`) for the opt-in `build:cuda` build on Linux
 
 ## Quickstart
 
@@ -353,7 +356,7 @@ These keys back the `whisper_context`. Changing any of them between jobs forces 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `model` | string | Optional override; usually set via `args.files.model`. |
-| `use_gpu` | boolean | Enable GPU acceleration. Enabled by default (whisper.cpp default); set `false` to force CPU. The GPU backend is chosen per platform at build time: Metal on macOS/iOS, Vulkan on Linux/Windows (plus CUDA on the linux-x64 prebuild and on `build:cuda` builds, preferred when an NVIDIA device and the CUDA runtime are present), OpenCL/Vulkan on Android. |
+| `use_gpu` | boolean | Enable GPU acceleration. Enabled by default (whisper.cpp default); set `false` to force CPU. The GPU backend is chosen per platform at build time: Metal on macOS/iOS, Vulkan on Linux/Windows (plus CUDA on the linux-x64 prebuild and on Linux `build:cuda` builds, preferred when an NVIDIA device and the CUDA runtime are present), OpenCL/Vulkan on Android. |
 | `flash_attn` | boolean | Enable flash attention. |
 | `gpu_device` | number | Select a non-default GPU device. |
 

--- a/packages/bci-whispercpp/test/unit/build-backends.test.js
+++ b/packages/bci-whispercpp/test/unit/build-backends.test.js
@@ -24,6 +24,7 @@ const CUDA_CMAKE_OPTION = 'ENABLE_CUDA'
 const CUDA_MANIFEST_FEATURE = 'cuda'
 const SPEECH_PORT = 'speech-cpp'
 const DESKTOP_PLATFORM = '!(osx | ios | android)'
+const CUDA_PLATFORM = 'linux'
 
 function speechDependencies(dependencies) {
   return dependencies.filter((dependency) => dependency.name === SPEECH_PORT)
@@ -85,9 +86,9 @@ test('[build] the cuda feature forwards to the speech-cpp CUDA backend', (t) => 
   t.is(cudaSpeechDependency()['default-features'], false)
 })
 
-test('[build] the cuda feature is confined to the platforms that have NVIDIA GPUs', (t) => {
-  t.is(cudaFeature().supports, DESKTOP_PLATFORM)
-  t.is(cudaSpeechDependency().platform, DESKTOP_PLATFORM)
+test('[build] the cuda feature is confined to Linux, the one supported CUDA build platform', (t) => {
+  t.is(cudaFeature().supports, CUDA_PLATFORM)
+  t.is(cudaSpeechDependency().platform, CUDA_PLATFORM)
 })
 
 test('[build] the cuda feature requires a speech-cpp that declares it', (t) => {

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -44,8 +44,8 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable the CUDA GPU backend (Linux / Windows on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ENABLE_CUDA=ON`. The runtime needs only the NVIDIA driver.",
-      "supports": "!(osx | ios | android)",
+      "description": "Enable the CUDA GPU backend (Linux on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ENABLE_CUDA=ON`. The runtime needs the NVIDIA driver plus the CUDA 13 runtime libraries; hosts without them fall back to Vulkan or CPU. Not supported on Windows, where ggml-cuda links statically and the addon carries no CUDA runtime link.",
+      "supports": "linux",
       "dependencies": [
         {
           "name": "speech-cpp",
@@ -54,7 +54,7 @@
           "features": [
             "cuda"
           ],
-          "platform": "!(osx | ios | android)"
+          "platform": "linux"
         }
       ]
     },

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Declare the `cuda` feature Linux-only (`supports: linux`). A Windows CUDA
+  build never worked: ggml-cuda links statically there and the addon carries
+  no CUDA runtime link, so the build failed with unresolved CUDA runtime
+  symbols. Selecting the feature on Windows now fails fast at manifest
+  resolution instead of at link time.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -42,7 +42,8 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable CUDA GPU acceleration",
+      "description": "Enable CUDA GPU acceleration (Linux on NVIDIA). Not supported on Windows, where ggml-cuda links statically and the addon carries no CUDA runtime link.",
+      "supports": "linux",
       "dependencies": [
         {
           "name": "speech-cpp",
@@ -51,7 +52,7 @@
           "features": [
             "cuda"
           ],
-          "platform": "!(osx | ios | android)"
+          "platform": "linux"
         }
       ]
     },


### PR DESCRIPTION
## What problem does this PR solve?

The asr-ggml, bci-whispercpp and tts-ggml docs claim CUDA source builds work on "Linux / Windows on NVIDIA", but no speech addon links the CUDA runtime and the ggml-speech port only builds hybrid GGML_BACKEND_DL on Linux/Android. On win32 ggml-cuda is a statically linked backend whose imported interface carries only `CUDA::cuda_driver`, so a Windows CUDA build of any of the four addons fails at DLL link with unresolved cudart/cuBLAS symbols (historically `__cudaRegisterFatBinary`). No CI lane builds win32 with CUDA and there is no git evidence the path was ever exercised. Surfaced by the #4140 self-review; the overclaim predates that PR.

## How does it solve it?

Decision: scope the claim to Linux rather than restore a WIN32-only CUDA runtime link. The link would ship an untested capability with no CI coverage and diverge from the reviewed no-linkage pattern (bci's and asr's build-wiring tests pin it); `supports: linux` upgrades the failure from a cryptic link error to a clear vcpkg resolution error. If Windows CUDA is wanted later, the way in is a WIN32-gated `CUDA::cudart/cublas/cublasLt` link plus a CI lane that actually builds it.

- `vcpkg.json` (all four speech addons): the `cuda` feature declares `"supports": "linux"`, the `speech-cpp[cuda]` dependency platform narrows to `linux`, and the description documents the runtime requirements and the Windows exclusion. audiogen made no Windows claim in its docs, but its manifest allowed the same broken feature selection, so it gets the same narrowing for consistency.
- READMEs (asr, bci, audiogen): CUDA sections now say Linux, explain why Windows is excluded, and the prerequisites lines drop Windows. tts's README already scoped CUDA to Linux everywhere.
- Build-wiring tests (asr, bci): the platform assertions pin `supports` and the dependency platform to `linux` (9/9 pass locally; prettier and lunte clean).
- CHANGELOGs: one entry per package under Unreleased.

Originally stacked on #4140 (it edits the same README paragraphs); now that #4140 is merged, the branch is rebased onto `main` and carries this single commit.

## Breaking changes

None in practice: selecting the `cuda` feature on Windows previously failed at link time; it now fails at manifest resolution with a clear message. Linux behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
