### PR TITLE
QVAC-24385 test[tts-ggml]: pre-stage the parler GGUF for the mobile functional lane

### DIFF
--- a/packages/tts-ggml/scripts/__tests__/generate-mobile-model-manifest.test.js
+++ b/packages/tts-ggml/scripts/__tests__/generate-mobile-model-manifest.test.js
@@ -23,6 +23,7 @@ const {
   FUNCTIONAL_MODELS,
   LAVASR_MODELS,
   COSYVOICE_MODELS,
+  PARLER_MODELS,
   QUALITY_MODELS
 } = require('../generate-mobile-model-manifest')
 
@@ -39,6 +40,7 @@ test('the manifest exposes benchmark and functional model sections', () => {
   assert.equal(manifest.functional.length, 4, 'functional section has every Supertonic 3 tier')
   assert.equal(manifest.lavasr.length, 2, 'lavasr section has the enhancer + denoiser')
   assert.equal(manifest.cosyvoice.length, 6, 'cosyvoice section has the 6 model-dir files')
+  assert.equal(manifest.parler.length, 1, 'parler section has the mini q8_0 GGUF')
   assert.equal(manifest.quality.length, 1, 'quality section has the mobile Whisper model')
 })
 
@@ -110,6 +112,18 @@ test('the lavasr entries are signed from the published fp16 registry paths', () 
   assert.match(denoiser.url, /ggml\/lavasr\/2026-07-03\/lavasr-denoiser-f16\.gguf$/)
 })
 
