### PR TITLE
fix[notask]: keep the audiogen-ggml native binding in the mobile app bundle

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore mobile (Android / iOS) support. The generated `index.js` carried a
+  template literal whose two quoted `${exports.…}` interpolations desynchronised
+  `bare-module-lexer`, so `bare-pack` stopped discovering imports partway
+  through the file and left `binding.js` out of the app bundle. Every on-device
+  model load then failed with `MODULE_NOT_FOUND: Cannot find module './binding'`,
+  even though the file ships in the tarball. The engine validation message is
+  now assembled without that construct, and a package test asserts every
+  relative `require` in the generated scripts stays visible to the bundler.
+
 ## [0.3.1] - 2026-08-28
 
 ### Added

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -27,6 +27,7 @@ const audio_format_1 = require("./lib/audio-format");
 const error_1 = require("./error");
 exports.ENGINE_ACESTEP = 'acestep';
 exports.ENGINE_MINIMAX = 'minimax';
+const SUPPORTED_ENGINES = [exports.ENGINE_ACESTEP, exports.ENGINE_MINIMAX];
 exports.MINIMAX_FRAMES_PER_SECOND = 25;
 exports.MINIMAX_DEFAULT_MAX_FRAMES = 300;
 const MINIMAX_MIN_FRAMES = 1;
