### PR TITLE
QVAC-24406 chore: typecheck the whole cli test tree

### DIFF
--- a/packages/cli/src/serve/schemas/chat.ts
+++ b/packages/cli/src/serve/schemas/chat.ts
@@ -43,7 +43,7 @@ export const CHAT_UNSUPPORTED_PARAMS = [
   'stop'
 ] as const
 
-interface OpenAIMessage {
+export interface OpenAIMessage {
   role: string
   content: string | null | undefined | MessageContentPart[]
   tool_calls?: Array<{

--- a/packages/cli/test/audio.test.ts
+++ b/packages/cli/test/audio.test.ts
@@ -10,9 +10,9 @@ import {
   buildWavHeader,
   buildWavBuffer,
   speechAliasKey
-} from '../src/serve/audio.js'
-import { parseServeConfig } from '../src/serve/config.js'
-import { speechEncodeArgs, ENCODED_SPEECH_FORMATS } from '../src/serve/lib/audio-transcode.js'
+} from '@/serve/audio'
+import { parseServeConfig } from '@/serve/config'
+import { speechEncodeArgs, ENCODED_SPEECH_FORMATS } from '@/serve/lib/audio-transcode'
 
 describe('mapResponseFormat', () => {
   it('returns the documented default for missing input', () => {

--- a/packages/cli/test/audio.test.ts
+++ b/packages/cli/test/audio.test.ts
@@ -259,8 +259,8 @@ describe('parseServeConfig — openai.audio.speech.voices', () => {
       },
       {}
     )
-    assert.equal(cfg.openai.audio.speech.voices?.alloy, 'tts-a')
-    assert.equal(cfg.openai.audio.speech.voices?.echo, 'tts-b')
+    assert.equal(cfg.openai.audio.speech.voices?.['alloy'], 'tts-a')
+    assert.equal(cfg.openai.audio.speech.voices?.['echo'], 'tts-b')
   })
 
   it('rejects a non-object voices value', () => {

--- a/packages/cli/test/cancel-bridge.test.ts
+++ b/packages/cli/test/cancel-bridge.test.ts
@@ -2,8 +2,8 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import type { ServerResponse } from 'node:http'
-import type { Logger } from '../src/logger.js'
-import { bindClientDisconnectCancel } from '../src/serve/core/cancel-bridge.js'
+import type { Logger } from '@/logger'
+import { bindClientDisconnectCancel } from '@/serve/core/cancel-bridge'
 
 function makeLogger(): Logger & { debugs: string[] } {
   const debugs: string[] = []

--- a/packages/cli/test/chat-agent-shapes.test.ts
+++ b/packages/cli/test/chat-agent-shapes.test.ts
@@ -1,10 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import {
-  chatCompletionChunk,
-  chatCompletionResponse
-} from '../src/serve/adapters/openai/chat-shapes.js'
-import { sdkToolCallsToOpenaiDeltas } from '../src/serve/adapters/openai/tool-calls.js'
+import { chatCompletionChunk, chatCompletionResponse } from '@/serve/adapters/openai/chat-shapes'
+import { sdkToolCallsToOpenaiDeltas } from '@/serve/adapters/openai/tool-calls'
 
 describe('chat agent OpenAI shapes', () => {
   it('maps blocking SDK tool calls to OpenAI chat tool_calls', () => {

--- a/packages/cli/test/chunk-attribution-store.test.ts
+++ b/packages/cli/test/chunk-attribution-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { createChunkAttributionStore } from '../src/serve/adapters/openai/chunk-attribution-store.js'
+import { createChunkAttributionStore } from '@/serve/adapters/openai/chunk-attribution-store'
 
 describe('createChunkAttributionStore', () => {
   it('records and looks up attribution under a vector store id', () => {

--- a/packages/cli/test/completion-result.test.ts
+++ b/packages/cli/test/completion-result.test.ts
@@ -5,8 +5,8 @@ import { InferenceCancelledError } from '@qvac/sdk'
 import {
   drainCompletion,
   completionTokensFromStats
-} from '../src/serve/adapters/openai/completion-result.js'
-import { HttpError } from '../src/serve/lib/http-error.js'
+} from '@/serve/adapters/openai/completion-result'
+import { HttpError } from '@/serve/lib/http-error'
 
 function fakeRun(opts: {
   tokens?: string[]

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -1,12 +1,8 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { FLUX_2_KLEIN_4B_VAE, TTS_S3GEN_EN_CHATTERBOX, WHISPER_EN_TINY_Q8_0 } from '@qvac/sdk'
-import {
-  parseServeConfig,
-  resolveExplicitServeModel,
-  resolveModelConstant
-} from '../src/serve/config.js'
-import { resolveNestedModelSrcConstants } from '../src/serve/resolve-nested-model-src.js'
+import { parseServeConfig, resolveExplicitServeModel, resolveModelConstant } from '@/serve/config'
+import { resolveNestedModelSrcConstants } from '@/serve/resolve-nested-model-src'
 
 describe('resolveExplicitServeModel', () => {
   it('maps whispercpp-audio-translation to whispercpp-transcription and audio-translation', () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -45,7 +45,7 @@ describe('resolveExplicitServeModel', () => {
     })
     assert.equal(r.sdkType, 'whispercpp-transcription')
     assert.equal(r.endpointCategory, 'transcription')
-    assert.equal((r.config.whisperConfig as Record<string, unknown>).translate, false)
+    assert.equal((r.config['whisperConfig'] as Record<string, unknown>)['translate'], false)
   })
 })
 

--- a/packages/cli/test/configure.test.ts
+++ b/packages/cli/test/configure.test.ts
@@ -10,15 +10,15 @@ import {
   buildAdditions,
   buildEntry,
   buildGenericEntry
-} from '../src/configure/presets.js'
-import { CONFIG_DOCS_URL, docsUrlForAddon } from '../src/configure/docs-links.js'
+} from '@/configure/presets'
+import { CONFIG_DOCS_URL, docsUrlForAddon } from '@/configure/docs-links'
 import {
   foreignConfigPath,
   loadJsonConfig,
   mergeServeModels,
   serializeConfig,
   writeConfigAtomically
-} from '../src/configure/write-config.js'
+} from '@/configure/write-config'
 
 describe('configure: presets / buildEntry', () => {
   it('builds a bare {model, preload:false} for chat with the recommended default', () => {

--- a/packages/cli/test/doctor.test.ts
+++ b/packages/cli/test/doctor.test.ts
@@ -20,20 +20,20 @@ import {
   collectCheckSections,
   createDefaultContext,
   isReportOk
-} from '../src/doctor/checks/index.js'
-import type { CheckContext } from '../src/doctor/checks/index.js'
-import { runDoctor } from '../src/doctor/index.js'
+} from '@/doctor/checks/index'
+import type { CheckContext } from '@/doctor/checks/index'
+import { runDoctor } from '@/doctor/index'
 import {
   checkSdkRuntime,
   classifySdkRuntimeFailure,
   probeSdkRuntime,
   type SdkRuntimeProbeResult
-} from '../src/doctor/deep.js'
+} from '@/doctor/deep'
 import {
   DEEP_PROBE_MESSAGE_KIND,
   DEEP_PROBE_PROTOCOL_VERSION,
   isDeepProbeMessage
-} from '../src/doctor/deep-protocol.js'
+} from '@/doctor/deep-protocol'
 
 // Build a CheckContext with a minimal, deterministic baseline and spread
 // per-test overrides on top. Keeps each test assertion about a single

--- a/packages/cli/test/e2e/cli/configure.test.ts
+++ b/packages/cli/test/e2e/cli/configure.test.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runCli } from '../helpers/cli.js'
-import { parseServeConfig } from '../../../src/serve/config.js'
+import { parseServeConfig } from '@/serve/config'
 
 function tmp(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'qvac-configure-'))

--- a/packages/cli/test/e2e/helpers.test.ts
+++ b/packages/cli/test/e2e/helpers.test.ts
@@ -38,7 +38,7 @@ describe('e2e harness helpers', () => {
       { name: 'model', value: 'whisper' },
       { name: 'file', filename: 'a.wav', contentType: 'audio/wav', data: Buffer.from('RIFF') }
     ])
-    assert.match(headers['content-type'], /multipart\/form-data; boundary=/)
+    assert.match(headers['content-type']!, /multipart\/form-data; boundary=/)
     assert.ok(payload.includes('name="model"'))
     assert.ok(payload.includes('filename="a.wav"'))
   })

--- a/packages/cli/test/e2e/helpers.test.ts
+++ b/packages/cli/test/e2e/helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import Fastify from 'fastify'
-import { initSSE, sendSSE, endSSE } from '../../src/serve/lib/sse.js'
+import { initSSE, sendSSE, endSSE } from '@/serve/lib/sse'
 import { collectSSE, multipart, assertError, type InjectResponse } from './helpers/http.js'
 
 // Harness self-tests. The SSE case confirms app.inject captures hijacked

--- a/packages/cli/test/e2e/helpers/server.ts
+++ b/packages/cli/test/e2e/helpers/server.ts
@@ -3,11 +3,11 @@ import { before, after, type TestContext } from 'node:test'
 import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { buildServer, type StartServerOptions } from '../../../src/serve/index.js'
-import { preloadModels } from '../../../src/serve/core/lifecycle.js'
+import { buildServer, type StartServerOptions } from '@/serve/index'
+import { preloadModels } from '@/serve/core/lifecycle'
 import { MODELLESS_CONFIG, writeConfigDir } from './config.js'
 // Side-effect import: augments FastifyInstance with `.qvac`.
-import '../../../src/serve/lib/types.js'
+import '@/serve/lib/types'
 
 export interface CreateServerOptions {
   config?: unknown

--- a/packages/cli/test/e2e/http/audio-speech.test.ts
+++ b/packages/cli/test/e2e/http/audio-speech.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before } from 'node:test'
 import assert from 'node:assert/strict'
 import { useServer } from '../helpers/server.js'
 import { assertError, JSON_HEADERS, assertStatusAndError } from '../helpers/http.js'
-import { probeFfmpegAvailable } from '../../../src/serve/lib/video-transcode.js'
+import { probeFfmpegAvailable } from '@/serve/lib/video-transcode'
 
 describe('serve: speech validation', () => {
   const server = useServer({ cors: true, corsOrigins: ['https://trusted.example'] })

--- a/packages/cli/test/e2e/model/real-model.test.ts
+++ b/packages/cli/test/e2e/model/real-model.test.ts
@@ -65,7 +65,7 @@ describe('models', () => {
     const res = await post('/v1/embeddings', { model: E2E.embedLazy, input: 'lazy load me' })
     assert.equal(res.statusCode, 200)
     const body = res.json() as { data: Array<{ embedding: number[] }> }
-    assert.ok(body.data[0]?.embedding.length > 0)
+    assert.ok(body.data[0]!.embedding.length > 0)
 
     assert.equal(registry.getEntry(E2E.embedLazy)?.state, registry.STATES.READY)
   })

--- a/packages/cli/test/ephemeral-files-store.test.ts
+++ b/packages/cli/test/ephemeral-files-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { createEphemeralFilesStore } from '../src/serve/adapters/openai/ephemeral-files-store.js'
+import { createEphemeralFilesStore } from '@/serve/adapters/openai/ephemeral-files-store'
 
 describe('createEphemeralFilesStore', () => {
   it('put returns a file- prefixed id and get returns the same bytes', () => {

--- a/packages/cli/test/images.test.ts
+++ b/packages/cli/test/images.test.ts
@@ -14,6 +14,21 @@ import {
   InvalidImageStrengthError,
   UnsupportedImageOutputError
 } from '../src/serve/schemas/images.js'
+import type { Logger } from '../src/logger.js'
+
+// Collects warnings so the log-only helpers can be asserted on.
+function makeLogger(): { warnings: string[]; logger: Logger } {
+  const warnings: string[] = []
+  const logger: Logger = {
+    error: () => {},
+    warn: (message) => {
+      warnings.push(message)
+    },
+    info: () => {},
+    debug: () => {}
+  }
+  return { warnings, logger }
+}
 
 describe('parseImageSize', () => {
   it('returns null for undefined / null / empty', () => {
@@ -128,17 +143,6 @@ describe('extractImageGenerationParams', () => {
 })
 
 describe('logImageUnsupportedParams', () => {
-  function makeLogger(): {
-    warnings: string[]
-    logger: Parameters<typeof logImageUnsupportedParams>[1]
-  } {
-    const warnings: string[] = []
-    const logger = { warn: (msg: string) => warnings.push(msg) } as Parameters<
-      typeof logImageUnsupportedParams
-    >[1]
-    return { warnings, logger }
-  }
-
   it('does not warn on empty body', () => {
     const { warnings, logger } = makeLogger()
     logImageUnsupportedParams({}, logger)
@@ -328,17 +332,6 @@ describe('extractImageEditParams', () => {
 })
 
 describe('logImageEditExtraWarnings', () => {
-  function makeLogger(): {
-    warnings: string[]
-    logger: Parameters<typeof logImageEditExtraWarnings>[2]
-  } {
-    const warnings: string[] = []
-    const logger = { warn: (msg: string) => warnings.push(msg) } as Parameters<
-      typeof logImageEditExtraWarnings
-    >[2]
-    return { warnings, logger }
-  }
-
   it('warns on extra images', () => {
     const { warnings, logger } = makeLogger()
     logImageEditExtraWarnings({}, { extraImageCount: 2 }, logger)

--- a/packages/cli/test/images.test.ts
+++ b/packages/cli/test/images.test.ts
@@ -13,8 +13,8 @@ import {
   InvalidImageBatchCountError,
   InvalidImageStrengthError,
   UnsupportedImageOutputError
-} from '../src/serve/schemas/images.js'
-import type { Logger } from '../src/logger.js'
+} from '@/serve/schemas/images'
+import type { Logger } from '@/logger'
 
 // Collects warnings so the log-only helpers can be asserted on.
 function makeLogger(): { warnings: string[]; logger: Logger } {

--- a/packages/cli/test/lifecycle.test.ts
+++ b/packages/cli/test/lifecycle.test.ts
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { createModelRegistry } from '../src/serve/core/model-registry.js'
-import type { ResolvedModelEntry, ServeConfig } from '../src/serve/core/model-registry.js'
-import type { LoadManager } from '../src/serve/core/load-manager.js'
-import { preloadModels, formatErrorChain, shouldRefuseStart } from '../src/serve/core/lifecycle.js'
-import { createLogger } from '../src/logger.js'
+import { createModelRegistry } from '@/serve/core/model-registry'
+import type { ResolvedModelEntry, ServeConfig } from '@/serve/core/model-registry'
+import type { LoadManager } from '@/serve/core/load-manager'
+import { preloadModels, formatErrorChain, shouldRefuseStart } from '@/serve/core/lifecycle'
+import { createLogger } from '@/logger'
 
 const logger = createLogger('silent')
 

--- a/packages/cli/test/load-manager.test.ts
+++ b/packages/cli/test/load-manager.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { createModelRegistry } from '../src/serve/core/model-registry.js'
+import { createModelRegistry } from '@/serve/core/model-registry'
 import {
   createLoadManager,
   ModelLoadTimeoutError,
   type LoadModelFn
-} from '../src/serve/core/load-manager.js'
-import { createLogger } from '../src/logger.js'
+} from '@/serve/core/load-manager'
+import { createLogger } from '@/logger'
 
 const logger = createLogger('silent')
 

--- a/packages/cli/test/load-manager.test.ts
+++ b/packages/cli/test/load-manager.test.ts
@@ -100,9 +100,9 @@ describe('load-manager', () => {
     // a and b run; c is queued behind the concurrency=2 cap.
     await Promise.resolve()
     assert.ok(peak <= 2, `peak concurrency ${peak} should not exceed 2`)
-    gates.a!.resolve('sa')
-    gates.b!.resolve('sb')
-    gates.c!.resolve('sc')
+    gates['a']!.resolve('sa')
+    gates['b']!.resolve('sb')
+    gates['c']!.resolve('sc')
     await Promise.all([pa, pb, pc])
     assert.equal(peak, 2)
     assert.equal(reg.getEntry('c')?.state, reg.STATES.READY)

--- a/packages/cli/test/model-catalog.test.ts
+++ b/packages/cli/test/model-catalog.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { ModelConstant } from '@qvac/sdk'
-import { createModelRegistry } from '../src/serve/core/model-registry.js'
-import type { ResolvedModelEntry, ServeConfig } from '../src/serve/core/model-registry.js'
-import { buildCatalog, filterCatalog, paginate } from '../src/serve/core/model-catalog.js'
+import { createModelRegistry } from '@/serve/core/model-registry'
+import type { ResolvedModelEntry, ServeConfig } from '@/serve/core/model-registry'
+import { buildCatalog, filterCatalog, paginate } from '@/serve/core/model-catalog'
 
 function constant(name: string, over: Partial<ModelConstant> = {}): ModelConstant {
   return {

--- a/packages/cli/test/openai-coverage.test.ts
+++ b/packages/cli/test/openai-coverage.test.ts
@@ -4,12 +4,12 @@ import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { buildCoverageReport, DEFAULT_ROUTER } from '../src/openai/coverage/build-report.js'
-import { categorize } from '../src/openai/coverage/categorize.js'
-import { filterCoverageRows, formatCoverageReportHuman } from '../src/openai/coverage/format.js'
-import { parseRouter } from '../src/openai/coverage/parse-router.js'
-import { parseSpec } from '../src/openai/coverage/parse-spec.js'
-import { CONSUMER_PRIMARY_ENDPOINTS } from '../src/openai/coverage/primary.js'
+import { buildCoverageReport, DEFAULT_ROUTER } from '@/openai/coverage/build-report'
+import { categorize } from '@/openai/coverage/categorize'
+import { filterCoverageRows, formatCoverageReportHuman } from '@/openai/coverage/format'
+import { parseRouter } from '@/openai/coverage/parse-router'
+import { parseSpec } from '@/openai/coverage/parse-spec'
+import { CONSUMER_PRIMARY_ENDPOINTS } from '@/openai/coverage/primary'
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url))
 const FIXTURE_SPEC = join(TEST_DIR, 'fixtures', 'openai-spec-mini.yaml')

--- a/packages/cli/test/openai-spec-fetch.test.ts
+++ b/packages/cli/test/openai-spec-fetch.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it } from 'node:test'
-import { parseSpecWithDependencies } from '../src/openai/coverage/parse-spec.js'
+import { parseSpecWithDependencies } from '@/openai/coverage/parse-spec'
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url))
 const FIXTURE_SPEC = join(TEST_DIR, 'fixtures', 'openai-spec-mini.yaml')

--- a/packages/cli/test/openai-spec.test.ts
+++ b/packages/cli/test/openai-spec.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { emitOpenApiSpec, renderOpenApiSpec } from '../src/openai/spec.js'
+import { emitOpenApiSpec, renderOpenApiSpec } from '@/openai/spec'
 
 describe('renderOpenApiSpec', () => {
   it('returns a valid OpenAPI 3.1.0 JSON string by default', async () => {

--- a/packages/cli/test/param-schemas.test.ts
+++ b/packages/cli/test/param-schemas.test.ts
@@ -67,7 +67,7 @@ describe('configure: param-schemas', () => {
     assert.ok(schema)
     for (const engine of TTS_ENGINES) {
       const built = buildEntry('speech', engine)
-      assert.equal(built.entry.config?.ttsEngine, engine)
+      assert.equal(built.entry.config?.['ttsEngine'], engine)
       assert.ok(built.entry.src, `${engine} starter has a model`)
       const res = schema.safeParse(built.entry.config)
       assert.ok(
@@ -78,7 +78,9 @@ describe('configure: param-schemas', () => {
   })
 
   it('shows an object field shape and enforces it on input', () => {
-    const model = configParamModel(configSchemaForAddon('tts'))
+    const ttsSchema = configSchemaForAddon('tts')
+    assert.ok(ttsSchema)
+    const model = configParamModel(ttsSchema)
     assert.ok(model?.kind === 'variants')
     const audio8 = model.variants.find((v) => v.value === 'audio8')
     const ref = audio8?.fields.find((f) => f.name === 'referenceAudioSrc')

--- a/packages/cli/test/param-schemas.test.ts
+++ b/packages/cli/test/param-schemas.test.ts
@@ -6,8 +6,8 @@ import {
   paramFields,
   coerceParam,
   validateParam
-} from '../src/configure/param-schemas.js'
-import { TTS_ENGINES, buildEntry } from '../src/configure/presets.js'
+} from '@/configure/param-schemas'
+import { TTS_ENGINES, buildEntry } from '@/configure/presets'
 
 describe('configure: param-schemas', () => {
   it('resolves a config schema for every built-in addon', () => {

--- a/packages/cli/test/require-model.test.ts
+++ b/packages/cli/test/require-model.test.ts
@@ -2,16 +2,16 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import type { FastifyReply, FastifyRequest } from 'fastify'
-import { createModelRegistry } from '../src/serve/core/model-registry.js'
+import { createModelRegistry } from '@/serve/core/model-registry'
 import {
   createLoadManager,
   type LoadManagerDeps,
   type LoadModelFn
-} from '../src/serve/core/load-manager.js'
-import { ensureReady, resolveAndCheckModel } from '../src/serve/plugins/require-model.js'
-import { createLogger } from '../src/logger.js'
-import type { QvacContext } from '../src/serve/lib/types.js'
-import { HttpError } from '../src/serve/lib/http-error.js'
+} from '@/serve/core/load-manager'
+import { ensureReady, resolveAndCheckModel } from '@/serve/plugins/require-model'
+import { createLogger } from '@/logger'
+import type { QvacContext } from '@/serve/lib/types'
+import { HttpError } from '@/serve/lib/http-error'
 
 const logger = createLogger('silent')
 

--- a/packages/cli/test/responses-store.test.ts
+++ b/packages/cli/test/responses-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { createResponsesStore } from '../src/serve/adapters/openai/responses-store.js'
+import { createResponsesStore } from '@/serve/adapters/openai/responses-store'
 
 describe('createResponsesStore', () => {
   it('put then get returns record', () => {

--- a/packages/cli/test/responses-streaming.test.ts
+++ b/packages/cli/test/responses-streaming.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { ServerResponse } from 'node:http'
-import { writeStreamingResponse } from '../src/serve/adapters/openai/response-writers.js'
+import { writeStreamingResponse } from '@/serve/adapters/openai/response-writers'
 import type {
   ResponsesHandlerParams,
   ResponseWriterContext
-} from '../src/serve/adapters/openai/response-writers.js'
+} from '@/serve/adapters/openai/response-writers'
 import type { CompletionRun, CompletionStats, ToolCall } from '@qvac/sdk'
 
 function minimalRouteContext(): ResponseWriterContext {

--- a/packages/cli/test/responses.test.ts
+++ b/packages/cli/test/responses.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { ServerResponse } from 'node:http'
-import { buildResponseObject } from '../src/serve/adapters/openai/responses-shape.js'
-import { writeBlockingResponse } from '../src/serve/adapters/openai/response-writers.js'
+import { buildResponseObject } from '@/serve/adapters/openai/responses-shape'
+import { writeBlockingResponse } from '@/serve/adapters/openai/response-writers'
 import type {
   ResponsesHandlerParams,
   ResponseWriterContext
-} from '../src/serve/adapters/openai/response-writers.js'
+} from '@/serve/adapters/openai/response-writers'
 import type { CompletionRun, ToolCall, CompletionStats } from '@qvac/sdk'
 
 const uuidSuffix = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i

--- a/packages/cli/test/serve-cors.test.ts
+++ b/packages/cli/test/serve-cors.test.ts
@@ -3,15 +3,11 @@ import { mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
-import { resolveServeApiKey } from '../src/serve/api-key.js'
-import { createCorsOriginMatcher, isLoopbackHost, normalizeCorsOrigin } from '../src/serve/cors.js'
-import { parseServeConfig } from '../src/serve/config.js'
-import { buildServer } from '../src/serve/index.js'
-import {
-  checkNetworkExposure,
-  ServeOptionsError,
-  validateServeStartup
-} from '../src/serve/startup.js'
+import { resolveServeApiKey } from '@/serve/api-key'
+import { createCorsOriginMatcher, isLoopbackHost, normalizeCorsOrigin } from '@/serve/cors'
+import { parseServeConfig } from '@/serve/config'
+import { buildServer } from '@/serve/index'
+import { checkNetworkExposure, ServeOptionsError, validateServeStartup } from '@/serve/startup'
 
 describe('normalizeCorsOrigin', () => {
   it('normalizes HTTP(S) origins', () => {

--- a/packages/cli/test/serve-http.test.ts
+++ b/packages/cli/test/serve-http.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { tmpdir } from 'node:os'
-import { buildServer } from '../src/serve/index.js'
+import { buildServer } from '@/serve/index'
 
 // Wire-level validation lives in the e2e suite (test/e2e). This file only
 // pins the OpenAPI document because that's a unique testability angle.

--- a/packages/cli/test/synthetic-workspace.test.ts
+++ b/packages/cli/test/synthetic-workspace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { syntheticFromWorkspace } from '../src/serve/routes/vector-stores.js'
+import { syntheticFromWorkspace } from '@/serve/routes/vector-stores'
 
 describe('syntheticFromWorkspace', () => {
   const workspaces = [{ name: 'vs_known', open: false }]

--- a/packages/cli/test/transcription-response.test.ts
+++ b/packages/cli/test/transcription-response.test.ts
@@ -4,7 +4,7 @@ import type { TranscribeSegment } from '@qvac/sdk'
 import {
   formatTimedTranscription,
   isTimedTranscriptionFormat
-} from '../src/serve/lib/transcription-response.js'
+} from '@/serve/lib/transcription-response'
 
 const SEGMENTS: TranscribeSegment[] = [
   { id: 7, startMs: 0, endMs: 1_250, text: ' Hello', append: false },

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -8,26 +8,22 @@ import {
   InvalidResponseFormatError,
   UnsupportedImageContentError,
   extractGenerationParams
-} from '../src/serve/schemas/common.js'
-import {
-  openaiMessagesToHistory,
-  writeChatImages,
-  type OpenAIMessage
-} from '../src/serve/schemas/chat.js'
+} from '@/serve/schemas/common'
+import { openaiMessagesToHistory, writeChatImages, type OpenAIMessage } from '@/serve/schemas/chat'
 import {
   parseExpiresAfter,
   parseMetadata,
   InvalidExpiresAfterError,
   InvalidMetadataError
-} from '../src/serve/schemas/vector-stores.js'
+} from '@/serve/schemas/vector-stores'
 import {
   vectorStoreToOpenAI,
   searchResultsToOpenAI
-} from '../src/serve/adapters/openai/vector-stores-store.js'
+} from '@/serve/adapters/openai/vector-stores-store'
 import {
   sdkToolCallsToOpenai,
   sdkToolCallsToOpenaiDeltas
-} from '../src/serve/adapters/openai/tool-calls.js'
+} from '@/serve/adapters/openai/tool-calls'
 import {
   openaiResponsesInputToHistory,
   openaiResponsesToolsToSdk,
@@ -38,13 +34,13 @@ import {
   UnsupportedToolTypeError,
   InvalidResponsesConversationError,
   InvalidResponsesBackgroundError
-} from '../src/serve/schemas/responses.js'
+} from '@/serve/schemas/responses'
 import {
   parseLegacyPrompt,
   legacyPromptToHistory,
   InvalidPromptError
-} from '../src/serve/schemas/completions.js'
-import type { VectorStoreMeta } from '../src/serve/adapters/openai/vector-stores-store.js'
+} from '@/serve/schemas/completions'
+import type { VectorStoreMeta } from '@/serve/adapters/openai/vector-stores-store'
 
 describe('openaiMessagesToHistory', () => {
   it('converts simple user/assistant messages', () => {

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -9,7 +9,11 @@ import {
   UnsupportedImageContentError,
   extractGenerationParams
 } from '../src/serve/schemas/common.js'
-import { openaiMessagesToHistory, writeChatImages } from '../src/serve/schemas/chat.js'
+import {
+  openaiMessagesToHistory,
+  writeChatImages,
+  type OpenAIMessage
+} from '../src/serve/schemas/chat.js'
 import {
   parseExpiresAfter,
   parseMetadata,
@@ -44,7 +48,7 @@ import type { VectorStoreMeta } from '../src/serve/adapters/openai/vector-stores
 
 describe('openaiMessagesToHistory', () => {
   it('converts simple user/assistant messages', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       { role: 'user', content: 'hello' },
       { role: 'assistant', content: 'hi there' }
     ]
@@ -56,19 +60,19 @@ describe('openaiMessagesToHistory', () => {
   })
 
   it('handles null content gracefully', () => {
-    const messages = [{ role: 'assistant', content: null }]
+    const messages: OpenAIMessage[] = [{ role: 'assistant', content: null }]
     const history = openaiMessagesToHistory(messages, 'hermes')
     assert.equal(history[0]!.content, '')
   })
 
   it('handles undefined content gracefully', () => {
-    const messages = [{ role: 'assistant', content: undefined }]
+    const messages: OpenAIMessage[] = [{ role: 'assistant', content: undefined }]
     const history = openaiMessagesToHistory(messages, 'hermes')
     assert.equal(history[0]!.content, '')
   })
 
   it('synthesizes hermes JSON tool_call content for assistant messages', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'assistant',
         content: null,
@@ -93,7 +97,7 @@ describe('openaiMessagesToHistory', () => {
   // foreign shape and emit a malformed hybrid frame, which then leaks raw markup
   // into `content`. Render it in the model's native Pythonic-XML instead.
   it('synthesizes native qwen35 XML tool_call content for assistant messages', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'assistant',
         content: null,
@@ -116,7 +120,7 @@ describe('openaiMessagesToHistory', () => {
   })
 
   it('renders qwen35 non-string params as text/JSON per the parser contract', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'assistant',
         content: null,
@@ -139,7 +143,7 @@ describe('openaiMessagesToHistory', () => {
   })
 
   it('handles multiple tool calls in single message', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'assistant',
         content: null,
@@ -156,7 +160,7 @@ describe('openaiMessagesToHistory', () => {
   })
 
   it('handles malformed tool call arguments JSON', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'assistant',
         content: null,
@@ -174,13 +178,15 @@ describe('openaiMessagesToHistory', () => {
   })
 
   it('preserves tool_call_id messages as-is', () => {
-    const messages = [{ role: 'tool', content: '{"result": 42}', tool_call_id: 'call_1' }]
+    const messages: OpenAIMessage[] = [
+      { role: 'tool', content: '{"result": 42}', tool_call_id: 'call_1' }
+    ]
     const history = openaiMessagesToHistory(messages, 'hermes')
     assert.deepEqual(history[0], { role: 'tool', content: '{"result": 42}' })
   })
 
   it('concatenates text content parts into a string', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'user',
         content: [
@@ -197,7 +203,7 @@ describe('openaiMessagesToHistory', () => {
     // 1x1 transparent PNG.
     const dataUrl =
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'user',
         content: [
@@ -216,7 +222,9 @@ describe('openaiMessagesToHistory', () => {
 
   it('accepts a string (data URL) image_url', () => {
     const dataUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRg=='
-    const messages = [{ role: 'user', content: [{ type: 'image_url', image_url: dataUrl }] }]
+    const messages: OpenAIMessage[] = [
+      { role: 'user', content: [{ type: 'image_url', image_url: dataUrl }] }
+    ]
     const history = openaiMessagesToHistory(messages, 'hermes')
     assert.equal(history[0]!.attachments!.length, 1)
     assert.equal(history[0]!.attachments![0]!.ext, 'jpg')
@@ -225,7 +233,7 @@ describe('openaiMessagesToHistory', () => {
   // Reviewer ask: an image the server cannot materialize must fail loudly (→ 400) instead of
   // silently dropping to a text-only completion the user never asked for.
   it('throws on a remote (non-data) image_url', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       { role: 'user', content: [{ type: 'image_url', image_url: 'https://example.com/x.png' }] }
     ]
     assert.throws(() => openaiMessagesToHistory(messages, 'hermes'), UnsupportedImageContentError)
@@ -233,7 +241,7 @@ describe('openaiMessagesToHistory', () => {
 
   it('throws on an unsupported image format (e.g. webp)', () => {
     const webp = 'data:image/webp;base64,UklGRhIAAABXRUJQVlA4TAYAAAAvAAAAAAfQ//73v/+BiOh/AAA='
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'user',
         content: [
@@ -246,7 +254,7 @@ describe('openaiMessagesToHistory', () => {
   })
 
   it('throws on a payload that is not valid base64 image data', () => {
-    const messages = [
+    const messages: OpenAIMessage[] = [
       {
         role: 'user',
         content: [
@@ -260,7 +268,7 @@ describe('openaiMessagesToHistory', () => {
   it('writeChatImages materializes attachment bytes to flat temp files', async () => {
     const dataUrl =
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
-    const messages = [
+    const messages: OpenAIMessage[] = [
       { role: 'user', content: [{ type: 'image_url', image_url: { url: dataUrl } }] }
     ]
     const { history, tmpPaths } = await writeChatImages(openaiMessagesToHistory(messages, 'hermes'))
@@ -716,6 +724,7 @@ function fixtureMeta(overrides: Partial<VectorStoreMeta> = {}): VectorStoreMeta 
     expiresAfter: null,
     expiresAt: null,
     lastActiveAt: 1_700_000_000_000,
+    embeddingAlias: null,
     ...overrides
   }
 }

--- a/packages/cli/test/vector-stores-binary.test.ts
+++ b/packages/cli/test/vector-stores-binary.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { looksBinary } from '../src/serve/routes/vector-stores.js'
+import { looksBinary } from '@/serve/routes/vector-stores'
 
 describe('looksBinary', () => {
   it('returns false for plain UTF-8 text', () => {

--- a/packages/cli/test/vector-stores-store.test.ts
+++ b/packages/cli/test/vector-stores-store.test.ts
@@ -5,7 +5,7 @@ import {
   generateVectorStoreId,
   idToWorkspace,
   InvalidVectorStoreIdError
-} from '../src/serve/adapters/openai/vector-stores-store.js'
+} from '@/serve/adapters/openai/vector-stores-store'
 
 describe('generateVectorStoreId', () => {
   it('returns a vs_-prefixed id of expected length', () => {

--- a/packages/cli/test/verify-deps.test.ts
+++ b/packages/cli/test/verify-deps.test.ts
@@ -10,12 +10,12 @@ import {
   packageNameFromNpmLockPath,
   parseNpmPackageLock,
   UnsupportedLockfileError
-} from '../src/verify/deps/npm-lockfile.js'
+} from '@/verify/deps/npm-lockfile'
 import {
   collectNativePackages,
   type NativePackage,
   type UnclassifiedPackage
-} from '../src/verify/deps/native-packages.js'
+} from '@/verify/deps/native-packages'
 import {
   diffUnknownRemovedPackages,
   diffNativePackages,
@@ -25,7 +25,7 @@ import {
   hasUnclassifiedPackages,
   resolveLockfilePackageRoot,
   verifyDeps
-} from '../src/verify/deps/index.js'
+} from '@/verify/deps/index'
 
 async function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> {
   const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qvac-verify-deps-')))

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -6,10 +6,10 @@ import {
   nearestVideoFrameCount,
   InvalidVideoStrengthError,
   DEFAULT_FPS
-} from '../src/serve/schemas/videos.js'
-import { createVideoJobsStore, type VideoJob } from '../src/serve/core/video-jobs-store.js'
-import { tearDownJob, resolveInputReferenceImage } from '../src/serve/routes/videos.js'
-import type { QvacContext } from '../src/serve/lib/types.js'
+} from '@/serve/schemas/videos'
+import { createVideoJobsStore, type VideoJob } from '@/serve/core/video-jobs-store'
+import { tearDownJob, resolveInputReferenceImage } from '@/serve/routes/videos'
+import type { QvacContext } from '@/serve/lib/types'
 
 type CancelInput = Parameters<NonNullable<QvacContext['cancelOverride']>>[0]
 

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -11,6 +11,8 @@ import { createVideoJobsStore, type VideoJob } from '../src/serve/core/video-job
 import { tearDownJob, resolveInputReferenceImage } from '../src/serve/routes/videos.js'
 import type { QvacContext } from '../src/serve/lib/types.js'
 
+type CancelInput = Parameters<NonNullable<QvacContext['cancelOverride']>>[0]
+
 function expectIssue(input: unknown, path: string): { message: string } {
   const result = videosCreateBody.safeParse(input)
   assert.equal(result.success, false, `expected validation to fail for ${JSON.stringify(input)}`)
@@ -178,18 +180,18 @@ describe('extractVideoCreateParams', () => {
     it('returns mode=img2vid with init_image when initImage is provided', () => {
       const params = extractVideoCreateParams({ prompt: 'turns and smiles' }, initImage, 'm')
       assert.equal(params.mode, 'img2vid')
-      assert.equal((params as Record<string, unknown>).init_image, initImage)
+      assert.equal((params as Record<string, unknown>)['init_image'], initImage)
       assert.equal(params.prompt, 'turns and smiles')
     })
 
     it('includes coerced strength when provided as number', () => {
       const params = extractVideoCreateParams({ prompt: 'p', strength: 0.85 }, initImage, 'm')
-      assert.equal((params as Record<string, unknown>).strength, 0.85)
+      assert.equal((params as Record<string, unknown>)['strength'], 0.85)
     })
 
     it('coerces strength from string to float', () => {
       const params = extractVideoCreateParams({ prompt: 'p', strength: '0.5' }, initImage, 'm')
-      assert.equal((params as Record<string, unknown>).strength, 0.5)
+      assert.equal((params as Record<string, unknown>)['strength'], 0.5)
     })
 
     it('omits strength when not provided', () => {
@@ -554,7 +556,7 @@ describe('resolveInputReferenceImage', () => {
 
 describe('tearDownJob', () => {
   it('aborts the controller and cancels the SDK request for in-progress jobs', () => {
-    const cancelled: Array<{ requestId: string }> = []
+    const cancelled: CancelInput[] = []
     const ctx = makeCtxStub({
       // lunte-disable-next-line require-await
       cancelOverride: async (opts) => {
@@ -569,7 +571,7 @@ describe('tearDownJob', () => {
   })
 
   it('skips cancel for completed jobs', () => {
-    const cancelled: Array<{ requestId: string }> = []
+    const cancelled: CancelInput[] = []
     const ctx = makeCtxStub({
       // lunte-disable-next-line require-await
       cancelOverride: async (opts) => {
@@ -584,7 +586,7 @@ describe('tearDownJob', () => {
   })
 
   it('skips cancel when requestId is not yet set', () => {
-    const cancelled: Array<{ requestId: string }> = []
+    const cancelled: CancelInput[] = []
     const ctx = makeCtxStub({
       // lunte-disable-next-line require-await
       cancelOverride: async (opts) => {

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,11 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "src/**/*",
-    "test/chat-agent-shapes.test.ts",
-    "test/require-model.test.ts",
-    "test/cancel-bridge.test.ts"
-  ],
+  "include": ["src/**/*", "test/**/*"],
   "compilerOptions": {
     "rootDir": ".",
     "noEmit": true


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `tsconfig.test.json` opted in to three test files by name, so the rest of `test/` was never typechecked. Type errors in tests only showed up at runtime, or not at all.

## 📝 How does it solve it?

- `include` is now `["src/**/*", "test/**/*"]`.
- Fixed the errors that surfaces, across `audio`, `config`, `images`, `load-manager`, `param-schemas`, `translate`, `videos`, and two e2e helpers: bracket access for index-signature properties, narrowing before passing possibly-undefined values to non-optional parameters, and assertion types.
- One source fix in `serve/schemas/chat.ts`, where the test exposed a wrong type.

## 🧪 How was it tested?

- `npm run typecheck` covers `src/` and all of `test/` and passes.
- Unit and e2e suites pass unchanged; no test behaviour was altered.
