### PR TITLE
QVAC-24232 chore: raise the speech-cpp floor to 2026-08-26#2 (slim Vulkan shaders)

### DIFF
--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -90,20 +90,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both linux GPU runners carry an NVIDIA card and a prebuild that
-          # bundles the CUDA and Vulkan backends; pin one runner per backend so
-          # each keeps dedicated coverage instead of both resolving to the
-          # engine's CUDA-first preference.
           - os: ubuntu-22.04
             platform: linux
             arch: x64
             runner: qvac-ubuntu2204-x64-gpu
-            gpu_backend: cuda
           - os: ubuntu-24.04
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
-            gpu_backend: vulkan
           - os: ubuntu-26.04
             platform: linux
             arch: x64
@@ -245,11 +239,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_TIMEOUT: ${{ matrix.platform == 'win32' && '1800' || '600' }}
-          # /usr/local/cuda/lib64: the self-hosted linux GPU runners keep the
-          # CUDA toolkit there without registering it in ldconfig; the CUDA
-          # backend module's cudart/cuBLAS DT_NEEDED entries resolve from it.
-          # Harmless where the directory does not exist.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.platform == 'linux' && ':/usr/local/cuda/lib64' || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
 
       # Benchmark leg (run_rtf_benchmarks=true, set by
@@ -279,11 +269,7 @@ jobs:
           QVAC_TTS_GGML_BENCHMARK_MATRIX_OVERRIDE: ${{ inputs.benchmark_matrix_json }}
           QVAC_TTS_GGML_BENCHMARK_DEVICE: ${{ matrix.runner || matrix.os }}
           QVAC_TTS_GGML_BENCHMARK_RUNNER: ${{ matrix.runner || matrix.os }}
-          # /usr/local/cuda/lib64: the self-hosted linux GPU runners keep the
-          # CUDA toolkit there without registering it in ldconfig; the CUDA
-          # backend module's cudart/cuBLAS DT_NEEDED entries resolve from it.
-          # Harmless where the directory does not exist.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.platform == 'linux' && ':/usr/local/cuda/lib64' || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/prebuilds-tts-ggml.yml
+++ b/.github/workflows/prebuilds-tts-ggml.yml
@@ -42,7 +42,4 @@ jobs:
       linux-extra-packages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
       setup-python-on-windows: true
       include-vulkan-sdk: true
-      include-cuda: true
-      platform-cmake-defines: |
-        linux-x64: -D ENABLE_CUDA=ON
     secrets: inherit

--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -35,6 +35,15 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
   compiler comes from the shared linux toolchain. A CUDA build now loads on
   hosts without the CUDA runtime instead of failing with unresolved cudart
   symbols.
