### PR TITLE
doc[notask]: document which NVIDIA GPU generations the CUDA prebuild covers

### DIFF
--- a/packages/asr-ggml/README.md
+++ b/packages/asr-ggml/README.md
@@ -526,6 +526,14 @@ CUDA when a supported device is present and falls back to Vulkan otherwise.
 Both engines report the winner through `getBackendInfo()` as `backendId: 2`
 (`BackendId.CUDA`).
 
+The prebuilt CUDA module targets **compute capability 8.0 and newer**. It
+carries native code for 8.6 (RTX 30xx, A40) and 8.9 (RTX 40xx, L40) and
+JIT-compiles from 8.0 PTX for anything newer (Hopper, Blackwell / RTX 50xx),
+which costs a one-off compile on first use that the driver then caches. Cards
+below 8.0 — Turing (RTX 20xx, GTX 16xx, T4), Volta and Pascal — have no CUDA
+code path in the prebuild and should run on Vulkan; build from source with a
+wider `CMAKE_CUDA_ARCHITECTURES` if you need CUDA on them.
+
 The addon takes no direct CUDA linkage — the CUDA module carries its own CUDA
 `DT_NEEDED` entries, which is what makes the graceful fallback possible — and
 nvcc's clang host-compiler setup lives in

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -50,6 +50,13 @@ prefers CUDA when both GPU backends are usable. Elsewhere the CUDA backend is
 opt-in at build time via `bare-make generate -D ENABLE_CUDA=ON` (needs `nvcc`
 on the build host).
 
