### PR TITLE
chore[notask]: release @qvac/test-suite 0.11.1

### DIFF
--- a/packages/test-suite/CHANGELOG.md
+++ b/packages/test-suite/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.11.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.1
+
+A single fix: memory samples now appear in e2e reports on Windows. Desktop and Electron runs on Windows previously produced reports with no memory data at all, and did so silently.
+
+---
+
+## Bug Fixes
+
+### Memory sampling works on Windows
+
+The memory poller collected resident set size by shelling out to `ps`, which does not exist on Windows. Desktop and Electron consumers on Windows therefore reported no memory at all — and because the collector failed quietly rather than erroring, the gap looked like a suite that simply had nothing to report.
+
+Windows now has its own collector. It keeps a single PowerShell process alive and queries `Win32_Process` through CIM for process ids, parent ids and working-set bytes, so a whole test run costs one process start rather than one per sample. That matters at the polling rate involved: starting PowerShell per sample would have added enough overhead to distort the very numbers being measured.
+
+The collector reuses the existing process-tree aggregation, so a sample covers the consumer together with its Bare workers, and excludes the PowerShell collector itself from the total. Windows polls every 500 ms.
+
+Nothing changes for existing consumers. The POSIX path is untouched, the emitted `qvac/app-memory` payload keeps the same shape, and reports produced on macOS and Linux are byte-for-byte what they were before. Collector startup and any failure are now logged, so a future gap surfaces as a log line instead of an empty section.
+
+Process exits, stream failures, collector restarts and shutdown are all handled without leaking a PowerShell process or stalling the consumer, and outstanding snapshot requests are bounded.
+
 ## [0.11.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.0

--- a/packages/test-suite/changelog/0.11.1/CHANGELOG.md
+++ b/packages/test-suite/changelog/0.11.1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.11.1
+
+Release Date: 2026-09-01
+
+## 🐞 Fixes
+
+- Collect process-tree RSS on Windows. (see PR [#4160](https://github.com/tetherto/qvac/pull/4160))
+

--- a/packages/test-suite/changelog/0.11.1/CHANGELOG_LLM.md
+++ b/packages/test-suite/changelog/0.11.1/CHANGELOG_LLM.md
@@ -1,0 +1,21 @@
+# QVAC Test Suite v0.11.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.1
+
+A single fix: memory samples now appear in e2e reports on Windows. Desktop and Electron runs on Windows previously produced reports with no memory data at all, and did so silently.
+
+---
+
+## Bug Fixes
+
+### Memory sampling works on Windows
+
+The memory poller collected resident set size by shelling out to `ps`, which does not exist on Windows. Desktop and Electron consumers on Windows therefore reported no memory at all — and because the collector failed quietly rather than erroring, the gap looked like a suite that simply had nothing to report.
+
+Windows now has its own collector. It keeps a single PowerShell process alive and queries `Win32_Process` through CIM for process ids, parent ids and working-set bytes, so a whole test run costs one process start rather than one per sample. That matters at the polling rate involved: starting PowerShell per sample would have added enough overhead to distort the very numbers being measured.
+
+The collector reuses the existing process-tree aggregation, so a sample covers the consumer together with its Bare workers, and excludes the PowerShell collector itself from the total. Windows polls every 500 ms.
+
+Nothing changes for existing consumers. The POSIX path is untouched, the emitted `qvac/app-memory` payload keeps the same shape, and reports produced on macOS and Linux are byte-for-byte what they were before. Collector startup and any failure are now logged, so a future gap surfaces as a log line instead of an empty section.
+
+Process exits, stream failures, collector restarts and shutdown are all handled without leaking a PowerShell process or stalling the consumer, and outstanding snapshot requests are bounded.

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/test-suite",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Generic distributed testing framework for multi-platform execution",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 🎯 What problem does this solve?

Patch release of `@qvac/test-suite`, carrying one fix: #4160 (QVAC-23578) makes process-tree RSS collection work on Windows, so Desktop and Electron e2e runs there report memory instead of silently emitting nothing. That fix is on `main` but not published, so no consumer sees it yet.

## 📝 How is it solved?

- `packages/test-suite/package.json` → `0.11.1`
- `packages/test-suite/changelog/0.11.1/` with `CHANGELOG.md` and `CHANGELOG_LLM.md`
- Root `CHANGELOG.md` rebuilt from the version folders, so it prefers the human-readable file

`0.11.1` rather than `0.12.0`: the release contains a single `fix` and no API change.

**Changelog base.** Discovery used `--base-commit=92b9b65ce --base-version=0.11.0` instead of the `test-suite-v0.11.0` tag. The tag sits on `release-test-suite-0.11.0`, so it is not an ancestor of `main`, and the generator rejects that by design (`Base reference … is not an ancestor of HEAD`). `92b9b65ce` is the backmerge commit where 0.11.0's metadata landed on `main`, and it carries version `0.11.0`, so the range resolves to exactly the one PR being released. This is structural to the release-branch model, not a workaround: patches ship on release branches and reach `main` only via backmerge.

**NOTICE is unchanged.** `qv-notice-generate` was run for `test-suite` (88 JS dependencies scanned, `NOTICE_LOG.txt` 0 entries) and the output is byte-identical to the committed file, so it is not part of this release. That is consistent with the input not having moved: every dependency block in `package.json` is byte-identical to 0.11.0, the only change since then being this version bump.

## 🧪 How was this verified?

On this branch at `0.11.1`:

- `npm run check` (lunte + eslint + prettier) — clean
- `npm run typecheck` — clean
- `npm run build` — clean, and `node dist/cli/index.js --version` reports `0.11.1`
- The publish workflow's own gate: `grep -qE "^## \[0.11.1\]" packages/test-suite/CHANGELOG.md` — passes
- `npm run format` (the package's real CI format gate) — clean, and `prettier --check` on the hand-authored `changelog/0.11.1/CHANGELOG_LLM.md` is clean

**Scope.** The diff is four files: the version bump, the two new `0.11.1` changelog files, and the new section prepended to the aggregated `CHANGELOG.md`. Nothing under `changelog/0.11.0/` is touched, and the changelog files are byte-for-byte what the generator emits, so a later regeneration is a no-op.

## 📝 Note for reviewers

`changelog/0.11.0/CHANGELOG_LLM.md` uses emoji section headings (`## 🔌 API`, `## ⚙️ Infrastructure`, `## 🧹 Chores`), which `qv-sdk-changelog`'s format guide forbids — the docs site inlines that file verbatim, so the emoji leak into public headers. `0.11.1` follows the rule with plain headings. 0.11.0 is left alone here because it is already-published release notes and fixing it is not this release's business; worth a separate cleanup if the docs headers matter.

## 🚀 Workflow / Publish Changes

None. Publishing runs through `trigger-reusable-lib-test-suite.yml`.

Note for reviewers: `publish-release-npm` uses `environment: npm`, which has a required-reviewer rule — the publish job waits for approval.

## 🔄 Migration Notes

None for consumers: `0.11.1` is a drop-in patch over `0.11.0`. The emitted `qvac/app-memory` payload keeps its shape and the POSIX collector path is untouched, so reports on macOS and Linux are unchanged.

After this merges, backmerge the version bump and changelog into `main` — companion PR below.
