### PR TITLE
QVAC-24385 infra: retry a Device Farm run that errors before any test executes

### DIFF
--- a/.github/actions/run-mobile-integration-tests/monitor-test-run/action.yml
+++ b/.github/actions/run-mobile-integration-tests/monitor-test-run/action.yml
@@ -10,6 +10,12 @@ description: |
   dual-flagship runs (2 ARNs), embed single-pool (1 ARN), and LLM/OCR
   sharded mode (2-10 ARNs).
 
+  A run that Device Farm completes as ERRORED without executing a single test
+  is an infrastructure failure, not a result, and is rescheduled once on the
+  same device selection (see max-errored-retries). That needs the scheduling
+  inputs below plus run-specs from schedule-test-run; without them the retry
+  is skipped and monitoring behaves exactly as it did before.
+
 inputs:
   run-arns:
     description: "JSON array of Device Farm run ARNs"
@@ -26,6 +32,34 @@ inputs:
     description: "JSON array from upload-to-devicefarm: [{name, grep, arn}]. Used to print a run-to-tests legend. Optional; omit for non-sharded runs."
     required: false
     default: "[]"
+  run-specs:
+    description: "run-specs from schedule-test-run: the per-slot respawn recipe. Required for the errored-run retry; default [] disables it."
+    required: false
+    default: "[]"
+  test-package-upload-arn:
+    description: |
+      Device Farm upload ARN for the Appium test package, as passed to
+      schedule-test-run. Required for the errored-run retry: it is the one
+      scheduling parameter Device Farm does not report back on a run, so unlike
+      the project / app / timeout below it cannot be derived here.
+    required: false
+    default: ""
+  device-farm-project-arn:
+    description: "Optional override. Empty (default) derives the project ARN from the run ARN being retried, so callers do not have to re-pass the secret the scheduler already used."
+    required: false
+    default: ""
+  app-upload-arn:
+    description: "Optional override. Empty (default) reads the app upload ARN back off the errored run, which is by definition the one it was scheduled with."
+    required: false
+    default: ""
+  job-timeout-minutes:
+    description: "Optional override for a rescheduled run's jobTimeoutMinutes. Empty (default) reuses the errored run's own value, so a retry inherits whatever ceiling the scheduler set."
+    required: false
+    default: ""
+  max-errored-retries:
+    description: "How many times one run slot may be rescheduled after Device Farm errors it without executing any test. Default 1 (retry once); 0 disables. Never applies to FAILED runs — those are real results."
+    required: false
+    default: "1"
 
 outputs:
   test-result:
@@ -49,6 +83,14 @@ outputs:
   user-test-failed:
     description: "Devices failed (user-defined non-PASSED jobs)"
     value: ${{ steps.monitor.outputs.user_test_failed }}
+  run-arns:
+    description: |
+      JSON array of the run ARNs actually monitored: index-aligned with the
+      run-arns input, with any rescheduled slot replaced by its new ARN. Use it
+      for log collection so a retried slot's artifacts come from the run that
+      executed. Empty when monitoring never reached the end of the polling loop,
+      so callers should fall back to the scheduler's run-arns.
+    value: ${{ steps.monitor.outputs.effective_run_arns }}
 
 runs:
   using: composite
@@ -60,6 +102,12 @@ runs:
         RUN_ARNS_JSON: ${{ inputs.run-arns }}
         MAX_WAIT_TIME_SECONDS: ${{ inputs.max-wait-time-seconds }}
         TEST_SPECS_JSON: ${{ inputs.test-specs }}
+        RUN_SPECS_JSON: ${{ inputs.run-specs }}
+        PROJECT_ARN: ${{ inputs.device-farm-project-arn }}
+        APP_ARN: ${{ inputs.app-upload-arn }}
+        TEST_PACKAGE_ARN: ${{ inputs.test-package-upload-arn }}
+        JOB_TIMEOUT_MINUTES: ${{ inputs.job-timeout-minutes }}
+        MAX_ERRORED_RETRIES: ${{ inputs.max-errored-retries }}
       run: |
         set -euo pipefail
 
@@ -93,6 +141,158 @@ runs:
           echo "  Run $((i+1)): ${RUN_ARNS[$i]}"
         done
         echo ""
