### PR TITLE
QVAC-24142 infra: decouple mobile group validation from the llm generator

### DIFF
--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -31,7 +31,7 @@
     "test:integration:generate": "npm run generate:benchmark-shards && brittle -r test/integration/all.js test/integration/*.test.js && npm run test:mobile:generate",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
     "test:prestage": "node --test scripts/__tests__/*.test.js ../../.github/actions/cache-models/warm-models.test.mjs",
-    "test:unit": "npm run build:ts && npm run test:unit:generate && bare test/unit/all.js --exit && npm run test:prestage",
+    "test:unit": "npm run build:ts && npm run test:unit:generate && bare test/unit/all.js --exit && npm run test:prestage && npm run test:mobile:validate",
     "test:cpp:build": "bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test",
     "test:cpp:models": "node scripts/download-unit-test-models.js",
     "test:cpp:models:ci": "node scripts/download-unit-test-models.js --ci",

--- a/packages/llm-llamacpp/scripts/__tests__/mobile-test-groups.test.js
+++ b/packages/llm-llamacpp/scripts/__tests__/mobile-test-groups.test.js
@@ -1,0 +1,245 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  validateTestGroups,
+  generatedRunnerNames,
+  platformFamily,
+  platformNames,
+  isOverrideOnly
+} = require('../lib/validate-test-groups.js')
+const groups = require('../../test/mobile/test-groups.json')
+
+const integrationAutoPath = path.resolve(__dirname, '../../test/mobile/integration.auto.cjs')
+
+// The families validate-mobile-tests.js pins. Kept in one place here so the
+// assertions below describe the same requirement the script enforces.
+const PLATFORMS = ['ios', 'android']
+
+// The extractor under test, not a copy of it: validate-mobile-tests.js calls the
+// same `generatedRunnerNames`, so a change to the pattern is caught here.
+function committedRunners() {
+  return generatedRunnerNames(fs.readFileSync(integrationAutoPath, 'utf8'))
+}
+
+test('the committed test-groups.json covers every generated runner', () => {
+  assert.deepEqual(validateTestGroups(groups, committedRunners(), { platforms: PLATFORMS }), [])
+})
+
+test('the runner extractor reads the committed integration.auto.cjs', () => {
+  // Pins the shared extractor against real generated output, so a template
+  // change that renames the declarations cannot silently yield zero runners —
+  // which would make every coverage rule below vacuously pass.
+  const runners = committedRunners()
+  assert.ok(runners.length > 0, 'integration.auto.cjs must declare at least one runner')
+  assert.ok(runners.includes('runApiBehaviorTest'))
+  assert.ok(runners.every((name) => name.startsWith('run')))
+})
+
+test('the committed file schedules the weekly suites as a disjoint subset', () => {
+  // The premise of family pooling: the weekly maps are not a duplicate of the
+  // daily ones. If they ever became a subset of them, pooling would be dead
+  // weight and this suite would stop proving anything about it.
+  const daily = new Set(Object.values(groups.ios).flat())
+  const weekly = Object.values(groups.iosWeekly).flat()
+  assert.ok(
+    weekly.some((name) => !daily.has(name)),
+    'iosWeekly must schedule at least one runner that ios does not'
+  )
+})
+
+test('coverage is pooled across a family, not demanded of each map', () => {
+  // Without pooling, `iosWeekly` would owe full coverage of every runner — the
+  // exact failure mode the vla-ggml lib's shape inference would produce here.
+  const pooled = {
+    ios: { light: ['runDailyTest'] },
+    iosWeekly: { heavy: ['runWeeklyTest'] },
+    android: { light: ['runDailyTest'], heavy: ['runWeeklyTest'] }
+  }
+  const runners = ['runDailyTest', 'runWeeklyTest']
+  assert.deepEqual(validateTestGroups(pooled, runners, { platforms: PLATFORMS }), [])
+
+  // Inference agrees, because it folds `iosWeekly` into `ios` rather than
+  // returning it as a platform of its own.
+  assert.deepEqual(platformNames(pooled).sort(), ['android', 'ios'])
+  assert.deepEqual(validateTestGroups(pooled, runners), [])
+})
+
+test('a runner missing from the whole family is reported once per family', () => {
+  const problems = validateTestGroups(groups, [...committedRunners(), 'runBrandNewTest'], {
+    platforms: PLATFORMS
+  })
+  assert.equal(problems.length, PLATFORMS.length)
+  assert.ok(problems.every((p) => p.includes('runBrandNewTest')))
+  assert.ok(problems.some((p) => p.includes('Add them to a ios or iosWeekly group')))
+})
+
+test('benchmark shards stay exempt from the coverage requirement', () => {
+  // The Benchmark Performance workflow schedules runBenchmarkPerf* through an
+  // explicit test_groups override, and finetuning-moe.test.js is likewise driven
+  // by its own workflow, so both are deliberately absent from test-groups.json;
+  // requiring them here would make the committed file red.
+  assert.ok(isOverrideOnly('runBenchmarkPerf2bQ40F16Test'))
+  assert.ok(isOverrideOnly('runFinetuningMoeTest'))
+  assert.ok(!isOverrideOnly('runBenchmarkSomethingElseTest'))
+
+  // A newly generated shard is exempt; an ordinary new test in the same run is
+  // not — so the exemption cannot be masking a real gap.
+  const withNewShard = validateTestGroups(
+    groups,
+    [...committedRunners(), 'runBenchmarkPerf4bQ80F16Test'],
+    { platforms: PLATFORMS }
+  )
+  assert.deepEqual(withNewShard, [])
+
+  const withNewTest = validateTestGroups(groups, [...committedRunners(), 'runBrandNewTest'], {
+    platforms: PLATFORMS
+  })
+  assert.equal(withNewTest.length, PLATFORMS.length)
+})
+
+test('an override-only runner named by a group must still exist', () => {
+  // Exempt from coverage is not exempt from correctness: the override workflows
+  // grep integration.auto.cjs for these names.
+  const typo = {
+    ios: { bench: ['runBenchmarkPerfGoneTest'] },
+    android: { bench: ['runBenchmarkPerfGoneTest'] }
+  }
+  const problems = validateTestGroups(typo, [], { platforms: PLATFORMS })
+  assert.equal(problems.length, 2)
+  assert.ok(problems.every((p) => p.includes('runBenchmarkPerfGoneTest')))
+  assert.ok(problems.every((p) => p.includes('do not exist')))
+})
+
+test('the family of a platform drops only a trailing Weekly', () => {
+  assert.equal(platformFamily('iosWeekly'), 'ios')
+  assert.equal(platformFamily('android'), 'android')
+  assert.equal(platformFamily('weeklyIos'), 'weeklyIos')
+})
+
+test('a pinned platform missing from the file is reported', () => {
+  const problems = validateTestGroups({ ios: { light: ['runAddonTest'] } }, ['runAddonTest'], {
+    platforms: PLATFORMS
+  })
+  assert.equal(problems.length, 1)
+  assert.ok(problems[0].startsWith('[android]'))
+  assert.ok(problems[0].includes('no `{'))
+})
+
+test('a group map belonging to no required platform is named', () => {
+  // Pooling by family is what makes this dangerous: `iosWekly` folds into a
+  // family nobody requires, so its runners quietly stop counting and `ios` is
+  // blamed for not covering them. Both problems are reported.
+  const typo = {
+    ios: { light: ['runDailyTest'] },
+    iosWekly: { heavy: ['runWeeklyTest'] },
+    android: { light: ['runDailyTest'], heavy: ['runWeeklyTest'] }
+  }
+  const problems = validateTestGroups(typo, ['runDailyTest', 'runWeeklyTest'], {
+    platforms: PLATFORMS
+  })
+  assert.ok(problems.some((p) => p.includes('no required platform') && p.includes('iosWekly')))
+  assert.ok(problems.some((p) => p.startsWith('[ios]') && p.includes('runWeeklyTest')))
+})
+
+test('a typo in a group is reported', () => {
+  const typo = {
+    ios: { light: ['runAddonTest', 'runTypoTest'] },
+    android: { light: ['runAddonTest'] }
+  }
+  const problems = validateTestGroups(typo, ['runAddonTest'], { platforms: PLATFORMS })
+  assert.ok(problems.some((p) => p.includes('runTypoTest') && p.includes('do not exist')))
+})
+
+test('deferral excuses a runner from coverage', () => {
+  // The escape hatch the hardcoded `isOverrideOnly` allowlist cannot express:
+  // an ordinary test that is knowingly not scheduled on device.
+  const deferred = {
+    ios: { light: ['runAddonTest'] },
+    android: { light: ['runAddonTest'] },
+    deferred: ['runBigTest']
+  }
+  assert.deepEqual(
+    validateTestGroups(deferred, ['runAddonTest', 'runBigTest'], { platforms: PLATFORMS }),
+    []
+  )
+})
+
+test('deferral can be scoped per family', () => {
+  const perFamily = {
+    ios: { light: ['runAddonTest'] },
+    android: { light: ['runAddonTest'], heavy: ['runBigTest'] },
+    deferred: { ios: ['runBigTest'] }
+  }
+  assert.deepEqual(
+    validateTestGroups(perFamily, ['runAddonTest', 'runBigTest'], { platforms: PLATFORMS }),
+    []
+  )
+
+  const flat = {
+    ios: { light: ['runAddonTest'] },
+    android: { light: ['runAddonTest'], heavy: ['runBigTest'] },
+    deferred: ['runBigTest']
+  }
+  const problems = validateTestGroups(flat, ['runAddonTest', 'runBigTest'], {
+    platforms: PLATFORMS
+  })
+  assert.ok(problems.some((p) => p.startsWith('[android]') && p.includes('both scheduled')))
+})
+
+test('a per-family "deferred" keyed by a non-platform is reported', () => {
+  // `io` defers nothing, so runBigTest is still unassigned on ios — without this
+  // rule the typo reads as a clean file.
+  const typo = {
+    ios: { light: ['runAddonTest'] },
+    android: { light: ['runAddonTest'], heavy: ['runBigTest'] },
+    deferred: { io: ['runBigTest'] }
+  }
+  const problems = validateTestGroups(typo, ['runAddonTest', 'runBigTest'], {
+    platforms: PLATFORMS
+  })
+  assert.ok(problems.some((p) => p.includes('not platforms') && p.includes('io')))
+  assert.ok(problems.some((p) => p.startsWith('[ios]') && p.includes('runBigTest')))
+})
+
+test('a stale deferred entry is reported', () => {
+  const stale = {
+    ios: { light: ['runAddonTest'] },
+    android: { light: ['runAddonTest'] },
+    deferred: ['runRemovedTest']
+  }
+  const problems = validateTestGroups(stale, ['runAddonTest'], { platforms: PLATFORMS })
+  assert.ok(problems.some((p) => p.includes('runRemovedTest') && p.includes('do not exist')))
+})
+
+test('"deferred" is a top-level key, never a platform', () => {
+  // The Device Farm composites read only `.<platform>`, so a `deferred` key
+  // nested inside ios/android would be scheduled as a real shard — and it is
+  // otherwise indistinguishable from a shard, so every other rule passes.
+  const nested = {
+    ios: { light: ['runAddonTest'], deferred: ['runBigTest'] },
+    iosWeekly: { heavy: ['runBigTest'] },
+    android: { light: ['runAddonTest'], deferred: ['runBigTest'] }
+  }
+  const problems = validateTestGroups(nested, ['runAddonTest', 'runBigTest'], {
+    platforms: PLATFORMS
+  })
+
+  assert.equal(problems.length, 2, 'exactly one problem per map that nests it')
+  for (const source of ['ios', 'android']) {
+    const reported = problems.some(
+      (p) => p.startsWith(`[${source}]`) && p.includes('nested inside the platform map')
+    )
+    assert.ok(reported, `${source} must report the nested "deferred" key`)
+  }
+})
+
+test('a file with no platform maps is reported rather than passing vacuously', () => {
+  const problems = validateTestGroups({}, ['runAddonTest'])
+  assert.equal(problems.length, 1)
+  assert.ok(problems[0].includes('declares no platform maps'))
+})

