### PR TITLE
QVAC-24232 fix: drop the bundled CUDA backend from the tts-ggml prebuild

### DIFF
--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -90,20 +90,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both linux GPU runners carry an NVIDIA card and a prebuild that
-          # bundles the CUDA and Vulkan backends; pin one runner per backend so
-          # each keeps dedicated coverage instead of both resolving to the
-          # engine's CUDA-first preference.
           - os: ubuntu-22.04
             platform: linux
             arch: x64
             runner: qvac-ubuntu2204-x64-gpu
-            gpu_backend: cuda
           - os: ubuntu-24.04
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
-            gpu_backend: vulkan
           - os: ubuntu-26.04
             platform: linux
             arch: x64
@@ -245,11 +239,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_TIMEOUT: ${{ matrix.platform == 'win32' && '1800' || '600' }}
-          # /usr/local/cuda/lib64: the self-hosted linux GPU runners keep the
-          # CUDA toolkit there without registering it in ldconfig; the CUDA
-          # backend module's cudart/cuBLAS DT_NEEDED entries resolve from it.
-          # Harmless where the directory does not exist.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.platform == 'linux' && ':/usr/local/cuda/lib64' || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
 
       # Benchmark leg (run_rtf_benchmarks=true, set by
@@ -279,11 +269,7 @@ jobs:
           QVAC_TTS_GGML_BENCHMARK_MATRIX_OVERRIDE: ${{ inputs.benchmark_matrix_json }}
           QVAC_TTS_GGML_BENCHMARK_DEVICE: ${{ matrix.runner || matrix.os }}
           QVAC_TTS_GGML_BENCHMARK_RUNNER: ${{ matrix.runner || matrix.os }}
-          # /usr/local/cuda/lib64: the self-hosted linux GPU runners keep the
-          # CUDA toolkit there without registering it in ldconfig; the CUDA
-          # backend module's cudart/cuBLAS DT_NEEDED entries resolve from it.
-          # Harmless where the directory does not exist.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.platform == 'linux' && ':/usr/local/cuda/lib64' || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/prebuilds-tts-ggml.yml
+++ b/.github/workflows/prebuilds-tts-ggml.yml
@@ -42,7 +42,4 @@ jobs:
       linux-extra-packages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
       setup-python-on-windows: true
       include-vulkan-sdk: true