+
+        # ── errored-run retry setup ─────────────────────────────────
+        # Device Farm sometimes completes a run as ERRORED without executing a
+        # single test: the slot sits in a pending state, then finishes with an
+        # empty message and a zero test tally (TTS iOS run 33418309222 — the same
+        # commit passed on a re-dispatch). That is an infrastructure failure, not
+        # a result. A real test failure reports FAILED with executed tests, and
+        # ERRORED with a non-zero tally means tests ran and blew up; neither is
+        # ever retried here.
+        #
+        # Rescheduling needs everything schedule-run needs. The project ARN, app
+        # upload and job timeout are read back off the errored run itself, so a
+        # caller cannot pass a project or ceiling that disagrees with the run it
+        # is retrying, and no secret has to be threaded through a second step.
+        # The other two cannot be derived: Device Farm never reports the test
+        # package ARN, and the device selection it reports back does not round
+        # trip reliably enough to retry on the same hardware — so the caller
+        # passes test-package-upload-arn and run-specs (the scheduler's own
+        # per-slot pool / filter). Missing either disables the retry rather than
+        # guessing, which keeps callers that pass neither on the old behaviour.
+        case "${MAX_ERRORED_RETRIES:-1}" in
+          ''|*[!0-9]*)
+            echo "::warning::max-errored-retries='${MAX_ERRORED_RETRIES:-}' is not a non-negative integer — treating it as 0 (no retry)."
+            MAX_ERRORED_RETRIES=0
+            ;;
+        esac
+        RETRY_CREATED_ARNS=""
+        SPEC_RECIPE_COUNT=0
+        if [ -n "$RUN_SPECS_JSON" ] && [ "$RUN_SPECS_JSON" != "[]" ]; then
+          SPEC_RECIPE_COUNT=$(echo "$RUN_SPECS_JSON" | jq 'length')
+        fi
+        RETRY_ENABLED=false
+        if [ "$MAX_ERRORED_RETRIES" -eq 0 ]; then
+          RETRY_REASON="max-errored-retries=0"
+        elif [ "$SPEC_RECIPE_COUNT" -ne "$RUN_COUNT" ]; then
+          RETRY_REASON="run-specs carries $SPEC_RECIPE_COUNT recipe(s) for $RUN_COUNT run(s)"
+        elif [ -z "$TEST_PACKAGE_ARN" ]; then
+          RETRY_REASON="test-package-upload-arn is not set"
+        else
+          RETRY_ENABLED=true
+        fi
+        if [ "$RETRY_ENABLED" = "true" ]; then
+          echo "🔁 Errored-run retry: up to $MAX_ERRORED_RETRIES reschedule(s) per slot, only when Device Farm errors a run before any test executes"
+        else
+          echo "🔁 Errored-run retry: disabled ($RETRY_REASON)"
+        fi
+        echo ""
+
+        # ERRORED with a zero test tally — the one shape we retry.
+        errored_before_any_test() {
+          local run_json="$1"
+          [ -n "$run_json" ] || return 1
+          local result total
+          result=$(echo "$run_json" | jq -r '.run.result // ""')
+          total=$(echo "$run_json" | jq -r '.run.counters.total // 0')
+          [ "$result" = "ERRORED" ] && [ "$total" = "0" ]
+        }
+
+        # Replay slot $1's recipe as a fresh run, echoing the new ARN. Same pool
+        # or device filter, same test spec, so the retry measures the same thing
+        # the slot was scheduled to measure.
+        reschedule_slot() {
+          local slot="$1"
+          local attempt="$2"
+          local old_arn="$3"
+          local run_json="$4"
+          local name spec_arn pool_arn filter retry_name
+          local project_arn app_arn timeout
+          name=$(echo "$RUN_SPECS_JSON" | jq -r ".[$slot].name // \"\"")
+          spec_arn=$(echo "$RUN_SPECS_JSON" | jq -r ".[$slot].specArn // \"\"")
+          pool_arn=$(echo "$RUN_SPECS_JSON" | jq -r ".[$slot].poolArn // \"\"")
+          filter=$(echo "$RUN_SPECS_JSON" | jq -r ".[$slot].filter // \"\"")
+          if [ -z "$spec_arn" ]; then
+            echo "  recipe for run $((slot+1)) has no test spec ARN" >&2
+            return 1
+          fi
+          # A run ARN is <partition-and-account>:run:<projectId>/<runId>, and the
+          # project ARN is the same prefix with :project:<projectId> — the same
+          # decomposition the console links below already rely on.
+          project_arn="$PROJECT_ARN"
+          if [ -z "$project_arn" ]; then
+            project_arn=$(echo "$old_arn" | sed -n 's|^\(arn:[^:]*:devicefarm:[^:]*:[^:]*\):run:\([^/]*\)/.*|\1:project:\2|p')
+          fi
+          app_arn="$APP_ARN"
+          [ -n "$app_arn" ] || app_arn=$(echo "$run_json" | jq -r '.run.appUpload // ""')
+          timeout="$JOB_TIMEOUT_MINUTES"
+          [ -n "$timeout" ] || timeout=$(echo "$run_json" | jq -r '.run.jobTimeoutMinutes // 120')
+          if [ -z "$project_arn" ] || [ -z "$app_arn" ]; then
+            echo "  could not resolve project ARN / app upload for run $((slot+1))" >&2
+            return 1
+          fi
+          retry_name="${name}-retry${attempt}"
+          if [ -n "$pool_arn" ]; then
+            aws devicefarm schedule-run \
+              --project-arn "$project_arn" \
+              --device-pool-arn "$pool_arn" \
+              --app-arn "$app_arn" \
+              --name "$retry_name" \
+              --test "type=APPIUM_NODE,testPackageArn=$TEST_PACKAGE_ARN,testSpecArn=$spec_arn" \
+              --execution-configuration jobTimeoutMinutes="$timeout" \
+              --query 'run.arn' --output text
+          elif [ -n "$filter" ]; then
+            aws devicefarm schedule-run \
+              --project-arn "$project_arn" \
+              --device-selection-configuration "$filter" \
+              --app-arn "$app_arn" \
+              --name "$retry_name" \
+              --test "type=APPIUM_NODE,testPackageArn=$TEST_PACKAGE_ARN,testSpecArn=$spec_arn" \
+              --execution-configuration jobTimeoutMinutes="$timeout" \
+              --query 'run.arn' --output text
+          else
+            echo "  recipe for run $((slot+1)) has neither a device pool nor a device filter" >&2
+            return 1
+          fi
+        }
+
+        # A run rescheduled here is invisible to the caller's cancel step, which
+        # only knows the ARNs the scheduler returned, so it would keep billing
+        # device minutes after a cancellation. Stop what this step created. Same
+        # SIGKILL limitation the scheduler's rollback documents: a hard kill can
+        # still orphan a run.
+        stop_created_retry_runs() {
+          [ -n "$RETRY_CREATED_ARNS" ] || return 0
+          for arn in $RETRY_CREATED_ARNS; do
+            if aws devicefarm stop-run --arn "$arn" >/dev/null 2>&1; then
+              echo "  stopped $arn"
+            else
+              echo "  ::warning::could not stop $arn (it may have already finished)"
+            fi
+          done
+        }
+
+        stop_retry_runs_on_exit() {
+          local status=$?
+          trap - ERR INT TERM
+          if [ -n "$RETRY_CREATED_ARNS" ]; then
+            echo "::warning::Monitor interrupted (status $status) — stopping the run(s) it rescheduled."
+            stop_created_retry_runs
+          fi
+          exit "$status"
+        }
+        trap stop_retry_runs_on_exit ERR INT TERM
+
+        # Effective ARNs for the caller: the input list with every rescheduled
+        # slot replaced, so log collection reads the run that actually executed.
+        publish_effective_run_arns() {
+          local json='[]' idx
+          for ((idx=0; idx<RUN_COUNT; idx++)); do
+            json=$(echo "$json" | jq -c --arg arn "${RUN_ARNS[$idx]}" '. + [$arn]')
+          done
+          echo "effective_run_arns=$json" >> "$GITHUB_OUTPUT"
+        }
 
         # ── run-to-tests legend ────────────────────────────────────
         # When test-specs is provided (sharded mode), print a table so
@@ -163,6 +363,10 @@ runs:
         echo "Transition notices (::notice::, shown at top of job UI):"
         echo "  '<state> -> RUNNING after <Q>s of queue time'   slot acquired a device"
         echo "  'queued <Q>s | executed <X>s | total <T>s'      slot finished; T == Q + X"
+        echo "  'RESCHEDULED -> ...'                            slot was retried; its times restart here"
+        echo "Rescheduling (::warning::):"
+        echo "  'Run N rescheduled'                             Device Farm errored the run with 0 tests executed"
+        echo "                                                  (infrastructure failure) and it was scheduled again"
         echo "::endgroup::"
         echo ""
 
@@ -180,12 +384,21 @@ runs:
         # used to compute queued vs executed time on COMPLETED.
         PREV_STATUS=()
         RUNNING_AT=()
+        # RETRIES_USED caps reschedules per slot. SLOT_EPOCH is the ELAPSED at
+        # which the slot's current run started being monitored — 0 for the runs
+        # the scheduler created, and the reschedule time for a retried slot, so
+        # the queue / execution figures below stay relative to the run they
+        # describe instead of counting the errored attempt's wait as queue time.
+        RETRIES_USED=()
+        SLOT_EPOCH=()
         for ((i=0; i<RUN_COUNT; i++)); do
           DONE[$i]="false"
           CUR_STATUS[$i]="PENDING"
           CUR_RESULT[$i]="PENDING"
           PREV_STATUS[$i]=""
           RUNNING_AT[$i]=""
+          RETRIES_USED[$i]=0
+          SLOT_EPOCH[$i]=0
         done
 
         # Run-level RUNNING is a coarse bucket. Every DEEP_DIVE_INTERVAL
@@ -204,8 +417,31 @@ runs:
               CUR_STATUS[$i]=$(echo "$RUN_JSON" | jq -r '.run.status // "UNKNOWN"')
               CUR_RESULT[$i]=$(echo "$RUN_JSON" | jq -r '.run.result // "UNKNOWN"')
               if [ "${CUR_STATUS[$i]}" = "COMPLETED" ]; then
-                DONE[$i]="true"
-                DONE_COUNT=$((DONE_COUNT + 1))
+                if [ "$RETRY_ENABLED" = "true" ] \
+                   && [ "${RETRIES_USED[$i]}" -lt "$MAX_ERRORED_RETRIES" ] \
+                   && errored_before_any_test "$RUN_JSON"; then
+                  _attempt=$(( ${RETRIES_USED[$i]} + 1 ))
+                  _old_arn="${RUN_ARNS[$i]}"
+                  _new_arn=$(reschedule_slot "$i" "$_attempt" "$_old_arn" "$RUN_JSON") || _new_arn=""
+                  if [ -n "$_new_arn" ] && [ "$_new_arn" != "None" ]; then
+                    RETRIES_USED[$i]=$_attempt
+                    RETRY_CREATED_ARNS="$RETRY_CREATED_ARNS $_new_arn"
+                    RUN_ARNS[$i]="$_new_arn"
+                    CUR_STATUS[$i]="PENDING"
+                    CUR_RESULT[$i]="PENDING"
+                    PREV_STATUS[$i]="RESCHEDULED"
+                    RUNNING_AT[$i]=""
+                    SLOT_EPOCH[$i]=$ELAPSED
+                    echo "::warning title=Device Farm Run $((i+1)) rescheduled::Device Farm errored this run before any test executed (attempt $_attempt of $MAX_ERRORED_RETRIES). Replaced $_old_arn with $_new_arn"
+                  else
+                    echo "::warning::Run $((i+1)) errored before any test executed and could not be rescheduled — keeping the ERRORED result."
+                    DONE[$i]="true"
+                    DONE_COUNT=$((DONE_COUNT + 1))
+                  fi
+                else
+                  DONE[$i]="true"
+                  DONE_COUNT=$((DONE_COUNT + 1))
+                fi
               fi
 
               # Transition signals. RUNNING / COMPLETED get promoted
