### PR TITLE
QVAC-23945 feat[api]: ACE-Step LRC generation (synchronized lyric timestamps)

### DIFF
--- a/packages/audiogen-ggml/vcpkg-configuration.json
+++ b/packages/audiogen-ggml/vcpkg-configuration.json
@@ -1,7 +1,8 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "cf1500e91d595db131c41421d4e1455f9143ec6e",
+    "baseline": "4f2fcec33224811d80a025a2cd758cbd8ecbf0cb",
+    "reference": "QVAC-23945/lrc-generation",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-31",
+      "version>=": "2026-09-01#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-31",
+      "version>=": "2026-09-01#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-08-31",
+      "version>=": "2026-09-01#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-28",
+          "version>=": "2026-09-01#2",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-08-31",
+          "version>=": "2026-09-01#2",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## What

CI chain for the ACE-Step LRC generation work (QVAC-23945), running the monorepo build against the unmerged ext-lib branch.

- Raises the `speech-cpp` floor to `2026-09-01#2`: ACE-Step LRC generation (synchronized lyric timestamps from a DiT cross-attention probe + DTW alignment) and a pre-armed cancellation entry precheck.
- Last commit is a **temporary CI-only** registry pointer at the registry work branch; it will be dropped before this PR is marked ready for review.

## Chain

- ext-lib: [`QVAC-23945/lrc-generation`](https://github.com/tetherto/qvac-fabric-speech.cpp/tree/QVAC-23945/lrc-generation) @ `bf2faec5`
- registry: [`QVAC-23945/lrc-generation`](https://github.com/tetherto/qvac-registry-vcpkg/tree/QVAC-23945/lrc-generation) @ `4f2fcec3` (speech-cpp `2026-09-01#2` → ext-lib `bf2faec5`)
