### PR TITLE
fix: resolve the ggml backends directory from the addon's real path

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.48.1] - 2026-09-01
+
+### Fixed
+
+- Model load inside a bundled application no longer fails with a misleading
+  `failed to fit params to free device memory`. The backends directory was
+  derived from `__dirname`, which in a `bare-build --standalone` or `bare-pack`
+  bundle is a path inside the bundle (`/app.bundle/...`) and not a real
+  directory. ggml skipped enumeration of that path, fell back to probing the
+  plain name `libqvac-ggml-cpu.so` -- which is never built, because
+  `GGML_CPU_ALL_VARIANTS` produces only microarch-tagged variants -- and
+  registered no CPU backend at all. `llama.cpp` needs a CPU device for host
+  buffers even when every layer is offloaded, so the load failed.
+
+  The directory is now derived from `require.addon.resolve()`, which reports the
+  addon's real on-disk location in both dev and bundled builds. Affects
+  `linux-*` and `android-*`, where ggml backends ship as sibling `.so` files;
+  Apple and Windows targets link them in and were never affected. In an
+  unbundled tree the resolved path is identical to the previous value, so there
+  is no behavioural change for existing deployments.
+
 ## [0.48.0] - 2026-08-31
 
 ### Removed

--- a/packages/llm-llamacpp/addon.js
+++ b/packages/llm-llamacpp/addon.js
@@ -4,6 +4,7 @@ exports.LlamaInterface = void 0;
 exports.mapAddonEvent = mapAddonEvent;
 /* eslint-disable @typescript-eslint/no-require-imports -- Bare modules expose CommonJS export shapes. */
 const path = require("bare-path");