@@ -215,6 +451,9 @@ runs:
               prev_status="${PREV_STATUS[$i]}"
               cur_status="${CUR_STATUS[$i]}"
               cur_result="${CUR_RESULT[$i]}"
+              # 0 unless this slot was rescheduled, so the figures below describe
+              # the run being reported rather than the whole monitoring window.
+              slot_epoch="${SLOT_EPOCH[$i]}"
               if [ -n "$cur_status" ] && [ "$cur_status" != "$prev_status" ]; then
                 TS=$(date -u +%H:%M:%S)
                 if [ -z "$prev_status" ]; then
@@ -227,19 +466,19 @@ runs:
                 elif [ "$cur_status" = "RUNNING" ]; then
                   if [ -z "${RUNNING_AT[$i]}" ]; then
                     RUNNING_AT[$i]=$ELAPSED
-                    echo "::notice title=Device Farm Run $((i+1)) acquired device::[$TS] $prev_status -> RUNNING after ${ELAPSED}s of queue time"
+                    echo "::notice title=Device Farm Run $((i+1)) acquired device::[$TS] $prev_status -> RUNNING after $((ELAPSED - slot_epoch))s of queue time"
                   fi
                 elif [ "$cur_status" = "COMPLETED" ]; then
                   running_at="${RUNNING_AT[$i]}"
                   if [ -n "$running_at" ]; then
                     exec_time=$((ELAPSED - running_at))
-                    echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | queued ${running_at}s | executed ${exec_time}s | total ${ELAPSED}s"
+                    echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | queued $((running_at - slot_epoch))s | executed ${exec_time}s | total $((ELAPSED - slot_epoch))s"
                   else
                     # Defensive: COMPLETED without ever observing
                     # RUNNING means we missed the RUNNING window between
                     # two 30s polls (rare, trivially short runs) or the
                     # run errored straight from a pending state.
-                    echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | total ${ELAPSED}s (no RUNNING window observed)"
+                    echo "::notice title=Device Farm Run $((i+1)) finished::[$TS] result=$cur_result | total $((ELAPSED - slot_epoch))s (no RUNNING window observed)"
                   fi
                 else
                   echo "🔄 Run $((i+1)): $prev_status -> $cur_status (elapsed ${ELAPSED}s)"
@@ -288,11 +527,24 @@ runs:
           if [ $ELAPSED -ge $MAX_WAIT_TIME ]; then
             echo ""
             echo "❌ Timeout: exceeded ${MAX_WAIT_TIME}s"
+            if [ -n "$RETRY_CREATED_ARNS" ]; then
+              echo "   A rescheduled run was still in flight. If that is routine here, raise max-wait-time-seconds: a retry restarts the slot's queue and execution inside this same budget."
+              # Timing out abandons monitoring, and the caller's cancel step does
+              # not know these ARNs, so stop them here rather than let them bill
+              # on to their own jobTimeoutMinutes.
+              stop_created_retry_runs
+            fi
+            publish_effective_run_arns
             exit 1
           fi
           sleep 30
           ELAPSED=$((ELAPSED + 30))
         done
+
+        publish_effective_run_arns
+        # Every slot is COMPLETED from here, so there is nothing left to stop and
+        # the aggregation below must not be able to trip the rollback.
+        trap - ERR INT TERM
 
         # ── aggregate results ────────────────────────────────────────
         DEVICE_COUNT=0