+The prebuilt CUDA module targets **compute capability 8.0 and newer**. It
+carries native code for 8.6 (RTX 30xx, A40) and 8.9 (RTX 40xx, L40) and
+JIT-compiles from 8.0 PTX for anything newer (Hopper, Blackwell / RTX 50xx),
+which costs a one-off compile on first use that the driver then caches. Cards
+below 8.0 — Turing (RTX 20xx, GTX 16xx, T4), Volta and Pascal — have no CUDA
+code path in the prebuild and should run on Vulkan.
+
 To build the native addon from source in a repository checkout:
 
 ```bash

--- a/packages/bci-whispercpp/README.md
+++ b/packages/bci-whispercpp/README.md
@@ -90,10 +90,17 @@ the `speech-cpp` dependency. On linux-x64 that
 flips ggml into hybrid dynamically-loaded backend mode: the CPU-variant,
 Vulkan, and CUDA backends ship as `.so` modules next to the addon, only the
 CUDA module depends on the CUDA runtime, and hosts that cannot resolve it
-skip the module and fall back to Vulkan or CPU. Only the NVIDIA driver plus
-the CUDA runtime libraries are needed at runtime; ggml registers CUDA ahead
-of Vulkan, so `use_gpu: true` prefers CUDA when a supported device is
-present.
+skip the module and fall back to Vulkan or CPU. The NVIDIA driver plus the
+CUDA 13 runtime libraries (cudart, cuBLAS — from a CUDA toolkit install) are
+needed at runtime; ggml registers CUDA ahead of Vulkan, so `use_gpu: true`
+prefers CUDA when a supported device is present.
+
+The prebuilt CUDA module targets **compute capability 8.0 and newer**. It
+carries native code for 8.6 (RTX 30xx, A40) and 8.9 (RTX 40xx, L40) and
+JIT-compiles from 8.0 PTX for anything newer (Hopper, Blackwell / RTX 50xx),
+which costs a one-off compile on first use that the driver then caches. Cards
+below 8.0 — Turing (RTX 20xx, GTX 16xx, T4), Volta and Pascal — have no CUDA
+code path in the prebuild and should run on Vulkan.
 
 ### Prerequisites
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -573,6 +573,12 @@ cuBLAS, from a CUDA toolkit install) resolvable at load time. On hosts
 without them — including CPU-only and non-NVIDIA machines — the module is
 skipped and the addon behaves exactly as before (Vulkan or CPU).
 
+The module targets **compute capability 8.0 and newer**: native code for 8.6
+(RTX 30xx, A40) and 8.9 (RTX 40xx, L40), and a JIT compile from 8.0 PTX for
+anything newer (Hopper, Blackwell / RTX 50xx) that the driver caches after
+first use. Cards below 8.0 — Turing (RTX 20xx, GTX 16xx, T4), Volta and
+Pascal — have no CUDA code path in the prebuild and run on Vulkan instead.
+
 > Both Chatterbox and Supertonic run on ARM Mali via Vulkan: `tts-cpp` sets
 > `allow_arm_mali=true` for both graphs. (Earlier `tts-cpp` builds declined
 > Mali for the Chatterbox / S3Gen graph and fell back to CPU there.)


### PR DESCRIPTION
## What problem does this PR solve?

Nothing tells a user whether their NVIDIA card actually gets CUDA from the speech addon prebuilds. It does not, for a large slice of the installed base, and that changed recently without being written down anywhere.

Measured with `cuobjdump` against the **currently shipping** linux-x64 module (`libqvac-speech-ggml-cuda.so`, from the `bci-whispercpp` 0.8.1 prebuild):

| | SASS (native) | PTX (JIT) |
|---|---|---|
| current | `sm_86`, `sm_89` | `compute_80` |
| before registry #338 | `sm_86`, `sm_89`, `sm_120a`, `sm_121a` | `compute_75`, `compute_80` |

PTX only JITs **forward**, so compute capability 8.0 is now the floor:

- **8.6 / 8.9** (RTX 30xx, A40, RTX 40xx, L40) — native SASS
- **9.0 / 12.x** (Hopper, Blackwell / RTX 50xx) — JIT from the 8.0 PTX, one-off compile the driver caches
- **below 8.0** (Turing RTX 20xx / GTX 16xx / T4, Volta, Pascal) — **no CUDA code path at all**, must use Vulkan

Turing regressed here: it was covered by the `75-virtual` PTX until registry [#338](https://github.com/tetherto/qvac-registry-vcpkg/pull/338) pinned `CMAKE_CUDA_ARCHITECTURES` to `80-virtual;86-real;89-real` to keep the addon tarballs under the npm size limit. Blackwell also went from native SASS to a JIT path.

## How does it solve it?

Adds a short, factual paragraph to the CUDA section of all four speech addon READMEs (`asr-ggml`, `tts-ggml`, `audiogen-ggml`, `bci-whispercpp`) stating the supported compute capabilities, the JIT behaviour, and that older cards fall back to Vulkan. Also fixes the one remaining "only the NVIDIA driver" sentence in bci's README so it matches asr and audiogen — the CUDA runtime libraries come from a toolkit install, not the driver.

Documentation only. No CHANGELOG entries: this describes behaviour that already shipped in 0.4.1 / 0.3.1 / 0.8.1 rather than changing anything.

## Two things for the team to decide (deliberately not done here)

1. **Should Turing be bought back?** Restoring `75-virtual` is a size trade-off against the constraint #338 was solving, not a doc fix. For scale: in the pre-#338 module the `sm_75` PTX is ~283 MB uncompressed, essentially the same as the `sm_80` PTX (~278 MB), so re-adding it roughly doubles the PTX payload of a module that is currently 77 MB on disk. That could well put the tarballs back over the limit, so I did not push a speculative change. Adding `120-real` for Blackwell has the same character.
2. **Do the released versions need a retroactive note?** A Turing user who upgraded to 0.4.1 / 0.3.1 / 0.8.1 silently lost CUDA and got Vulkan instead. That is arguably worth a line in those released sections, but it belongs to whoever owns #338 rather than to this PR.

Related risk, unverified: `ggml_cuda_init` enumerates devices via `cudaGetDeviceCount` and I could not find a compute-capability guard that would skip a device whose architecture is absent from the fatbin. If there is none, a Turing host with the CUDA runtime installed would have CUDA *selected* and then fail at first kernel launch ("no kernel image is available for execution on the device") instead of falling back cleanly to Vulkan. Confirming that needs a Turing card.

## Breaking changes

None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