-      include-cuda: true
-      platform-cmake-defines: |
-        linux-x64: -D ENABLE_CUDA=ON
     secrets: inherit

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The published linux-x64 prebuild no longer bundles the CUDA backend
+  module: its multi-architecture fatbin (138 MB unpacked) pushed the npm
+  package past the registry's upload size limit, which is why 0.8.0 never
+  reached npm. CUDA stays available as an opt-in local build — pass
+  `-D ENABLE_CUDA=ON` to `bare-make generate` on a host with `nvcc`. On the
+  published prebuild, `useGPU: true` selects Vulkan (or CPU) on linux-x64,
+  as in 0.7.x.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -6,8 +6,8 @@ GGML library.  Wraps multiple engines under one package: **Chatterbox**
 v1/v2 still loadable), **Parler** (mini/large English + indic 21-language,
 description-conditioned with voice/emotion templates), **CosyVoice3**
 (Fun-CosyVoice3-0.5B, instruct-conditioned, 24 kHz, CPU with opt-in
-Metal on Apple, CUDA/Vulkan on Linux, Vulkan on Windows, and OpenCL/Adreno
-GPU offload on Android), and **Audio8**
+Metal on Apple, Vulkan on Linux/Windows (CUDA in opt-in local builds), and
+OpenCL/Adreno GPU offload on Android), and **Audio8**
 (DualAR + neural codec, in-process voice cloning, desktop GPU), plus optional
 LavaSR neural denoise + 48 kHz bandwidth-extension enhancement.  Unsure
 which checkpoint to stage? Start with [Choosing a model](#choosing-a-model).
@@ -16,15 +16,16 @@ which checkpoint to stage? Start with [Choosing a model](#choosing-a-model).
 Runs in-process with a persistent native engine — the GGUFs, the S3Gen
 preload, the ggml backend, and any voice-conditioning tensors are
 loaded once and reused across every synthesis call.  GPU acceleration
-(Metal on macOS/iOS, CUDA or Vulkan on Linux, Vulkan on Windows,
-Vulkan / OpenCL on Android) is **opt-in** via `config: { useGPU: true }`;
-the default is CPU.  On
+(Metal on macOS/iOS, Vulkan on Linux and Windows, Vulkan / OpenCL on
+Android, plus CUDA in opt-in local builds) is **opt-in** via
+`config: { useGPU: true }`; the default is CPU.  On
 Android `useGPU` flows through to `tts-cpp`, which picks the GPU
 backend per its own per-vendor allowlist (Adreno → OpenCL,
-Xclipse/Mali → Vulkan). Parler supports Apple/Metal, linux CUDA, and the
-validated Android paths, including Vulkan on ARM Mali (see
-[Backends & GPU acceleration](#backends--gpu-acceleration)). Audio8 supports
-CUDA/Vulkan offload on Linux and Vulkan on Windows.
+Xclipse/Mali → Vulkan). Parler supports Apple/Metal, linux CUDA (opt-in
+local builds), and the validated Android paths, including Vulkan on ARM Mali
+(see [Backends & GPU acceleration](#backends--gpu-acceleration)). Audio8
+supports Vulkan offload on Linux and Windows, plus CUDA in opt-in local
+builds.
 
 [qvac-tts-cpp]: https://github.com/tetherto/qvac-fabric-speech.cpp/tree/master/engines/tts
 
@@ -556,8 +557,7 @@ host's policy:
 | Platform                | Default backend when `useGPU: true`          |
 |-------------------------|----------------------------------------------|
 | macOS / iOS             | Metal                                        |
-| Linux x64 — NVIDIA      | CUDA (the linux-x64 prebuild bundles CUDA and Vulkan; CUDA wins the cascade) |
-| Linux — other / Windows | Vulkan                                       |
+| Linux / Windows         | Vulkan (CUDA wins the cascade in an opt-in `ENABLE_CUDA` local build) |
 | Android — Adreno 700+   | OpenCL                                       |
 | Android — Mali / others | Vulkan                                       |
 | Everything else / CPU-only build | CPU                                 |
@@ -567,11 +567,14 @@ On hosts where more than one backend is usable, `TTS_CPP_GPU_BACKEND`
 and fails loudly when that backend cannot be resolved; unset (or empty)
 keeps the automatic preference above.
 
-The linux-x64 CUDA backend ships as a runtime-loaded module: engaging it
-requires the NVIDIA driver plus the CUDA 13 runtime libraries (cudart and
-cuBLAS, from a CUDA toolkit install) resolvable at load time. On hosts
-without them — including CPU-only and non-NVIDIA machines — the module is
-skipped and the addon behaves exactly as before (Vulkan or CPU).
+The published prebuilds do not carry the CUDA backend — its fatbin pushes
+the npm package past the registry's upload size limit. CUDA stays available
+as a local build: pass `-D ENABLE_CUDA=ON` to `bare-make generate` on a host
+with `nvcc` (see [Building from source](#building-from-source)). In such a
+build the CUDA backend is a runtime-loaded module: engaging it requires the
+NVIDIA driver plus the CUDA 13 runtime libraries (cudart and cuBLAS, from a
+CUDA toolkit install) resolvable at load time. On hosts without them the
+module is skipped and the addon falls back to Vulkan or CPU.
 
 > Both Chatterbox and Supertonic run on ARM Mali via Vulkan: `tts-cpp` sets
 > `allow_arm_mali=true` for both graphs. (Earlier `tts-cpp` builds declined
@@ -996,8 +999,10 @@ baseline commit.
 GPU backends are controlled by the `speech-cpp` port's vcpkg features:
 `metal` (default on osx/ios), `vulkan` (default on
 linux/windows/android), `opencl` (default on android), and `cuda`
-(opt-in via the addon's `ENABLE_CUDA` cmake option; the published
-linux-x64 prebuilds enable it).
+(opt-in via the addon's `ENABLE_CUDA` cmake option —
+`npx bare-make generate -D ENABLE_CUDA=ON` on a host with `nvcc`;
+the published prebuilds do not enable it, to keep the npm package under
+the registry's upload size limit).
 On Android the port is configured with
 `GGML_BACKEND_DL=ON` + `GGML_CPU_ALL_VARIANTS=ON`, so the build
 produces per-arch CPU + Vulkan + OpenCL `.so` files alongside the

--- a/packages/tts-ggml/test/integration/audio8.test.js
+++ b/packages/tts-ggml/test/integration/audio8.test.js
@@ -28,9 +28,9 @@ const platform = os.platform()
 const arch = os.arch()
 const isDesktopGpu = (platform === 'linux' || platform === 'win32') && arch === 'x64'
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
-// CI rows that pin the engine's GPU cascade (linux prebuilds bundle CUDA and
-// Vulkan) export TTS_CPP_GPU_BACKEND; the desktop assertion expects the pinned
-// backend and defaults to Vulkan when unset.
+// Runs that pin the engine's GPU cascade (opt-in ENABLE_CUDA builds carry
+// CUDA and Vulkan) export TTS_CPP_GPU_BACKEND; the desktop assertion expects
+// the pinned backend and defaults to Vulkan when unset.
 const pinnedGpuBackend = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 const expectedDesktopBackend = pinnedGpuBackend === 'cuda' ? CUDA_BACKEND : VULKAN_BACKEND
 const expectedDesktopBackendName = pinnedGpuBackend === 'cuda' ? 'CUDA' : 'Vulkan'

--- a/packages/tts-ggml/test/integration/chatterbox-kv-cache-gpu.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-kv-cache-gpu.test.js
@@ -25,9 +25,10 @@
 //   - The Vulkan-pinned linux/windows GPU runners can't reproduce the Metal
 //     bug in the q8_0 cell (tts-cpp forces quantized KV -> f32 there), but
 //     the f16/f32/default cells still guard those backends.
-//   - The CUDA-pinned linux runner (TTS_CPP_GPU_BACKEND=cuda) additionally
-//     sweeps the real q8_0 cell — CUDA implements the q8_0 CONT, so the
-//     memory-cheapest KV dtype runs natively there (see kvCacheMatrix.js).
+//   - A CUDA-pinned run (TTS_CPP_GPU_BACKEND=cuda against an opt-in
+//     ENABLE_CUDA build) additionally sweeps the real q8_0 cell — CUDA
+//     implements the q8_0 CONT, so the memory-cheapest KV dtype runs
+//     natively there (see kvCacheMatrix.js).
 //   - NO_GPU=true (the no-GPU matrix entries) skips the whole file.
 
 const fs = require('bare-fs')

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -50,13 +50,14 @@ const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 const isApple = platform === 'darwin' || platform === 'ios'
 const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
-// CI rows whose prebuild bundles more than one usable GPU backend (the linux
-// runners carry CUDA and Vulkan) pin the engine cascade through
-// TTS_CPP_GPU_BACKEND; the assertions expect whatever the row pinned and fall
+// Builds that carry more than one usable GPU backend (an opt-in ENABLE_CUDA
+// local build carries CUDA and Vulkan) pin the engine cascade through
+// TTS_CPP_GPU_BACKEND; the assertions expect whatever was pinned and fall
 // back to the platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
-// Parler GPU coverage is validated on Apple, the Android Device Farm, and the
-// linux CUDA lane. Keep desktop Vulkan out until dedicated runs prove it there.
+// Parler GPU coverage is validated on Apple, the Android Device Farm, and
+// CUDA-pinned linux runs against an ENABLE_CUDA build. Keep desktop Vulkan
+// out until dedicated runs prove it there.
 const isParlerGpuPlatform =
   isApple || platform === 'android' || (platform === 'linux' && PINNED_GPU_BACKEND === 'cuda')
 // CosyVoice3's tts-cpp allowlist is Metal (Apple), OpenCL/Adreno (Android),
@@ -94,7 +95,7 @@ function backendIdToName(id) {
 // Which platforms wire up a GPU backend in the speech-cpp vcpkg port
 // today (features in qvac-registry-vcpkg/ports/speech-cpp/vcpkg.json):
 //   - darwin / ios:        metal
-//   - linux / win32:       vulkan (linux-x64 prebuilds also bundle cuda)
+//   - linux / win32:       vulkan (cuda only in opt-in ENABLE_CUDA builds)
 //   - android:             vulkan + opencl
 function expectsGpu() {
   return (

--- a/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
+++ b/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
@@ -41,9 +41,9 @@ const isMobile = platform === 'ios' || platform === 'android'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
-// CI rows whose prebuild bundles more than one usable GPU backend (the linux
-// runners carry CUDA and Vulkan) pin the engine cascade through
-// TTS_CPP_GPU_BACKEND; the enhancer assertion expects whatever the row pinned
+// Builds that carry more than one usable GPU backend (an opt-in ENABLE_CUDA
+// local build carries CUDA and Vulkan) pin the engine cascade through
+// TTS_CPP_GPU_BACKEND; the enhancer assertion expects whatever was pinned
 // and falls back to the platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 
@@ -78,8 +78,8 @@ function backendIdToName(id) {
 }
 
 // Platforms that wire a GPU backend into tts-cpp's vcpkg port:
-// darwin/ios -> metal; linux/win32 -> vulkan (linux-x64 prebuilds also bundle
-// cuda); android -> vulkan + opencl.
+// darwin/ios -> metal; linux/win32 -> vulkan (cuda only in opt-in
+// ENABLE_CUDA builds); android -> vulkan + opencl.
 function expectsGpu() {
   return (
     platform === 'darwin' ||

--- a/packages/tts-ggml/test/utils/kvCacheMatrix.js
+++ b/packages/tts-ggml/test/utils/kvCacheMatrix.js
@@ -51,8 +51,8 @@ const RELAX = !!(proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1')
 // to validate that follow-up fix once it ships.
 const PROBE_UNSAFE = !!(proc.env && proc.env.QVAC_TTS_KV_PROBE_UNSAFE === '1')
 
-// CI rows that pin the engine's GPU cascade (linux prebuilds bundle CUDA and
-// Vulkan) export TTS_CPP_GPU_BACKEND.
+// Runs that pin the engine's GPU cascade (opt-in ENABLE_CUDA builds carry
+// CUDA and Vulkan) export TTS_CPP_GPU_BACKEND.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 
 // KV dtypes every GPU backend wired into tts-cpp can actually *run the whole


### PR DESCRIPTION
## Why

`@qvac/tts-ggml` 0.8.0 was never published: the release-branch `publish-npm` job failed with `npm error 413 Payload Too Large` ([run](https://github.com/tetherto/qvac/actions/runs/33081509601)). The 0.8.0 package bundled the CUDA backend module in the linux-x64 prebuild; its multi-architecture fatbin (`libqvac-speech-ggml-cuda.so`, 138 MB unpacked) pushed the tarball to 233.7 MB (502.5 MB unpacked), past the npm registry's upload limit. `latest` on npm is still 0.7.5.

## What

- `prebuilds-tts-ggml.yml` no longer installs the CUDA toolkit nor passes `-D ENABLE_CUDA=ON` on linux-x64. The linux-x64 prebuild returns to the 0.7.x shape (static Vulkan + CPU); the tarball goes back to roughly the 0.7.5 size, which published fine.
- CUDA stays available as an opt-in local build (`bare-make generate -D ENABLE_CUDA=ON` on a host with `nvcc`), the same posture as `asr-ggml`. `useGPU: true` on the published prebuild selects Vulkan (or CPU) on linux-x64.
- The integration-test matrix drops its CUDA-pinned row: without the module, `TTS_CPP_GPU_BACKEND=cuda` fails loudly. Both linux GPU runners assert the Vulkan default again. The pin mechanism itself stays for local `ENABLE_CUDA` runs.
- README, CHANGELOG (`[Unreleased]`), and stale test comments updated accordingly.

## Follow-up (separate PRs)

Vulkan payload slimming lands via the engine + registry chain, and cuts the remaining prebuild size roughly in half per Vulkan artifact (63 MB -> 34 MB on linux-x64), creating headroom to reintroduce a slimmer CUDA build later if wanted:

1. `qvac-ext-ggml`: opt-in `GGML_VULKAN_STRIP_UNUSED_SHADERS` (no-op stubs for iq*/mxfp4/nvfp4 and training/backward shader payloads).
2. `qvac-registry-vcpkg`: `ggml-speech` 2026-08-28 (strip enabled) + `speech-cpp` 2026-08-26#2 floor bump.
3. Monorepo: speech addon floor bumps to `speech-cpp` 2026-08-26#2.

After this PR merges, a 0.8.1 version-bump PR re-runs the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
