### PR TITLE
infra[notask]: fail PR sanity checks when a require is hidden from bare-pack

### DIFF
--- a/.github/actions/sanity-checks/action.yaml
+++ b/.github/actions/sanity-checks/action.yaml
@@ -97,6 +97,10 @@ runs:
           echo "::error::Step - Generated wrappers do not match src (run 'npm run build:ts' and commit the result)"
           count=$((count + 1))
         fi
+        if ! node scripts/ci/check-bundler-requires.mjs "$WORKDIR"; then
+          echo "::error::Step - A relative require is hidden from bare-pack, so the mobile app bundle would omit it"
+          count=$((count + 1))
+        fi
         if [ "${{ steps.run_tests.outcome }}" = "failure" ]; then
           echo "::error::Step - Lint or unit tests failed"
           count=$((count + 1))

--- a/scripts/ci/check-bundler-requires.mjs
+++ b/scripts/ci/check-bundler-requires.mjs
@@ -1,0 +1,124 @@
+// Fails when a shipped JavaScript file hides a relative `require` from
+// `bare-module-lexer`, the scanner `bare-pack` uses to walk the module graph.
+//
+// A lexer desync is invisible at build time: `bare-pack` exits 0 and writes a
+// bundle that silently omits every module discovered after the desync point.
+// The omission only surfaces on device, as `MODULE_NOT_FOUND` for a module that
+// is plainly present in the published tarball.
+//
+// Usage: node scripts/ci/check-bundler-requires.mjs [packageDir]
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { createRequire } from 'node:module'
+import { spawnSync } from 'node:child_process'
+
+const LEXER_PACKAGE = 'bare-module-lexer'
+// The mobile app bundle is produced by `bare-pack`, so the lexer has to be the
+// one `bare-pack` itself resolves. Reading it out of an ambient `node_modules`
+// picks up whatever version happens to be hoisted nearby, and the desync this
+// check hunts for differs between lexer releases.
+const BUNDLER_SPEC = 'bare-pack@^1.4.7'
+const REQUIRE_PATTERN = /require\(\s*['"]([^'"]+)['"]\s*\)/g
+// Only the runtime graph a mobile bundle pulls in. Generators under `scripts/`
+// and fixtures under `test/` embed require-looking strings in their output, and
+// none of them are ever bundled.
+const RUNTIME_DIRECTORIES = ['.', 'lib']
+
+function packageDirectory() {
+  return path.resolve(process.argv[2] ?? '.')
+}
+
+function isScript(name) {
+  return name.endsWith('.js') || name.endsWith('.cjs')
+}
+
+function scriptsIn(directory) {
+  if (!fs.existsSync(directory)) return []
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && isScript(entry.name))
+    .map((entry) => path.join(directory, entry.name))
+}
+
+function collectScripts(packageRoot) {
+  return RUNTIME_DIRECTORIES.flatMap((directory) => scriptsIn(path.join(packageRoot, directory)))
+}
+
+function installBundler() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundler-requires-'))
+  const result = spawnSync(
+    'npm',
+    ['install', '--no-save', '--no-audit', '--no-fund', '--prefix', root, BUNDLER_SPEC],
+    { encoding: 'utf8' }
+  )
+  if (result.status !== 0) {
+    throw new Error(`failed to install ${BUNDLER_SPEC}: ${result.stderr || result.stdout}`)
+  }
+  return path.join(root, 'node_modules', 'bare-pack', 'package.json')
+}
+
+function loadLexer() {
+  const bundlerManifest = installBundler()
+  const lexerPath = createRequire(bundlerManifest).resolve(LEXER_PACKAGE)
+  const lexer = createRequire(import.meta.url)(lexerPath)
+  const version = JSON.parse(
+    fs.readFileSync(path.join(path.dirname(lexerPath), 'package.json'), 'utf8')
+  ).version
+  process.stdout.write(`Using ${LEXER_PACKAGE}@${version} as resolved by ${BUNDLER_SPEC}.\n`)
+  return lexer
+}
+
+function writtenSpecifiers(source) {
+  return [...source.matchAll(REQUIRE_PATTERN)].map((match) => match[1])
+}
+
+function relativeOnly(specifiers) {
+  return new Set(specifiers.filter((specifier) => specifier.startsWith('.')))
+}
+
+function lexedSpecifiers(lex, source) {
+  return lex(Buffer.from(source)).imports.map((entry) => entry.specifier)
+}
+
+function hiddenSpecifiers(lex, scriptPath) {
+  const source = fs.readFileSync(scriptPath, 'utf8')
+  const lexed = relativeOnly(lexedSpecifiers(lex, source))
+  return [...relativeOnly(writtenSpecifiers(source))].filter((specifier) => !lexed.has(specifier))
+}
+
+function reportHidden(directory, scriptPath, specifiers) {
+  const relativePath = path.relative(directory, scriptPath)
+  for (const specifier of specifiers) {
+    process.stderr.write(
+      `::error file=${relativePath}::require('${specifier}') is invisible to bare-module-lexer, ` +
+        'so bare-pack will leave it out of the mobile app bundle\n'
+    )
+  }
+}
+
+function main() {
+  const directory = packageDirectory()
+  if (!fs.existsSync(path.join(directory, 'package.json'))) {
+    process.stderr.write(`no package.json in ${directory}\n`)
+    process.exit(1)
+  }
+  const lex = loadLexer()
+  const scripts = collectScripts(directory)
+  let hidden = 0
+  for (const scriptPath of scripts) {
+    const specifiers = hiddenSpecifiers(lex, scriptPath)
+    if (specifiers.length === 0) continue
+    reportHidden(directory, scriptPath, specifiers)
+    hidden += specifiers.length
+  }
+  process.stdout.write(
+    `Checked ${scripts.length} script(s) in ${path.basename(directory)}: ` +
+      `${hidden} require(s) hidden from the bundler.\n`
+  )
+  process.exit(hidden === 0 ? 0 : 1)
+}
+
+main()