+- Raise the `speech-cpp` floor to 2026-08-26#2, which consumes the slimmed
+  `ggml-speech` 2026-08-28 cut: Vulkan shader payloads for quantizations and
+  training ops no speech model uses (iq1/iq2/iq3/iq4, mxfp4/nvfp4, and the
+  backward/optimizer pipelines) ship as no-op stubs, shrinking every
+  Vulkan-carrying prebuild artifact by roughly 45% (the linux Vulkan backend
+  drops from 63 MB to 34 MB). Supported model quantizations
+  (q4_0/q5_0/q5_1/q8_0/k-quants/f16) are unaffected; loading an
+  iq*/mxfp4/nvfp4-quantized model on Vulkan is not supported by these
+  builds.
 
 ## [0.4.0] - 2026-08-27
 

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -24,7 +24,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -36,7 +36,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -61,7 +61,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26#1",
+          "version>=": "2026-08-26#2",
           "default-features": false,
           "features": [
             "cuda"

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AudiogenBackendName` type, so a consumer can name a `stats.backendId`
   without copying the code table out of this README.
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-08-26#2, which consumes the slimmed
+  `ggml-speech` 2026-08-28 cut: Vulkan shader payloads for quantizations and
+  training ops no speech model uses (iq1/iq2/iq3/iq4, mxfp4/nvfp4, and the
+  backward/optimizer pipelines) ship as no-op stubs, shrinking every
+  Vulkan-carrying prebuild artifact by roughly 45% (the linux Vulkan backend
+  drops from 63 MB to 34 MB). Supported model quantizations
+  (q4_0/q5_0/q5_1/q8_0/k-quants/f16) are unaffected; loading an
+  iq*/mxfp4/nvfp4-quantized model on Vulkan is not supported by these
+  builds.
+
 ## [0.3.0] - 2026-08-27
 
 ### Added

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26#1",
+          "version>=": "2026-08-26#2",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26#1",
+          "version>=": "2026-08-26#2",
           "default-features": false,
           "features": [
             "vulkan"

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime libraries (cudart, cuBLAS) are present; on every other host the
   CUDA module is skipped and the addon behaves as before (Vulkan or CPU).
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-08-26#2, which consumes the slimmed
+  `ggml-speech` 2026-08-28 cut: Vulkan shader payloads for quantizations and
+  training ops no speech model uses (iq1/iq2/iq3/iq4, mxfp4/nvfp4, and the
+  backward/optimizer pipelines) ship as no-op stubs, shrinking every
+  Vulkan-carrying prebuild artifact by roughly 45% (the linux Vulkan backend
+  drops from 63 MB to 34 MB). Supported model quantizations
+  (q4_0/q5_0/q5_1/q8_0/k-quants/f16) are unaffected; loading an
+  iq*/mxfp4/nvfp4-quantized model on Vulkan is not supported by these
+  builds.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -23,7 +23,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -33,7 +33,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -49,7 +49,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26#1",
+          "version>=": "2026-08-26#2",
           "default-features": false,
           "features": [
             "cuda"

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The published linux-x64 prebuild no longer bundles the CUDA backend
+  module: its multi-architecture fatbin (138 MB unpacked) pushed the npm
+  package past the registry's upload size limit, which is why 0.8.0 never
+  reached npm. CUDA stays available as an opt-in local build — pass
+  `-D ENABLE_CUDA=ON` to `bare-make generate` on a host with `nvcc`. On the
+  published prebuild, `useGPU: true` selects Vulkan (or CPU) on linux-x64,
+  as in 0.7.x.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `-D ENABLE_CUDA=ON` to `bare-make generate` on a host with `nvcc`. On the
   published prebuild, `useGPU: true` selects Vulkan (or CPU) on linux-x64,
   as in 0.7.x.
+- Raise the `speech-cpp` floor to 2026-08-26#2, which consumes the slimmed
+  `ggml-speech` 2026-08-28 cut: Vulkan shader payloads for quantizations and
+  training ops no speech model uses (iq1/iq2/iq3/iq4, mxfp4/nvfp4, and the
+  backward/optimizer pipelines) ship as no-op stubs, shrinking every
+  Vulkan-carrying prebuild artifact by roughly 45% (the linux Vulkan backend
+  drops from 63 MB to 34 MB). Supported model quantizations
+  (q4_0/q5_0/q5_1/q8_0/k-quants/f16) are unaffected; loading an
+  iq*/mxfp4/nvfp4-quantized model on Vulkan is not supported by these
+  builds.
 
 ## [0.8.0] - 2026-08-27
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -6,8 +6,8 @@ GGML library.  Wraps multiple engines under one package: **Chatterbox**
 v1/v2 still loadable), **Parler** (mini/large English + indic 21-language,
 description-conditioned with voice/emotion templates), **CosyVoice3**
 (Fun-CosyVoice3-0.5B, instruct-conditioned, 24 kHz, CPU with opt-in
-Metal on Apple, CUDA/Vulkan on Linux, Vulkan on Windows, and OpenCL/Adreno
-GPU offload on Android), and **Audio8**
+Metal on Apple, Vulkan on Linux/Windows (CUDA in opt-in local builds), and
+OpenCL/Adreno GPU offload on Android), and **Audio8**
 (DualAR + neural codec, in-process voice cloning, desktop GPU), plus optional
 LavaSR neural denoise + 48 kHz bandwidth-extension enhancement.  Unsure
 which checkpoint to stage? Start with [Choosing a model](#choosing-a-model).
@@ -16,15 +16,16 @@ which checkpoint to stage? Start with [Choosing a model](#choosing-a-model).
 Runs in-process with a persistent native engine — the GGUFs, the S3Gen
 preload, the ggml backend, and any voice-conditioning tensors are
 loaded once and reused across every synthesis call.  GPU acceleration
-(Metal on macOS/iOS, CUDA or Vulkan on Linux, Vulkan on Windows,
-Vulkan / OpenCL on Android) is **opt-in** via `config: { useGPU: true }`;
-the default is CPU.  On
+(Metal on macOS/iOS, Vulkan on Linux and Windows, Vulkan / OpenCL on
+Android, plus CUDA in opt-in local builds) is **opt-in** via
+`config: { useGPU: true }`; the default is CPU.  On
 Android `useGPU` flows through to `tts-cpp`, which picks the GPU
 backend per its own per-vendor allowlist (Adreno → OpenCL,
-Xclipse/Mali → Vulkan). Parler supports Apple/Metal, linux CUDA, and the
-validated Android paths, including Vulkan on ARM Mali (see
-[Backends & GPU acceleration](#backends--gpu-acceleration)). Audio8 supports
-CUDA/Vulkan offload on Linux and Vulkan on Windows.
+Xclipse/Mali → Vulkan). Parler supports Apple/Metal, linux CUDA (opt-in
+local builds), and the validated Android paths, including Vulkan on ARM Mali
+(see [Backends & GPU acceleration](#backends--gpu-acceleration)). Audio8
+supports Vulkan offload on Linux and Windows, plus CUDA in opt-in local
+builds.
 
 [qvac-tts-cpp]: https://github.com/tetherto/qvac-fabric-speech.cpp/tree/master/engines/tts
 
@@ -556,8 +557,7 @@ host's policy:
 | Platform                | Default backend when `useGPU: true`          |
 |-------------------------|----------------------------------------------|
 | macOS / iOS             | Metal                                        |
-| Linux x64 — NVIDIA      | CUDA (the linux-x64 prebuild bundles CUDA and Vulkan; CUDA wins the cascade) |
-| Linux — other / Windows | Vulkan                                       |
+| Linux / Windows         | Vulkan (CUDA wins the cascade in an opt-in `ENABLE_CUDA` local build) |
 | Android — Adreno 700+   | OpenCL                                       |
 | Android — Mali / others | Vulkan                                       |
 | Everything else / CPU-only build | CPU                                 |
@@ -567,11 +567,14 @@ On hosts where more than one backend is usable, `TTS_CPP_GPU_BACKEND`
 and fails loudly when that backend cannot be resolved; unset (or empty)
 keeps the automatic preference above.
 
-The linux-x64 CUDA backend ships as a runtime-loaded module: engaging it
-requires the NVIDIA driver plus the CUDA 13 runtime libraries (cudart and
-cuBLAS, from a CUDA toolkit install) resolvable at load time. On hosts
-without them — including CPU-only and non-NVIDIA machines — the module is
-skipped and the addon behaves exactly as before (Vulkan or CPU).
+The published prebuilds do not carry the CUDA backend — its fatbin pushes
+the npm package past the registry's upload size limit. CUDA stays available
+as a local build: pass `-D ENABLE_CUDA=ON` to `bare-make generate` on a host
+with `nvcc` (see [Building from source](#building-from-source)). In such a
+build the CUDA backend is a runtime-loaded module: engaging it requires the
+NVIDIA driver plus the CUDA 13 runtime libraries (cudart and cuBLAS, from a
+CUDA toolkit install) resolvable at load time. On hosts without them the
+module is skipped and the addon falls back to Vulkan or CPU.
 
 > Both Chatterbox and Supertonic run on ARM Mali via Vulkan: `tts-cpp` sets
 > `allow_arm_mali=true` for both graphs. (Earlier `tts-cpp` builds declined
@@ -996,8 +999,10 @@ baseline commit.
 GPU backends are controlled by the `speech-cpp` port's vcpkg features:
 `metal` (default on osx/ios), `vulkan` (default on
 linux/windows/android), `opencl` (default on android), and `cuda`
-(opt-in via the addon's `ENABLE_CUDA` cmake option; the published
-linux-x64 prebuilds enable it).
+(opt-in via the addon's `ENABLE_CUDA` cmake option —
+`npx bare-make generate -D ENABLE_CUDA=ON` on a host with `nvcc`;
+the published prebuilds do not enable it, to keep the npm package under
+the registry's upload size limit).
 On Android the port is configured with
 `GGML_BACKEND_DL=ON` + `GGML_CPU_ALL_VARIANTS=ON`, so the build
 produces per-arch CPU + Vulkan + OpenCL `.so` files alongside the

--- a/packages/tts-ggml/test/integration/audio8.test.js
+++ b/packages/tts-ggml/test/integration/audio8.test.js
@@ -28,9 +28,9 @@ const platform = os.platform()
 const arch = os.arch()
 const isDesktopGpu = (platform === 'linux' || platform === 'win32') && arch === 'x64'
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
-// CI rows that pin the engine's GPU cascade (linux prebuilds bundle CUDA and
-// Vulkan) export TTS_CPP_GPU_BACKEND; the desktop assertion expects the pinned
-// backend and defaults to Vulkan when unset.
+// Runs that pin the engine's GPU cascade (opt-in ENABLE_CUDA builds carry
+// CUDA and Vulkan) export TTS_CPP_GPU_BACKEND; the desktop assertion expects
+// the pinned backend and defaults to Vulkan when unset.
 const pinnedGpuBackend = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 const expectedDesktopBackend = pinnedGpuBackend === 'cuda' ? CUDA_BACKEND : VULKAN_BACKEND
 const expectedDesktopBackendName = pinnedGpuBackend === 'cuda' ? 'CUDA' : 'Vulkan'

--- a/packages/tts-ggml/test/integration/chatterbox-kv-cache-gpu.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-kv-cache-gpu.test.js
@@ -25,9 +25,10 @@
 //   - The Vulkan-pinned linux/windows GPU runners can't reproduce the Metal
 //     bug in the q8_0 cell (tts-cpp forces quantized KV -> f32 there), but
 //     the f16/f32/default cells still guard those backends.
-//   - The CUDA-pinned linux runner (TTS_CPP_GPU_BACKEND=cuda) additionally
-//     sweeps the real q8_0 cell — CUDA implements the q8_0 CONT, so the
-//     memory-cheapest KV dtype runs natively there (see kvCacheMatrix.js).
+//   - A CUDA-pinned run (TTS_CPP_GPU_BACKEND=cuda against an opt-in
+//     ENABLE_CUDA build) additionally sweeps the real q8_0 cell — CUDA
+//     implements the q8_0 CONT, so the memory-cheapest KV dtype runs
+//     natively there (see kvCacheMatrix.js).
 //   - NO_GPU=true (the no-GPU matrix entries) skips the whole file.
 
 const fs = require('bare-fs')

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -50,13 +50,14 @@ const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 const isApple = platform === 'darwin' || platform === 'ios'
 const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
-// CI rows whose prebuild bundles more than one usable GPU backend (the linux
-// runners carry CUDA and Vulkan) pin the engine cascade through
-// TTS_CPP_GPU_BACKEND; the assertions expect whatever the row pinned and fall
+// Builds that carry more than one usable GPU backend (an opt-in ENABLE_CUDA
+// local build carries CUDA and Vulkan) pin the engine cascade through
+// TTS_CPP_GPU_BACKEND; the assertions expect whatever was pinned and fall
 // back to the platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
-// Parler GPU coverage is validated on Apple, the Android Device Farm, and the
-// linux CUDA lane. Keep desktop Vulkan out until dedicated runs prove it there.
+// Parler GPU coverage is validated on Apple, the Android Device Farm, and
+// CUDA-pinned linux runs against an ENABLE_CUDA build. Keep desktop Vulkan
+// out until dedicated runs prove it there.
 const isParlerGpuPlatform =
   isApple || platform === 'android' || (platform === 'linux' && PINNED_GPU_BACKEND === 'cuda')
 // CosyVoice3's tts-cpp allowlist is Metal (Apple), OpenCL/Adreno (Android),
@@ -94,7 +95,7 @@ function backendIdToName(id) {
 // Which platforms wire up a GPU backend in the speech-cpp vcpkg port
 // today (features in qvac-registry-vcpkg/ports/speech-cpp/vcpkg.json):
 //   - darwin / ios:        metal
-//   - linux / win32:       vulkan (linux-x64 prebuilds also bundle cuda)
+//   - linux / win32:       vulkan (cuda only in opt-in ENABLE_CUDA builds)
 //   - android:             vulkan + opencl
 function expectsGpu() {
   return (

--- a/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
+++ b/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
@@ -41,9 +41,9 @@ const isMobile = platform === 'ios' || platform === 'android'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
-// CI rows whose prebuild bundles more than one usable GPU backend (the linux
-// runners carry CUDA and Vulkan) pin the engine cascade through
-// TTS_CPP_GPU_BACKEND; the enhancer assertion expects whatever the row pinned
+// Builds that carry more than one usable GPU backend (an opt-in ENABLE_CUDA
+// local build carries CUDA and Vulkan) pin the engine cascade through
+// TTS_CPP_GPU_BACKEND; the enhancer assertion expects whatever was pinned
 // and falls back to the platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 
@@ -78,8 +78,8 @@ function backendIdToName(id) {
 }
 
 // Platforms that wire a GPU backend into tts-cpp's vcpkg port:
-// darwin/ios -> metal; linux/win32 -> vulkan (linux-x64 prebuilds also bundle
-// cuda); android -> vulkan + opencl.
+// darwin/ios -> metal; linux/win32 -> vulkan (cuda only in opt-in
+// ENABLE_CUDA builds); android -> vulkan + opencl.
 function expectsGpu() {
   return (
     platform === 'darwin' ||

--- a/packages/tts-ggml/test/utils/kvCacheMatrix.js
+++ b/packages/tts-ggml/test/utils/kvCacheMatrix.js
@@ -51,8 +51,8 @@ const RELAX = !!(proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1')
 // to validate that follow-up fix once it ships.
 const PROBE_UNSAFE = !!(proc.env && proc.env.QVAC_TTS_KV_PROBE_UNSAFE === '1')
 
-// CI rows that pin the engine's GPU cascade (linux prebuilds bundle CUDA and
-// Vulkan) export TTS_CPP_GPU_BACKEND.
+// Runs that pin the engine's GPU cascade (opt-in ENABLE_CUDA builds carry
+// CUDA and Vulkan) export TTS_CPP_GPU_BACKEND.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 
 // KV dtypes every GPU backend wired into tts-cpp can actually *run the whole

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "tts",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "tts",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-26#1",
+      "version>=": "2026-08-26#2",
       "default-features": false,
       "features": [
         "tts",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26#1",
+          "version>=": "2026-08-26#2",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-26#1",
+          "version>=": "2026-08-26#2",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## Why

Third step of the tts-ggml 0.8.0 publish-failure remediation (`413 Payload Too Large`; see #4147). The slimmed `ggml-speech` 2026-08-28 cut (tetherto/qvac-ext-ggml#74, tetherto/qvac-registry-vcpkg#339) replaces the Vulkan shader payloads no speech model uses — iq1/iq2/iq3/iq4, mxfp4/nvfp4 weight quantizations and the training/backward pipelines — with no-op stubs, shrinking every Vulkan-carrying prebuild artifact by roughly 45% (linux Vulkan backend: 63 MB -> 34 MB).

## What

- Raise every speech addon's `speech-cpp` floor from `2026-08-26#1` to `2026-08-26#2` (asr-ggml, audiogen-ggml, bci-whispercpp, tts-ggml move together, keeping the aligned floor).
- CHANGELOG `[Unreleased]` entries in all four packages.

Supported model quantizations (`q4_0`/`q5_0`/`q5_1`/`q8_0`/k-quants/`f16`) are unaffected. Loading an iq*/mxfp4/nvfp4-quantized model on Vulkan is not supported by the slim builds (same tradeoff diffusion-cpp shipped in 0.13.1). Verified with a full `test-backend-ops -b Vulkan0` run on an RTX 5090: 13089/13706 cases pass, all 617 failures exactly the stripped families.

## Stacked / blocked

- Stacked on #4147 (contains its commit; merge #4147 first).
- Blocked on tetherto/qvac-ext-ggml#74 -> tetherto/qvac-registry-vcpkg#339 (the `2026-08-26#2` port must exist in the registry before CI here can resolve it). Draft until then.

## Heads-up: asr/audiogen/bci next releases are queued to hit the same E413

`main` now enables CUDA bundling in the asr-ggml (`ASR_CUDA=ON`), audiogen-ggml, and bci-whispercpp (`ENABLE_CUDA=ON`) prebuild workflows, with `[Unreleased]` changelog entries advertising it. The tts-ggml 0.8.0 tarball with a bundled CUDA fatbin was 233.7 MB and was rejected by npm; the other three will land in the same range on their next release even with the Vulkan slimming. Decide per package whether to drop the bundled CUDA module (as #4147 does for tts-ggml) or verify the post-slim tarball actually clears the limit before cutting releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