--- a/.github/actions/run-mobile-integration-tests/monitor-test-run/test/errored-run-retry.test.mjs
+++ b/.github/actions/run-mobile-integration-tests/monitor-test-run/test/errored-run-retry.test.mjs
@@ -1,0 +1,342 @@
+'use strict'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Exercises the monitor's Device Farm retry against a fake AWS CLI: a run that
+// completes as ERRORED with zero tests executed is an infrastructure failure and
+// must be rescheduled exactly once, while a real FAILED result never is. Runs the
+// action's own shell body, so the assertions cover the shipped code rather than a
+// reimplementation of it.
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ACTION = join(HERE, '..', 'action.yml')
+
+const RUN_A = 'arn:aws:devicefarm:us-west-2:833707431398:run:proj-1/aaa'
+const RUN_B = 'arn:aws:devicefarm:us-west-2:833707431398:run:proj-1/bbb'
+const RETRY_1 = 'arn:aws:devicefarm:us-west-2:833707431398:run:proj-1/retry1'
+const DERIVED_PROJECT = 'arn:aws:devicefarm:us-west-2:833707431398:project:proj-1'
+
+const POOL_RECIPE = { name: 'PR-1-iOS-lavasr', specArn: 'arn:spec:1', poolArn: 'arn:pool:ios', filter: '' }
+const FILTER_RECIPE = {
+  name: 'PR-1-iOS-lavasr-iPhone17',
+  specArn: 'arn:spec:1',
+  poolArn: '',
+  filter: '{"filters":[],"maxDevices":1}'
+}
+const RECIPES = JSON.stringify([POOL_RECIPE, FILTER_RECIPE])
+
+const PASSED = 'COMPLETED PASSED 3 0 3'
+const ERRORED_NO_TESTS = 'COMPLETED ERRORED 0 0 0'
+
+// The action embeds one `run: |` block; take its body and undo the YAML indent.
+function actionScript() {
+  const lines = readFileSync(ACTION, 'utf8').split('\n')
+  const start = lines.indexOf('      run: |')
+  assert.notEqual(start, -1, 'monitor action must contain a single run block')
+  return collectBlock(lines.slice(start + 1)).join('\n')
+}
+
+function collectBlock(lines) {
+  const body = []
+  for (const line of lines) {
+    if (line.trim() !== '' && !line.startsWith('        ')) break
+    body.push(line.slice(8))
+  }
+  return body
+}
+
+// Minimal `aws devicefarm` stand-in. Run outcomes are seeded per ARN as
+// "<status> <result> <total> <failed> <passed>"; schedule-run records what it was
+// asked for and seeds the replacement run's outcome.
+const FAKE_AWS = `#!/usr/bin/env node
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const state = process.env.FAKE_AWS_STATE
+const argv = process.argv.slice(2)
+const action = argv[1]
+const valueOf = (flag) => {
+  const at = argv.indexOf(flag)
+  return at === -1 ? '' : argv[at + 1]
+}
+const keyFor = (arn) => arn.replace(/[^A-Za-z0-9]/g, '_')
+const outcomeOf = (arn) => {
+  const path = join(state, 'runs', keyFor(arn))
+  const line = existsSync(path) ? readFileSync(path, 'utf8').trim() : 'COMPLETED UNKNOWN 0 0 0'
+  const [status, result, total, failed, passed] = line.split(/\\s+/)
+  return { status, result, total: Number(total), failed: Number(failed), passed: Number(passed) }
+}
+
+if (action === 'get-run') {
+  const arn = valueOf('--arn')
+  const o = outcomeOf(arn)
+  process.stdout.write(JSON.stringify({
+    run: {
+      arn,
+      name: 'run-' + arn,
+      status: o.status,
+      result: o.result,
+      appUpload: process.env.FAKE_APP_UPLOAD || 'arn:upload:app-from-run',
+      jobTimeoutMinutes: Number(process.env.FAKE_JOB_TIMEOUT || 90),
+      counters: { total: o.total, failed: o.failed, passed: o.passed, errored: 0, skipped: 0 }
+    }
+  }))
+} else if (action === 'list-jobs') {
+  process.stdout.write(JSON.stringify({ jobs: [{ arn: valueOf('--arn') + '/job0' }] }))
+} else if (action === 'get-job') {
+  const o = outcomeOf(valueOf('--arn').replace(/\\/job0$/, ''))
+  process.stdout.write(JSON.stringify({
+    job: {
+      device: { name: 'Fake Phone' },
+      result: o.result,
+      counters: { total: o.total, failed: o.failed, passed: o.passed, errored: 0, skipped: 0 }
+    }
+  }))
+} else if (action === 'schedule-run') {
+  const pool = valueOf('--device-pool-arn')
+  const selector = pool ? 'pool:' + pool : 'filter:' + valueOf('--device-selection-configuration')
+  const callsPath = join(state, 'schedule_calls')
+  const previous = existsSync(callsPath) ? readFileSync(callsPath, 'utf8').split('\\n').filter(Boolean) : []
+  appendFileSync(callsPath, valueOf('--name') + '|' + selector + '\\n')
+  appendFileSync(join(state, 'schedule_params'), [
+    'project=' + valueOf('--project-arn'),
+    'app=' + valueOf('--app-arn'),
+    'timeout=' + valueOf('--execution-configuration'),
+    'test=' + valueOf('--test')
+  ].join(' ') + '\\n')
+  const arn = 'arn:aws:devicefarm:us-west-2:833707431398:run:proj-1/retry' + (previous.length + 1)
+  const outcomePath = join(state, 'retry_outcome')
+  const outcome = existsSync(outcomePath) ? readFileSync(outcomePath, 'utf8').trim() : 'COMPLETED PASSED 3 0 3'
+  writeFileSync(join(state, 'runs', keyFor(arn)), outcome + '\\n')
+  process.stdout.write(arn)
+} else if (action === 'stop-run') {
+  appendFileSync(join(state, 'stop_calls'), valueOf('--arn') + '\\n')
+} else {
+  process.stderr.write('fake aws: unsupported ' + argv.join(' ') + '\\n')
+  process.exit(1)
+}
+`
+
+function writeFakeCli(root) {
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  const aws = join(bin, 'aws')
+  writeFileSync(aws, FAKE_AWS)
+  chmodSync(aws, 0o755)
+  // The poll loop sleeps 30s between iterations; the fake keeps tests instant.
+  const sleep = join(bin, 'sleep')
+  writeFileSync(sleep, '#!/bin/sh\nexit 0\n')
+  chmodSync(sleep, 0o755)
+  return bin
+}
+
+function seedRuns(state, runs) {
+  mkdirSync(join(state, 'runs'), { recursive: true })
+  for (const [arn, outcome] of Object.entries(runs)) {
+    writeFileSync(join(state, 'runs', arn.replace(/[^A-Za-z0-9]/g, '_')), outcome + '\n')
+  }
+}
+
+function readLines(path) {
+  return existsSync(path) ? readFileSync(path, 'utf8').split('\n').filter(Boolean) : []
+}
+
+function parseOutputs(path) {
+  const outputs = {}
+  for (const line of readLines(path)) {
+    const at = line.indexOf('=')
+    if (at > 0) outputs[line.slice(0, at)] = line.slice(at + 1)
+  }
+  return outputs
+}
+
+// Only the two inputs Device Farm cannot report back; project ARN, app upload and
+// job timeout are expected to be derived from the errored run itself.
+const RETRY_ENV = { RUN_SPECS_JSON: RECIPES, TEST_PACKAGE_ARN: 'arn:upload:testpkg', MAX_ERRORED_RETRIES: '1' }
+
+function runMonitor({ runs, env = {}, retryOutcome }) {
+  const root = mkdtempSync(join(tmpdir(), 'monitor-retry-'))
+  try {
+    const state = join(root, 'state')
+    seedRuns(state, runs)
+    if (retryOutcome) writeFileSync(join(state, 'retry_outcome'), retryOutcome + '\n')
+    const bin = writeFakeCli(root)
+    const script = join(root, 'monitor.sh')
+    writeFileSync(script, actionScript())
+    const githubOutput = join(root, 'github_output')
+    const githubSummary = join(root, 'github_summary')
+    writeFileSync(githubOutput, '')
+    writeFileSync(githubSummary, '')
+
+    let status = 0
+    let stdout = ''
+    try {
+      stdout = execFileSync('bash', [script], {
+        encoding: 'utf8',
+        timeout: 120000,
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          FAKE_AWS_STATE: state,
+          RUN_ARNS_JSON: JSON.stringify([RUN_A, RUN_B]),
+          MAX_WAIT_TIME_SECONDS: '600',
+          TEST_SPECS_JSON: '[]',
+          RUN_SPECS_JSON: '[]',
+          PROJECT_ARN: '',
+          APP_ARN: '',
+          TEST_PACKAGE_ARN: '',
+          JOB_TIMEOUT_MINUTES: '',
+          MAX_ERRORED_RETRIES: '1',
+          GITHUB_OUTPUT: githubOutput,
+          GITHUB_STEP_SUMMARY: githubSummary,
+          RUNNER_TEMP: root,
+          ...env
+        }
+      })
+    } catch (error) {
+      status = error.status ?? 1
+      stdout = `${error.stdout ?? ''}${error.stderr ?? ''}`
+    }
+
+    return {
+      status,
+      stdout,
+      scheduleCalls: readLines(join(state, 'schedule_calls')),
+      scheduleParams: readLines(join(state, 'schedule_params')),
+      stopCalls: readLines(join(state, 'stop_calls')),
+      outputs: parseOutputs(githubOutput)
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('an ERRORED run with zero tests executed is rescheduled once and can then pass', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: RETRY_ENV,
+    retryOutcome: PASSED
+  })
+  assert.deepEqual(r.scheduleCalls, ['PR-1-iOS-lavasr-retry1|pool:arn:pool:ios'])
+  assert.equal(r.status, 0, r.stdout)
+  assert.equal(r.outputs.test_result, 'PASSED')
+  assert.equal(r.outputs.effective_run_arns, JSON.stringify([RETRY_1, RUN_B]))
+})
+
+test('the reschedule derives project, app upload and timeout from the errored run', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: RETRY_ENV,
+    retryOutcome: PASSED
+  })
+  const params = r.scheduleParams[0]
+  assert.match(params, new RegExp(`project=${DERIVED_PROJECT.replace(/[:]/g, '\\:')} `))
+  assert.match(params, /app=arn:upload:app-from-run/)
+  assert.match(params, /timeout=jobTimeoutMinutes=90/)
+  assert.match(params, /testPackageArn=arn:upload:testpkg/)
+})
+
+test('a FAILED run with executed tests is never rescheduled', () => {
+  const r = runMonitor({ runs: { [RUN_A]: 'COMPLETED FAILED 3 1 2', [RUN_B]: PASSED }, env: RETRY_ENV })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.equal(r.status, 1)
+})
+
+test('an ERRORED run that executed tests is never rescheduled', () => {
+  const r = runMonitor({ runs: { [RUN_A]: 'COMPLETED ERRORED 3 2 1', [RUN_B]: PASSED }, env: RETRY_ENV })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.equal(r.status, 1)
+})
+
+test('a rescheduled run that errors again is not rescheduled a second time', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: RETRY_ENV,
+    retryOutcome: ERRORED_NO_TESTS
+  })
+  assert.equal(r.scheduleCalls.length, 1)
+  assert.equal(r.status, 1)
+})
+
+test('each slot is retried on its own device selection', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: PASSED, [RUN_B]: ERRORED_NO_TESTS },
+    env: RETRY_ENV,
+    retryOutcome: PASSED
+  })
+  assert.equal(r.scheduleCalls.length, 1)
+  assert.ok(
+    r.scheduleCalls[0].startsWith('PR-1-iOS-lavasr-iPhone17-retry1|filter:'),
+    `slot 2 must replay its own filter recipe, got ${r.scheduleCalls[0]}`
+  )
+  assert.equal(r.outputs.effective_run_arns, JSON.stringify([RUN_A, RETRY_1]))
+})
+
+test('the retry stays off unless the caller supplies recipes and the test package ARN', () => {
+  const r = runMonitor({ runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED } })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.equal(r.status, 1)
+  assert.match(r.stdout, /retry: disabled/)
+})
+
+test('max-errored-retries=0 disables the retry', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: { ...RETRY_ENV, MAX_ERRORED_RETRIES: '0' }
+  })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.equal(r.status, 1)
+})
+
+test('a non-numeric max-errored-retries warns and disables the retry', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: { ...RETRY_ENV, MAX_ERRORED_RETRIES: 'yes' }
+  })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.match(r.stdout, /not a non-negative integer/)
+})
+
+test('run-specs that do not line up with the run ARNs disable the retry', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: { ...RETRY_ENV, RUN_SPECS_JSON: JSON.stringify([POOL_RECIPE]) }
+  })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.match(r.stdout, /recipe\(s\) for 2 run\(s\)/)
+})
+
+test('timing out with a reschedule in flight stops it and still publishes the ARNs', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: ERRORED_NO_TESTS, [RUN_B]: PASSED },
+    env: { ...RETRY_ENV, MAX_WAIT_TIME_SECONDS: '120' },
+    // The replacement never completes, so the poll loop runs out its budget.
+    retryOutcome: 'RUNNING PENDING 0 0 0'
+  })
+  assert.equal(r.status, 1)
+  assert.match(r.stdout, /Timeout: exceeded/)
+  assert.deepEqual(r.stopCalls, [RETRY_1], 'the run the monitor created must not be left billing')
+  assert.equal(r.outputs.effective_run_arns, JSON.stringify([RETRY_1, RUN_B]))
+})
+
+test('timing out without any reschedule stops nothing', () => {
+  const r = runMonitor({
+    runs: { [RUN_A]: 'RUNNING PENDING 0 0 0', [RUN_B]: PASSED },
+    env: { ...RETRY_ENV, MAX_WAIT_TIME_SECONDS: '120' }
+  })
+  assert.equal(r.status, 1)
+  assert.deepEqual(r.stopCalls, [])
+  assert.deepEqual(r.scheduleCalls, [])
+})
+
+test('every run passing leaves the retry path untouched', () => {
+  const r = runMonitor({ runs: { [RUN_A]: PASSED, [RUN_B]: PASSED }, env: RETRY_ENV })
+  assert.deepEqual(r.scheduleCalls, [])
+  assert.equal(r.status, 0, r.stdout)
+  assert.equal(r.outputs.effective_run_arns, JSON.stringify([RUN_A, RUN_B]))
+})

