### PR TITLE
QVAC-24113 feat[api]: return the per-device memory projection in fit results

### DIFF
--- a/packages/model-fit/README.md
+++ b/packages/model-fit/README.md
@@ -55,12 +55,18 @@ const plan = fitParams({
 
 ### The memory projection
 
-`projection` explains the verdict in bytes: one row per device in registration
-order, then a final `"host"` row, each carrying `totalBytes`/`freeBytes` (the
-budget the verdict was judged against) and `modelBytes`/`contextBytes`/
-`computeBytes` (the projected demand at the **resolved** parameters). A
-`does-not-fit` with numbers shows how far it missed; a `fits` shows how much
-headroom the margin left.
+`projection` explains the verdict in bytes: one row per device the model was
+assigned to, in the order llama.cpp holds them (`llama_model_get_device`, the
+same index `tensorSplit` uses), then a final `"host"` row. Each row carries
+`totalBytes`/`freeBytes` (the budget the verdict was judged against) and
+`modelBytes`/`contextBytes`/`computeBytes` (the projected demand at the
+**resolved** parameters). A `does-not-fit` with numbers shows how far it
+missed; a `fits` shows how much headroom the margin left.
+
+The device rows are not `nDevices`. `nDevices` is `ggml_backend_dev_count()`
+and includes the CPU device, whose demand is folded into the `"host"` row, so
+`projection.length - 1` is usually `nDevices - 1`. Match rows by `name`, never
+by position against `nDevices`.
 
 It is present on SUCCESS and FAILURE, and absent in three cases a consumer must
 handle: an ERROR verdict, a result from an older addon or process runner, and a
@@ -418,7 +424,5 @@ returns a real projection rather than `ERROR`.
 - Narrow llama.cpp LLM path only. Multimodal `mmproj` GPU memory is **not**
   counted by the fitter yet (upstream issue) — projections under-count for
   VLM/OCR models, so treat those as "unknown".
-- The per-device MiB breakdown is only emitted to the log by llama.cpp
-  (`llama_memory_breakdown_print`); it is not exposed as data here. This addon
-  returns the actionable plan (layers / context / split), not the raw byte
-  breakdown.
+- The per-device byte breakdown (`projection`) comes from one extra no-alloc
+  probe after the fit, so a result costs roughly two probes instead of one.

--- a/packages/model-fit/README.md
+++ b/packages/model-fit/README.md
@@ -48,9 +48,29 @@ const plan = fitParams({
 //   maxDevices,   // llama_max_devices() — a build-time bound, NOT a detection
 //   nDevices,     // devices actually registered; 0 => ERROR
 //   nGpuDevices,  // of those, GPU/iGPU; 0 => host-only projection
-//   tensorSplit   // number[] offload proportion per device
+//   tensorSplit,  // number[] offload proportion per device
+//   projection    // per-device projected memory (see below); optional
 // }
 ```
+
+### The memory projection
+
+`projection` explains the verdict in bytes: one row per device in registration
+order, then a final `"host"` row, each carrying `totalBytes`/`freeBytes` (the
+budget the verdict was judged against) and `modelBytes`/`contextBytes`/
+`computeBytes` (the projected demand at the **resolved** parameters). A
+`does-not-fit` with numbers shows how far it missed; a `fits` shows how much
+headroom the margin left.
+
+It is present on SUCCESS and FAILURE, and absent in three cases a consumer must
+handle: an ERROR verdict, a result from an older addon or process runner, and a
+failure of the extra no-alloc probe that gathers it. That probe costs roughly
+what the fit itself cost.
+
+`freeBytes` inherits every caveat of the underlying backend gauges
+(per-process accounting on Metal, host-memory assumptions — see the fit
+semantics above), so the rows are "what the fitter believed", not ground truth
+about the machine.
 
 ### Backend registration
 

--- a/packages/model-fit/README.md
+++ b/packages/model-fit/README.md
@@ -58,10 +58,15 @@ const plan = fitParams({
 `projection` explains the verdict in bytes: one row per device the model was
 assigned to, in the order llama.cpp holds them (`llama_model_get_device`, the
 same index `tensorSplit` uses), then a final `"host"` row. Each row carries
-`totalBytes`/`freeBytes` (the budget the verdict was judged against) and
+`totalBytes`/`freeBytes` (the raw backend gauge), `marginBytes` (the margin
+the fitter applied to that row, `marginMiB` × 1 MiB) and
 `modelBytes`/`contextBytes`/`computeBytes` (the projected demand at the
-**resolved** parameters). A `does-not-fit` with numbers shows how far it
-missed; a `fits` shows how much headroom the margin left.
+**resolved** parameters). The budget the verdict was judged against is
+`freeBytes - marginBytes`, so headroom on a row is
+`freeBytes - marginBytes - (modelBytes + contextBytes + computeBytes)`; the
+raw `freeBytes` alone reads positive for a `does-not-fit` that missed by less
+than the margin. A `does-not-fit` with numbers shows how far it missed; a
+`fits` shows how much headroom the margin left.
 
 The device rows are not `nDevices`. `nDevices` is `ggml_backend_dev_count()`
 and includes the CPU device, whose demand is folded into the `"host"` row, so

--- a/packages/model-fit/addon/src/fit/FitParams.cpp
+++ b/packages/model-fit/addon/src/fit/FitParams.cpp
@@ -40,7 +40,8 @@ std::mutex
 /// `mparams`/`cparams` must still borrow from live storage when this is called.
 void captureProjection(
     const std::string& modelPath, const llama_model_params& mparams,
-    const llama_context_params& cparams, FitResult& out) {
+    const llama_context_params& cparams, uint64_t marginBytes,
+    FitResult& out) {
   try {
     std::vector<ggml_backend_dev_t> devs;
     uint32_t hpNgl = 0;
@@ -70,6 +71,7 @@ void captureProjection(
           {name == nullptr ? "" : name,
            static_cast<uint64_t>(rows[i].total),
            static_cast<uint64_t>(rows[i].free),
+           marginBytes,
            static_cast<uint64_t>(rows[i].model),
            static_cast<uint64_t>(rows[i].context),
            static_cast<uint64_t>(rows[i].compute)});
@@ -473,8 +475,9 @@ FitResult runFit(const FitRequest& req) {
   // A fitted 0 means "the trained context", not a usable load plan.
   detail::finalizeFitContext(out, trainedCtx);
 
-  if (status != COMMON_PARAMS_FIT_STATUS_ERROR) {
-    captureProjection(req.modelPath, mparams, cparams, out);
+  // `out.status`, not the local: finalize above may have downgraded to ERROR.
+  if (out.status != static_cast<int>(COMMON_PARAMS_FIT_STATUS_ERROR)) {
+    captureProjection(req.modelPath, mparams, cparams, margins[0], out);
   }
 
   return out;
@@ -593,8 +596,14 @@ FitResult runLlamaFit(const LlamaLoadFitRequest& req) {
 
   // Before the tensorSplit move below: `modelParams.tensor_split` points into
   // `execution.tensorSplit`, and the projection probe reads modelParams.
+  // finalizeFitContext runs after this and clears the rows if it downgrades.
   if (status != COMMON_PARAMS_FIT_STATUS_ERROR) {
-    captureProjection(req.modelPath, modelParams, contextParams, out);
+    captureProjection(
+        req.modelPath,
+        modelParams,
+        contextParams,
+        static_cast<uint64_t>(req.marginMiB) * 1024ULL * 1024ULL,
+        out);
   }
 
   out.tensorSplit = std::move(execution.tensorSplit);

--- a/packages/model-fit/addon/src/fit/FitParams.cpp
+++ b/packages/model-fit/addon/src/fit/FitParams.cpp
@@ -40,8 +40,7 @@ std::mutex
 /// `mparams`/`cparams` must still borrow from live storage when this is called.
 void captureProjection(
     const std::string& modelPath, const llama_model_params& mparams,
-    const llama_context_params& cparams, uint64_t marginBytes,
-    FitResult& out) {
+    const llama_context_params& cparams, uint64_t marginBytes, FitResult& out) {
   try {
     std::vector<ggml_backend_dev_t> devs;
     uint32_t hpNgl = 0;

--- a/packages/model-fit/addon/src/fit/FitParams.cpp
+++ b/packages/model-fit/addon/src/fit/FitParams.cpp
@@ -33,6 +33,49 @@ namespace {
 std::mutex
     g_fitMutex; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+/// Attaches the per-device memory projection for the resolved parameters.
+///
+/// Runs one more no-alloc probe, so it costs roughly what the fit cost. A probe
+/// failure leaves `out.projection` empty and never touches `out.status`.
+/// `mparams`/`cparams` must still borrow from live storage when this is called.
+void captureProjection(
+    const std::string& modelPath, const llama_model_params& mparams,
+    const llama_context_params& cparams, FitResult& out) {
+  try {
+    std::vector<ggml_backend_dev_t> devs;
+    uint32_t hpNgl = 0;
+    uint32_t hpNctTrain = 0;
+    uint32_t hpNexpert = 0;
+    const common_device_memory_data_vec rows = common_get_device_memory_data(
+        modelPath.c_str(),
+        &mparams,
+        &cparams,
+        devs,
+        hpNgl,
+        hpNctTrain,
+        hpNexpert,
+        GGML_LOG_LEVEL_INFO);
+    // One row per device in `devs` order, then the host row.
+    if (rows.size() != devs.size() + 1) {
+      return;
+    }
+    out.projection.reserve(rows.size());
+    for (size_t i = 0; i < rows.size(); ++i) {
+      const bool isHost = i == devs.size();
+      const char* name = isHost ? "host" : ggml_backend_dev_name(devs[i]);
+      out.projection.push_back(
+          {name == nullptr ? "" : name,
+           static_cast<uint64_t>(rows[i].total),
+           static_cast<uint64_t>(rows[i].free),
+           static_cast<uint64_t>(rows[i].model),
+           static_cast<uint64_t>(rows[i].context),
+           static_cast<uint64_t>(rows[i].compute)});
+    }
+  } catch (const std::exception&) {
+    out.projection.clear();
+  }
+}
+
 /// Resolves the directory the packaged ggml backends are loaded from.
 ///
 /// The resolved path is handed to `ggml_backend_load_all_from_path`, which
@@ -427,6 +470,10 @@ FitResult runFit(const FitRequest& req) {
   // A fitted 0 means "the trained context", not a usable load plan.
   detail::finalizeFitContext(out, trainedCtx);
 
+  if (status != COMMON_PARAMS_FIT_STATUS_ERROR) {
+    captureProjection(req.modelPath, mparams, cparams, out);
+  }
+
   return out;
 }
 
@@ -540,6 +587,13 @@ FitResult runLlamaFit(const LlamaLoadFitRequest& req) {
   out.nCtx = contextParams.n_ctx;
   out.nBatch = contextParams.n_batch;
   out.nUbatch = contextParams.n_ubatch;
+
+  // Before the tensorSplit move below: `modelParams.tensor_split` points into
+  // `execution.tensorSplit`, and the projection probe reads modelParams.
+  if (status != COMMON_PARAMS_FIT_STATUS_ERROR) {
+    captureProjection(req.modelPath, modelParams, contextParams, out);
+  }
+
   out.tensorSplit = std::move(execution.tensorSplit);
   out.splitMode = static_cast<int32_t>(modelParams.split_mode);
   out.mainGpu = modelParams.main_gpu;

--- a/packages/model-fit/addon/src/fit/FitParams.cpp
+++ b/packages/model-fit/addon/src/fit/FitParams.cpp
@@ -55,7 +55,10 @@ void captureProjection(
         hpNctTrain,
         hpNexpert,
         GGML_LOG_LEVEL_INFO);
-    // One row per device in `devs` order, then the host row.
+    // `devs` is the model's device list (`llama_model_get_device`), filled by
+    // the same probe that produced `rows`, so the zip cannot drift. It is not
+    // `nDevices` (`ggml_backend_dev_count`): the CPU device is counted there
+    // but its demand is folded into the trailing host row.
     if (rows.size() != devs.size() + 1) {
       return;
     }

--- a/packages/model-fit/addon/src/fit/FitParams.hpp
+++ b/packages/model-fit/addon/src/fit/FitParams.hpp
@@ -195,9 +195,11 @@ struct FitResult {
   /// means the projection is host-only and carries no GPU offload information.
   size_t nGpuDevices = 0;
 
-  /// Per-device projected memory at the resolved parameters, ending with the
-  /// host row. Populated on SUCCESS and FAILURE; empty on ERROR, and empty when
-  /// the probe that produces it fails.
+  /// Projected memory per device the model was assigned to, in
+  /// `llama_model_get_device` order (the index `tensorSplit` uses), ending with
+  /// the host row. Not `nDevices`: the CPU device is counted there but its
+  /// demand lands in the host row. Populated on SUCCESS and FAILURE; empty on
+  /// ERROR, and empty when the probe that produces it fails.
   std::vector<FitProjectionRow> projection;
 };
 

--- a/packages/model-fit/addon/src/fit/FitParams.hpp
+++ b/packages/model-fit/addon/src/fit/FitParams.hpp
@@ -125,6 +125,19 @@ struct BuftOverride {
   std::string bufferType;
 };
 
+/// Projected memory for one device (or the host row) at the resolved
+/// parameters, in bytes. `total`/`free` are the budget the verdict was judged
+/// against; `model`/`context`/`compute` are the projected demand.
+struct FitProjectionRow {
+  /// Device name as the backend reports it, or "host" for the host row.
+  std::string name;
+  uint64_t totalBytes = 0;
+  uint64_t freeBytes = 0;
+  uint64_t modelBytes = 0;
+  uint64_t contextBytes = 0;
+  uint64_t computeBytes = 0;
+};
+
 /// Result of `runFit`. `status` mirrors `enum common_params_fit_status`
 /// (0 SUCCESS, 1 FAILURE, 2 ERROR). The remaining fields carry the fitted
 /// "load plan" the SDK can hand to the LLM addon.
@@ -181,6 +194,11 @@ struct FitResult {
   /// Subset of `nDevices` that are accelerators (GPU or integrated GPU). Zero
   /// means the projection is host-only and carries no GPU offload information.
   size_t nGpuDevices = 0;
+
+  /// Per-device projected memory at the resolved parameters, ending with the
+  /// host row. Populated on SUCCESS and FAILURE; empty on ERROR, and empty when
+  /// the probe that produces it fails.
+  std::vector<FitProjectionRow> projection;
 };
 
 /// Runs `common_fit_params` for `req`. Never loads weight data — the fitter

--- a/packages/model-fit/addon/src/fit/FitParams.hpp
+++ b/packages/model-fit/addon/src/fit/FitParams.hpp
@@ -132,7 +132,10 @@ struct FitProjectionRow {
   /// Device name as the backend reports it, or "host" for the host row.
   std::string name;
   uint64_t totalBytes = 0;
+  /// Raw backend gauge. The fitter judged against `freeBytes - marginBytes`.
   uint64_t freeBytes = 0;
+  /// The margin applied to this row, in bytes (`marginMiB` * MiB).
+  uint64_t marginBytes = 0;
   uint64_t modelBytes = 0;
   uint64_t contextBytes = 0;
   uint64_t computeBytes = 0;

--- a/packages/model-fit/addon/src/fit/FitResultContext.cpp
+++ b/packages/model-fit/addon/src/fit/FitResultContext.cpp
@@ -10,6 +10,8 @@ void finalizeFitContext(FitResult& result, uint32_t trainedCtx) {
       result.status = 2;
       result.fits = false;
       result.reason = FitReason::ModelUnreadable;
+      // ERROR carries no projection; the probe may already have run.
+      result.projection.clear();
     }
   }
 }

--- a/packages/model-fit/addon/src/js-interface/binding.cpp
+++ b/packages/model-fit/addon/src/js-interface/binding.cpp
@@ -185,6 +185,37 @@ js_value_t* fitResultObject(js_env_t* env, const FitResult& result) {
     overrides.set(env, index, entry);
   }
   out.setProperty(env, "buftOverrides", overrides);
+
+  // Byte counts as doubles: every value here is a memory size, far below
+  // Number.MAX_SAFE_INTEGER.
+  auto projection = jsu::Array::create(env);
+  for (size_t index = 0; index < result.projection.size(); ++index) {
+    const FitProjectionRow& row = result.projection[index];
+    auto entry = jsu::Object::create(env);
+    entry.setProperty(env, "name", jsu::String::create(env, row.name.c_str()));
+    entry.setProperty(
+        env,
+        "totalBytes",
+        jsu::Number::create(env, static_cast<double>(row.totalBytes)));
+    entry.setProperty(
+        env,
+        "freeBytes",
+        jsu::Number::create(env, static_cast<double>(row.freeBytes)));
+    entry.setProperty(
+        env,
+        "modelBytes",
+        jsu::Number::create(env, static_cast<double>(row.modelBytes)));
+    entry.setProperty(
+        env,
+        "contextBytes",
+        jsu::Number::create(env, static_cast<double>(row.contextBytes)));
+    entry.setProperty(
+        env,
+        "computeBytes",
+        jsu::Number::create(env, static_cast<double>(row.computeBytes)));
+    projection.set(env, index, entry);
+  }
+  out.setProperty(env, "projection", projection);
   return out;
 }
 

--- a/packages/model-fit/addon/src/js-interface/binding.cpp
+++ b/packages/model-fit/addon/src/js-interface/binding.cpp
@@ -203,6 +203,10 @@ js_value_t* fitResultObject(js_env_t* env, const FitResult& result) {
         jsu::Number::create(env, static_cast<double>(row.freeBytes)));
     entry.setProperty(
         env,
+        "marginBytes",
+        jsu::Number::create(env, static_cast<double>(row.marginBytes)));
+    entry.setProperty(
+        env,
         "modelBytes",
         jsu::Number::create(env, static_cast<double>(row.modelBytes)));
     entry.setProperty(

--- a/packages/model-fit/index.d.ts
+++ b/packages/model-fit/index.d.ts
@@ -86,6 +86,20 @@ export interface FitBuftOverride {
     /** ggml buffer type the matching tensors were placed in. */
     bufferType: string;
 }
+/**
+ * Projected memory for one device — or the trailing `"host"` row — at the
+ * resolved parameters, in bytes. `totalBytes`/`freeBytes` are the budget the
+ * verdict was judged against; the remaining fields are the projected demand.
+ */
+export interface FitProjectionRow {
+    /** Device name as the backend reports it, or `"host"` for the host row. */
+    name: string;
+    totalBytes: number;
+    freeBytes: number;
+    modelBytes: number;
+    contextBytes: number;
+    computeBytes: number;
+}
 /** What the fitter measured against. Present on every outcome. */
 export interface FitDeviceInventory {
     /**
@@ -97,6 +111,13 @@ export interface FitDeviceInventory {
     nDevices: number;
     /** Of those, how many are accelerators (GPU or iGPU). 0 means host-only. */
     nGpuDevices: number;
+    /**
+     * Per-device projected memory at the resolved parameters, ending with the
+     * host row. Populated on SUCCESS and FAILURE; empty on ERROR, and empty when
+     * the probe that produces it fails. Optional because results decoded from an
+     * older addon or process runner predate the field.
+     */
+    projection?: FitProjectionRow[];
 }
 /** The fitted load plan. Only meaningful on a SUCCESS. */
 export interface FitPlan {

--- a/packages/model-fit/index.d.ts
+++ b/packages/model-fit/index.d.ts
@@ -112,10 +112,15 @@ export interface FitDeviceInventory {
     /** Of those, how many are accelerators (GPU or iGPU). 0 means host-only. */
     nGpuDevices: number;
     /**
-     * Per-device projected memory at the resolved parameters, ending with the
-     * host row. Populated on SUCCESS and FAILURE; empty on ERROR, and empty when
-     * the probe that produces it fails. Optional because results decoded from an
-     * older addon or process runner predate the field.
+     * Projected memory per device the model was assigned to, in the order
+     * llama.cpp holds them (`llama_model_get_device`, the index `tensorSplit`
+     * uses), ending with the host row. The device rows are not `nDevices`: the
+     * CPU device is counted there but its demand lands in the host row. Match
+     * rows by `name`, not by position against `nDevices`.
+     *
+     * Populated on SUCCESS and FAILURE; empty on ERROR, and empty when the probe
+     * that produces it fails. Optional because results decoded from an older
+     * addon or process runner predate the field.
      */
     projection?: FitProjectionRow[];
 }

--- a/packages/model-fit/index.d.ts
+++ b/packages/model-fit/index.d.ts
@@ -95,7 +95,13 @@ export interface FitProjectionRow {
     /** Device name as the backend reports it, or `"host"` for the host row. */
     name: string;
     totalBytes: number;
+    /**
+     * Raw backend gauge, before the margin. The budget the verdict was judged
+     * against is `freeBytes - marginBytes`; headroom is that minus the demand.
+     */
     freeBytes: number;
+    /** The margin applied to this row, in bytes (`marginMiB` × 1 MiB). */
+    marginBytes: number;
     modelBytes: number;
     contextBytes: number;
     computeBytes: number;

--- a/packages/model-fit/process.js
+++ b/packages/model-fit/process.js
@@ -56,6 +56,24 @@ function assertFitPlan(result, required) {
         }
     }
 }
+// Optional on every outcome: older addon and runner results predate the field.
+// When present it must be well-formed — a truncated row is a malformed
+// response, not missing evidence.
+function assertProjection(result) {
+    if (result['projection'] === undefined)
+        return;
+    if (!Array.isArray(result['projection'])) {
+        throw new TypeError('Fit process result projection must be an array');
+    }
+    for (const row of result['projection']) {
+        if (!isRecord(row) || typeof row['name'] !== 'string') {
+            throw new TypeError('Fit process result projection rows must carry a string name');
+        }
+        for (const key of ['totalBytes', 'freeBytes', 'modelBytes', 'contextBytes', 'computeBytes']) {
+            assertNumber(row, key);
+        }
+    }
+}
 // `unsupported-config` is reachable only through the v2 llama-load path, so the
 // parser enforces that rather than accepting it on either envelope: a v1
 // response carrying it is malformed, not merely unusual.
@@ -68,6 +86,7 @@ function assertFitResultShape(value, errorReasons) {
     assertNumber(value, 'maxDevices');
     assertNumber(value, 'nDevices');
     assertNumber(value, 'nGpuDevices');
+    assertProjection(value);
     switch (value['status']) {
         case 0:
             if (value['fits'] !== true || value['reason'] !== 'fits') {

--- a/packages/model-fit/process.js
+++ b/packages/model-fit/process.js
@@ -69,7 +69,14 @@ function assertProjection(result) {
         if (!isRecord(row) || typeof row['name'] !== 'string') {
             throw new TypeError('Fit process result projection rows must carry a string name');
         }
-        for (const key of ['totalBytes', 'freeBytes', 'modelBytes', 'contextBytes', 'computeBytes']) {
+        for (const key of [
+            'totalBytes',
+            'freeBytes',
+            'marginBytes',
+            'modelBytes',
+            'contextBytes',
+            'computeBytes'
+        ]) {
             assertNumber(row, key);
         }
     }

--- a/packages/model-fit/src/index.ts
+++ b/packages/model-fit/src/index.ts
@@ -98,6 +98,21 @@ export interface FitBuftOverride {
   bufferType: string
 }
 
+/**
+ * Projected memory for one device — or the trailing `"host"` row — at the
+ * resolved parameters, in bytes. `totalBytes`/`freeBytes` are the budget the
+ * verdict was judged against; the remaining fields are the projected demand.
+ */
+export interface FitProjectionRow {
+  /** Device name as the backend reports it, or `"host"` for the host row. */
+  name: string
+  totalBytes: number
+  freeBytes: number
+  modelBytes: number
+  contextBytes: number
+  computeBytes: number
+}
+
 /** What the fitter measured against. Present on every outcome. */
 export interface FitDeviceInventory {
   /**
@@ -109,6 +124,13 @@ export interface FitDeviceInventory {
   nDevices: number
   /** Of those, how many are accelerators (GPU or iGPU). 0 means host-only. */
   nGpuDevices: number
+  /**
+   * Per-device projected memory at the resolved parameters, ending with the
+   * host row. Populated on SUCCESS and FAILURE; empty on ERROR, and empty when
+   * the probe that produces it fails. Optional because results decoded from an
+   * older addon or process runner predate the field.
+   */
+  projection?: FitProjectionRow[]
 }
 
 /** The fitted load plan. Only meaningful on a SUCCESS. */

--- a/packages/model-fit/src/index.ts
+++ b/packages/model-fit/src/index.ts
@@ -125,10 +125,15 @@ export interface FitDeviceInventory {
   /** Of those, how many are accelerators (GPU or iGPU). 0 means host-only. */
   nGpuDevices: number
   /**
-   * Per-device projected memory at the resolved parameters, ending with the
-   * host row. Populated on SUCCESS and FAILURE; empty on ERROR, and empty when
-   * the probe that produces it fails. Optional because results decoded from an
-   * older addon or process runner predate the field.
+   * Projected memory per device the model was assigned to, in the order
+   * llama.cpp holds them (`llama_model_get_device`, the index `tensorSplit`
+   * uses), ending with the host row. The device rows are not `nDevices`: the
+   * CPU device is counted there but its demand lands in the host row. Match
+   * rows by `name`, not by position against `nDevices`.
+   *
+   * Populated on SUCCESS and FAILURE; empty on ERROR, and empty when the probe
+   * that produces it fails. Optional because results decoded from an older
+   * addon or process runner predate the field.
    */
   projection?: FitProjectionRow[]
 }

--- a/packages/model-fit/src/index.ts
+++ b/packages/model-fit/src/index.ts
@@ -107,7 +107,13 @@ export interface FitProjectionRow {
   /** Device name as the backend reports it, or `"host"` for the host row. */
   name: string
   totalBytes: number
+  /**
+   * Raw backend gauge, before the margin. The budget the verdict was judged
+   * against is `freeBytes - marginBytes`; headroom is that minus the demand.
+   */
   freeBytes: number
+  /** The margin applied to this row, in bytes (`marginMiB` × 1 MiB). */
+  marginBytes: number
   modelBytes: number
   contextBytes: number
   computeBytes: number

--- a/packages/model-fit/src/process.ts
+++ b/packages/model-fit/src/process.ts
@@ -148,7 +148,14 @@ function assertProjection (result: Record<string, unknown>): void {
     if (!isRecord(row) || typeof row['name'] !== 'string') {
       throw new TypeError('Fit process result projection rows must carry a string name')
     }
-    for (const key of ['totalBytes', 'freeBytes', 'modelBytes', 'contextBytes', 'computeBytes']) {
+    for (const key of [
+      'totalBytes',
+      'freeBytes',
+      'marginBytes',
+      'modelBytes',
+      'contextBytes',
+      'computeBytes'
+    ]) {
       assertNumber(row, key)
     }
   }

--- a/packages/model-fit/src/process.ts
+++ b/packages/model-fit/src/process.ts
@@ -136,6 +136,24 @@ function assertFitPlan (result: Record<string, unknown>, required: boolean): voi
   }
 }
 
+// Optional on every outcome: older addon and runner results predate the field.
+// When present it must be well-formed — a truncated row is a malformed
+// response, not missing evidence.
+function assertProjection (result: Record<string, unknown>): void {
+  if (result['projection'] === undefined) return
+  if (!Array.isArray(result['projection'])) {
+    throw new TypeError('Fit process result projection must be an array')
+  }
+  for (const row of result['projection']) {
+    if (!isRecord(row) || typeof row['name'] !== 'string') {
+      throw new TypeError('Fit process result projection rows must carry a string name')
+    }
+    for (const key of ['totalBytes', 'freeBytes', 'modelBytes', 'contextBytes', 'computeBytes']) {
+      assertNumber(row, key)
+    }
+  }
+}
+
 // `unsupported-config` is reachable only through the v2 llama-load path, so the
 // parser enforces that rather than accepting it on either envelope: a v1
 // response carrying it is malformed, not merely unusual.
@@ -149,6 +167,7 @@ function assertFitResultShape (value: unknown, errorReasons: string[]): void {
   assertNumber(value, 'maxDevices')
   assertNumber(value, 'nDevices')
   assertNumber(value, 'nGpuDevices')
+  assertProjection(value)
 
   switch (value['status']) {
     case 0:

--- a/packages/model-fit/test/desktop/process.test.js
+++ b/packages/model-fit/test/desktop/process.test.js
@@ -192,6 +192,7 @@ test('response parser accepts, omits, and rejects projections', async (t) => {
           name: 'MTL0',
           totalBytes: 19998441472,
           freeBytes: 1443887104,
+          marginBytes: 1073741824,
           modelBytes: 11355000000,
           contextBytes: 6442450944,
           computeBytes: 460000000
@@ -200,6 +201,7 @@ test('response parser accepts, omits, and rejects projections', async (t) => {
           name: 'host',
           totalBytes: 25769803776,
           freeBytes: 20000000000,
+          marginBytes: 1073741824,
           modelBytes: 0,
           contextBytes: 0,
           computeBytes: 46137344
@@ -225,6 +227,7 @@ test('response parser accepts, omits, and rejects projections', async (t) => {
           name: 'MTL0',
           totalBytes: 19998441472,
           freeBytes: 0,
+          marginBytes: 1073741824,
           modelBytes: 19998441472,
           contextBytes: 0,
           computeBytes: 0
@@ -260,11 +263,40 @@ test('response parser accepts, omits, and rejects projections', async (t) => {
         result: {
           ...completedFitResult(),
           projection: [
-            { totalBytes: 1, freeBytes: 1, modelBytes: 1, contextBytes: 1, computeBytes: 1 }
+            {
+              totalBytes: 1,
+              freeBytes: 1,
+              marginBytes: 1,
+              modelBytes: 1,
+              contextBytes: 1,
+              computeBytes: 1
+            }
           ]
         }
       }),
     /must carry a string name/
+  )
+  // A row without the margin cannot be turned into a budget.
+  await t.exception.all(
+    () =>
+      parseFitProcessResponse({
+        version: 1,
+        status: 'completed',
+        result: {
+          ...completedFitResult(),
+          projection: [
+            {
+              name: 'MTL0',
+              totalBytes: 1,
+              freeBytes: 1,
+              modelBytes: 1,
+              contextBytes: 1,
+              computeBytes: 1
+            }
+          ]
+        }
+      }),
+    /marginBytes must be a number/
   )
   await t.exception.all(
     () =>

--- a/packages/model-fit/test/desktop/process.test.js
+++ b/packages/model-fit/test/desktop/process.test.js
@@ -180,6 +180,103 @@ test('response parser accepts canonical results and unsupported config', (t) => 
   t.is(unsupported.result.reason, 'unsupported-config')
 })
 
+test('response parser accepts, omits, and rejects projections', async (t) => {
+  // Present and well-formed: accepted on success and on does-not-fit alike.
+  const withProjection = parseFitProcessResponse({
+    version: 1,
+    status: 'completed',
+    result: {
+      ...completedFitResult(),
+      projection: [
+        {
+          name: 'MTL0',
+          totalBytes: 19998441472,
+          freeBytes: 1443887104,
+          modelBytes: 11355000000,
+          contextBytes: 6442450944,
+          computeBytes: 460000000
+        },
+        {
+          name: 'host',
+          totalBytes: 25769803776,
+          freeBytes: 20000000000,
+          modelBytes: 0,
+          contextBytes: 0,
+          computeBytes: 46137344
+        }
+      ]
+    }
+  })
+  t.is(withProjection.result.projection.length, 2)
+  t.is(withProjection.result.projection[1].name, 'host')
+
+  const failureWithProjection = parseFitProcessResponse({
+    version: 1,
+    status: 'completed',
+    result: {
+      status: 1,
+      fits: false,
+      reason: 'does-not-fit',
+      maxDevices: 1,
+      nDevices: 1,
+      nGpuDevices: 1,
+      projection: [
+        {
+          name: 'MTL0',
+          totalBytes: 19998441472,
+          freeBytes: 0,
+          modelBytes: 19998441472,
+          contextBytes: 0,
+          computeBytes: 0
+        }
+      ]
+    }
+  })
+  t.is(failureWithProjection.result.projection[0].freeBytes, 0)
+
+  // Absent: an older addon or runner predates the field.
+  const withoutProjection = parseFitProcessResponse({
+    version: 1,
+    status: 'completed',
+    result: completedFitResult()
+  })
+  t.is(withoutProjection.result.projection, undefined)
+
+  // Present but malformed.
+  await t.exception.all(
+    () =>
+      parseFitProcessResponse({
+        version: 1,
+        status: 'completed',
+        result: { ...completedFitResult(), projection: [{ name: 'MTL0', totalBytes: 1 }] }
+      }),
+    /must be a number/
+  )
+  await t.exception.all(
+    () =>
+      parseFitProcessResponse({
+        version: 1,
+        status: 'completed',
+        result: {
+          ...completedFitResult(),
+          projection: [
+            { totalBytes: 1, freeBytes: 1, modelBytes: 1, contextBytes: 1, computeBytes: 1 }
+          ]
+        }
+      }),
+    /must carry a string name/
+  )
+  await t.exception.all(
+    () =>
+      parseFitProcessResponse({
+        version: 1,
+        status: 'completed',
+        result: { ...completedFitResult(), projection: {} }
+      }),
+    /projection must be an array/
+  )
+})
+
 test('response parser rejects malformed results', async (t) => {
   await t.exception.all(() => parseFitProcessResponse(null), /must be an object/)
   await t.exception.all(

--- a/packages/model-fit/test/integration/fit.test.js
+++ b/packages/model-fit/test/integration/fit.test.js
@@ -286,12 +286,22 @@ test('a decided verdict carries its per-device memory projection', async functio
   t.is(host.name, 'host', 'the trailing row is the host')
   for (const row of res.projection) {
     t.ok(typeof row.name === 'string' && row.name.length > 0, 'row is named')
-    for (const key of ['totalBytes', 'freeBytes', 'modelBytes', 'contextBytes', 'computeBytes']) {
+    for (const key of [
+      'totalBytes',
+      'freeBytes',
+      'marginBytes',
+      'modelBytes',
+      'contextBytes',
+      'computeBytes'
+    ]) {
       t.ok(
         Number.isFinite(row[key]) && row[key] >= 0,
         `${row.name}.${key} is a non-negative number`
       )
     }
+    // The budget the verdict was judged against is `freeBytes - marginBytes`,
+    // so the row has to carry the margin the request asked for.
+    t.is(row.marginBytes, 1024 * 1024 * 1024, `${row.name} carries the requested margin`)
   }
 
   // Describes this load, not a machine snapshot: the weight bytes must land somewhere.

--- a/packages/model-fit/test/integration/fit.test.js
+++ b/packages/model-fit/test/integration/fit.test.js
@@ -274,6 +274,31 @@ test('fitParams on a real GGUF projects a load plan', async function (t) {
   }
 })
 
+test('a decided verdict carries its per-device memory projection', async function (t) {
+  const modelPath = process.env.FIT_MODEL_PATH || (await ensureModelPath())
+  const res = fitParams({ modelPath, nCtx: 2048, nCtxMin: 512, marginMiB: 1024 })
+
+  t.not(res.status, FIT_STATUS.ERROR, 'fixture yields a decided verdict')
+  t.ok(Array.isArray(res.projection), 'projection is present on a decided verdict')
+  t.ok(res.projection.length >= 1, 'projection has at least the host row')
+
+  const host = res.projection[res.projection.length - 1]
+  t.is(host.name, 'host', 'the trailing row is the host')
+  for (const row of res.projection) {
+    t.ok(typeof row.name === 'string' && row.name.length > 0, 'row is named')
+    for (const key of ['totalBytes', 'freeBytes', 'modelBytes', 'contextBytes', 'computeBytes']) {
+      t.ok(
+        Number.isFinite(row[key]) && row[key] >= 0,
+        `${row.name}.${key} is a non-negative number`
+      )
+    }
+  }
+
+  // Describes this load, not a machine snapshot: the weight bytes must land somewhere.
+  const projectedModelBytes = res.projection.reduce((sum, row) => sum + row.modelBytes, 0)
+  t.ok(projectedModelBytes > 0, 'the model bytes were projected onto some row')
+})
+
 test('the plan carries every parameter the fitter is free to rewrite', async function (t) {
   const modelPath = process.env.FIT_MODEL_PATH || (await ensureModelPath())
   const res = fitParams({ modelPath, nCtx: 2048, nCtxMin: 512, marginMiB: 1024 })

--- a/packages/model-fit/test/types/narrowing.test-d.ts
+++ b/packages/model-fit/test/types/narrowing.test-d.ts
@@ -3,7 +3,7 @@
 // way an SDK would rely on. Type-checked by `npm run test:dts`, never executed.
 
 import { fitParams, FIT_STATUS } from '../../index'
-import type { FitConfig, FitResult, FitReason, FitPlan } from '../../index'
+import type { FitConfig, FitResult, FitReason, FitPlan, FitProjectionRow } from '../../index'
 
 declare function assertNever (value: never): never
 
@@ -23,6 +23,16 @@ const devices: number = result.nDevices
 const accelerators: number = result.nGpuDevices
 void devices
 void accelerators
+
+// Readable on every branch, but optional: a consumer must handle absence.
+const projection: FitProjectionRow[] | undefined = result.projection
+const hostRow: FitProjectionRow | undefined = projection?.[projection.length - 1]
+const hostFree: number | undefined = hostRow?.freeBytes
+void hostFree
+
+// @ts-expect-error the projection is optional; unguarded access must not compile
+const unguarded: FitProjectionRow[] = result.projection
+void unguarded
 
 if (result.status === FIT_STATUS.SUCCESS) {
   // SUCCESS: the plan is fully present, no optional-chaining needed.

--- a/packages/model-fit/test/unit/FitResultContext.test.cpp
+++ b/packages/model-fit/test/unit/FitResultContext.test.cpp
@@ -2,20 +2,51 @@
 
 #include <iostream>
 
-int main() {
+namespace {
+
+model_fit::FitResult fittedWithZeroContext() {
   model_fit::FitResult result;
   result.status = 0;
   result.fits = true;
   result.reason = model_fit::FitReason::Fits;
   result.nCtx = 0;
+  result.projection.push_back({"MTL0", 1, 1, 1, 1, 1, 1});
+  result.projection.push_back({"host", 1, 1, 1, 1, 1, 1});
+  return result;
+}
 
-  model_fit::detail::finalizeFitContext(result, 0);
+} // namespace
 
-  if (result.status != 2 || result.fits ||
-      result.reason != model_fit::FitReason::ModelUnreadable) {
-    std::cerr << "missing trained context must produce "
-                 "ERROR/model-unreadable\n";
-    return 1;
+int main() {
+  {
+    model_fit::FitResult result = fittedWithZeroContext();
+    model_fit::detail::finalizeFitContext(result, 0);
+
+    if (result.status != 2 || result.fits ||
+        result.reason != model_fit::FitReason::ModelUnreadable) {
+      std::cerr << "missing trained context must produce "
+                   "ERROR/model-unreadable\n";
+      return 1;
+    }
+    if (!result.projection.empty()) {
+      std::cerr << "a downgrade to ERROR must drop the projection\n";
+      return 1;
+    }
+  }
+
+  {
+    model_fit::FitResult result = fittedWithZeroContext();
+    model_fit::detail::finalizeFitContext(result, 4096);
+
+    if (result.status != 0 || !result.fits || result.nCtx != 4096) {
+      std::cerr << "a readable trained context must fill nCtx and keep "
+                   "SUCCESS\n";
+      return 1;
+    }
+    if (result.projection.size() != 2) {
+      std::cerr << "a SUCCESS must keep its projection\n";
+      return 1;
+    }
   }
 
   return 0;


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

QVAC-24113. A fit verdict is a bare `fits` / `does-not-fit`. The fitter
computes projected per-device memory internally and fabric exposes it via
`common_get_device_memory_data`, but `@qvac/model-fit` dropped all of it.
Consumers could not:

- see how far a verdict sat from its budget — the measured gpt-oss-20B @128k
  f32-KV false negative (QVAC-22629 hardware evidence) was a few hundred MiB
  of projection error against a 1024 MiB margin, completely invisible in the
  result;
- reconcile a verdict with `getSystemResources`;
- tune margins from evidence instead of guesswork.

## 📝 How does it solve it?

`FitResult` gains an optional `projection`: one row per device the model was
assigned to (`llama_model_get_device` order, the `tensorSplit` index) plus a
trailing `"host"` row, each carrying `totalBytes`/`freeBytes` (the raw backend
gauge), `marginBytes` (the margin the fitter applied to the row) and
`modelBytes`/`contextBytes`/`computeBytes` (the projected demand at the
**resolved** parameters), captured with fabric's own
`common_get_device_memory_data` after the fit settles. The budget the verdict
was judged against is `freeBytes - marginBytes`.

- Populated on SUCCESS and FAILURE — a does-not-fit with numbers is the point.
  Empty on ERROR (including a `finalizeFitContext` downgrade), and empty when
  the extra no-alloc probe that gathers it fails: the projection is the
  verdict's explanation, and a missing explanation never changes the verdict
  (the probe costs roughly what the fit itself cost).
- In the llama-load (protocol v2) path the capture runs **before**
  `execution.tensorSplit` is moved into the result, while
  `modelParams.tensor_split` still points into that vector.
- Advisory semantics unchanged: `status`/`reason` behave exactly as before.

## 🔌 API Changes

Additive. `FitProjectionRow` is exported; `FitDeviceInventory` gains
`projection?: FitProjectionRow[]`, so it rides every outcome of both
`fitParams()` and the process protocol without widening the union.

```ts
const res = fitParams({ modelPath, nCtx: 32768 })
for (const row of res.projection ?? []) {
  const demand = row.modelBytes + row.contextBytes + row.computeBytes
  console.log(row.name, row.freeBytes - row.marginBytes - demand)
}
```

Optional because results decoded from an older addon or process runner predate
the field — the codec accepts absence, and rejects a present-but-malformed
projection as a malformed response. README documents the field and its
caveats (the rows inherit every limitation of the backend memory gauges; they
are "what the fitter believed", not ground truth).

## 🧪 How was it tested?

- `npm run test:process` — all protocol/codec cases pass, including new
  decoder cases: projection accepted on success and on does-not-fit, absence
  accepted, truncated row / missing name / missing margin / non-array all
  rejected.
- `npm run test:types` — typecheck, declaration-consumer narrowing (new
  coverage: optional access compiles, unguarded access is a
  `@ts-expect-error`), and `check:generated`.
- `npm run test:cpp` — `FitResultContext` unit test covers the downgrade
  dropping the projection and a SUCCESS keeping it.
- `npm run lint` — clean.
- New integration case (needs a runner with a real GGUF): a decided verdict
  carries named, non-negative rows ending in `"host"`, each carrying the
  requested margin, and the model bytes land on some row — i.e. the projection
  describes *this* load, not a generic machine snapshot.
- Local caveat as noted at the top: the pre-existing native-boundary runner
  test crashes at Metal init on clean `main` on this machine too, so native
  runtime verification is delegated to CI.

Acceptance fixture from the ticket for whoever runs it on a 24 GiB M4 Pro:
gpt-oss-20B @128k f32 KV should report a projection near the measured
~17.7 GiB real usage, making the margin-tipping visible.
