### PR TITLE
fix[notask]: stop the mobile Device Farm monitor hanging when _work/_temp is swept

### DIFF
--- a/.github/actions/run-mobile-integration-tests/monitor-test-run/action.yml
+++ b/.github/actions/run-mobile-integration-tests/monitor-test-run/action.yml
@@ -26,6 +26,15 @@ inputs:
     description: "JSON array from upload-to-devicefarm: [{name, grep, arn}]. Used to print a run-to-tests legend. Optional; omit for non-sharded runs."
     required: false
     default: "[]"
+  max-consecutive-aws-failures:
+    description: |
+      Abort the polling loop after this many CONSECUTIVE failed AWS calls. A
+      transient throttle clears within a cycle; a credential that has been
+      destroyed mid-job never does, and the loop cannot otherwise tell the two
+      apart from "test still running" (it just keeps polling to
+      max-wait-time-seconds). Default 5 ≈ 4 minutes.
+    required: false
+    default: "5"
 
 outputs:
   test-result:
@@ -60,21 +69,100 @@ runs:
         RUN_ARNS_JSON: ${{ inputs.run-arns }}
         MAX_WAIT_TIME_SECONDS: ${{ inputs.max-wait-time-seconds }}
         TEST_SPECS_JSON: ${{ inputs.test-specs }}
+        MAX_AWS_FAIL_STREAK: ${{ inputs.max-consecutive-aws-failures }}
       run: |
         set -euo pipefail
 
         # ── helpers ──────────────────────────────────────────────────
         # Bash 3.2 compat: no mapfile, no declare -A.
+
+        # The AWS CLI's two streams go to FILES, not shell variables. Every
+        # aws_retry call site consumes the function's stdout through $(...),
+        # which runs it in a SUBSHELL — anything assigned to a variable in
+        # there is lost to the caller, so a captured-stderr variable would
+        # always read back empty. A file survives the subshell.
+        #
+        # Deliberately not under $RUNNER_TEMP: _work/_temp is swept on this
+        # self-hosted fleet while jobs are still running, which is the very
+        # failure this diagnosis has to stay readable through.
+        AWS_IO_DIR="${RUNNER_WORKSPACE:-${GITHUB_WORKSPACE:-/tmp}}/.df-monitor-io"
+        rm -rf "$AWS_IO_DIR"
+        mkdir -p "$AWS_IO_DIR"
+        trap 'rm -rf "$AWS_IO_DIR"' EXIT
+        AWS_OUT_FILE="$AWS_IO_DIR/aws-stdout"
+        AWS_ERR_FILE="$AWS_IO_DIR/aws-stderr"
+        : > "$AWS_ERR_FILE"
+
+        aws_last_error() {
+          local err=""
+          err=$(tr '\n' ' ' < "$AWS_ERR_FILE" 2>/dev/null || true)
+          if [ -z "$err" ]; then
+            echo "<no stderr captured>"
+          else
+            echo "${err:0:400}"
+          fi
+        }
+
         aws_retry() {
-          local max_attempts=3 attempt=1 result=""
-          while [ $attempt -le $max_attempts ]; do
-            result=$("$@" 2>/dev/null) && { echo "$result"; return 0; }
-            echo "  ⚠️  AWS API attempt $attempt/$max_attempts failed, retrying in 5s..." >&2
+          local max_attempts=3 attempt=1 rc=0
+          while [ "$attempt" -le "$max_attempts" ]; do
+            rc=0
+            "$@" >"$AWS_OUT_FILE" 2>"$AWS_ERR_FILE" || rc=$?
+            if [ "$rc" -eq 0 ]; then
+              cat "$AWS_OUT_FILE"
+              return 0
+            fi
+            # This used to be `2>/dev/null`, so a permanently destroyed
+            # credential logged the same opaque line as a transient throttle.
+            # Run 33413219852 emitted 274 of them and nothing else, turning a
+            # one-line cause ("The config profile (seed) could not be found")
+            # into a two-hour hang and a two-hour investigation.
+            echo "  ⚠️  AWS API attempt $attempt/$max_attempts failed (exit $rc): $(aws_last_error)" >&2
             sleep 5
             attempt=$((attempt + 1))
           done
-          echo ""
           return 1
+        }
+
+        # ── permanent-failure guard ──────────────────────────────────
+        # The polling loop cannot distinguish "the AWS call failed" from "the
+        # test is still running": a failed poll simply leaves the slot
+        # unfinished and the loop sleeps again. A transient error clears on the
+        # next cycle; a deleted credential never does, so the step used to burn
+        # the entire max-wait budget without ever reading a result. Count
+        # CONSECUTIVE failures (reset by any success) and abort instead.
+        #
+        # aws_ok / aws_failed MUST be called from the main shell — never inside
+        # $(...) — or the counter update is discarded with the subshell.
+        AWS_FAIL_STREAK=0
+
+        diagnose_aws() {
+          echo "──────── AWS credential diagnosis ────────"
+          echo "AWS_PROFILE=${AWS_PROFILE:-<unset>}"
+          echo "AWS_CONFIG_FILE=${AWS_CONFIG_FILE:-<unset>}"
+          echo "last stderr: $(aws_last_error)"
+          if [ -n "${AWS_CONFIG_FILE:-}" ] && [ ! -f "${AWS_CONFIG_FILE}" ]; then
+            echo "::error title=AWS config file vanished::${AWS_CONFIG_FILE} no longer exists."
+            echo "It was written earlier in THIS job by 'Bootstrap auto-refreshing AWS"
+            echo "credentials' (seed-and-presign-models). Something outside the job deleted it"
+            echo "mid-run — on the self-hosted fleet that is the runner cleanup that sweeps"
+            echo "_work/_temp when any job on the host finishes, including a sibling job."
+          fi
+          echo "aws sts get-caller-identity:"
+          aws sts get-caller-identity --output text || true
+          echo "──────────────────────────────────────────"
+        }
+
+        aws_ok() { AWS_FAIL_STREAK=0; }
+
+        aws_failed() {
+          AWS_FAIL_STREAK=$((AWS_FAIL_STREAK + 1))
+          echo "::warning title=Device Farm monitor: AWS call failed::$1 failed (${AWS_FAIL_STREAK}/${MAX_AWS_FAIL_STREAK} consecutive): $(aws_last_error)"
+          if [ "$AWS_FAIL_STREAK" -ge "$MAX_AWS_FAIL_STREAK" ]; then
+            echo "::error title=Device Farm monitor: AWS unreachable::${MAX_AWS_FAIL_STREAK} consecutive AWS failures — aborting instead of polling on to the ${MAX_WAIT_TIME:-?}s ceiling. The Device Farm runs themselves may well be healthy; it is this observer that can no longer see them."
+            diagnose_aws
+            exit 1
+          fi
         }
 
         # ── parse ARNs ──────────────────────────────────────────────
