### PR TITLE
QVAC-24343 fix: regenerate the SDK contract and Python client for zod 4.5

### DIFF
--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
@@ -15779,7 +15779,7 @@ class OcrStreamResponseBlocksItem(GeneratedBaseModel):
         extra="forbid",
     )
     text: str
-    bbox: list[Any] | None = None
+    bbox: tuple[float, float, float, float] | None = None
     confidence: float | None = None
 
 

--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -1020,20 +1020,7 @@
                               "enum": {
                                 "type": "array",
                                 "items": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "number"
-                                    },
-                                    {
-                                      "type": "boolean"
-                                    },
-                                    {
-                                      "type": "null"
-                                    }
-                                  ]
+                                  "type": ["string", "number", "boolean", "null"]
                                 }
                               }
                             },
@@ -1990,20 +1977,7 @@
                         "enum": {
                           "type": "array",
                           "items": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "boolean"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
+                            "type": ["string", "number", "boolean", "null"]
                           }
                         }
                       },
@@ -2598,20 +2572,7 @@
                         "enum": {
                           "type": "array",
                           "items": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "boolean"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
+                            "type": ["string", "number", "boolean", "null"]
                           }
                         }
                       },
@@ -15780,7 +15741,10 @@
                   {
                     "type": "number"
                   }
-                ]
+                ],
+                "items": false,
+                "minItems": 4,
+                "maxItems": 4
               },
               "confidence": {
                 "type": "number"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`SDK Pod Checks` is red on every PR that touches `packages/sdk/**`, and takes `qvac-merge-guard / validate-pr` down with it:

```
##[error][sdk] test:unit [workspace] failed    ← not ok 1 - contract/schema.json matches a fresh export
##[error][sdk] contract:check failed           ← contract/schema.json is out of date
```

Currently blocking #4083 and #4146, neither of which touches `packages/sdk/{src,contract,scripts}`.

**Nothing in this repository changed to cause it.** The SDK's wire contract is produced by converting zod schemas to JSON Schema, and both packages that feed the export float their zod: `packages/sdk` declares `^4.3.0`, `packages/inference` declares `^4.4.3`. A fresh CI install resolves 4.5.4 in each, while the committed artifacts were generated with 4.4.3.

| Event | Time (UTC) |
|---|---|
| #4083 last green pod-check | Aug 28 12:59 |
| #4146 green pod-check | Aug 28 16:47 |
| **zod 4.5.0 / 4.5.1 published** | Aug 28 17:58 / 18:14 |
| every pod-check since, re-runs included | red |

## 📝 How is it solved?

`bun run contract:export`, then `scripts/generate.py` for the Python client. zod 4.5 changed two encodings:

**Primitive union** — 3 occurrences, from the SDK schemas:

BEFORE:

```json
"items": { "anyOf": [{ "type": "string" }, { "type": "number" }, { "type": "boolean" }, { "type": "null" }] }
```

AFTER:

```json
"items": { "type": ["string", "number", "boolean", "null"] }
```

**Tuple length** — 1 occurrence, from the inference surface:

BEFORE:

```json
{ "type": "array", "prefixItems": [ ... 4 numbers ... ] }
```

AFTER:

```json
{ "type": "array", "prefixItems": [ ... 4 numbers ... ], "items": false, "minItems": 4, "maxItems": 4 }
```

Both are the same wire format described more precisely; `contract/manifest.json` is unchanged.

The tuple change propagates into the generated Python client, so it is regenerated in the same commit per the lockstep rule. The result is a strictly better type — the OCR bbox stops being an unconstrained list:

BEFORE:

```python
bbox: list[Any] | None = None
```

AFTER:

```python
bbox: tuple[float, float, float, float] | None = None
```

Reviewers may want to weigh whether that generated-type refinement deserves a tag; the wire format itself did not change, only its description.

## 🧪 How was this verified?

Causation, not correlation — the failure was reproduced and then removed locally on `main`, using the same `workspace` source CI uses (`sdk-source:workspace`, which links the in-repo `@qvac/inference`) plus a clean `packages/inference` rebuild:

| zod in `packages/sdk` / `packages/inference` | `contract:check` |
|---|---|
| 4.4.3 / 4.4.3 (what generated the committed artifacts) | passes |
| 4.5.4 / 4.4.3 | fails — and regenerating here is **not** enough for CI |
| 4.5.4 / 4.5.4 (what CI resolves) | fails, and this is the pair that reproduces CI exactly |

The middle row is why the first push of this PR was still red: aligning only the SDK's zod produces an artifact CI still rejects. Both copies matter, because the surface schemas are built by the inference package's own zod instance.

With both aligned to 4.5.4 and the artifacts regenerated:

- `bun run contract:check` → exit 0
- `bun run scripts/run-unit-tests.ts` (what `test:unit` invokes) → exit 0, zero `not ok`, including `export is deterministic across runs` and `committed artifacts are up to date`
- `packages/sdk-python`: `generate.py --check` → 0, `black --check` → 0, `ruff check` → 0, `pytest` → 203 passed / 1 skipped

Not verified locally: `mypy`, which fails in my venv on `numpy/__init__.pyi` because the venv is Python 3.14 while `PR Checks (SDK Python)` pins 3.10. CI is the authority there.

Ruled out along the way, so reviewers don't re-tread it: the contract's only inputs are `@qvac/inference` `/surface` and `/models` (`src/models/registry/` imports nothing from addon packages), prettier is 3.9.6 both locally and in CI, and `packages/sdk/{src,scripts,contract}` plus `packages/inference` are byte-identical between `main` and the blocked PRs' heads — so no code change could have caused this.

## 🔄 Migration Notes

This unblocks the gate but does not stop it recurring: two committed artifacts are generated by a floating dependency, so zod's next minor within `^4.3.0` / `^4.4.3` will stale them again, and the failure will land on whichever unrelated PR touches `packages/sdk` next.

The durable fix is to pin `zod` to an exact version in both `packages/sdk` and `packages/inference`. I have deliberately left that out of this PR: `zod` is a runtime dependency of the published SDK, so pinning it exactly affects consumer dedupe and is a call for the SDK owners rather than a drive-by change in a CI-unblocking PR. Worth a follow-up ticket.