+const fs = require("bare-fs");
 // Index-matched to the C++ GenerationStopReason enum (SequenceDriver.hpp).
 const STOP_REASONS = [
     "none",
@@ -70,6 +71,50 @@ function mapAddonEvent(rawEvent, rawData, rawError) {
     return { type: type, data: rawData, error: rawError };
 }
 /**
+ * Resolve the directory holding this platform's prebuilt ggml backends.
+ *
+ * `__dirname` is not usable here. In a bundled app -- `bare-build --standalone`
+ * or any `bare-pack` bundle -- it is a path *inside* the bundle
+ * (`/app.bundle/node_modules/@qvac/llm-llamacpp`, or `<bundle-file>/...`),
+ * which is not a real directory. ggml's `fs::exists()` check on it then fails,
+ * `ggml_backend_load_all_from_path()` skips enumeration entirely, and no CPU
+ * backend is ever registered -- surfacing as a misleading
+ * "failed to fit params to free device memory" from common/fit.cpp.
+ *
+ * `require.addon.resolve()` reports the addon's real on-disk location in both
+ * dev and bundled builds, so derive the directory from that instead. In an
+ * unbundled tree it yields exactly what `path.join(__dirname, "prebuilds")`
+ * did, so this is a no-op for existing deployments.
+ *
+ * Returns undefined when nothing usable is found, so the caller can leave
+ * `backendsDir` unset and let ggml fall back to its own executable-dir/cwd
+ * search (LlamaLazyInitializeBackend.cpp calls plain `ggml_backend_load_all()`
+ * when backendsDir is empty). Passing a known-bad path is strictly worse than
+ * passing none, because a non-null dir_path replaces those defaults.
+ */
+function resolveBackendsDir() {
+    try {
+        // IMPORTANT: keep this as a literal `require.addon.resolve(".")` call.
+        // bare-pack resolves addons by *statically* traversing this expression at
+        // pack time and recording an entry for the referring module. Hoisting it
+        // into a variable or calling it indirectly makes the traversal miss it, and
+        // the call then throws ADDON_NOT_FOUND at runtime inside a bundle -- which
+        // silently reintroduces exactly the bug this function exists to fix.
+        // `resolve` is typed `unknown` (see src/bare-modules.d.ts); the guard below
+        // is what makes it a string.
+        // <...>/prebuilds/<host>/<module>.bare  ->  <...>/prebuilds
+        const resolved = require.addon.resolve(".");
+        if (typeof resolved === "string" && resolved.length > 0) {
+            return path.dirname(path.dirname(resolved));
+        }
+    }
+    catch {
+        // No addon resolvable for this host; fall through to the __dirname guess.
+    }
+    const fromDirname = path.join(__dirname, "prebuilds");
+    return fs.existsSync(fromDirname) ? fromDirname : undefined;
+}
+/**
  * An interface between Bare addon in C++ and JS runtime.
  */
 class LlamaInterface {
@@ -81,7 +126,10 @@ class LlamaInterface {
             configurationParams.config = {};
         }
         if (!configurationParams.config.backendsDir) {
-            configurationParams.config.backendsDir = path.join(__dirname, "prebuilds");
+            const backendsDir = resolveBackendsDir();
+            if (backendsDir !== undefined) {
+                configurationParams.config.backendsDir = backendsDir;
+            }
         }
         this._handle = this._binding.createInstance(this, configurationParams, outputCb, null);
     }

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/llm-llamacpp/src/addon.ts
+++ b/packages/llm-llamacpp/src/addon.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports -- Bare modules expose CommonJS export shapes. */
 import path = require("bare-path");
+import fs = require("bare-fs");
 /* eslint-enable @typescript-eslint/no-require-imports */
 import type { FinetuneOptions, GenerationParams } from "./index";
 
@@ -185,6 +186,51 @@ export function mapAddonEvent(
 }
 
 /**
+ * Resolve the directory holding this platform's prebuilt ggml backends.
+ *
+ * `__dirname` is not usable here. In a bundled app -- `bare-build --standalone`
+ * or any `bare-pack` bundle -- it is a path *inside* the bundle
+ * (`/app.bundle/node_modules/@qvac/llm-llamacpp`, or `<bundle-file>/...`),
+ * which is not a real directory. ggml's `fs::exists()` check on it then fails,
+ * `ggml_backend_load_all_from_path()` skips enumeration entirely, and no CPU
+ * backend is ever registered -- surfacing as a misleading
+ * "failed to fit params to free device memory" from common/fit.cpp.
+ *
+ * `require.addon.resolve()` reports the addon's real on-disk location in both
+ * dev and bundled builds, so derive the directory from that instead. In an
+ * unbundled tree it yields exactly what `path.join(__dirname, "prebuilds")`
+ * did, so this is a no-op for existing deployments.
+ *
+ * Returns undefined when nothing usable is found, so the caller can leave
+ * `backendsDir` unset and let ggml fall back to its own executable-dir/cwd
+ * search (LlamaLazyInitializeBackend.cpp calls plain `ggml_backend_load_all()`
+ * when backendsDir is empty). Passing a known-bad path is strictly worse than
+ * passing none, because a non-null dir_path replaces those defaults.
+ */
+function resolveBackendsDir(): string | undefined {
+  try {
+    // IMPORTANT: keep this as a literal `require.addon.resolve(".")` call.
+    // bare-pack resolves addons by *statically* traversing this expression at
+    // pack time and recording an entry for the referring module. Hoisting it
+    // into a variable or calling it indirectly makes the traversal miss it, and
+    // the call then throws ADDON_NOT_FOUND at runtime inside a bundle -- which
+    // silently reintroduces exactly the bug this function exists to fix.
+    // `resolve` is typed `unknown` (see src/bare-modules.d.ts); the guard below
+    // is what makes it a string.
+    // <...>/prebuilds/<host>/<module>.bare  ->  <...>/prebuilds
+    const resolved = require.addon.resolve(".");
+    if (typeof resolved === "string" && resolved.length > 0) {
+      return path.dirname(path.dirname(resolved));
+    }
+  } catch {
+    // No addon resolvable for this host; fall through to the __dirname guess.
+  }
+
+  const fromDirname = path.join(__dirname, "prebuilds");
+  return fs.existsSync(fromDirname) ? fromDirname : undefined;
+}
+
+/**
  * An interface between Bare addon in C++ and JS runtime.
  */
 export class LlamaInterface {
@@ -203,7 +249,10 @@ export class LlamaInterface {
     }
 
     if (!configurationParams.config.backendsDir) {
-      configurationParams.config.backendsDir = path.join(__dirname, "prebuilds");
+      const backendsDir = resolveBackendsDir();
+      if (backendsDir !== undefined) {
+        configurationParams.config.backendsDir = backendsDir;
+      }
     }
 
     this._handle = this._binding.createInstance(this, configurationParams, outputCb, null);

--- a/packages/llm-llamacpp/src/bare-modules.d.ts
+++ b/packages/llm-llamacpp/src/bare-modules.d.ts
@@ -2,5 +2,19 @@
 declare module "bare-path" {
   export function join(...paths: string[]): string;
   export function basename(path: string): string;
+  export function dirname(path: string): string;
   export function isAbsolute(path: string): boolean;
+}
+
+// Bare's `require` carries an `addon` surface that @types/node's NodeJS.Require
+// does not model. Only the part resolveBackendsDir() in addon.ts needs.
+// `resolve` is intentionally `unknown` (matching bare-module's own typing) so
+// callers must narrow it.
+declare namespace NodeJS {
+  interface Require {
+    addon: {
+      (specifier?: string): unknown;
+      resolve(specifier: string): unknown;
+    };
+  }
 }


### PR DESCRIPTION
## Problem

Loading a model inside a **bundled** application fails on desktop Linux with a misleading error:

```
common_fit_params: encountered an error while trying to fit params to free device memory: failed to load model
cmn  common_init_: failed to load model '…_Llama-3.2-1B-Instruct-Q4_0.gguf'
```

Nothing about memory is wrong. Reported against a `bare-build --standalone` binary on CachyOS; **reproduced
here on Ubuntu 22.04 with byte-identical output**, so it is not a distro issue. Also reproduced with a plain
`bare-pack --offload` bundle, so it is not specific to `--standalone`.

## Cause

`backendsDir` was derived from `__dirname`. In any bundled build that is a path *inside* the bundle
(`/app.bundle/node_modules/@qvac/llm-llamacpp`, or `<bundle-file>/…`), which is not a real directory. So:

1. ggml's `fs::exists()` check on it fails, and `ggml_backend_load_all_from_path()` skips enumeration
   entirely — no directory listing, no `ggml_backend_score` comparison, no variant selection.
2. It falls back to probing the exact base name `libqvac-ggml-cpu.so`, which is **never built** —
   `GGML_CPU_ALL_VARIANTS` produces only microarch-tagged variants (`-zen4`, `-alderlake`, …).
3. No CPU backend registers. `llama.cpp` needs a CPU device for host buffers even when every layer is
   offloaded, so the load fails, and `common/fit.cpp` relabels it under a memory-fit banner.

`libqvac-ggml-vulkan.so` has a single variant and therefore a plain name, so it loads from that *same*
directory by that *same* fallback. That asymmetry is why a healthy GPU init line appears immediately before
the failure — and why this is easy to misdiagnose as a VRAM problem:

```
openat(… "/tmp/<app>-<hash>/…/libqvac-ggml-cpu.so",    O_RDONLY|O_CLOEXEC) = -1 ENOENT
openat(… "/tmp/<app>-<hash>/…/libqvac-ggml-vulkan.so", O_RDONLY|O_CLOEXEC) = 13
```

## Fix

Derive the directory from `require.addon.resolve()`, which reports the addon's real on-disk location in both
dev and bundled builds. Return `undefined` when nothing resolves, so `backendsDir` is left unset and
`LlamaLazyInitializeBackend` falls back to plain `ggml_backend_load_all()` — passing a known-bad path is
strictly worse than passing none, because a non-null `dir_path` *replaces* ggml's executable-dir and cwd
defaults.

No C++, no new platform-conditional code.

## Verification (linux-x64)

Measured under `strace`, standalone bundle, no env vars, no symlinks:

| | before | **after** | dev mode |
|---|---|---|---|
| `O_DIRECTORY` opens on the backend dir | 0 | **15** | 15 |
| CPU variants probed | 0 | **all 14** | all 14 |
| Variant selected | none | **`alderlake`** | `alderlake` |
| `/app.bundle` backend lookups | many | **0** | n/a |
| Result | fails | **loads** | loads |

**No behavioural change unbundled.** In a normal `node_modules` tree the resolved value is identical to what
`path.join(__dirname, "prebuilds")` produced, confirmed by probe. The SDK runs the unbundled
`worker.entry.mjs` on desktop, so Node, Electron and Snap consumers are unaffected either way.

Checks run locally: `build:ts`, `typecheck`, `lint:ts`, `lint:js`, `test:types:consumer` — all clean, and
`build:ts` is idempotent so `check:generated` will pass.

## Reviewer note — please keep the call form

`require.addon.resolve(".")` must stay a **literal** expression. `bare-pack` resolves addons by *statically*
traversing it at pack time; hoisting it into a variable or calling it indirectly makes the traversal miss it,
and the call then throws `ADDON_NOT_FOUND` at runtime inside a bundle — silently reintroducing this exact bug.
I hit this while developing the patch, hence the comment in the code.

## Scope / follow-ups (not in this PR)

- **Five sibling addons have the identical defect** and need the same change: `embed-llamacpp`, `model-fit`,
  `vla-ggml`, `ocr-ggml`, `translation-nmtcpp` — all `qvac-fabric` consumers with a `__dirname`-derived
  backends path. (`model-fit` already guards with `statSync`, so it degrades rather than misdirects.)
  Identified by inspection; not built or run.
- **No CI lane builds a bundled desktop-Linux app**, on any distro — which is why this shipped. A single
  `linux-x64` smoke test that builds a `--standalone` binary and loads a model would have caught it.
- **Fail loudly when no CPU backend registers.** The true error (`no CPU backend found`) is never printed at
  all today — grepping the failure log for it returns nothing. That absence is what turned this into roughly
  a day of debugging.
- Not affected: `darwin-*`, `ios-*`, `win32-x64` link the backends into the addon. Android has an
  `#ifdef __ANDROID__` bare-name fallback list, so it degrades quietly instead of failing — separately, that
  list stops at `armv8.6_1` while the build produces `armv9.x`, which deserves its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
