### PR TITLE
QVAC-24385 chore[audiogen-ggml]: bump version to 0.3.2

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-09-01
+
 ### Added
 
 - Report why a `useGPU: true` run resolved to the CPU. `stats.gpuFallbackReason`

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
Version bump only, in its own PR per the packages rule. No code changes, so nothing here needs a test or workflow run.

- `package.json`: `0.3.1` → `0.3.2`
- `CHANGELOG.md`: closes the `[Unreleased]` section as `## [0.3.2] - 2026-09-01`, leaving `[Unreleased]` empty at the top (same shape as the 0.3.1 bump in #4148)

0.3.2 therefore ships the two changes that were sitting in `[Unreleased]`: the `stats.gpuFallbackReason` API addition (#4166) and the mobile bundle fix that restores Android / iOS support (#4185).

Releasing this is what unblocks the AudioGen mobile Device Farm lane end to end: dispatches of `integration-mobile-test-audiogen-ggml.yml` that pin `package_spec: @qvac/audiogen-ggml@<version>` resolve the addon from npm, so they only pick up the #4185 fix once a version containing it is published. The artifact-first lane already has it from #4185.

Consistency check (per the version-bump rule): no dependency change in this bump, so `vcpkg.json` keeps its `speech-cpp` floor at `2026-08-28` — matching what the 0.3.1 changelog entry documents — and the registry baseline in `vcpkg-configuration.json` stays untouched.

Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218047087370434