### PR TITLE
QVAC-23752 chore: bump llm-llamacpp to 0.48.0

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.48.0] - 2026-08-31
+
+### Removed
+
+- Sliding-context support. `n_discarded` is no longer consumed, so it reaches
+  qvac-fabric's own argument parser and fails model load as an unknown option.
+- `contextSlides` from the runtime stats snapshot and from `RuntimeStats` in the
+  type declarations.
+
+### Changed
+
+- A generation that fills the context window now stops with
+  `stopReason=contextOverflow` and still returns what it produced. A batched
+  sequence that fills its window reports the same, where it previously reported
+  `sequenceLimit`, which is the per-sequence cap and not what was hit.
+- Reasoning-block compaction rewinds to a boundary and re-decodes the tokens it
+  keeps, instead of removing the thinking span and shifting the tail down over
+  it. No `seq_add` remains in the addon.
+- A reasoning close marker that tokenizes to several pieces is now supported;
+  the policy previously refused it.
+- `generatedTokens` is counted where tokens are committed rather than read from
+  qvac-fabric's performance counters, which key on batch size rather than
+  meaning. A batched request that stops on EOG reports one less than before, and
+  one that stops on the prediction limit reports one more, so the batched and
+  single-prompt paths now agree at both boundaries. `TPS` shifts with it.
+- `generationParams` with a key the addon does not read now throws instead of
+  being silently ignored. Only own keys are read and forwarded.
+
+### Fixed
+
+- Time to first token on the batched path is stamped from the token the caller
+  actually receives, so a `predict: 1` request no longer returns output while
+  reporting `TTFT` 0.
+- Compaction replay runs outside the scheduler mutex, so a reasoning turn no
+  longer stalls co-tenant slots or blocks a cross-thread `cancel()` for the
+  length of the replay.
+- A multimodal reasoning turn that ends through EOS substitution now seeds the
+  close marker for replay, so the compacted cache cannot be left holding an
+  unbalanced thinking block.
+
 ## [0.47.0] - 2026-08-24
 
 ### Added

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The sliding-context removal merged in #3938 without a version bump, so the change is not released.

## 📝 How does it solve it?

Minor bump to 0.48.0 with the changelog entry. Minor rather than major because the package is pre-1.0 and the change is breaking: `n_discarded` is no longer consumed, `contextSlides` is gone from the runtime stats, a full window reports `contextOverflow` rather than `sequenceLimit`, `generatedTokens` changes by one at both stop boundaries, and an unknown `generationParams` key now throws.

## 🧪 How was it tested?

Version and changelog only, no code change. The CHANGELOG heading is `## [0.48.0]`, which is the form `create-github-release.yml` greps for.