--- a/packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js
+++ b/packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js
@@ -8,7 +8,19 @@ const repoRoot = path.resolve(__dirname, '..')
 const integrationDir = path.join(repoRoot, 'test', 'integration')
 const mobileDir = path.join(repoRoot, 'test', 'mobile')
 const outputFile = path.join(mobileDir, 'integration.auto.cjs')
-const groupsFile = path.join(mobileDir, 'test-groups.json')
+
+// This generator deliberately does not read test/mobile/test-groups.json. Group
+// coverage is a Device Farm scheduling question, not a question about whether
+// integration.auto.cjs was written correctly, and it is enforced separately by
+// scripts/validate-mobile-tests.js (rules in scripts/lib/validate-test-groups.js)
+// under `npm run test:unit`.
+//
+// It used to be checked here, and the coupling cost a red main: this script runs
+// inside `npm run test:integration` (via test:integration:generate), so editing a
+// scheduling file that no desktop test reads aborted the desktop suite on every
+// platform — after the output file had already been written, so the abort bought
+// nothing. A scheduling-only PR has no native changes, so the mobile job that
+// would have caught it is skipped. See PR #4006 / #4031.
 
 // The benchmark-perf-*.test.js shards are generated, not committed (see
 // .gitignore), but the committed integration.auto.cjs references them. Enumerating
