### PR TITLE
doc[notask]: correct the CUDA runtime requirement in the asr and bci cuda features

### DIFF
--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -56,7 +56,7 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable the CUDA GPU backend for both engines (Linux / Windows on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ASR_CUDA=ON`. The runtime needs only the NVIDIA driver.",
+      "description": "Enable the CUDA GPU backend for both engines (Linux / Windows on NVIDIA). Off by default; the published linux-x64 prebuild enables it, and building it elsewhere needs nvcc on the build host, so opt in with `bare-make generate -D ASR_CUDA=ON`. At runtime CUDA engages only where the NVIDIA driver and the CUDA 13 runtime libraries (cudart, cuBLAS) both resolve; hosts without them skip the CUDA backend and fall back to Vulkan or CPU.",
       "supports": "!(osx | ios | android)",
       "dependencies": [
         {

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -44,7 +44,7 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable the CUDA GPU backend (Linux / Windows on NVIDIA). Off by default because it needs nvcc on the build host; opt in with `bare-make generate -D ENABLE_CUDA=ON`. The runtime needs only the NVIDIA driver.",
+      "description": "Enable the CUDA GPU backend (Linux / Windows on NVIDIA). Off by default; the published linux-x64 prebuild enables it, and building it elsewhere needs nvcc on the build host, so opt in with `bare-make generate -D ENABLE_CUDA=ON`. At runtime CUDA engages only where the NVIDIA driver and the CUDA 13 runtime libraries (cudart, cuBLAS) both resolve; hosts without them skip the CUDA backend and fall back to Vulkan or CPU.",
       "supports": "!(osx | ios | android)",
       "dependencies": [
         {


### PR DESCRIPTION
## What problem does this PR solve?

The `cuda` feature descriptions in `packages/asr-ggml/vcpkg.json` and `packages/bci-whispercpp/vcpkg.json` claim **"The runtime needs only the NVIDIA driver."** That is wrong, and it is the claim most likely to mislead someone deciding whether CUDA will engage on their machine.

The CUDA backend module links `libcudart.so.13`, `libcublas.so.13` and `libcublasLt.so.13`. Those ship with a **CUDA Toolkit install**, not with the driver — the driver package provides `libcuda.so.1` only. So a host with an NVIDIA card and just the driver cannot `dlopen` the CUDA module; ggml skips it and the addon falls back to Vulkan or CPU.

Verified against the published linux-x64 prebuild from the QVAC-24301 merge:

- `readelf -d libqvac-speech-ggml-cuda.so` → `libcudart.so.13`, `libcublas.so.13`, `libcublasLt.so.13`, `libcuda.so.1`
- on a test box those three resolve from `/usr/local/cuda/...` (toolkit), while `libcuda.so.1` is owned by `libnvidia-compute-595` (driver)

The descriptions also still implied the prebuilds carry no CUDA, which stopped being true when QVAC-24301 turned on `ASR_CUDA` / `ENABLE_CUDA` for the linux-x64 prebuilds.

## How does it solve it?

Rewrites the two sentences to state the real runtime requirement and the fallback behaviour, and to note that the linux-x64 prebuild now enables the feature. The README wording is already correct (QVAC-24301 rewrote it) — this is the manifest half that was missed.

Deliberately **out of scope**: the `Linux / Windows on NVIDIA` wording and the `supports` / dependency `platform` expressions are untouched, because Windows CUDA support is planned. (A Windows CUDA build does not currently link, since ggml-cuda is static there and no addon links the CUDA runtime — that is the separate piece of work, not this PR.)

Also left alone: `audiogen-ggml` and `tts-ggml`, whose descriptions are just "Enable CUDA GPU acceleration" — terse but not inaccurate. Happy to give all four the same treatment in review if that reads better.

Notes:

- `vcpkg.json` is not in either package's npm `files` list, so per the packages CHANGELOG rule this carries no changelog entry.
- asr build-wiring suite 9/9; neither wiring suite asserts description text; both manifests re-validated as JSON with `supports`/`platform`/`features` unchanged.

## Breaking changes

None — documentation strings only, no resolution behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