+// The registry date is pinned so a prestage-path change fails here as a
+// reminder to keep it in lockstep with REGISTRY_DATE_PARLER in
+// test/utils/downloadModel.js (the on-device resolver that would fetch the
+// same GGUF). The target stays the flat registry filename ensureParlerModel
+// scans for directly in <modelsDir>.
+test('the parler entry is signed from the published mini q8_0 registry path', () => {
+  const { manifest } = buildManifest(fakePresign)
+  const [parler] = manifest.parler
+  assert.equal(parler.targetName, 'parler-mini-v1-q8_0.gguf')
+  assert.match(parler.url, /ggml\/parler-tts\/2026-07-20\/parler-mini-v1-q8_0\.gguf$/)
+})
+
 test('LAVASR_MODELS keeps the fp16 registry key / on-disk target split', () => {
   const [enhancer, denoiser] = LAVASR_MODELS
   assert.match(enhancer.s3Key, /lavasr-enhancer-f16\.gguf$/)
@@ -126,7 +140,8 @@ test('signedCount counts each distinct GGUF once across all sections', () => {
       ...Q8_MODELS,
       ...FUNCTIONAL_MODELS,
       ...LAVASR_MODELS,
-      ...COSYVOICE_MODELS
+      ...COSYVOICE_MODELS,
+      ...PARLER_MODELS
     ].map((entry) => entry.name)
   )
   assert.equal(signedCount, distinct.size)

--- a/packages/tts-ggml/scripts/__tests__/generate-prestage-block.test.js
+++ b/packages/tts-ggml/scripts/__tests__/generate-prestage-block.test.js
@@ -157,7 +157,14 @@ const FUNCTIONAL_MANIFEST = {
       targetName: 'supertonic2.gguf',
       url: 'https://s3/s2-q4.gguf'
     }
-  ])
+  ]),
+  parler: [
+    {
+      name: 'parler-mini-v1-q8_0.gguf',
+      targetName: 'parler-mini-v1-q8_0.gguf',
+      url: 'https://s3/parler-q8.gguf'
+    }
+  ]
 }
 
 function decodeBlockTsv(block) {
@@ -302,7 +309,10 @@ test('functionalModelsByTest maps each functional runner to only its required st
     modelsByTest.runSupertonicTest.map((entry) => entry.targetName),
     ['supertonic.gguf']
   )
-  assert.deepEqual(modelsByTest.runParlerTest, [])
+  assert.deepEqual(
+    modelsByTest.runParlerTest.map((entry) => entry.targetName),
+    ['parler-mini-v1-q8_0.gguf']
+  )
   assert.deepEqual(
     modelsByTest.runCosyvoice3Test.map((entry) => entry.targetName),
     [
@@ -386,13 +396,15 @@ test('selectFunctionalEntries regex-matches runner names and deduplicates shared
     ['chatterbox-t3-turbo.gguf', 'chatterbox-s3gen.gguf']
   )
 
-  // An empty grep is benign (no shard resolved -> stage nothing). A model-free
-  // but KNOWN runner (runParlerTest -> []) still matches its manifest key, so it
-  // stages nothing without erroring. A zero-match typo or an invalid regex is a
-  // test-groups <-> model-map drift and fails CLOSED: the workflow_call lanes
-  // never run validate-devices, so an under-staged run must surface here.
+  // An empty grep is benign (no shard resolved -> stage nothing). A zero-match
+  // typo or an invalid regex is a test-groups <-> model-map drift and fails
+  // CLOSED: the workflow_call lanes never run validate-devices, so an
+  // under-staged run must surface here.
   assert.deepEqual(selectFunctionalEntries(mappings, ''), [])
-  assert.deepEqual(selectFunctionalEntries(mappings, 'runParlerTest'), [])
+  assert.deepEqual(
+    selectFunctionalEntries(mappings, 'runParlerTest').map((entry) => entry.targetName),
+    ['parler-mini-v1-q8_0.gguf']
+  )
   assert.throws(
     () => selectFunctionalEntries(mappings, 'runMissingTest'),
     /matched no known runner/
@@ -413,6 +425,10 @@ test('functional mapping fails when any required manifest target is absent', () 
     () => functionalModelsByTest({ ...FUNCTIONAL_MANIFEST, lavasr: [] }),
     /Missing LavaSR manifest target/
   )
+  assert.throws(
+    () => functionalModelsByTest({ ...FUNCTIONAL_MANIFEST, parler: [] }),
+    /Missing Parler manifest target/
+  )
 })
 
 test('functional prestage script reads the explicit shard grep and deduplicates targets', () => {
@@ -428,7 +444,7 @@ test('functional prestage script reads the explicit shard grep and deduplicates 
   assert.match(script, /adb push/)
 })
 
-test('functional selector executes deduplication and accepts a zero-model Parler shard', () => {
+test('functional selector executes deduplication and stages the Parler shard GGUF', () => {
   const directory = mkdtempSync(join(tmpdir(), 'tts-functional-prestage-'))
   const manifestPath = join(directory, 'manifest.json')
   const listPath = join(directory, 'list.tsv')
@@ -477,11 +493,14 @@ test('functional selector executes deduplication and accepts a zero-model Parler
   assert.notEqual(typo.status, 0)
   assert.match(typo.stderr, /matched no known runner/)
 
-  // A model-free but KNOWN runner (runParlerTest -> []) matches its manifest key,
-  // so it stages nothing without erroring.
+  // Parler stages its single GGUF like every other runner — it used to be the
+  // one on-device downloader and its registry fetch was the CI timeout flake.
   const parler = run('runParlerTest')
   assert.equal(parler.status, 0, parler.stderr)
-  assert.equal(readFileSync(listPath, 'utf8'), '')
+  assert.equal(
+    readFileSync(listPath, 'utf8'),
+    'parler-mini-v1-q8_0.gguf\thttps://s3/parler-q8.gguf\n'
+  )
   rmSync(directory, { recursive: true, force: true })
 })
 
@@ -491,7 +510,10 @@ test('functional prestage block embeds CosyVoice and LavaSR mappings without sta
   assert.ok(match)
   const mappings = JSON.parse(Buffer.from(match[1], 'base64').toString('utf8'))
 
-  assert.equal(mappings.runParlerTest.length, 0)
+  assert.deepEqual(
+    mappings.runParlerTest.map((entry) => entry.targetName),
+    ['parler-mini-v1-q8_0.gguf']
+  )
   assert.ok(
     mappings.runCosyvoice3Test.some(
       (entry) => entry.targetName === 'cosyvoice3/cosyvoice3-llm-q8_0.gguf'

--- a/packages/tts-ggml/scripts/generate-mobile-model-manifest.js
+++ b/packages/tts-ggml/scripts/generate-mobile-model-manifest.js
@@ -184,6 +184,22 @@ const QUALITY_MODELS = [
   )
 ]
 
+// Parler stages the mini q8_0 GGUF the functional runner synthesizes with
+// (ensureParlerModel's default variant + quant). The target keeps the flat
+// registry filename: the on-device resolver scans <modelsDir> for exactly
+// `parler-mini-v1-q8_0.gguf`, so no subdir is involved. Staging it removes the
+// last on-device registry download in the functional lane — the ~1.1 GB fetch
+// over Device Farm Wi-Fi is exactly the REQUEST_TIMEOUT flake that failed CI.
+// The date below must match REGISTRY_DATE_PARLER in test/utils/downloadModel.js
+// (the on-device resolver); generate-mobile-model-manifest.test.js pins it so a
+// drift fails there, since this Node script can't require that Bare-only module.
+const PARLER_MODELS = [
+  model(
+    'parler-mini-v1-q8_0.gguf',
+    'qvac_models_compiled/ggml/parler-tts/2026-07-20/parler-mini-v1-q8_0.gguf'
+  )
+]
+
 function presignModel(bucket, entry, expiresIn) {
   const url = execFileSync(
     'aws',
@@ -212,6 +228,7 @@ function buildManifest(presign) {
     functional: FUNCTIONAL_MODELS.map(signOnce),
     lavasr: LAVASR_MODELS.map(signOnce),
     cosyvoice: COSYVOICE_MODELS.map(signOnce),
+    parler: PARLER_MODELS.map(signOnce),
     quality: QUALITY_MODELS
   }
   return { manifest, signedCount: signed.size }
@@ -242,5 +259,6 @@ module.exports = {
   FUNCTIONAL_MODELS,
   LAVASR_MODELS,
   COSYVOICE_MODELS,
+  PARLER_MODELS,
   QUALITY_MODELS
 }

--- a/packages/tts-ggml/scripts/generate-prestage-block.js
+++ b/packages/tts-ggml/scripts/generate-prestage-block.js
@@ -38,6 +38,7 @@ const FUNCTIONAL_MODEL_TARGETS = {
   ],
   lavasrEnhancer: ['lavasr/lavasr-enhancer.gguf'],
   lavasrDenoiser: ['lavasr/lavasr-denoiser.gguf'],
+  parler: ['parler-mini-v1-q8_0.gguf'],
   cosyvoice3: [
     'cosyvoice3/cosyvoice3-llm-q8_0.gguf',
     'cosyvoice3/cosyvoice3-flow-f32.gguf',
@@ -181,6 +182,8 @@ function functionalModelsByTest(manifest) {
     FUNCTIONAL_MODEL_TARGETS.cosyvoice3,
     'CosyVoice3'
   )
+  const parlerModels = Array.isArray(manifest.parler) ? manifest.parler : []
+  const parler = requiredEntriesByTarget(parlerModels, FUNCTIONAL_MODEL_TARGETS.parler, 'Parler')
 
   return {
     runAddonTest: chatterbox,
@@ -193,7 +196,7 @@ function functionalModelsByTest(manifest) {
     runLavasrEnhancerTest: combineTargets(chatterbox, supertonic, lavasrEnhancer),
     runMultipleRunsTest: combineTargets(chatterbox, supertonic),
     runOutputSampleRateTest: supertonic,
-    runParlerTest: [],
+    runParlerTest: parler,
     runSupertonicMtlTest: supertonicMtl,
     runSupertonicTest: supertonic,
     runSupertonic3QuantTest: supertonic3
@@ -204,9 +207,10 @@ function functionalModelsByTest(manifest) {
 // values, or the manual `tests` dispatch input). Match it against the known
 // runner keys and stage the union of their models — so a partial pattern like
 // `runChatterbox` correctly stages every runner it will run on device, not just
-// an exact key. `modelsByTest` enumerates EVERY functional runner as a key
-// (including no-model ones such as runParlerTest -> []), so a runner that needs
-// no models still matches and stages nothing without erroring. An empty grep is
+// an exact key. `modelsByTest` enumerates EVERY functional runner as a key,
+// and a runner mapped to an empty model list would still match and stage
+// nothing without erroring (every current runner stages at least one file —
+// Parler was the last on-device downloader and is now staged). An empty grep is
 // benign (no shard resolved). A NON-empty grep that fails to compile or matches
 // zero runner keys is FATAL: the workflow_call lanes (weekend / on-merge /
 // benchmarks) never run validate-devices, so a test-groups <-> model-map drift


### PR DESCRIPTION
## Problem

The TTS Android functional lane [failed](https://github.com/tetherto/qvac/actions/runs/33414055957) in the `parler` runner: `runParlerTest` downloads `parler-mini-v1-q8_0.gguf` (~1.1 GB) from the QVAC registry on-device, and the fetch hit the registry client's request timeout after ~4 minutes:

```
[QVACRegistryClient] [ERROR] Error downloading model HypercoreError: REQUEST_TIMEOUT
not ok 1 - Parler GGUF not available - registry fetch failed.
```

A re-dispatch 30 minutes later passed, so the download is flaky rather than broken — but parler is the only functional runner still fetching its model over the device's network. Every other runner is pre-staged from the Device Farm host precisely to avoid this failure mode (see the `runGpuSmokeTest` mapping comment: the on-device registry fetch "is exactly the Device Farm flake this mapping prevents").

## Fix

- Add a `parler` group (mini q8_0, registry date `2026-07-20`, matching `REGISTRY_DATE_PARLER` in `test/utils/downloadModel.js`) to the mobile model manifest.
- Map `runParlerTest` to it in the functional prestage block, so the Android host pushes the GGUF into `/data/local/tmp/qvac-tts-ggml/models` before Appium starts.

`ensureParlerModel` already scans that directory for exactly this filename, so no device-side change is needed. The iOS functional lane keeps its on-device registry path, unchanged like the other runners there.

## Verification

- All 42 tests across `generate-mobile-model-manifest.test.js`, `generate-prestage-block.test.js`, and `mobile-test-groups.test.js` pass, including new pins for the parler registry date, the manifest group, and the `runParlerTest` staging list.
- The manifest date pin mirrors the LavaSR/CosyVoice convention so a future registry-path change fails the unit test rather than drifting from the on-device resolver.

No CHANGELOG entry: the prestage scripts and their tests are not part of the published npm package.

Generated with [Claude Code](https://claude.com/claude-code)