--- a/.github/actions/run-mobile-integration-tests/monitor-test-run/test/errored-run-retry.test.mjs
+++ b/.github/actions/run-mobile-integration-tests/monitor-test-run/test/errored-run-retry.test.mjs
@@ -235,10 +235,14 @@ test('the reschedule derives project, app upload and timeout from the errored ru
     retryOutcome: PASSED
   })
   const params = r.scheduleParams[0]
-  assert.match(params, new RegExp(`project=${DERIVED_PROJECT.replace(/[:]/g, '\\:')} `))
-  assert.match(params, /app=arn:upload:app-from-run/)
-  assert.match(params, /timeout=jobTimeoutMinutes=90/)
-  assert.match(params, /testPackageArn=arn:upload:testpkg/)
+  // Containment, not pattern matching: the claim is that schedule-run was called
+  // with these exact arguments. Building a regex here meant escaping an ARN into
+  // it by hand, which is the kind of partial escaper that silently stops matching
+  // what it claims to. The trailing space pins the end of the project ARN field.
+  assert.ok(params.includes(`project=${DERIVED_PROJECT} `), params)
+  assert.ok(params.includes('app=arn:upload:app-from-run'), params)
+  assert.ok(params.includes('timeout=jobTimeoutMinutes=90'), params)
+  assert.ok(params.includes('testPackageArn=arn:upload:testpkg'), params)
 })
 
 test('a FAILED run with executed tests is never rescheduled', () => {

--- a/.github/actions/run-mobile-integration-tests/schedule-test-run/action.yml
+++ b/.github/actions/run-mobile-integration-tests/schedule-test-run/action.yml
@@ -105,6 +105,15 @@ outputs:
   run-count:
     description: "Number of scheduled runs"
     value: ${{ steps.schedule.outputs.run_count }}
+  run-specs:
+    description: |
+      JSON array index-aligned with run-arns: the recipe each slot was
+      scheduled from, as [{ name, specArn, poolArn, filter }] (exactly one of
+      poolArn / filter is non-empty). Pass to monitor-test-run so it can
+      reschedule a slot Device Farm errored before running any test, on the
+      same device selection the slot originally used. Empty array if the
+      recipes could not be recorded 1:1, which disables that retry.
+    value: ${{ steps.schedule.outputs.run_specs }}
 
 runs:
   using: composite
@@ -218,10 +227,28 @@ runs:
           CREATED_RUN_ARNS="$CREATED_RUN_ARNS $1"
         }
 
+        # Respawn recipes, one JSONL line per scheduled run, appended by the two
+        # schedule_run_* helpers below. They run inside $(...) command
+        # substitution, so a shell variable would be lost with the subshell — a
+        # file survives. Appending inside the helpers keeps the recipe list
+        # aligned with RUN_ARNS_JSON by construction (both grow once per call, in
+        # call order) instead of relying on every branch to record it. A helper
+        # that fails after writing its line leaves the file one ahead, but that
+        # aborts the whole step through the trap, so no caller ever sees it.
+        RUN_SPECS_FILE="${RUNNER_TEMP:-/tmp}/devicefarm-run-specs.jsonl"
+        : > "$RUN_SPECS_FILE"
+
+        record_run_spec() {
+          jq -nc --arg name "$1" --arg specArn "$2" --arg poolArn "$3" --arg filter "$4" \
+            '{name: $name, specArn: $specArn, poolArn: $poolArn, filter: $filter}' \
+            >> "$RUN_SPECS_FILE"
+        }
+
         schedule_run_with_pool() {
           local pool_arn="$1"
           local name="$2"
           local spec_arn="$3"
+          record_run_spec "$name" "$spec_arn" "$pool_arn" ""
           aws devicefarm schedule-run \
             --project-arn "$PROJECT_ARN" \
             --device-pool-arn "$pool_arn" \
@@ -236,6 +263,7 @@ runs:
           local name="$1"
           local filter="$2"
           local spec_arn="$3"
+          record_run_spec "$name" "$spec_arn" "" "$filter"
           aws devicefarm schedule-run \
             --project-arn "$PROJECT_ARN" \
             --device-selection-configuration "$filter" \
@@ -446,8 +474,20 @@ runs:
         echo "Scheduled $RUN_COUNT run(s):"
         echo "$RUN_ARNS_JSON" | jq .
 
+        # Publish the respawn recipes only when they line up 1:1 with the ARNs.
+        # The monitor keys them by slot index, so a mismatch would retry a slot
+        # on another slot's device selection; emitting [] instead just turns that
+        # retry off and leaves every other behaviour untouched.
+        RUN_SPECS_JSON=$(jq -sc '.' "$RUN_SPECS_FILE")
+        SPECS_RECORDED=$(echo "$RUN_SPECS_JSON" | jq 'length')
+        if [ "$SPECS_RECORDED" != "$RUN_COUNT" ]; then
+          echo "::warning::Recorded $SPECS_RECORDED run spec(s) for $RUN_COUNT run(s) — publishing none, so monitor-test-run will not retry errored runs."
+          RUN_SPECS_JSON='[]'
+        fi
+
         echo "run_arns=$(echo "$RUN_ARNS_JSON" | jq -c .)" >> "$GITHUB_OUTPUT"
         echo "run_count=$RUN_COUNT" >> "$GITHUB_OUTPUT"
+        echo "run_specs=$RUN_SPECS_JSON" >> "$GITHUB_OUTPUT"
 
         # Outputs are published: the caller now has the ARNs and owns cleanup (its
         # cancel step covers cancellation and failure from here). Disarm so the EXIT

--- a/.github/actions/run-mobile-integration-tests/schedule-test-run/test/run-specs-alignment.test.mjs
+++ b/.github/actions/run-mobile-integration-tests/schedule-test-run/test/run-specs-alignment.test.mjs
@@ -1,0 +1,215 @@
+'use strict'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The scheduler publishes run-specs so monitor-test-run can reschedule a slot
+// Device Farm errored before any test ran. The monitor keys those recipes by slot
+// index, so a list that drifts out of step with run-arns would retry a slot on
+// another slot's hardware. These tests pin the 1:1 alignment across every
+// scheduling mode by running the action's own shell body.
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ACTION = join(HERE, '..', 'action.yml')
+
+// The action interpolates workflow context before bash ever sees it.
+const CONTEXT = new Map([
+  ['${{ github.event_name }}', 'push'],
+  ['${{ github.run_number }}', '7'],
+  ['${{ github.event.pull_request.number || github.run_number }}', '42'],
+  ['${{ github.run_id }}', '1234'],
+  ['${{ github.run_attempt }}', '1']
+])
+
+const ONE_SPEC = JSON.stringify([{ name: 'functional', grep: '', arn: 'arn:spec:1' }])
+const TWO_SPECS = JSON.stringify([
+  { name: 'lavasr', grep: 'runLavasr', arn: 'arn:spec:1' },
+  { name: 'parler', grep: 'runParler', arn: 'arn:spec:2' }
+])
+
+function actionScript() {
+  const lines = readFileSync(ACTION, 'utf8').split('\n')
+  const start = lines.indexOf('      run: |')
+  assert.notEqual(start, -1, 'scheduler action must contain a single run block')
+  let script = collectBlock(lines.slice(start + 1)).join('\n')
+  for (const [expression, value] of CONTEXT) script = script.split(expression).join(value)
+  assert.equal(
+    /\$\{\{/.test(script),
+    false,
+    'every workflow expression must be substituted before running the script'
+  )
+  return script
+}
+
+function collectBlock(lines) {
+  const body = []
+  for (const line of lines) {
+    if (line.trim() !== '' && !line.startsWith('        ')) break
+    body.push(line.slice(8))
+  }
+  return body
+}
+
+// `aws devicefarm schedule-run` is the only call these modes make; echo a unique
+// ARN so run_arns grows once per call, exactly as the real CLI does.
+const FAKE_AWS = `#!/usr/bin/env node
+import { appendFileSync, existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const state = process.env.FAKE_AWS_STATE
+const argv = process.argv.slice(2)
+if (argv[1] !== 'schedule-run') {
+  process.stdout.write('')
+  process.exit(0)
+}
+const path = join(state, 'calls')
+const seen = existsSync(path) ? readFileSync(path, 'utf8').split('\\n').filter(Boolean) : []
+appendFileSync(path, 'call\\n')
+process.stdout.write('arn:aws:devicefarm:us-west-2:1:run:proj-1/run' + (seen.length + 1))
+`
+
+function writeFakeCli(root) {
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  const aws = join(bin, 'aws')
+  writeFileSync(aws, FAKE_AWS)
+  chmodSync(aws, 0o755)
+  return bin
+}
+
+function parseOutputs(path) {
+  const outputs = {}
+  if (!existsSync(path)) return outputs
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const at = line.indexOf('=')
+    if (at > 0) outputs[line.slice(0, at)] = line.slice(at + 1)
+  }
+  return outputs
+}
+
+function schedule(env = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'schedule-specs-'))
+  try {
+    const state = join(root, 'state')
+    mkdirSync(state)
+    const bin = writeFakeCli(root)
+    const script = join(root, 'schedule.sh')
+    writeFileSync(script, actionScript())
+    const githubOutput = join(root, 'github_output')
+    writeFileSync(githubOutput, '')
+
+    execFileSync('bash', [script], {
+      encoding: 'utf8',
+      timeout: 60000,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        FAKE_AWS_STATE: state,
+        PLATFORM: 'Android',
+        PROJECT_ARN: 'arn:project:1',
+        ANDROID_POOL_ARN: 'arn:pool:android',
+        IOS_POOL_ARN: 'arn:pool:ios',
+        APP_ARN: 'arn:aws:devicefarm:us-west-2:1:upload:proj/appupload',
+        TEST_PACKAGE_ARN: 'arn:upload:testpkg',
+        TEST_SPECS_JSON: ONE_SPEC,
+        SCHEDULING_MODE: 'dual-flagship',
+        MULTI_SPEC_DUAL_FLAGSHIP: 'false',
+        DEVICE_MODEL: '',
+        DEVICE_MODEL_OPERATOR: '',
+        DEVICE_MANUFACTURER: '',
+        DEVICE_MODELS: '',
+        JOB_TIMEOUT_MINUTES: '120',
+        GITHUB_OUTPUT: githubOutput,
+        RUNNER_TEMP: root,
+        ...env
+      }
+    })
+
+    const outputs = parseOutputs(githubOutput)
+    return { arns: JSON.parse(outputs.run_arns), specs: JSON.parse(outputs.run_specs) }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function selectorKinds(specs) {
+  return specs.map((spec) => (spec.poolArn ? 'pool' : 'filter'))
+}
+
+function assertWellFormed(specs, arns) {
+  assert.equal(specs.length, arns.length, 'one recipe per scheduled run')
+  for (const spec of specs) {
+    assert.ok(spec.name, `recipe needs a run name: ${JSON.stringify(spec)}`)
+    assert.ok(spec.specArn, `recipe needs a test spec ARN: ${JSON.stringify(spec)}`)
+    assert.notEqual(
+      Boolean(spec.poolArn),
+      Boolean(spec.filter),
+      `recipe needs exactly one of poolArn / filter: ${JSON.stringify(spec)}`
+    )
+  }
+}
+
+test('dual-flagship Android records a recipe per flagship filter', () => {
+  const { arns, specs } = schedule()
+  assert.equal(arns.length, 2)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(selectorKinds(specs), ['filter', 'filter'])
+})
+
+test('dual-flagship iOS records the pool run and the iPhone filter run in order', () => {
+  const { arns, specs } = schedule({ PLATFORM: 'iOS' })
+  assert.equal(arns.length, 2)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(selectorKinds(specs), ['pool', 'filter'])
+})
+
+test('sharded mode records one pool recipe per spec', () => {
+  const { arns, specs } = schedule({ TEST_SPECS_JSON: TWO_SPECS })
+  assert.equal(arns.length, 2)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(selectorKinds(specs), ['pool', 'pool'])
+  assert.deepEqual(specs.map((s) => s.specArn), ['arn:spec:1', 'arn:spec:2'])
+})
+
+test('multi-spec dual-flagship records a recipe for all four runs', () => {
+  const { arns, specs } = schedule({ TEST_SPECS_JSON: TWO_SPECS, MULTI_SPEC_DUAL_FLAGSHIP: 'true' })
+  assert.equal(arns.length, 4)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(selectorKinds(specs), ['filter', 'filter', 'filter', 'filter'])
+})
+
+test('single-pool mode records one pool recipe', () => {
+  const { arns, specs } = schedule({ SCHEDULING_MODE: 'single-pool' })
+  assert.equal(arns.length, 1)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(selectorKinds(specs), ['pool'])
+})
+
+test('single-device mode records one filter recipe', () => {
+  const { arns, specs } = schedule({ SCHEDULING_MODE: 'single-device', DEVICE_MODEL: 'Pixel 9' })
+  assert.equal(arns.length, 1)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(selectorKinds(specs), ['filter'])
+})
+
+test('manual-devices keeps recipes in the spec-major order the ARNs use', () => {
+  const { arns, specs } = schedule({
+    SCHEDULING_MODE: 'manual-devices',
+    DEVICE_MODELS: 'Pixel 9, Galaxy S25 Ultra',
+    TEST_SPECS_JSON: TWO_SPECS
+  })
+  assert.equal(arns.length, 4)
+  assertWellFormed(specs, arns)
+  assert.deepEqual(specs.map((s) => s.specArn), [
+    'arn:spec:1',
+    'arn:spec:1',
+    'arn:spec:2',
+    'arn:spec:2'
+  ])
+  assert.ok(specs.slice(0, 2).every((s) => s.name.includes('lavasr')))
+  assert.ok(specs.slice(2).every((s) => s.name.includes('parler')))
+})

--- a/.github/workflows/integration-mobile-test-asr-ggml.yml
+++ b/.github/workflows/integration-mobile-test-asr-ggml.yml
@@ -543,6 +543,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
           # Functional multi-spec runs need headroom beyond Device Farm's
           # 120-minute execution ceiling for normal queue variance.
@@ -564,7 +569,9 @@ jobs:
           # Unconditional, for the same reason as the upload step above.
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       # merge=true unions per-device performance-report.json payloads (Android
       # pools can run more than one device). unzip-customer-artifacts=true is

--- a/.github/workflows/integration-mobile-test-audiogen-ggml.yml
+++ b/.github/workflows/integration-mobile-test-audiogen-ggml.yml
@@ -371,6 +371,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -388,7 +393,9 @@ jobs:
           addon-npm-name: '@qvac/audiogen-ggml'
           enables-perf: ${{ inputs.run_rtf_benchmarks && 'true' || 'false' }}
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       # A benchmark run prints one [PERF_REPORT_START] block (plus chunked
       # fragments, for log sinks that truncate) into bare_console.log. The

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -302,6 +302,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -319,7 +324,9 @@ jobs:
           addon-npm-name: '@qvac/bci-whispercpp'
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Extract and report BCI performance
         if: always() && steps.schedule.outputs.run-arns != '[]' && steps.schedule.outputs.run-arns != ''

--- a/.github/workflows/integration-mobile-test-classification-ggml.yml
+++ b/.github/workflows/integration-mobile-test-classification-ggml.yml
@@ -296,6 +296,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -313,7 +318,9 @@ jobs:
           addon-npm-name: '@qvac/classification-ggml'
           enables-perf: 'false'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Comment results on PR
         if: always()

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -280,6 +280,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -297,7 +302,9 @@ jobs:
           addon-npm-name: '@qvac/decoder-audio'
           enables-perf: 'false'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Comment results on PR
         if: always() && !cancelled()

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -370,6 +370,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -387,7 +392,9 @@ jobs:
           addon-npm-name: '@qvac/diffusion-cpp'
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Extract & upload addon perf report (Diffusion CPP)
         if: always() && !cancelled()

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -406,6 +406,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -423,7 +428,9 @@ jobs:
           addon-npm-name: '@qvac/embed-llamacpp'
           enables-perf: ${{ inputs.test_groups != '' && 'true' || 'false' }}
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
           # Benchmark calls this reusable workflow once per (batchSize, flashAttn)
           # batch with a distinct artifact_suffix; pass it through so each batch's
           # console-logs/perf-report artifacts get a unique name instead of all 8

--- a/.github/workflows/integration-mobile-test-inference-addon-cpp.yml
+++ b/.github/workflows/integration-mobile-test-inference-addon-cpp.yml
@@ -694,6 +694,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       # On failure as well as cancellation: a monitor/upload error would otherwise leave
@@ -715,7 +720,9 @@ jobs:
           addon-npm-name: 'inference-addon-cpp-mobile-tests'
           enables-perf: 'false'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Comment results on PR
         if: always() && !cancelled()

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -615,6 +615,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -633,7 +638,9 @@ jobs:
           artifact-name-suffix: ${{ inputs.artifact_suffix }}
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       # QVAC-17830: VLM image tests are split across multiple
       # `image-*.test.js` files; each Device Farm group emits its own

--- a/.github/workflows/integration-mobile-test-model-fit.yml
+++ b/.github/workflows/integration-mobile-test-model-fit.yml
@@ -290,6 +290,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -307,7 +312,9 @@ jobs:
           addon-npm-name: '@qvac/model-fit'
           enables-perf: 'false'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Comment results on PR
         if: always() && !cancelled()

--- a/.github/workflows/integration-mobile-test-ocr-ggml.yml
+++ b/.github/workflows/integration-mobile-test-ocr-ggml.yml
@@ -352,6 +352,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
 
       - name: Cancel Device Farm runs on workflow cancellation
         if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
@@ -368,7 +373,9 @@ jobs:
           addon-npm-name: '@qvac/ocr-ggml'
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Extract & upload addon perf report (OCR GGML)
         if: always() && steps.schedule.outputs.run-count != '0' && steps.schedule.outputs.run-count != ''

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -334,6 +334,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
 
       - name: Cancel Device Farm runs on workflow cancellation
@@ -351,7 +356,9 @@ jobs:
           addon-npm-name: '@qvac/translation-nmtcpp'
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       - name: Extract and report NMT performance
         if: always() && steps.schedule.outputs.run-arns != '[]' && steps.schedule.outputs.run-arns != ''

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -453,6 +453,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
           test-specs: ${{ steps.upload.outputs.test-specs }}
           # Functional multi-spec runs need headroom beyond Device Farm's
           # 120-minute execution ceiling for normal queue variance.
@@ -473,7 +478,9 @@ jobs:
           addon-npm-name: '@qvac/tts-ggml'
           enables-perf: ${{ inputs.run_rtf_benchmarks && 'true' || 'false' }}
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       # Benchmark runs (run_rtf_benchmarks=true) print one [PERF_REPORT_START]
       # block per suite (RTF + streaming) into bare_console.log. Scrape every

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -500,6 +500,11 @@ jobs:
         with:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
+          # Errored-run retry (documented in monitor-test-run): run-specs carries
+          # each slot's device selection, and the test package upload is the one
+          # scheduling input Device Farm never reports back on a run.
+          run-specs: ${{ steps.schedule.outputs.run-specs }}
+          test-package-upload-arn: ${{ steps.upload.outputs.test-package-upload-arn }}
 
       - name: Cancel Device Farm runs on workflow cancellation
         if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
@@ -516,7 +521,9 @@ jobs:
           addon-npm-name: '@qvac/vla-ggml'
           enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          # The monitor's list, so a rescheduled slot's logs come from the run
+          # that executed; falls back to the scheduler's when it never published.
+          run-arns: ${{ steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns }}
 
       # VLA's chunked perf-report markers land in bare_console.log inside
       # Customer_Artifacts.zip, so unzip-customer-artifacts=true is required.

--- a/.github/workflows/on-pr-shared-ci-infra.yml
+++ b/.github/workflows/on-pr-shared-ci-infra.yml
@@ -8,6 +8,8 @@ on:
       - ".github/workflows/on-pr-shared-ci-infra.yml"
       - ".github/actions/cache-models/**"
       - ".github/actions/run-mobile-integration-tests/seed-and-presign-models/**"
+      - ".github/actions/run-mobile-integration-tests/monitor-test-run/**"
+      - ".github/actions/run-mobile-integration-tests/schedule-test-run/**"
       - "scripts/perf-report/**"
       - "vcpkg-overlays/triplets/**"
       - "vcpkg-overlays/toolchains/**"
@@ -36,6 +38,14 @@ jobs:
         run: node --test .github/actions/cache-models/test/*.test.mjs
       - name: Run seed-and-presign action unit tests
         run: node --test .github/actions/run-mobile-integration-tests/seed-and-presign-models/test/*.test.mjs
+      # These two run the composites' own shell bodies against a fake AWS CLI, so
+      # the Device Farm errored-run retry (and the run-specs alignment it depends
+      # on) is covered without spending device minutes. They need jq, which the
+      # ubuntu runner image already ships.
+      - name: Run Device Farm monitor action unit tests
+        run: node --test .github/actions/run-mobile-integration-tests/monitor-test-run/test/*.test.mjs
+      - name: Run Device Farm scheduler action unit tests
+        run: node --test .github/actions/run-mobile-integration-tests/schedule-test-run/test/*.test.mjs
 
   # The per-addon benchmark aggregators are plain Node scripts shared by the
   # benchmark-performance-*.yml workflows, which only run on demand — so without

--- a/docs/ci/MOBILE-ON-DEMAND.md
+++ b/docs/ci/MOBILE-ON-DEMAND.md
@@ -360,6 +360,20 @@ gh workflow run integration-mobile-test-tts-ggml.yml --ref <branch> \
 This is the cheap, fast loop for reproducing/fixing a single failure without paying
 for the whole pool again.
 
+### Runs Device Farm errors before the tests start
+
+Device Farm occasionally completes a run as `ERRORED` with **0 tests executed** —
+the slot waits in a pending state, then finishes with an empty message. That is an
+infrastructure failure rather than a result, so the monitor reschedules that slot
+**once**, on the same device selection, and logs a `Run N rescheduled` warning with
+the old and new run ARNs. Nothing to re-dispatch by hand; the retried run's logs are
+what gets collected.
+
+Real test failures are never retried: they report `FAILED` with executed tests, as
+does an `ERRORED` run that got far enough to run something. If the reschedule itself
+errors again the job fails with the ERRORED result, which is the point at which a
+manual re-dispatch (or a Device Farm status check) is worth it.
+
 ### Run-count cap (fail-fast)
 
 To stop a single dispatch from spraying the whole fleet, two safety rails are


### PR DESCRIPTION
## Problem

Device Farm occasionally completes a run as `ERRORED` with a **zero test tally**: the slot waits in a pending state, then finishes with an empty message before a single test starts. That fails the whole mobile job today even though nothing was actually tested.

Observed on TTS iOS [run 33418309222](https://github.com/tetherto/qvac/actions/runs/33418309222) — the `lavasr` slot (`.../c1a827de-5717-4a5b-ab8b-af5c52451626`) sat PENDING for ~450 s, then:

```
device=Apple iPhone 17 | state=RUNNING result=PENDING | counters=0P/0F/0E/0S of 0
--- Run 7: ...-lavasr-Apple_iPhone_17 (Result: ERRORED) [tests: runLavasrEnhancerTest] ---
   ❌ Apple iPhone 17: ERRORED (0F/0E of 0)
Device Farm totals: 24 | Passed: 24 | Failed: 0 | Skipped: 0
```

Eight of nine slots passed, 24/24 tests passed, and the job still failed. A manual re-dispatch of the same commit two hours later was green.

## What changed

`monitor-test-run` reschedules such a slot **once**, on the device selection it was originally scheduled with, and keeps monitoring it.

Never retried:
- `FAILED` — tests ran and failed. A real result.
- `ERRORED` with a non-zero tally — tests ran and blew up. Also a real result.
- Anything already retried `max-errored-retries` times (default **1**, `0` disables).

Rescheduling needs what `schedule-run` needs, and the split is deliberate:

- **Derived from the errored run** — project ARN (from the run ARN's `:run:<projectId>/<runId>` shape, the same decomposition the console links already use), app upload, and `jobTimeoutMinutes`. So no secret is threaded through a second step, and a caller cannot pass a project or ceiling that disagrees with the run being retried.
- **Passed in** — the test package ARN, which Device Farm never reports back on a run, and the device selection. `schedule-test-run` gains a `run-specs` output carrying each slot's pool or filter; the selection Device Farm reports back does not round trip reliably enough to trust for retrying on the same hardware.

`run-specs` is recorded **inside** the two `schedule_run_*` helpers, so it grows once per scheduled run in call order and stays index-aligned with `run-arns` by construction rather than by every branch remembering to append. If it ever does not line up 1:1, the scheduler publishes `[]` and the retry disables itself instead of retrying a slot on another slot's hardware.

Two supporting changes:
- The monitor publishes an effective `run-arns` output (input list, retried slots replaced) and all 14 mobile workflows now collect logs from it (`steps.monitor.outputs.run-arns || steps.schedule.outputs.run-arns`), so a retried slot's artifacts come from the run that executed.
- A run the monitor creates is invisible to the caller's cancel step, which only knows the scheduler's ARNs. The monitor therefore stops its own reschedules on cancellation, on an unexpected error, and on the poll-loop timeout — same approach, and the same documented SIGKILL limitation, as the scheduler's existing partial-scheduling rollback.

Queue/execution figures are now slot-relative, so a retried slot reports its own run's queue time instead of counting the errored attempt's wait. Identical numbers when nothing is retried.

## Backwards compatibility

Every new input is optional. A caller passing none of them logs `🔁 Errored-run retry: disabled (<reason>)` and behaves exactly as before — useful because the release-environment jobs pull these composites from the **default branch** via the `trusted-actions` checkout, so this only takes effect after merge, and any workflow not updated here keeps working.

## Tests

Both composites gain unit tests that run their **real shell bodies** against a fake AWS CLI, in the existing `node --test` convention and wired into `on-pr-shared-ci-infra.yml` (which previously had no coverage for these two actions):

`monitor-test-run` — 13 scenarios: ERRORED-with-zero-tests is rescheduled once and can then pass; the reschedule derives project/app/timeout off the errored run and uses the caller's test package ARN; `FAILED` and `ERRORED`-with-tests are never rescheduled; a retry that errors again is not retried; each slot replays **its own** recipe (pool vs filter); retry off without recipes or the test package ARN; `max-errored-retries=0` and a non-numeric value both disable it with a warning; mismatched `run-specs` disables it; timing out with a reschedule in flight stops that run and still publishes the ARNs; all-passing runs never touch the retry path.

`schedule-test-run` — 7 scenarios, one per scheduling mode (dual-flagship Android and iOS, sharded, multi-spec dual-flagship, single-pool, single-device, manual-devices), each asserting one recipe per run, exactly one of `poolArn`/`filter`, and spec-major ordering that matches the ARN order.

All 20 pass locally, as do YAML parse + `bash -n` on both composites and a wiring check across all 14 workflows.

No CHANGELOG entry: nothing here ships in an npm package.

Generated with [Claude Code](https://claude.com/claude-code)