@@ -200,51 +288,64 @@ runs:
           for ((i=0; i<RUN_COUNT; i++)); do
             arn="${RUN_ARNS[$i]}"
             if [ "${DONE[$i]}" != "true" ]; then
-              RUN_JSON=$(aws_retry aws devicefarm get-run --arn "$arn" --output json) || true
-              CUR_STATUS[$i]=$(echo "$RUN_JSON" | jq -r '.run.status // "UNKNOWN"')
-              CUR_RESULT[$i]=$(echo "$RUN_JSON" | jq -r '.run.result // "UNKNOWN"')
-              if [ "${CUR_STATUS[$i]}" = "COMPLETED" ]; then
-                DONE[$i]="true"
-                DONE_COUNT=$((DONE_COUNT + 1))
+              RUN_JSON=""
+              if RUN_JSON=$(aws_retry aws devicefarm get-run --arn "$arn" --output json); then
+                aws_ok
+              else
+                # Leave CUR_STATUS at its last known value rather than
+                # overwriting it with UNKNOWN: the run is almost certainly
+                # still fine, it is the observer that has gone blind, and a
+                # fake UNKNOWN transition would pollute the log on the way to
+                # the abort that aws_failed schedules.
+                aws_failed "get-run (Run $((i+1)))"
+                RUN_JSON=""
               fi