### PR DESCRIPTION
**Merge after #4180.** This check fails on `packages/audiogen-ggml` until that
fix lands — which is the whole point of it. Nothing here depends on #4180's code,
so the diff is just the two files below; the ordering is about the check passing,
not about conflicts.

(`on-pr-audiogen-ggml.yml` is path-scoped to `packages/audiogen-ggml/**`, so this
PR does not itself trigger the audiogen sanity checks.)

## Why

The audiogen-ggml mobile break in #4180 cost days of red Device Farm runs for a
reason worth fixing structurally: **the failure is completely silent at build
time.**

When `bare-module-lexer` desynchronises on a construct in a generated file,
`bare-pack` reports the imports it managed to find, drops everything past the
desync point, writes a bundle and exits 0. The build log says
`App bundled successfully`. The omission only surfaces on a real device, as a
`MODULE_NOT_FOUND` for a module that is plainly present in the tarball.

The triggering construct is emitted by `tsc`, not written by hand, so code
review cannot realistically catch it either.

## What this adds

`scripts/ci/check-bundler-requires.mjs` — for a given package, compares the
relative `require`s written in its runtime scripts against the ones
`bare-module-lexer` can actually see, and fails with a GitHub annotation per
hidden specifier.

Two details that matter for it being trustworthy:

- **The lexer is resolved through `bare-pack` itself** (`bare-pack@^1.4.7`,
  matching `qvac-test-addon-mobile`), not from an ambient `node_modules`.
  This is not hypothetical: the `bare-module-lexer` that happens to be hoisted
  at this repo's root is 1.5.1, which desyncs on a construct in
  `ocr-ggml/index.js` that 1.6.4 handles fine. An earlier revision of this
  script read whatever was nearby and reported a phantom failure for ocr-ggml.
  Pinning to the bundler's own resolution is the only way the check means what
  it claims.
- **Scope is the runtime graph only** (package root + `lib/`). Generators under
  `scripts/` embed require-looking strings in their output and are never
  bundled; including them produced false positives across six packages.

Wired into `.github/actions/sanity-checks`, so every package PR gets it with no
new workflow and no merge-guard registration. It is **inlined into the existing
"Check for errors" step on purpose** — that file documents that adding a step to
this composite breaks the post-step indices ("Index was out of range"), since
the action checks out the PR head over its own definition. Step count is
unchanged at 6.

## Verification

- Clean across all 31 packages.
- Fails with exit 1 and the right annotation on the pre-fix audiogen `index.js`;
  passes with exit 0 after.
- Harmless when `workdir` defaults to `.` (0 scripts, exit 0).
- `action.yaml` still parses and still has exactly 6 steps.

## Cost

One `npm install` of `bare-pack` into a temp dir per sanity-checks run, a few
seconds. If that is judged too expensive per PR, the alternative is pinning
`bare-module-lexer` directly and accepting that it can drift from whatever
version `bare-pack` actually resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
