### PR TITLE
QVAC-24253 chore[mod]: bump @qvac/fabric to ^0.10.0 for the npm-runtime addons

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2026-09-01
+
+### Changed
+
+- `@qvac/fabric` dependency bumped `^0.8.0` -> `^0.10.0`, which carries `qvac-fabric`
+  `10297.0.0` -> `10297.1.1` (MTP drafter, pipeline-parallel ACCEL fix, Metal
+  optimisations, Qwen4-Next support and fit host-memory budgeting, plus the Qwen4-Next
+  perf follow-ups and the Vulkan top-k radix-select shader). This package consumes the
+  shared runtime via npm rather than building the vcpkg port, so the range bump is what
+  picks up the new fabric. A caret on a `0.x` version locks the minor, so `^0.8.0` would
+  not have resolved `0.10.0` on its own. No API change for this package.
+
+  This bump crosses **two** fabric minors, so it also picks up `@qvac/fabric` 0.9.0's
+  ROCm/HIP compute backend — shipped as a `GGML_BACKEND_DL` module in the linux-x64
+  prebuild, loaded only on AMD hosts and otherwise skipped in favour of Vulkan/CPU.
+
+  This addon runs MobileNetV3-Small on CPU and exposes no GPU or vector-index surface,
+  so none of the above changes its own inference API. The bump keeps classification on
+  the current shared runtime rather than leaving it two minors behind on a superseded
+  fabric.
+
+- `check:generated` now compares against `git status --porcelain` instead of
+  `git diff --exit-code`, so an untracked generated wrapper is caught rather than
+  silently passing. Build-script only; no runtime effect.
+
 ## [0.22.0] - 2026-08-24
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {
@@ -84,7 +84,7 @@
     "typescript-eslint": "^8.63.0"
   },
   "dependencies": {
-    "@qvac/fabric": "^0.8.0",
+    "@qvac/fabric": "^0.10.0",
     "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",
     "bare-env": "^3.0.0",

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [0.24.0] - 2026-09-01
+
+### Changed
+
+- **This package no longer builds the `qvac-fabric` vcpkg port.** It now consumes the
+  shared runtime through the published npm package `@qvac/fabric`, resolving backends
+  from `node_modules` on desktop and staging fabric for the C++ unit tests. The
+  `qvac-fabric[hip-backend]` vcpkg dependency is gone — ROCm/HIP now arrives inside the
+  fabric prebuilds. `.github/fabric-consumers.json` lists this package under
+  `npm_runtime` accordingly, so it is no longer part of a `qvac-fabric` rollout.
+
+  This migration landed in [#3998](https://github.com/tetherto/qvac/pull/3998) with its
+  version bump and changelog entry deliberately deferred, so it is released here rather
+  than in the release it merged during.
+
+- `@qvac/fabric` dependency bumped `^0.9.0` -> `^0.10.0`, which carries `qvac-fabric`
+  `10297.0.0` -> `10297.1.1` (MTP drafter, pipeline-parallel ACCEL fix, Metal
+  optimisations, Qwen4-Next support and fit host-memory budgeting, plus the Qwen4-Next
+  perf follow-ups and the Vulkan top-k radix-select shader). Following the migration
+  above, the range bump is what picks up a new fabric. A caret on a `0.x` version locks
+  the minor, so `^0.9.0` would not have resolved `0.10.0` on its own. No API change for
+  this package.
+
+- C++ unit tests now run through `scripts/run-cpp-tests.js` rather than invoking
+  `addon-test` directly, so `ASAN_OPTIONS` relaxes `alloc-dealloc-mismatch` and leak
+  detection at the `@qvac/fabric` boundary. The previous workflow env var never reached
+  Linux CI.
+
+- Mobile test groups are validated by `scripts/lib/validate-test-groups.js`, with unit
+  coverage for the group definitions and the generator.
+
 ## [0.23.0] - 2026-08-24
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {
@@ -64,7 +64,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://qvac.tether.io",
   "dependencies": {
-    "@qvac/fabric": "^0.9.0",
+    "@qvac/fabric": "^0.10.0",
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.6.2",
     "@qvac/logging": "^0.1.0",


### PR DESCRIPTION
## 🎯 Problem

`classification-ggml` and `vla-ggml` consume the shared ggml runtime through the **published npm package
`@qvac/fabric`**, not the `qvac-fabric` vcpkg port. The `qvac-fabric 10297.1.1` rollout
([#4121](https://github.com/tetherto/qvac/pull/4121)) therefore never reached them —
`.github/fabric-consumers.json` lists both under `npm_runtime` precisely because they sit outside it.

They cannot pick the new runtime up on their own. **A caret on a `0.x` version locks the minor**, so
`^0.8.0` and `^0.9.0` will never resolve `0.10.0` no matter how long they wait. Left alone, both keep
installing a superseded fabric indefinitely, and nothing fails loudly to say so.

## 📝 How

| package | version | `@qvac/fabric` |
|---|---|---|
| `classification-ggml` | 0.22.0 → **0.23.0** | `^0.8.0` → **`^0.10.0`** |
| `vla-ggml` | 0.23.0 → **0.24.0** | `^0.9.0` → **`^0.10.0`** |

Both move `qvac-fabric 10297.0.0` → `10297.1.1`. `classification-ggml` crosses **two** fabric minors, so
it additionally picks up `@qvac/fabric` 0.9.0's ROCm/HIP `GGML_BACKEND_DL` module; `vla-ggml` already had
it.

Neither addon exposes a GPU or vector-index surface of its own, so **no API changes** — the bump keeps
them on the current shared runtime rather than a stale one.

### `vla-ggml` also releases work already on `main`

[#3998](https://github.com/tetherto/qvac/pull/3998) migrated `vla-ggml` off the vcpkg port onto the npm
runtime and **deliberately deferred** its version bump and changelog entry:

> *"Park the fabric-migration changelog and version bump for a follow-up PR after this cycle."*

This is that follow-up. Its `0.24.0` entry therefore documents the migration, the ASAN C++ test-runner
change and the mobile test-group validation **alongside** the caret bump, rather than publishing them
silently under a version whose changelog mentions none of them.

`classification-ggml`'s only other unreleased change is a `check:generated` script tweak, noted in its
entry for completeness.

## 🧪 Tested

- `@qvac/fabric@0.10.0` is **published and resolvable** — npm `latest` is `0.10.0`, git tag
  `fabric-v0.10.0` exists. This was the blocking precondition: opening this PR before fabric published
  would leave its own CI unable to resolve `^0.10.0` and go red for an unrelated reason.
- Diff is exactly 4 files — 2 × `package.json`, 2 × `CHANGELOG.md`. No source, no workflows.
- Both `package.json` files parse, and both changelog headings use the bracketed
  `## [<version>] - <date>` form the release-merge-guard requires.
- Both addons' pre-bump versions matched npm `latest` (0.22.0 / 0.23.0), so neither had an unreleased
  version already pending.

## ⚠️ Breaking

None. Both bumps are minor on `0.x`, no API surface changes, and the ROCm/HIP module is fail-safe at
runtime — the DL loader skips it on non-AMD hosts and falls back to Vulkan/CPU.

**Squash-merging publishes 2 packages:** `@qvac/classification-ggml 0.23.0` and `@qvac/vla-ggml 0.24.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