-
-              # Transition signals. RUNNING / COMPLETED get promoted
-              # to ::notice:: so they surface at the top of the job
-              # UI; everything else goes to a plain echo so the log
-              # still tells the full story without notice spam.
-              prev_status="${PREV_STATUS[$i]}"
-              cur_status="${CUR_STATUS[$i]}"
-              cur_result="${CUR_RESULT[$i]}"
-              if [ -n "$cur_status" ] && [ "$cur_status" != "$prev_status" ]; then
-                TS=$(date -u +%H:%M:%S)
-                if [ -z "$prev_status" ]; then
-                  # First observation. We don't know the real
-                  # transition time so just announce the attach.
-                  echo "🔌 Monitor attached: Run $((i+1)) starting from state=$cur_status (t=${ELAPSED}s)"
-                  if [ "$cur_status" = "RUNNING" ]; then
-                    RUNNING_AT[$i]=$ELAPSED
-                  fi
-                elif [ "$cur_status" = "RUNNING" ]; then
-                  if [ -z "${RUNNING_AT[$i]}" ]; then
-                    RUNNING_AT[$i]=$ELAPSED
-                    echo "::notice title=Device Farm Run $((i+1)) acquired device::[$TS] $prev_status -> RUNNING after ${ELAPSED}s of queue time"
-                  fi
-                elif [ "$cur_status" = "COMPLETED" ]; then
-                  running_at="${RUNNING_AT[$i]}"
-                  if [ -n "$running_at" ]; then
-                    exec_time=$((ELAPSED - running_at))
-                    echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | queued ${running_at}s | executed ${exec_time}s | total ${ELAPSED}s"
-                  else
-                    # Defensive: COMPLETED without ever observing
-                    # RUNNING means we missed the RUNNING window between
-                    # two 30s polls (rare, trivially short runs) or the
-                    # run errored straight from a pending state.
-                    echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | total ${ELAPSED}s (no RUNNING window observed)"
-                  fi
-                else
-                  echo "🔄 Run $((i+1)): $prev_status -> $cur_status (elapsed ${ELAPSED}s)"
+              if [ -n "$RUN_JSON" ]; then
+                CUR_STATUS[$i]=$(echo "$RUN_JSON" | jq -r '.run.status // "UNKNOWN"')
+                CUR_RESULT[$i]=$(echo "$RUN_JSON" | jq -r '.run.result // "UNKNOWN"')
+                if [ "${CUR_STATUS[$i]}" = "COMPLETED" ]; then
+                  DONE[$i]="true"
+                  DONE_COUNT=$((DONE_COUNT + 1))
                 fi
-                PREV_STATUS[$i]="$cur_status"
+
+                # Transition signals. RUNNING / COMPLETED get promoted
+                # to ::notice:: so they surface at the top of the job
+                # UI; everything else goes to a plain echo so the log
+                # still tells the full story without notice spam.
+                prev_status="${PREV_STATUS[$i]}"
+                cur_status="${CUR_STATUS[$i]}"
+                cur_result="${CUR_RESULT[$i]}"
+                if [ -n "$cur_status" ] && [ "$cur_status" != "$prev_status" ]; then
+                  TS=$(date -u +%H:%M:%S)
+                  if [ -z "$prev_status" ]; then
+                    # First observation. We don't know the real
+                    # transition time so just announce the attach.
+                    echo "🔌 Monitor attached: Run $((i+1)) starting from state=$cur_status (t=${ELAPSED}s)"
+                    if [ "$cur_status" = "RUNNING" ]; then
+                      RUNNING_AT[$i]=$ELAPSED
+                    fi
+                  elif [ "$cur_status" = "RUNNING" ]; then
+                    if [ -z "${RUNNING_AT[$i]}" ]; then
+                      RUNNING_AT[$i]=$ELAPSED
+                      echo "::notice title=Device Farm Run $((i+1)) acquired device::[$TS] $prev_status -> RUNNING after ${ELAPSED}s of queue time"
+                    fi
+                  elif [ "$cur_status" = "COMPLETED" ]; then
+                    running_at="${RUNNING_AT[$i]}"
+                    if [ -n "$running_at" ]; then
+                      exec_time=$((ELAPSED - running_at))
+                      echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | queued ${running_at}s | executed ${exec_time}s | total ${ELAPSED}s"
+                    else
+                      # Defensive: COMPLETED without ever observing
+                      # RUNNING means we missed the RUNNING window between
+                      # two 30s polls (rare, trivially short runs) or the
+                      # run errored straight from a pending state.
+                      echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | total ${ELAPSED}s (no RUNNING window observed)"
+                    fi
+                  else
+                    echo "🔄 Run $((i+1)): $prev_status -> $cur_status (elapsed ${ELAPSED}s)"
+                  fi
+                  PREV_STATUS[$i]="$cur_status"
+                fi
               fi
             fi
             [ -n "$STATUS_LINE" ] && STATUS_LINE="${STATUS_LINE} | "