@@ -247,9 +248,15 @@ const ACESTEP_GENERATE_KEYS = [
 function hasAnyFile(files, keys) {
     return keys.some((key) => files[key] !== undefined);
 }
+function quoteEngine(engine) {
+    return `'${engine}'`;
+}
+function supportedEnginesMessage() {
+    return SUPPORTED_ENGINES.map(quoteEngine).join(' or ');
+}
 function validateEngineType(engine) {
-    if (engine !== undefined && engine !== exports.ENGINE_ACESTEP && engine !== exports.ENGINE_MINIMAX) {
-        throw invalidInput(`engine must be '${exports.ENGINE_ACESTEP}' or '${exports.ENGINE_MINIMAX}'`);
+    if (engine !== undefined && !SUPPORTED_ENGINES.includes(engine)) {
+        throw invalidInput(`engine must be ${supportedEnginesMessage()}`);
     }
 }
 function detectEngineType(files = {}, explicitEngine) {

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -90,6 +90,7 @@
   ],
   "devDependencies": {
     "@qvac/registry-client": "^0.6.1",
+    "bare-module-lexer": "^1.6.4",
     "brittle": "^3.17.0",
     "cmake-bare": "^1.7.5",
     "cmake-vcpkg": "^1.1.0",

--- a/packages/audiogen-ggml/src/index.ts
+++ b/packages/audiogen-ggml/src/index.ts
@@ -43,6 +43,7 @@ import { ERR_CODES, QvacErrorAudioGen } from './error'
 
 export const ENGINE_ACESTEP = 'acestep'
 export const ENGINE_MINIMAX = 'minimax'
+const SUPPORTED_ENGINES: readonly string[] = [ENGINE_ACESTEP, ENGINE_MINIMAX]
 export const MINIMAX_FRAMES_PER_SECOND = 25
 export const MINIMAX_DEFAULT_MAX_FRAMES = 300
 const MINIMAX_MIN_FRAMES = 1
@@ -563,9 +564,17 @@ function hasAnyFile(files: AudioGenFiles, keys: Array<keyof AudioGenFiles>): boo
   return keys.some((key) => files[key] !== undefined)
 }
 
+function quoteEngine(engine: string): string {
+  return `'${engine}'`
+}
+
+function supportedEnginesMessage(): string {
+  return SUPPORTED_ENGINES.map(quoteEngine).join(' or ')
+}
+
 function validateEngineType(engine: string | undefined): void {
-  if (engine !== undefined && engine !== ENGINE_ACESTEP && engine !== ENGINE_MINIMAX) {
-    throw invalidInput(`engine must be '${ENGINE_ACESTEP}' or '${ENGINE_MINIMAX}'`)
+  if (engine !== undefined && !SUPPORTED_ENGINES.includes(engine)) {
+    throw invalidInput(`engine must be ${supportedEnginesMessage()}`)
   }
 }
 

--- a/packages/audiogen-ggml/test/package/package-contract.test.js
+++ b/packages/audiogen-ggml/test/package/package-contract.test.js
@@ -6,6 +6,7 @@ const path = require('path')
 const { spawnSync } = require('child_process')
 const { builtinModules } = require('module')
 const test = require('brittle')
+const lex = require('bare-module-lexer')
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..', '..')
 const COMMAND_NAME = 'qvac-audiogen-download-models'
@@ -41,6 +42,7 @@ const REQUIRED_PATHS = [
   ...BENCHMARK_PATHS
 ]
 const FORBIDDEN_PREFIXES = ['package/test/integration/', 'package/test/mobile/']
+const SOURCE_ROOT = path.join(PACKAGE_ROOT, 'src')
 
 function run(command, args, cwd) {
   const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
@@ -144,6 +146,38 @@ function assertForbiddenPaths(t, entries) {
   t.absent(entries.some(isInternalTestUtility), 'tarball excludes internal test utilities')
 }
 
+function walkFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    return entry.isDirectory() ? walkFiles(entryPath) : [entryPath]
+  })
+}
+
+function generatedScripts() {
+  return walkFiles(SOURCE_ROOT)
+    .filter((filePath) => filePath.endsWith('.ts') && !filePath.endsWith('.d.ts'))
+    .map((filePath) => `${path.relative(SOURCE_ROOT, filePath).slice(0, -'.ts'.length)}.js`)
+    .map((filePath) => filePath.split(path.sep).join('/'))
+    .filter((filePath) => fs.existsSync(path.join(PACKAGE_ROOT, filePath)))
+}
+
+function relativeSpecifiers(specifiers) {
+  return new Set(specifiers.filter((specifier) => specifier.startsWith('.')))
+}
+
+function lexedSpecifiers(source) {
+  return lex(Buffer.from(source)).imports.map((entry) => entry.specifier)
+}
+
+function assertBundlerSeesRequires(t, scriptPath) {
+  const source = fs.readFileSync(path.join(PACKAGE_ROOT, scriptPath), 'utf8')
+  const written = relativeSpecifiers(importedModules(source))
+  const lexed = relativeSpecifiers(lexedSpecifiers(source))
+  for (const specifier of written) {
+    t.ok(lexed.has(specifier), `bare-pack resolves ${specifier} from ${scriptPath}`)
+  }
+}
+
 function runDownloader(downloaderPath, cwd) {
   if (IS_WINDOWS) return run(process.execPath, [downloaderPath, '--help'], cwd)
   fs.accessSync(downloaderPath, fs.constants.X_OK)
@@ -234,4 +268,10 @@ test('published package contains only consumer contract files', (t) => {
     missingRegistryClient.stderr.includes('Install @qvac/registry-client'),
     'downloader explains how to install its optional runtime'
   )
+})
+
+test('generated scripts keep every relative require visible to the bundler', (t) => {
+  const scripts = generatedScripts()
+  t.ok(scripts.includes('index.js'), 'entry point is a generated script')
+  scripts.forEach((scriptPath) => assertBundlerSeesRequires(t, scriptPath))
 })


### PR DESCRIPTION
## Problem

Every AudioGen GGML mobile Device Farm run has failed since the suite was added
(26, 27 and 31 August; Android and iOS alike). Each on-device model load dies
immediately with:

```
MODULE_NOT_FOUND: Cannot find module './binding'
  imported from 'file:///app.bundle/node_modules/@qvac/audiogen-ggml/index.js'
```

`binding.js` is in the published tarball and the `android-arm64` prebuilds are
staged correctly, so the failure looks impossible — the file sits right next to
`index.js`.

Most recent run: https://github.com/tetherto/qvac/actions/runs/33414059474

## Cause

`bare-pack` walks the module graph with `bare-module-lexer`. The generated
`index.js` contained:

```js
throw invalidInput(`engine must be '${exports.ENGINE_ACESTEP}' or '${exports.ENGINE_MINIMAX}'`);
```

Two single-quote-wrapped `${exports.…}` interpolations in one template literal
desynchronise the lexer. It reports the imports found up to that point and
silently abandons the rest of the file — 8 imports instead of 13. The lazy
`require('./binding')` further down sits past the desync point, so `bare-pack`
never learns about it, writes a bundle without `binding.js`, and **exits 0**.
The build log says `App bundled successfully`.

The construct comes out of the TypeScript compiler, not the source: `src/index.ts`
interpolates the plain consts `ENGINE_ACESTEP` / `ENGINE_MINIMAX`, and `tsc`
rewrites exported consts to `exports.…`. That is why review never caught it.

Narrowed with `bare-module-lexer@1.6.4`, the version `bare-pack@^1.4.7` resolves:

| construct | lexer keeps scanning |
| --- | --- |
| `` `must be '${exports.A}' or '${exports.B}'` `` | no |
| `` `must be '${foo.A}' or '${foo.B}'` `` | yes |
| `` `must be ${exports.A} or ${exports.B}` `` | yes |
| `` `must be '${exports.A}'` `` | yes |

Note this also explains why the `exports` map entry added in 0.3.0 ("Expose
`binding.js` through the package `exports` map … so mobile bundlers that resolve
the native binding through exports can load the addon") did not help. I tested
that hypothesis directly: adding or removing `"./binding.js"` from `exports`
makes no difference to what lands in the bundle. Same symptom, wrong cause.

## Fix

Assemble the message through a helper so no quoted `${exports.…}` pair is
emitted, and drive both the check and the message off one `SUPPORTED_ENGINES`
constant instead of repeating the engine names. The thrown message is byte for
byte what it was: `engine must be 'acestep' or 'minimax'`.

Two other candidate fixes were tested and rejected: writing the require with an
explicit extension (`require('./binding.js')`) does **not** help, and neither
does changing the `exports` map. A probe module proved `bare-pack` does follow
requires nested inside function bodies in general, which is what pointed at a
lexer desync rather than a resolution rule.

## Verification

- `bare-module-lexer` on the rebuilt `index.js`: 8 → 13 imports, `./binding` back.
- End-to-end: ran the framework's exact command
  (`bare-pack --target ios-arm64 --target android-arm64 --linked`) against the
  published `@qvac/audiogen-ggml@0.3.1` with this `index.js`. `binding.js` is in
  the bundle, matching what `@qvac/tts-ggml` produces. Before the fix it was absent.
- Audited all 10 addon entry points in the monorepo — audiogen-ggml was the only
  one affected; the other nine were already clean.
- `npm run lint` (prettier, lunte, eslint, typecheck, dts, `check:generated`) passes.
- Unit, node and package-contract suites pass.

## Regression guard

`test/package/package-contract.test.js` now asserts that every relative
`require` written in each generated script is also visible to
`bare-module-lexer`. Confirmed it fails on the pre-fix `index.js` and passes
after — it would have caught this before a single Device Farm minute was spent.

## Follow-up

A green mobile run still needs a dispatch of
`integration-mobile-test-audiogen-ggml.yml` after this merges.

Two problems in `tetherto/qvac-test-addon-mobile` made this expensive to
diagnose and are worth separate issues there: `bare-pack`'s output is swallowed
by `scripts/bundle.sh`, and `[bare-log] after flush failed: The first argument
must be of type string …` hides the app's own logs exactly when a run fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
