### PR TITLE
QVAC-23347 infra: gate the remaining wrapper publishers, de-vacuum the policy test

### DIFF
--- a/.github/scripts/test/publish-gate-policy.test.mjs
+++ b/.github/scripts/test/publish-gate-policy.test.mjs
@@ -2,13 +2,22 @@
 // on-merge-* never runs on a pull request, and actionlint checks structure,
 // not semantics.
 //
+// The expected set is derived from the *packages* -- every on-merge-*.yml that
+// invokes a publish action for a package defining `check:generated` -- and
+// deliberately NOT from which workflows already call the verify reusable. An
+// earlier revision filtered on the latter, which is the very property these
+// tests assert: the list could never contain a pipeline that omitted the gate,
+// so three wrapper publishers stayed ungated without failing anything.
+// Filtering a conformance list on the conformance property makes the
+// assertions vacuous.
+//
 // The `result == 'success'` assertion below is not redundant with the `needs:`
 // one. An `if:` containing `!cancelled()`, `always()` or `failure()` stops
 // GitHub skipping the job on a failed dependency, so `needs:` alone silently
 // fail-opens (the M5 defect); every publish-npm job uses `!cancelled()`.
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -54,13 +63,13 @@ function eachJob(source) {
   return jobs
 }
 
-// A wrapper pipeline is any on-merge-*.yml that calls the verify reusable.
-// Derived so a new pipeline cannot opt out of these assertions by omission.
-function wrapperPipelines() {
+// Every merge-triggered pipeline, gated or not. The gate must never take part
+// in building this list -- see the header.
+function onMergeWorkflows() {
   return readdirSync(WORKFLOW_DIR)
     .filter((name) => /^on-merge-.*\.ya?ml$/.test(name))
+    .sort()
     .map((name) => `.github/workflows/${name}`)
-    .filter((path) => read(path).includes(`uses: ${VERIFY_REUSABLE}`))
 }
 
 // Publish jobs are identified by what they do -- invoking a publish action --
@@ -68,6 +77,57 @@ function wrapperPipelines() {
 // is still covered.
 function publishJobs(source) {
   return eachJob(source).filter((job) => /uses:.*publish-library-to-(gpr|npm)/.test(job.text))
+}
+
+function unquote(value) {
+  return value.replace(/^["']/, '').replace(/["']$/, '')
+}
+
+// Job-level `env:` only (four-space key, six-space entries). Step-level env
+// blocks are indented deeper and must not leak into the lookup.
+function jobEnv(jobText) {
+  const env = new Map()
+  const block = jobText.match(/^ {4}env:\n((?: {6}[A-Za-z_][A-Za-z0-9_]*:.*\n)*)/m)
+  if (!block) return env
+  for (const line of block[1].split('\n')) {
+    const entry = line.match(/^ {6}([A-Za-z_][A-Za-z0-9_]*):[ \t]*(.*?)[ \t]*$/)
+    if (entry) env.set(entry[1], unquote(entry[2]))
+  }
+  return env
+}
+
+// The package directory a job acts on, read off the `workdir:` it hands the
+// publish action. Several pipelines pass that as `${{ env.PKG_DIR }}` or
+// `${{ env.WORKDIR }}`, so job-level env is resolved first. The filename is
+// not a usable substitute: on-merge-vla.yml publishes packages/vla-ggml.
+function packageDirs(jobText) {
+  const env = jobEnv(jobText)
+  const dirs = new Set()
+  for (const match of jobText.matchAll(/^\s*workdir:[ \t]*(.+?)[ \t]*$/gm)) {
+    let value = unquote(match[1])
+    const expression = value.match(/^\$\{\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}$/)
+    if (expression) value = env.get(expression[1]) ?? ''
+    if (/^packages\/[^/]+$/.test(value)) dirs.add(value)
+  }
+  return [...dirs]
+}
+
+// A package with no `check:generated` has no committed tsc output to drift
+// (e.g. fabric), and gating its publish on the reusable would only fail the
+// verify job on a missing npm script.
+function definesCheckGenerated(packageDir) {
+  const manifestPath = join(root, packageDir, 'package.json')
+  if (!existsSync(manifestPath)) return false
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  return typeof manifest.scripts?.['check:generated'] === 'string'
+}
+
+// Package-derived, so a new wrapper publisher is covered the moment it lands
+// and cannot opt out of the assertions below by omitting the gate.
+function wrapperPipelines() {
+  return onMergeWorkflows().filter((path) =>
+    publishJobs(read(path)).some((job) => packageDirs(job.text).some(definesCheckGenerated)),
+  )
 }
 
 // The `if:` value, flattened to one line. Both `>-` and `|` styles appear.
@@ -78,11 +138,33 @@ function ifExpression(jobText) {
   return inline ? inline[1].trim() : null
 }
 
+// Guards the derivation itself. If `packageDirs` silently resolved nothing --
+// a renamed input, a new indirection -- `wrapperPipelines()` would quietly
+// empty out and every assertion below would pass while gating nothing.
+test('every on-merge publish job resolves to exactly one package directory', () => {
+  const offenders = []
+
+  for (const path of onMergeWorkflows()) {
+    for (const job of publishJobs(read(path))) {
+      const dirs = packageDirs(job.text)
+      if (dirs.length !== 1) {
+        offenders.push(`${path}::${job.name}: resolved ${dirs.length} package dirs (${dirs})`)
+        continue
+      }
+      if (!existsSync(join(root, dirs[0], 'package.json'))) {
+        offenders.push(`${path}::${job.name}: ${dirs[0]}/package.json does not exist`)
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, [])
+})
+
 test('wrapper publish pipelines are discovered', () => {
   const pipelines = wrapperPipelines()
   assert.ok(
-    pipelines.length >= 9,
-    `expected at least the nine TypeScript-wrapper pipelines, found ${pipelines.length}`,
+    pipelines.length >= 13,
+    `expected at least the thirteen wrapper publish pipelines, found ${pipelines.length}: ${pipelines}`,
   )
 })
 
@@ -128,6 +210,32 @@ test('every wrapper publish job is gated on verify-generated', () => {
   assert.deepEqual(offenders, [])
 })
 
+// The converse of the gating test: a pipeline wired to the reusable for a
+// package with no `check:generated` would fail the verify job on every run,
+// because the reusable deliberately runs the script without --if-present.
+test('every pipeline calling the verify reusable has a check:generated to run', () => {
+  const offenders = []
+
+  for (const path of onMergeWorkflows()) {
+    const source = read(path)
+    if (!source.includes(`uses: ${VERIFY_REUSABLE}`)) continue
+
+    for (const job of eachJob(source)) {
+      if (!job.text.includes(`uses: ${VERIFY_REUSABLE}`)) continue
+      const dirs = packageDirs(job.text)
+      if (dirs.length !== 1) {
+        offenders.push(`${path}::${job.name}: verify caller resolved ${dirs.length} workdirs`)
+        continue
+      }
+      if (!definesCheckGenerated(dirs[0])) {
+        offenders.push(`${path}::${job.name}: ${dirs[0]} defines no check:generated script`)
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, [])
+})
+
 test('the verify job stays unprivileged and secretless', () => {
   const source = withoutComments(read('.github/workflows/verify-generated-wrappers.yml'))
 
@@ -146,7 +254,7 @@ test('the verify job stays unprivileged and secretless', () => {
 test('callers grant the verify job no more than contents: read', () => {
   const offenders = []
 
-  for (const path of wrapperPipelines()) {
+  for (const path of onMergeWorkflows()) {
     for (const job of eachJob(read(path))) {
       if (!job.text.includes(`uses: ${VERIFY_REUSABLE}`)) continue
       if (!/^ {4}permissions:\n {6}contents: read\n/m.test(job.text)) {
@@ -154,6 +262,37 @@ test('callers grant the verify job no more than contents: read', () => {
       }
       if (/^ {4}secrets:/m.test(job.text)) {
         offenders.push(`${path}::${job.name}: caller must not pass secrets to the verify job`)
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, [])
+})
+
+// A drift check that cannot see untracked files passes on an emitted wrapper
+// that was never committed. `git status --porcelain --untracked-files=all`
+// sees it; `git diff --exit-code` does not.
+test('every check:generated script observes untracked output', () => {
+  const offenders = []
+  const seen = new Set()
+
+  for (const path of wrapperPipelines()) {
+    for (const job of publishJobs(read(path))) {
+      for (const dir of packageDirs(job.text)) {
+        if (seen.has(dir)) continue
+        seen.add(dir)
+        const manifest = JSON.parse(read(join(dir, 'package.json')))
+        const script = manifest.scripts?.['check:generated']
+        if (!script) continue
+        // Delegating to a script file is fine; those assert tracked-ness
+        // themselves (see packages/*/scripts/check-generated.mjs).
+        if (/\bnode\b[^&|]*check-generated/.test(script)) continue
+        if (/git diff\b/.test(script)) {
+          offenders.push(`${dir}: check:generated uses git diff, which cannot see untracked files`)
+        }
+        if (!/--untracked-files=all/.test(script)) {
+          offenders.push(`${dir}: check:generated must pass --untracked-files=all`)
+        }
       }
     }
   }

--- a/.github/workflows/on-merge-audiogen-ggml.yml
+++ b/.github/workflows/on-merge-audiogen-ggml.yml
@@ -84,10 +84,18 @@ jobs:
       ref: ${{ github.ref }}
       workdir: "packages/audiogen-ggml"
 
+  verify-generated:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/verify-generated-wrappers.yml
+    with:
+      workdir: packages/audiogen-ggml
+
   publish-gpr:
-    needs: [build, publish-logic]
+    needs: [build, publish-logic, verify-generated]
     if: >-
-      needs.publish-logic.outputs.publish_main == 'true' || needs.publish-logic.outputs.publish_feature == 'true' || needs.publish-logic.outputs.publish_tmp == 'true'
+      needs.verify-generated.result == 'success' &&
+      (needs.publish-logic.outputs.publish_main == 'true' || needs.publish-logic.outputs.publish_feature == 'true' || needs.publish-logic.outputs.publish_tmp == 'true')
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:
@@ -148,8 +156,10 @@ jobs:
       - build
       - publish-logic
       - release-merge-guard
+      - verify-generated
     if: >-
-      (!cancelled() && needs.build.result == 'success' && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
+      needs.verify-generated.result == 'success' &&
+      ((!cancelled() && needs.build.result == 'success' && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')))
     runs-on: ubuntu-latest
     environment: npm
     outputs:

--- a/.github/workflows/on-merge-embed-llamacpp.yml
+++ b/.github/workflows/on-merge-embed-llamacpp.yml
@@ -83,13 +83,22 @@ jobs:
     with:
       workdir: "packages/embed-llamacpp"
 
+  verify-generated:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/verify-generated-wrappers.yml
+    with:
+      workdir: packages/embed-llamacpp
+
   # Publish to GitHub Package Registry (GPR) for non-release branches
   publish-gpr:
     needs:
       - build
       - publish-logic
+      - verify-generated
     if: >-
-      (needs.publish-logic.outputs.publish_main == 'true' || needs.publish-logic.outputs.publish_feature == 'true' || needs.publish-logic.outputs.publish_tmp == 'true')
+      needs.verify-generated.result == 'success' &&
+      ((needs.publish-logic.outputs.publish_main == 'true' || needs.publish-logic.outputs.publish_feature == 'true' || needs.publish-logic.outputs.publish_tmp == 'true'))
     continue-on-error: true
     runs-on: ubuntu-latest
     environment: release
@@ -125,8 +134,10 @@ jobs:
       - build
       - publish-logic
       - release-merge-guard
+      - verify-generated
     if: >-
-      (!cancelled() && needs.build.result == 'success' && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
+      needs.verify-generated.result == 'success' &&
+      ((!cancelled() && needs.build.result == 'success' && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')))
     runs-on: ubuntu-latest
     environment: npm
     outputs:

--- a/.github/workflows/on-merge-model-fit.yml
+++ b/.github/workflows/on-merge-model-fit.yml
@@ -83,13 +83,22 @@ jobs:
     with:
       workdir: "packages/model-fit"
 
+  verify-generated:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/verify-generated-wrappers.yml
+    with:
+      workdir: packages/model-fit
+
   # Publish to GitHub Package Registry (GPR) for non-release branches
   publish-gpr:
     needs:
       - build
       - publish-logic
+      - verify-generated
     if: >-
-      needs.publish-logic.outputs.publish_main == 'true' || needs.publish-logic.outputs.publish_feature == 'true' || needs.publish-logic.outputs.publish_tmp == 'true'
+      needs.verify-generated.result == 'success' &&
+      (needs.publish-logic.outputs.publish_main == 'true' || needs.publish-logic.outputs.publish_feature == 'true' || needs.publish-logic.outputs.publish_tmp == 'true')
     continue-on-error: true
     runs-on: ubuntu-latest
     environment: release
@@ -125,8 +134,10 @@ jobs:
       - build
       - publish-logic
       - release-merge-guard
+      - verify-generated
     if: >-
-      !cancelled() && needs.build.result == 'success' && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+      needs.verify-generated.result == 'success' &&
+      (!cancelled() && needs.build.result == 'success' && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
     runs-on: ubuntu-latest
     environment: npm
     outputs:

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build:ts && npm run build:native",
     "build:native": "bare-make generate && bare-make build && bare-make install",
     "build:ts": "tsc -p tsconfig.build.json",
-    "check:generated": "npm run build:ts && npm run test:types:consumer && git diff --exit-code -- index.js index.mjs addon.js addonLogging.js idMapIndex.js idMapIndex.mjs index.d.ts addon.d.ts addonLogging.d.ts idMapIndex.d.ts test/types/consumer-cjs.test.js",
+    "check:generated": "npm run build:ts && npm run test:types:consumer && out=$(git status --porcelain --untracked-files=all -- index.js index.mjs addon.js addonLogging.js idMapIndex.js idMapIndex.mjs index.d.ts addon.d.ts addonLogging.d.ts idMapIndex.d.ts test/types/consumer-cjs.test.js) && { [ -z \"$out\" ] || { echo \"$out\"; exit 1; }; }",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build:pack": "npm run build:ts && mkdir -p dist && npm pack --pack-destination dist",
     "mobile:copy-prebuilds": "cp -r prebuilds/android-arm64 prebuilds/android-ia32 || echo 'Warning: Failed to copy embed-llamacpp prebuilds to android-ia32'; cp -r prebuilds/android-arm64 prebuilds/android-arm || echo 'Warning: Failed to copy embed-llamacpp prebuilds to android-arm'; cp -r prebuilds/android-arm64 prebuilds/android-x64 || echo 'Warning: Failed to copy embed-llamacpp prebuilds to android-x64'; cp -r prebuilds/ios-arm64 prebuilds/ios-arm64-simulator 2>/dev/null || echo 'iOS prebuilds already present'; cp -r prebuilds/ios-arm64 prebuilds/ios-x64-simulator 2>/dev/null || echo 'iOS prebuilds already present'",

--- a/packages/model-fit/package.json
+++ b/packages/model-fit/package.json
@@ -7,7 +7,7 @@
     "build": "npm run build:ts && npm run build:native",
     "build:native": "bare-make generate && bare-make build && bare-make install",
     "build:ts": "tsc -p tsconfig.build.json",
-    "check:generated": "npm run build:ts && git diff --exit-code -- index.js index.d.ts process.js process.d.ts process-internal.js process-internal.d.ts process-runner.js process-runner.d.ts",
+    "check:generated": "npm run build:ts && out=$(git status --porcelain --untracked-files=all -- index.js index.d.ts process.js process.d.ts process-internal.js process-internal.d.ts process-runner.js process-runner.d.ts) && { [ -z \"$out\" ] || { echo \"$out\"; exit 1; }; }",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build:pack": "npm run build:ts && mkdir -p dist && npm pack --pack-destination dist",
     "lint": "npm run lint:js && npm run lint:ts",


### PR DESCRIPTION
Follow-up to #3850, raised by @Proletter in review: https://github.com/tetherto/qvac/pull/3850#discussion_r3842955051

## Problem

#3850 removed the publish-time `npm install` + `tsc` from the TypeScript-wrapper publish pipelines and replaced it with an unprivileged gate, `.github/workflows/verify-generated-wrappers.yml`, wired as a `needs:` gate on the publish jobs.

Three pipelines that publish committed tsc output were never wired into it:

| package | `check:generated` mechanism | gated at merge time? |
|---|---|---|
| audiogen-ggml | `node scripts/check-generated.mjs` (derived list) | no → **yes** |
| embed-llamacpp | `git diff --exit-code -- <paths>` | no → **yes** |
| model-fit | `git diff --exit-code -- <paths>` | no → **yes** |

All three set `outDir: "."`, commit their emitted `.js`/`.d.ts`, and publish on merge. So for `workflow_dispatch` and pushes to `release-*` / `feature-*` / `tmp-*` — events that never open a PR, and so never run `sanity-checks` — nothing verified their committed wrappers matched `src/`.

This is not a regression; those three were never gated. What did not hold is the merge-time half of the invariant #3850 describes ("every trigger that can publish").

## The part that made it silent

`.github/scripts/test/publish-gate-policy.test.mjs` derived its pipeline list as "`on-merge-*.yml` files that already `uses:` the verify reusable" — a filter on the very property it asserts. The list could never contain a pipeline that omitted the gate, so the `>= 9` lower bound was satisfied by the already-wired ones and could never fail on an omission.

## Changes

**1. Wire the gate into the three pipelines.** A `verify-generated` caller job, added to the `needs:` of both publish jobs, and led in each publish `if:` by `needs.verify-generated.result == 'success' &&` with the original condition parenthesised.

Both halves are required:
- `needs:` alone does not gate when the `if:` contains `!cancelled()` / `always()` / `failure()` — GitHub then stops skipping the job on a failed dependency (the M5 defect), and every `publish-npm` here uses `!cancelled()`.
- `&&` binds tighter than `||`, so an unparenthesised `A || B || C && gate` parses as `A || B || (C && gate)` and publishes on a failed gate.

**2. Derive the policy test's expected set from the packages, not from the gate.** It is now every `on-merge-*.yml` that invokes a publish action for a package defining `check:generated`, resolving the package from the publish job's `workdir:` and following `${{ env.PKG_DIR }}` / `${{ env.WORKDIR }}`. The filename is not a usable substitute — `on-merge-vla.yml` publishes `packages/vla-ggml`.

Three assertions come with it:
- every publish job resolves to exactly one existing package directory, so the derivation cannot silently empty out and make the suite vacuous again;
- every pipeline calling the reusable has a `check:generated` to run, since the reusable deliberately omits `--if-present`;
- no `check:generated` uses `git diff`, which cannot see untracked files.

**3. Move embed-llamacpp and model-fit off `git diff --exit-code`** onto the `out=$(git status --porcelain --untracked-files=all -- <paths>) && { [ -z "$out" ] || { echo "$out"; exit 1; }; }` form the others use. audiogen-ggml needs no change; its script already asserts tracked-ness.

This is **higher** severity than the review note assumed. The note reasoned that neither package lists an emit-target directory in `files` (only `prebuilds` / `LICENSE` / `NOTICE`), so a stray emit was never published for them. In fact both list every emit target in `files` by name — `index.js`, `index.mjs`, `addon.js`, `addonLogging.js`, `idMapIndex.*` for embed-llamacpp; `index.*`, `process*.{js,d.ts}` for model-fit — and none are gitignored, so a stray untracked emit at one of those names would have been packed and published.

## Verification

- `node --test` on the five files `security-baseline.yml` runs: **202 pass, 0 fail**.
- **Mutation-tested** the rewritten policy test. With audiogen-ggml's gate stripped back out, the old test **passes** and the new one **fails**. Three mutations, all detected: dropping the job and both gate clauses; keeping `needs:` but dropping the `if:` clause (the M5 fail-open); and moving the gate off the leading position.
- `actionlint`: no new findings. The four it reports on the touched files (`SC2001` ×2 in audiogen-ggml, `npm_published_version` in embed-llamacpp and model-fit) are pre-existing on unchanged lines, confirmed against the pristine `origin/main` copies.
- The `if:` expressions were parsed as YAML to confirm the folded scalars produce `needs.verify-generated.result == 'success' && (...)` on all six publish jobs.
- Verified the new shell form against a throwaway repo: it returns 1 on an emitted-but-never-committed file (where `git diff --exit-code` returns 0), 1 on a modified tracked file, and 128 rather than failing open when git itself errors.

## Notes on the reported scope

Checked against `origin/main`, three details in the review note have moved or were inaccurate:

- **decoder-audio is already gated.** #3850 wired ten pipelines, not nine. It defines `check:generated` via a derived-list script, contrary to the note placing it out of scope for lacking one.
- **onnx no longer exists** in the monorepo (removed in #4012).
- **fabric is the only on-merge publisher genuinely out of scope** — no `check:generated`, so nothing to drift.
- **infer-base** also publishes committed tsc output, but from `trigger-reusable-infer-base.yml` rather than an `on-merge-*.yml`. It is already gated by its own inline `validate-artifacts` job with the correct leading-clause shape, so it is not a fourth gap — though it sits outside what this test enumerates. Worth a separate look if the invariant should cover non-`on-merge` publish triggers too.

The commit is titled `QVAC-23347` after the parent task, since this follow-up's own Asana ID was not to hand — happy to retitle.