@@ -267,7 +368,13 @@ runs:
               for ((i=0; i<RUN_COUNT; i++)); do
                 if [ "${CUR_STATUS[$i]}" = "RUNNING" ]; then
                   arn="${RUN_ARNS[$i]}"
-                  JOBS_JSON=$(aws_retry aws devicefarm list-jobs --arn "$arn" --output json) || true
+                  JOBS_JSON=""
+                  if JOBS_JSON=$(aws_retry aws devicefarm list-jobs --arn "$arn" --output json); then
+                    aws_ok
+                  else
+                    aws_failed "list-jobs (Run $((i+1)), deep dive)"
+                    JOBS_JSON=""
+                  fi
                   if [ -n "$JOBS_JSON" ]; then
                     echo "Run $((i+1)):"
                     echo "$JOBS_JSON" | jq -r '.jobs[]? | "  device=\(.device.name // "?") os=\(.device.os // "?") | state=\(.status // "?") result=\(.result // "?") | counters=\((.counters // {}).passed // 0)P/\((.counters // {}).failed // 0)F/\((.counters // {}).errored // 0)E/\((.counters // {}).skipped // 0)S of \((.counters // {}).total // 0) | started=\(.started // "-") msg=\((.message // "") | gsub("\n"; " ") | .[0:120])"' || echo "  (jq parse failed)"
@@ -314,7 +421,13 @@ runs:
         RUN_INDEX=0
         for RUN_ARN in "${RUN_ARNS[@]}"; do
           RUN_INDEX=$((RUN_INDEX + 1))
-          RUN_DETAILS=$(aws_retry aws devicefarm get-run --arn "$RUN_ARN" --output json) || true
+          RUN_DETAILS=""
+          if RUN_DETAILS=$(aws_retry aws devicefarm get-run --arn "$RUN_ARN" --output json); then
+            aws_ok
+          else
+            aws_failed "get-run (Run $RUN_INDEX, final aggregation)"
+            RUN_DETAILS=""
+          fi
           [ -z "$RUN_DETAILS" ] && RUN_DETAILS='{}'
           RESULT=$(echo "$RUN_DETAILS" | jq -r '.run.result // "UNKNOWN"')
           RUN_NAME_LABEL=$(echo "$RUN_DETAILS" | jq -r '.run.name // "unknown"')
@@ -349,11 +462,23 @@ runs:
             echo "Result: $RESULT"
           fi
 
-          JOBS=$(aws_retry aws devicefarm list-jobs --arn "$RUN_ARN" --output json) || true
+          JOBS=""
+          if JOBS=$(aws_retry aws devicefarm list-jobs --arn "$RUN_ARN" --output json); then
+            aws_ok
+          else
+            aws_failed "list-jobs (Run $RUN_INDEX, final aggregation)"
+            JOBS=""
+          fi
           [ -z "$JOBS" ] && JOBS='{"jobs":[]}'
           for JOB_ARN in $(echo "$JOBS" | jq -r '.jobs[].arn'); do
             DEVICE_COUNT=$((DEVICE_COUNT + 1))
-            JOB_DETAILS=$(aws_retry aws devicefarm get-job --arn "$JOB_ARN" --output json) || true
+            JOB_DETAILS=""
+            if JOB_DETAILS=$(aws_retry aws devicefarm get-job --arn "$JOB_ARN" --output json); then
+              aws_ok
+            else
+              aws_failed "get-job ($JOB_ARN)"
+              JOB_DETAILS=""
+            fi
             [ -z "$JOB_DETAILS" ] && JOB_DETAILS='{}'
             DEVICE_NAME=$(echo "$JOB_DETAILS" | jq -r '.job.device.name // "Unknown Device"')
             JOB_RESULT=$(echo "$JOB_DETAILS" | jq -r '.job.result // "UNKNOWN"')