@@ -85,64 +97,6 @@ function buildFileContents(files) {
   return `${lines.join('\n')}\n`
 }
 
-// A platform's OS family is its name without the optional `Weekly` suffix, so
-// `iosWeekly` belongs to the `ios` family. Coverage is validated per family
-// (the union of its regular + weekly splits), letting the weekend-only suite
-// hold a disjoint subset of tests rather than duplicating the daily ones.
-function platformFamily(platform) {
-  return platform.replace(/Weekly$/, '')
-}
-
-function validateGroups(functionNames) {
-  if (!fs.existsSync(groupsFile)) {
-    console.warn('[warn] test-groups.json not found — skipping split validation')
-    return
-  }
-  const groups = JSON.parse(fs.readFileSync(groupsFile, 'utf-8'))
-  const nameSet = new Set(functionNames)
-
-  // Benchmark shards (benchmark-perf-*.test.js -> runBenchmarkPerf*) are
-  // scheduled only by the Benchmark Performance workflow via an explicit
-  // test_groups override, and are deliberately absent from test-groups.json
-  // so normal mobile integration runs never trigger the heavy benchmark.
-  // Exclude them from the group-coverage requirement.
-  const isOverrideOnly = (n) => n.startsWith('runBenchmarkPerf') || n === 'runFinetuningMoeTest'
-
-  const coveredByFamily = new Map()
-  for (const [platform, splits] of Object.entries(groups)) {
-    const family = platformFamily(platform)
-    const covered = coveredByFamily.get(family) ?? new Set()
-    for (const name of Object.values(splits).flat()) {
-      covered.add(name)
-    }
-    coveredByFamily.set(family, covered)
-  }
-
-  for (const [family, covered] of coveredByFamily) {
-    const missing = functionNames.filter((n) => !covered.has(n) && !isOverrideOnly(n))
-    const extra = [...covered].filter((n) => !nameSet.has(n))
-    if (missing.length) {
-      throw new Error(
-        '[' +
-          family +
-          '] Tests not assigned to any group in test-groups.json:\n  ' +
-          missing.join('\n  ') +
-          `\nAdd them to a ${family} or ${family}Weekly group in test/mobile/test-groups.json.`
-      )
-    }
-    if (extra.length) {
-      throw new Error(
-        '[' +
-          family +
-          '] test-groups.json references non-existent tests:\n  ' +
-          extra.join('\n  ') +
-          '\nRemove them or check for typos.'
-      )
-    }
-  }
-  console.log('Group coverage validated — all tests assigned for every OS family.')
-}
-
 function main() {
   assertBenchmarkShardsPresent()
   const files = getIntegrationFiles()
@@ -150,11 +104,9 @@ function main() {
     throw new Error(`No integration test files found inside ${integrationDir}`)
   }
 
-  const functionNames = files.map(toFunctionName)
   const content = buildFileContents(files)
   fs.writeFileSync(outputFile, content, 'utf8')
   console.log(`Generated ${outputFile} with ${files.length} integration runners.`)
-  validateGroups(functionNames)
 }
 
 if (require.main === module) {

--- a/packages/llm-llamacpp/scripts/lib/validate-test-groups.js
+++ b/packages/llm-llamacpp/scripts/lib/validate-test-groups.js
@@ -1,0 +1,269 @@
+'use strict'
+
+// Group-coverage rules for test/mobile/test-groups.json.
+//
+// Deliberately dependency-free and side-effect-free (no fs, no process.exit) so
+// the same rules run under `node` from validate-mobile-tests.js and are unit
+// testable from scripts/__tests__/mobile-test-groups.test.js.
+//
+// This check lives OUTSIDE the generator on purpose. It answers a mobile
+// scheduling question — "is every on-device runner assigned to a Device Farm
+// shard?" — which has no bearing on whether integration.auto.cjs was written
+// correctly. Bundling it into the generator once let a Device Farm scheduling
+// edit abort `npm run test:integration`, taking desktop CI down on every
+// platform (PR #4006, reverted for vla-ggml by PR #4031).
+//
+// Modelled on packages/vla-ggml/scripts/lib/validate-test-groups.js. The two
+// differences are llm-specific and load-bearing: coverage is pooled per OS
+// family (`platformFamily`), and the benchmark shards are exempt
+// (`isOverrideOnly`).
+
+// Runners deliberately not scheduled on Device Farm are listed under this
+// top-level key. It sits beside the platform maps rather than inside one
+// because the CI composites consume only `.<platform>` and ignore every other
+// top-level key (see .github/actions/run-mobile-integration-tests/
+// upload-to-devicefarm/action.yml). Nesting it under `ios`/`android` would
+// instead schedule it as a real shard.
+const DEFERRED_KEY = 'deferred'
+
+// integration.auto.cjs declares one `async function run<Name>` per on-device
+// test; once it is confirmed in sync with test/integration/, those declarations
+// are the authoritative runner-name list — the same source that
+// .github/actions/run-mobile-integration-tests/validate-devices greps.
+//
+// The extractor lives here, beside the rules that consume its output, so
+// validate-mobile-tests.js and the unit tests share one implementation instead
+// of each keeping its own copy of the pattern (a test asserting on its own copy
+// proves nothing about the extractor that actually runs). It takes the file
+// contents rather than a path to keep this module fs-free.
+function generatedRunnerNames(content) {
+  const declaration = /^async function (run[A-Za-z0-9_]+)\s*\(/gm
+  return Array.from(content.matchAll(declaration), (m) => m[1])
+}
+
+// A platform entry is a `{ groupName: [runner, ...] }` map. Anything else at the
+// top level is metadata for another consumer — a `perf_report_filter` string, or
+// an object-form `deferred` — and is not a platform.
+function isPlatformEntry(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// A platform's OS family is its name without the optional `Weekly` suffix, so
+// `iosWeekly` belongs to the `ios` family. Coverage is validated per family (the
+// union of its regular + weekly splits), letting the weekend-only suite
+// (.github/workflows/weekend-mobile-test-llm-llamacpp.yml, which reads the
+// `iosWeekly`/`androidWeekly` maps) hold a disjoint subset of tests rather than
+// duplicating the daily ones.
+function platformFamily(platform) {
+  return platform.replace(/Weekly$/, '')
+}
+
+// Benchmark shards (benchmark-perf-*.test.js -> runBenchmarkPerf*) and the MoE
+// finetuning test are scheduled only by their own workflows via an explicit
+// `test_groups` override, and are deliberately absent from test-groups.json so
+// normal mobile integration runs never trigger the heavy benchmark. They are
+// therefore exempt from the coverage requirement — but not from the
+// "referenced runner must exist" rule, which still applies wherever a group
+// does name one.
+function isOverrideOnly(name) {
+  return name.startsWith('runBenchmarkPerf') || name === 'runFinetuningMoeTest'
+}
+
+// The families that must be fully covered. `options.platforms` overrides
+// inference; callers are expected to pin it, because inference cannot tell a
+// platform that was deleted by accident from one this addon never had.
+//
+// Inference here folds `iosWeekly` into `ios` rather than returning it as a
+// platform of its own — the top-level weekly maps are schedules, not platforms,
+// and demanding full coverage of each would fail the committed file, whose
+// weekly maps hold a deliberately disjoint subset.
+function platformNames(groups, platforms) {
+  if (platforms) {
+    return [...platforms]
+  }
+  const inferred = Object.keys(groups)
+    .filter((key) => key !== DEFERRED_KEY && isPlatformEntry(groups[key]))
+    .map(platformFamily)
+  return [...new Set(inferred)]
+}
+
+// Every top-level map that feeds a family's coverage: `ios` and `iosWeekly` for
+// the `ios` family.
+function familySources(groups, family) {
+  return Object.keys(groups).filter(
+    (key) => key !== DEFERRED_KEY && isPlatformEntry(groups[key]) && platformFamily(key) === family
+  )
+}
+
+function coveredRunners(platformEntry) {
+  return Object.values(platformEntry).filter(Array.isArray).flat()
+}
+
+// `deferred` is either a flat array — deferred on every family — or a
+// `{ <family>: [runner, ...] }` map, for a runner that is scheduled on one
+// family and deferred on another. The map form is why `platformNames` excludes
+// DEFERRED_KEY by name rather than by shape.
+function deferredRunners(groups, family) {
+  const deferred = groups[DEFERRED_KEY]
+  if (Array.isArray(deferred)) {
+    return deferred
+  }
+  if (isPlatformEntry(deferred)) {
+    const forFamily = deferred[family]
+    return Array.isArray(forFamily) ? forFamily : []
+  }
+  return []
+}
+
+function allDeferredRunners(groups) {
+  const deferred = groups[DEFERRED_KEY]
+  if (Array.isArray(deferred)) {
+    return deferred
+  }
+  if (isPlatformEntry(deferred)) {
+    return Object.values(deferred).filter(Array.isArray).flat()
+  }
+  return []
+}
+
+// Returns a list of human-readable problem strings; empty means valid.
+// `runners` is the authoritative runner-name list, derived from the generated
+// integration.auto.cjs by the caller. `options.platforms` pins the OS families
+// that must be covered instead of inferring them from the file's shape.
+function validateTestGroups(groups, runners, options = {}) {
+  const problems = []
+  const known = new Set(runners)
+
+  // A stale `deferred` entry is worse than a noisy one: it would silently
+  // excuse a runner that no longer exists, and mask a real gap if the name is
+  // ever reused.
+  const unknownDeferred = [...new Set(allDeferredRunners(groups))].filter(
+    (name) => !known.has(name)
+  )
+  if (unknownDeferred.length) {
+    problems.push(
+      `[${DEFERRED_KEY}] lists runners that do not exist:\n  ` +
+        unknownDeferred.join('\n  ') +
+        '\nRemove them or check for typos.'
+    )
+  }
+
+  const families = platformNames(groups, options.platforms)
+  if (families.length === 0) {
+    problems.push(
+      'test-groups.json declares no platform maps.\n' +
+        'Expected at least one top-level `{ "<platform>": { "<group>": [runners] } }` entry.'
+    )
+    return problems
+  }
+
+  // A per-family `deferred` keyed by a name that is not a family defers
+  // nothing, so a typo there reads as a clean file while the runner stays
+  // unassigned on the family it was meant to excuse.
+  const deferredKeyed = groups[DEFERRED_KEY]
+  if (isPlatformEntry(deferredKeyed)) {
+    const unknownFamilies = Object.keys(deferredKeyed).filter((key) => !families.includes(key))
+    if (unknownFamilies.length) {
+      problems.push(
+        `[${DEFERRED_KEY}] is keyed by names that are not platforms:\n  ` +
+          unknownFamilies.join('\n  ') +
+          `\nExpected one of: ${families.join(', ')}.`
+      )
+    }
+  }
+
+  // Pooling by family is what makes a misspelled top-level map dangerous: its
+  // runners simply stop counting towards any required family, and the loop
+  // below would blame the correctly-spelled sibling for not covering them.
+  // Naming the stray key turns that confusing report into an obvious one.
+  const stray = Object.keys(groups).filter(
+    (key) =>
+      key !== DEFERRED_KEY &&
+      isPlatformEntry(groups[key]) &&
+      !families.includes(platformFamily(key))
+  )
+  if (stray.length) {
+    problems.push(
+      'group maps belong to no required platform:\n  ' +
+        stray.join('\n  ') +
+        `\nExpected <platform> or <platform>Weekly for one of: ${families.join(', ')}.`
+    )
+  }
+
+  for (const family of families) {
+    const sources = familySources(groups, family)
+    if (sources.length === 0) {
+      problems.push(
+        `[${family}] is required to be covered but test-groups.json has no ` +
+          `\`{ "<group>": [runners] }\` map for it.`
+      )
+      continue
+    }
+
+    // `deferred` nested inside a platform is indistinguishable from a shard: to
+    // `coveredRunners` below it is just another array of runner names, so the
+    // whole file would validate clean — and `upload-to-devicefarm` turns every
+    // `{ groupName: [runners] }` entry into a Device Farm spec, so those runners
+    // would be scheduled (and billed) under a shard literally named "deferred".
+    // Reserving the name here is what makes the top-level rule enforceable
+    // rather than merely documented.
+    for (const source of sources) {
+      if (Object.prototype.hasOwnProperty.call(groups[source], DEFERRED_KEY)) {
+        problems.push(
+          `[${source}] "${DEFERRED_KEY}" is nested inside the platform map.\n` +
+            `It must be a top-level key: nested here it is scheduled as a real Device Farm shard.`
+        )
+      }
+    }
+
+    const covered = new Set(sources.flatMap((source) => coveredRunners(groups[source])))
+    const deferredSet = new Set(deferredRunners(groups, family))
+
+    const missing = runners.filter(
+      (name) => !covered.has(name) && !deferredSet.has(name) && !isOverrideOnly(name)
+    )
+    if (missing.length) {
+      problems.push(
+        `[${family}] runners not assigned to any group:\n  ` +
+          missing.join('\n  ') +
+          `\nAdd them to a ${family} or ${family}Weekly group in test/mobile/test-groups.json, ` +
+          `or to the top-level "${DEFERRED_KEY}" list if they are intentionally not run on device.`
+      )
+    }
+
+    const extra = [...covered].filter((name) => !known.has(name))
+    if (extra.length) {
+      problems.push(
+        `[${family}] groups reference runners that do not exist:\n  ` +
+          extra.join('\n  ') +
+          '\nRemove them or check for typos.'
+      )
+    }
+
+    // A runner in both a shard and `deferred` is contradictory: it would run on
+    // device while claiming to be deferred. Scoped per family, so the map form
+    // of `deferred` can legitimately defer a runner on ios while android
+    // schedules it.
+    const contradictory = [...covered].filter((name) => deferredSet.has(name))
+    if (contradictory.length) {
+      problems.push(
+        `[${family}] runners are both scheduled and listed as "${DEFERRED_KEY}":\n  ` +
+          contradictory.join('\n  ') +
+          `\nRemove them from one or the other.`
+      )
+    }
+  }
+
+  return problems
+}
+
+module.exports = {
+  DEFERRED_KEY,
+  validateTestGroups,
+  generatedRunnerNames,
+  platformFamily,
+  platformNames,
+  familySources,
+  isOverrideOnly,
+  deferredRunners
+}

--- a/packages/llm-llamacpp/scripts/validate-mobile-tests.js
+++ b/packages/llm-llamacpp/scripts/validate-mobile-tests.js
@@ -4,9 +4,18 @@
 const fs = require('fs')
 const path = require('path')
 
+const { validateTestGroups, generatedRunnerNames } = require('./lib/validate-test-groups.js')
+
 const repoRoot = path.resolve(__dirname, '..')
 const integrationDir = path.join(repoRoot, 'test', 'integration')
 const mobileAutoFile = path.join(repoRoot, 'test', 'mobile', 'integration.auto.cjs')
+const groupsFile = path.join(repoRoot, 'test', 'mobile', 'test-groups.json')
+
+// The OS families that must schedule every generated runner. Pinned rather than
+// inferred from the file's shape: test-groups.json also holds top-level
+// `iosWeekly`/`androidWeekly` maps, which are schedules pooled into their family
+// (see lib/validate-test-groups.js), not platforms owing coverage of their own.
+const REQUIRED_PLATFORMS = ['ios', 'android']
 
 function getIntegrationTestFiles() {
   if (!fs.existsSync(integrationDir)) {
@@ -73,7 +82,27 @@ try {
     process.exit(0)
   }
 
-  console.log('✅ Mobile integration tests are up to date')
+  // Device Farm shard coverage. This lives here rather than in the generator so
+  // that a mobile scheduling mistake can never abort `npm run test:integration`
+  // and take desktop CI down with it.
+  if (!fs.existsSync(groupsFile)) {
+    console.log('✅ Mobile integration tests are up to date (no test-groups.json — single-spec)')
+    process.exit(0)
+  }
+
+  const groups = JSON.parse(fs.readFileSync(groupsFile, 'utf8'))
+  const runners = generatedRunnerNames(mobileAutoContent)
+  const problems = validateTestGroups(groups, runners, { platforms: REQUIRED_PLATFORMS })
+
+  if (problems.length > 0) {
+    console.error('❌ test-groups.json does not cover every mobile runner\n')
+    problems.forEach((problem) => console.error(`   ${problem}\n`))
+    process.exit(1)
+  }
+
+  console.log(
+    `✅ Mobile integration tests are up to date (${runners.length} runner(s), group coverage OK)`
+  )
   process.exit(0)
 } catch (error) {
   console.error('Error validating mobile tests:', error.message)

--- a/packages/llm-llamacpp/test/mobile/README.md
+++ b/packages/llm-llamacpp/test/mobile/README.md
@@ -41,6 +41,19 @@ between the `android`/`ios` and `androidWeekly`/`iosWeekly` sections — no
 workflow edits required. The weekend run posts a pass/fail report to a
 `weekly-mobile-report`-labelled GitHub issue and to the run's Summary page.
 
+Every generated runner must appear in some group, and every group must name a
+runner that exists. Coverage is pooled per OS family — `ios` + `iosWeekly` count
+as one set — so a test moved to the weekend cadence is still covered. The
+`runBenchmarkPerf*` shards and `runFinetuningMoeTest` are exempt: their own
+workflows schedule them through an explicit `test_groups` override.
+
+The rules live in `scripts/lib/validate-test-groups.js` and are enforced by
+`npm run test:mobile:validate`, which `npm run test:unit` runs. They are
+deliberately **not** in `scripts/generate-mobile-integration-tests.js`: that
+generator runs inside `npm run test:integration`, so checking a Device Farm
+scheduling file there let a scheduling-only edit abort the desktop suite on
+every platform (PR #4006).
+
 ## Model Pre-Staging (`model-manifest.json`)
 
 Android Device Farm runs never let the phone download weights. The host


### PR DESCRIPTION
## Problem

`packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js` wrote `test/mobile/integration.auto.cjs`, logged success, and then called a throwing `validateGroups` from `main()`. It threw when a generated runner appeared in no group, and when a group named a runner that did not exist.

```
test:integration              (package.json:21)
  -> test:integration:generate  (package.json:31)
    -> test:mobile:generate     (package.json:22)
      -> bare ./scripts/generate-mobile-integration-tests.js
```

So editing `test/mobile/test-groups.json` — a Device Farm scheduling file that no desktop test reads — aborted `npm run test:integration` before a single desktop test ran, on every platform. Generation had already succeeded by then: the file was written before the check, and the abort was purely the policy check, so the coupling bought nothing.

A PR doing only that has no native changes, so the `integration-tests` job is skipped on it — the one job that would have caught the mistake is the one the gate skips, and the breakage lands on `main`. PR #4006 did exactly this to `vla-ggml`, and `main` was red for every VLA PR running integration tests until PR #4031. This is the same fix for `llm-llamacpp`.

## What changed

- **`validateGroups` is gone from the generator.** It now only generates; it cannot throw on scheduling state.
- **The rules moved to a pure, fs-free `scripts/lib/validate-test-groups.js`**, modelled on `packages/vla-ggml/scripts/lib/validate-test-groups.js`. llm-specific behaviour is preserved:
  - **family pooling** via `platformFamily`, so `ios` and `iosWeekly` share one coverage set and the weekend suite can hold a disjoint subset;
  - the **`isOverrideOnly` allowlist** (`runBenchmarkPerf*` and `runFinetuningMoeTest`) that keeps override-scheduled shards out of the coverage requirement — though a group that *names* one must still name a runner that exists.
- **Platforms are pinned by the caller** (`options.platforms = ['ios', 'android']`). Inferring them from shape, as the vla-ggml lib does, would read the top-level `iosWeekly`/`androidWeekly` maps as platforms in their own right and demand full coverage of each.
- **`scripts/validate-mobile-tests.js` enforces the rules**, and the previously unreferenced **`test:mobile:validate` is wired into `test:unit`**. `ts-checks` (`on-pr-llm-llamacpp.yml`) needs only fork-approval and authorize and already runs `run-lint-and-unit-tests`, so this lands as an ungated check.
- **`scripts/__tests__/mobile-test-groups.test.js`** joins the three suites already in that directory; the existing `test:prestage` glob picks it up.
- Short note in `test/mobile/README.md` recording where the rules live and why they are not in the generator.

Also carried over from the vla-ggml lib, none of which fire on the committed file: a top-level `deferred` escape hatch (flat or per-family), reserving `deferred` as a nested key so it cannot be scheduled as a real Device Farm shard, and stale/contradictory `deferred` entries. Plus one rule the family pooling makes necessary — a group map whose family is not a required platform (`iosWekly`) is named directly, instead of silently dropping its runners and blaming `ios` for not covering them.

## Verification

- `integration.auto.cjs` regenerates **byte-identical** (`git status` clean after a regen).
- `test-groups.json` is **untouched** — Device Farm scheduling output is unchanged.
- Adding an unassigned integration test: the generator exits `0`; `validate-mobile-tests.js` exits `1` naming the runner for both families.
- Emptying a group in `test-groups.json`: the generator exits `0`; `validate-mobile-tests.js` exits `1`. This is the case that used to take desktop CI down.
- `node --test scripts/__tests__/*.test.js` — 73 pass (17 new).
- `prettier --check` and `lunte` clean on all changed files.

Ref: QVAC-24142. Reference implementation: PR #4031.