--- a/.github/actions/run-mobile-integration-tests/seed-and-presign-models/action.yml
+++ b/.github/actions/run-mobile-integration-tests/seed-and-presign-models/action.yml
@@ -57,7 +57,20 @@ runs:
         # credential_process helper the AWS CLI re-invokes near expiry, so a long
         # first seed survives the 2h STS cap. It mints a fresh OIDC JWT and
         # exchanges it via assume-role-with-web-identity (no pre-existing creds).
-        CRED_HELPER="${RUNNER_TEMP}/oidc-cred-process-seed.sh"
+        # NOT $RUNNER_TEMP. On the self-hosted fleet _work/_temp is swept while
+        # jobs are still running — the runner's job-completed hook fires for any
+        # job on the host and takes files belonging to jobs that have not
+        # finished. The profile and its credential_process helper then vanish
+        # mid-job and every subsequent AWS call fails with "The config profile
+        # (seed) could not be found": immediately in a short step, or as a
+        # two-hour hang in the Device Farm polling loop (run 33413219852).
+        # $RUNNER_WORKSPACE (_work/<repo>) is per-runner-instance, lives outside
+        # _temp, and is outside the addon checkout that gets bundled into the
+        # Device Farm app — so nothing sweeps it and nothing ships it.
+        CRED_DIR="${RUNNER_WORKSPACE:-${GITHUB_WORKSPACE:-${RUNNER_TEMP}}}/.qvac-aws-seed"
+        mkdir -p "${CRED_DIR}"
+        chmod 700 "${CRED_DIR}"
+        CRED_HELPER="${CRED_DIR}/oidc-cred-process-seed.sh"
         cat > "${CRED_HELPER}" <<'HELPER'
         #!/usr/bin/env bash
         set -euo pipefail
@@ -78,7 +91,7 @@ runs:
         HELPER
         chmod +x "${CRED_HELPER}"
 
-        AWS_CONFIG_FILE="${RUNNER_TEMP}/aws-config-seed"
+        AWS_CONFIG_FILE="${CRED_DIR}/aws-config-seed"
         cat > "${AWS_CONFIG_FILE}" <<CONFIG
         [profile seed]
         credential_process = ${CRED_HELPER}

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -285,7 +285,10 @@ jobs:
           manifest-path: addon/${{ inputs.workdir || 'packages/diffusion-cpp' }}/test/integration/models.manifest.json
           s3-prefix: qvac_models_compiled/mobile-pilot/diffusion/
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          output-map: ${{ runner.temp }}/diffusion-url-map.json
+          # github.workspace, not runner.temp: _work/_temp is swept mid-job on
+          # the self-hosted fleet, which has already made this map disappear
+          # between the presign step and the step that reads it.
+          output-map: ${{ github.workspace }}/diffusion-url-map.json
           # Only the two models a phone actually downloads (the rest are
           # skip = isMobile || noGpu and keep their HF fallback).
           model-names: stable-diffusion-v2-1-Q8_0.gguf,RealESRGAN_x4plus_anime_6B.pth
@@ -296,7 +299,7 @@ jobs:
       - name: Repoint diffusion manifest to US bucket
         env:
           MANIFEST_PATH: addon/${{ inputs.workdir || 'packages/diffusion-cpp' }}/test/integration/models.manifest.json
-          URL_MAP: ${{ runner.temp }}/diffusion-url-map.json
+          URL_MAP: ${{ github.workspace }}/diffusion-url-map.json
         run: |
           node ./.github/actions/run-mobile-integration-tests/seed-and-presign-models/rewrite-manifest-urls.mjs
 

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -306,7 +306,10 @@ jobs:
           manifest-path: addon/packages/embed-llamacpp/test/integration/models.manifest.json
           s3-prefix: qvac_models_compiled/mobile-pilot/embed/
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          output-map: ${{ runner.temp }}/embed-url-map.json
+          # github.workspace, not runner.temp: _work/_temp is swept mid-job on
+          # the self-hosted fleet, which has already made this map disappear
+          # between the presign step and the prestage step that reads it.
+          output-map: ${{ github.workspace }}/embed-url-map.json
           mode: presign
 
       # Generate the model pre-stage script. The Device Farm host has reliable
@@ -319,7 +322,7 @@ jobs:
         working-directory: addon/packages/embed-llamacpp
         # Repoint staged models to the US-bucket presigned URLs from the seed step.
         env:
-          PRESTAGE_URL_MAP: ${{ runner.temp }}/embed-url-map.json
+          PRESTAGE_URL_MAP: ${{ github.workspace }}/embed-url-map.json
         run: |
           node scripts/generate-prestage-block.js android > "$RUNNER_TEMP/prestage-block.txt"
           {
@@ -334,7 +337,7 @@ jobs:
         working-directory: addon/packages/embed-llamacpp
         # Repoint staged models to the US-bucket presigned URLs from the seed step.
         env:
-          PRESTAGE_URL_MAP: ${{ runner.temp }}/embed-url-map.json
+          PRESTAGE_URL_MAP: ${{ github.workspace }}/embed-url-map.json
         run: |
           node scripts/generate-prestage-block.js ios > "$RUNNER_TEMP/prestage-block.txt"
           {

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -474,7 +474,11 @@ jobs:
           manifest-path: addon/packages/llm-llamacpp/test/integration/models.manifest.json
           s3-prefix: qvac_models_compiled/mobile-pilot/llm/
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          output-map: ${{ runner.temp }}/llm-url-map.json
+          # github.workspace, not runner.temp: _work/_temp is swept mid-job on
+          # the self-hosted fleet, which has already made this map disappear
+          # between the presign step and the prestage step that reads it
+          # (ENOENT on _work/_temp/llm-url-map.json, run 33382613103 attempt 4).
+          output-map: ${{ github.workspace }}/llm-url-map.json
           model-names: ${{ steps.mobileset.outputs.names }}
           mode: presign
 
@@ -513,7 +517,7 @@ jobs:
         working-directory: addon/packages/llm-llamacpp
         # Repoint staged models to the US-bucket presigned URLs from the seed step.
         env:
-          PRESTAGE_URL_MAP: ${{ runner.temp }}/llm-url-map.json
+          PRESTAGE_URL_MAP: ${{ github.workspace }}/llm-url-map.json
         run: |
           node scripts/generate-prestage-block.js android > "$RUNNER_TEMP/prestage-block.txt"
           {
@@ -528,7 +532,7 @@ jobs:
         working-directory: addon/packages/llm-llamacpp
         # Repoint staged models to the US-bucket presigned URLs from the seed step.
         env:
-          PRESTAGE_URL_MAP: ${{ runner.temp }}/llm-url-map.json
+          PRESTAGE_URL_MAP: ${{ github.workspace }}/llm-url-map.json
         run: |
           node scripts/generate-prestage-block.js ios > "$RUNNER_TEMP/ios-prestage-block.txt"
           {


### PR DESCRIPTION
## 🎯 Problem

The Android leg of the mobile integration tests can burn its entire 120-minute budget without ever reading a Device Farm result.

Run [33413219852](https://github.com/tetherto/qvac/actions/runs/33413219852) (`embed-llamacpp`, Samsung Galaxy S25 Ultra) did exactly that on both attempts. The devices were acquired and the tests were `RUNNING`:

```
18:39:45  ⏳ Run 1: RUNNING (PENDING) | Run 2: RUNNING (PENDING) | 60s      ← healthy
18:40:16  ⚠️  AWS API attempt 1/3 failed, retrying in 5s...                ← never recovers
          … 274 identical lines …
19:29:38  job cancelled (attempt 1 had already hit the 120-min timeout)
```

Nothing was wrong with the branch or the test suite. The devices were fine; the **observer** lost its credentials.

The AWS profile the monitor authenticates with lives in `$RUNNER_TEMP` (`_work/_temp`), which is swept on the self-hosted fleet **while jobs are still running** — the runner's job-completed hook fires for any job on the host and takes files belonging to jobs that have not finished. The profile and its `credential_process` helper vanish mid-job, and every subsequent AWS call fails with `The config profile (seed) could not be found`.

Three separate defects turned that into a two-hour hang rather than a one-line error:

1. **`aws_retry` sent the CLI's stderr to `/dev/null`.** A permanently destroyed credential logged the same opaque line as a transient throttle, so the actual message never reached the log.
2. **The polling loop could not distinguish "AWS call failed" from "test still running".** A failed poll simply left the slot unfinished and the loop slept again — for two hours.
3. **The credential seed lives in a directory that gets swept**, which is the cause itself.

The same fault has been seen in `llm-llamacpp` (immediate, legible failures in short steps, including `ENOENT` on `_work/_temp/llm-url-map.json`) and `model-fit`. `embed` runs the longest Device Farm suite of the four, so its monitoring window is the widest — and the window is exactly the exposure.

## 📝 How

**`monitor-test-run/action.yml`**

- `aws_retry` now captures the AWS CLI's stderr and prints it on every failed attempt. The two streams go to **files**, not shell variables, on purpose: every call site consumes `aws_retry`'s stdout through `$(...)`, which runs the function in a subshell, so anything it assigns to a variable is discarded before the caller can read it. (The obvious `err=$({ result=$(cmd 2>&1 1>&3); } 3>&1)` idiom has this exact bug — `result` comes back empty.)
- A consecutive-failure guard: `aws_ok` / `aws_failed` bookend all five `aws_retry` call sites and track a streak that any success resets. After `max-consecutive-aws-failures` (new input, default **5** ≈ 4 min) the step aborts with a credential diagnosis that checks whether `$AWS_CONFIG_FILE` still exists and says so by name, instead of polling on to the ceiling.
- On a failed poll the slot keeps its **last known** status rather than being overwritten with `UNKNOWN`, so the log doesn't fill with fake transitions on the way to the abort.

**`seed-and-presign-models/action.yml`**

- The `[profile seed]` config and its OIDC `credential_process` helper move from `$RUNNER_TEMP` to `${RUNNER_WORKSPACE}/.qvac-aws-seed` (mode `0700`), falling back to `$GITHUB_WORKSPACE` then `$RUNNER_TEMP`. `_work/<repo>` is per-runner-instance, is outside `_temp`, and is outside the addon checkout that gets bundled into the Device Farm app — so nothing sweeps it and nothing ships it.

**`integration-mobile-test-{embed-llamacpp,llm-llamacpp,diffusion-cpp}.yml`**

- The presigned-URL maps move from `${{ runner.temp }}` to `${{ github.workspace }}` for the same reason. This one is not hypothetical: `llm`'s map has already disappeared between the presign step that writes it and the prestage step that reads it.

## 🧪 Tested

The monitor step's script was extracted from the YAML and driven against a stubbed `aws` CLI on **bash 3.2** (the version the file's `# Bash 3.2 compat` note targets), under the real env the action sets:

| Scenario | Expected | Result |
|---|---|---|
| All calls succeed, run `COMPLETED`/`PASSED` | green, output unchanged | ✅ exit 0, identical summary/outputs to before |
| Healthy poll, then every call fails (credential destroyed) | fast red, real cause in the log | ✅ exit 1 after 5 consecutive failures; each attempt logs `The config profile (seed) could not be found`; diagnosis names the missing config file |
| 4 consecutive failures, then recovery | streak resets, run completes | ✅ exit 0, no abort |

Also verified:
- The credential bootstrap step run in isolation writes `aws-config-seed` + `oidc-cred-process-seed.sh` under `$RUNNER_WORKSPACE/.qvac-aws-seed` (`drwx------`), points the profile at the helper, exports the new `AWS_CONFIG_FILE` through `GITHUB_ENV`, and the generated helper passes `bash -n`.
- All 5 changed files parse as YAML, and every embedded `run:` script in them passes `bash -n`.
- No step in the three touched workflows asserts a clean tree, so the url-map landing in the workspace is inert.

Not verified locally: real Device Farm behaviour. Suggested check on merge — re-run embed Android and confirm the credentials no longer resolve under `_work/_temp`, and that a long suite survives a sibling job finishing on the same runner.

## ⚠️ Breaking

None. `max-consecutive-aws-failures` is a new optional input with a default; every existing caller is unchanged.

**This is a mitigation, not the root cause.** The runner cleanup that deletes `_work/_temp` files belonging to *running* jobs still needs a DevOps fix — either scope the sweep to the completing job's own temp directory, or give each runner instance an isolated `_temp`. Until then, other consumers of `$RUNNER_TEMP` in this pipeline remain exposed (notably the multi-GB model download dir in `seed-and-presign.mjs`, which uses `os.tmpdir()`, and the runner's own `_runner_file_commands`, which no workflow change can protect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
