### PR TITLE
infra[notask]: gate the assembled prebuilds tree on size

### DIFF
--- a/.github/actions/check-prebuild-size/action.yml
+++ b/.github/actions/check-prebuild-size/action.yml
@@ -1,0 +1,34 @@
+name: Check prebuild size
+description: |
+  Measures an assembled prebuilds tree and reports its total, per-target and
+  largest-file breakdown to the job summary. Fails the job when the total
+  exceeds `max-total-mb`, so a jump in what ships (a wider GPU fatbin, a new
+  shader payload) surfaces on the PR that causes it rather than at publish
+  time, where npm rejects a package whose unpacked size is over its ceiling.
+  Reporting only when `max-total-mb` is empty.
+
+inputs:
+  path:
+    description: Directory holding the assembled prebuilds tree.
+    required: true
+  max-total-mb:
+    description: |
+      Fail when the tree exceeds this many megabytes (decimal MB, matching
+      npm's own reporting). Empty reports without failing.
+    required: false
+    default: ''
+  top-count:
+    description: How many of the largest files to list in the summary.
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - name: Measure prebuilds
+      shell: bash
+      env:
+        PREBUILD_DIR: ${{ inputs.path }}
+        MAX_TOTAL_MB: ${{ inputs.max-total-mb }}
+        TOP_COUNT: ${{ inputs.top-count }}
+      run: node "${GITHUB_ACTION_PATH}/check-prebuild-size.mjs"

--- a/.github/actions/check-prebuild-size/check-prebuild-size.mjs
+++ b/.github/actions/check-prebuild-size/check-prebuild-size.mjs
@@ -1,0 +1,50 @@
+import fs from 'node:fs'
+import process from 'node:process'
+
+import { measure, renderReport, parseLimitMb, exceedsLimit, formatMb, DEFAULT_TOP_COUNT } from './measure-prebuilds.mjs'
+
+function appendStepSummary (report, env) {
+  const target = env.GITHUB_STEP_SUMMARY
+  if (!target) {
+    return
+  }
+  fs.appendFileSync(target, report)
+}
+
+function fail (message) {
+  process.stdout.write(`::error::${message}\n`)
+  process.exitCode = 1
+}
+
+export function run (env = process.env) {
+  const dir = env.PREBUILD_DIR
+  if (!dir) {
+    throw new Error('PREBUILD_DIR is required')
+  }
+  if (!fs.existsSync(dir)) {
+    throw new Error(`PREBUILD_DIR does not exist: ${dir}`)
+  }
+
+  const limitMb = parseLimitMb(env.MAX_TOTAL_MB)
+  const topCount = Number(env.TOP_COUNT ?? DEFAULT_TOP_COUNT)
+  const measurement = measure(dir, { topCount })
+  const report = renderReport(measurement, limitMb)
+
+  process.stdout.write(`${report}\n`)
+  appendStepSummary(report, env)
+
+  if (exceedsLimit(measurement.bytes, limitMb)) {
+    fail(
+      `prebuilds total ${formatMb(measurement.bytes)} exceeds the configured limit of ${limitMb.toFixed(1)} MB. ` +
+      'The published package is roughly this plus the JS layer, and npm rejects a package whose unpacked size is ' +
+      'over its ceiling, so either trim what ships (GPU fatbin architectures and shader payloads dominate) or ' +
+      'raise max-prebuild-mb deliberately.'
+    )
+  }
+
+  return measurement
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run()
+}

--- a/.github/actions/check-prebuild-size/measure-prebuilds.mjs
+++ b/.github/actions/check-prebuild-size/measure-prebuilds.mjs
@@ -1,0 +1,136 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const BYTES_PER_MB = 1000 * 1000
+export const DEFAULT_TOP_COUNT = 10
+
+function isSizedEntry (entry) {
+  return entry.isFile() || entry.isSymbolicLink()
+}
+
+function entrySize (absolutePath) {
+  const stat = fs.lstatSync(absolutePath)
+  return stat.isSymbolicLink() ? 0 : stat.size
+}
+
+function readDirEntries (dir) {
+  return fs.readdirSync(dir, { withFileTypes: true })
+}
+
+export function collectFiles (root) {
+  const files = []
+  const pending = [root]
+
+  while (pending.length > 0) {
+    const dir = pending.pop()
+    for (const entry of readDirEntries(dir)) {
+      const absolutePath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        pending.push(absolutePath)
+        continue
+      }
+      if (!isSizedEntry(entry)) {
+        continue
+      }
+      files.push({
+        relativePath: path.relative(root, absolutePath),
+        bytes: entrySize(absolutePath)
+      })
+    }
+  }
+
+  return files
+}
+
+export function totalBytes (files) {
+  return files.reduce((sum, file) => sum + file.bytes, 0)
+}
+
+export function largestFiles (files, count = DEFAULT_TOP_COUNT) {
+  return [...files].sort((a, b) => b.bytes - a.bytes).slice(0, count)
+}
+
+function targetOf (relativePath) {
+  const [first] = relativePath.split(path.sep)
+  return first ?? relativePath
+}
+
+export function bytesByTarget (files) {
+  const totals = new Map()
+  for (const file of files) {
+    const target = targetOf(file.relativePath)
+    totals.set(target, (totals.get(target) ?? 0) + file.bytes)
+  }
+  return [...totals.entries()]
+    .map(([target, bytes]) => ({ target, bytes }))
+    .sort((a, b) => b.bytes - a.bytes)
+}
+
+export function toMb (bytes) {
+  return bytes / BYTES_PER_MB
+}
+
+export function formatMb (bytes) {
+  return `${toMb(bytes).toFixed(1)} MB`
+}
+
+export function exceedsLimit (bytes, limitMb) {
+  if (limitMb === null) {
+    return false
+  }
+  return toMb(bytes) > limitMb
+}
+
+export function measure (root, { topCount = DEFAULT_TOP_COUNT } = {}) {
+  const files = collectFiles(root)
+  return {
+    fileCount: files.length,
+    bytes: totalBytes(files),
+    byTarget: bytesByTarget(files),
+    largest: largestFiles(files, topCount)
+  }
+}
+
+function renderTargetRows (byTarget) {
+  return byTarget.map(({ target, bytes }) => `| \`${target}\` | ${formatMb(bytes)} |`)
+}
+
+function renderLargestRows (largest) {
+  return largest.map(({ relativePath, bytes }) => `| \`${relativePath}\` | ${formatMb(bytes)} |`)
+}
+
+export function renderReport (measurement, limitMb) {
+  const limitLine = limitMb === null
+    ? 'No limit configured (reporting only).'
+    : `Limit: ${limitMb.toFixed(1)} MB.`
+
+  return [
+    '## Prebuild size',
+    '',
+    `Total: **${formatMb(measurement.bytes)}** across ${measurement.fileCount} files. ${limitLine}`,
+    '',
+    '| Target | Size |',
+    '| --- | --- |',
+    ...renderTargetRows(measurement.byTarget),
+    '',
+    `<details><summary>${measurement.largest.length} largest files</summary>`,
+    '',
+    '| File | Size |',
+    '| --- | --- |',
+    ...renderLargestRows(measurement.largest),
+    '',
+    '</details>',
+    ''
+  ].join('\n')
+}
+
+export function parseLimitMb (raw) {
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return null
+  }
+  const limit = Number(raw)
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new Error(`max-total-mb must be a positive number, got "${raw}"`)
+  }
+  return limit
+}

--- a/.github/actions/check-prebuild-size/test/check-prebuild-size.test.mjs
+++ b/.github/actions/check-prebuild-size/test/check-prebuild-size.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import test from 'node:test'
+
+import { run } from '../check-prebuild-size.mjs'
+import { BYTES_PER_MB } from '../measure-prebuilds.mjs'
+
+function makeTree (bytes) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'prebuild-gate-'))
+  fs.mkdirSync(path.join(root, 'linux-x64'), { recursive: true })
+  fs.writeFileSync(path.join(root, 'linux-x64/cuda.so'), Buffer.alloc(bytes))
+  return root
+}
+
+function withExitCode (fn) {
+  const previous = process.exitCode
+  process.exitCode = 0
+  try {
+    fn()
+    return process.exitCode
+  } finally {
+    process.exitCode = previous
+  }
+}
+
+test('run passes when the tree is under the limit', () => {
+  const dir = makeTree(BYTES_PER_MB)
+
+  const code = withExitCode(() => {
+    const measurement = run({ PREBUILD_DIR: dir, MAX_TOTAL_MB: '10' })
+    assert.equal(measurement.bytes, BYTES_PER_MB)
+  })
+
+  assert.equal(code, 0)
+})
+
+test('run fails the job when the tree exceeds the limit', () => {
+  const dir = makeTree(3 * BYTES_PER_MB)
+
+  const code = withExitCode(() => {
+    run({ PREBUILD_DIR: dir, MAX_TOTAL_MB: '2' })
+  })
+
+  assert.equal(code, 1)
+})
+
+test('run reports without failing when no limit is set', () => {
+  const dir = makeTree(50 * BYTES_PER_MB)
+
+  const code = withExitCode(() => {
+    run({ PREBUILD_DIR: dir, MAX_TOTAL_MB: '' })
+  })
+
+  assert.equal(code, 0)
+})
+
+test('run appends its report to the step summary when one is configured', () => {
+  const dir = makeTree(BYTES_PER_MB)
+  const summary = path.join(dir, 'summary.md')
+
+  withExitCode(() => {
+    run({ PREBUILD_DIR: dir, MAX_TOTAL_MB: '10', GITHUB_STEP_SUMMARY: summary })
+  })
+
+  assert.match(fs.readFileSync(summary, 'utf8'), /## Prebuild size/)
+})
+
+test('run rejects a missing directory', () => {
+  assert.throws(
+    () => run({ PREBUILD_DIR: path.join(os.tmpdir(), 'definitely-absent-prebuilds') }),
+    /does not exist/
+  )
+})
+
+test('run requires a directory', () => {
+  assert.throws(() => run({}), /PREBUILD_DIR is required/)
+})

--- a/.github/actions/check-prebuild-size/test/measure-prebuilds.test.mjs
+++ b/.github/actions/check-prebuild-size/test/measure-prebuilds.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  BYTES_PER_MB,
+  bytesByTarget,
+  collectFiles,
+  exceedsLimit,
+  formatMb,
+  largestFiles,
+  measure,
+  parseLimitMb,
+  renderReport,
+  totalBytes
+} from '../measure-prebuilds.mjs'
+
+function makeTree (layout) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'prebuild-size-'))
+  for (const [relativePath, bytes] of Object.entries(layout)) {
+    const absolutePath = path.join(root, relativePath)
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+    fs.writeFileSync(absolutePath, Buffer.alloc(bytes))
+  }
+  return root
+}
+
+test('collectFiles walks nested directories and records relative paths', () => {
+  const root = makeTree({
+    'linux-x64/mod/a.so': 10,
+    'linux-x64/mod/b.so': 20,
+    'darwin-arm64/mod/c.dylib': 30
+  })
+
+  const files = collectFiles(root)
+
+  assert.equal(files.length, 3)
+  assert.deepEqual(
+    files.map((file) => file.relativePath).sort(),
+    ['darwin-arm64/mod/c.dylib', 'linux-x64/mod/a.so', 'linux-x64/mod/b.so']
+  )
+  assert.equal(totalBytes(files), 60)
+})
+
+test('collectFiles counts a symlink as zero rather than following it', () => {
+  const root = makeTree({ 'linux-x64/real.so': 100 })
+  fs.symlinkSync(path.join(root, 'linux-x64/real.so'), path.join(root, 'linux-x64/link.so'))
+
+  const files = collectFiles(root)
+
+  assert.equal(files.length, 2)
+  assert.equal(totalBytes(files), 100)
+})
+
+test('collectFiles returns nothing for an empty tree', () => {
+  const root = makeTree({})
+
+  assert.deepEqual(collectFiles(root), [])
+  assert.equal(totalBytes([]), 0)
+})
+
+test('bytesByTarget subtotals by the first path segment, largest first', () => {
+  const files = [
+    { relativePath: 'linux-x64/a.so', bytes: 5 },
+    { relativePath: 'linux-x64/b.so', bytes: 15 },
+    { relativePath: 'win32-x64/c.dll', bytes: 8 }
+  ]
+
+  assert.deepEqual(bytesByTarget(files), [
+    { target: 'linux-x64', bytes: 20 },
+    { target: 'win32-x64', bytes: 8 }
+  ])
+})
+
+test('largestFiles orders by size and honours the requested count', () => {
+  const files = [
+    { relativePath: 'a', bytes: 1 },
+    { relativePath: 'b', bytes: 3 },
+    { relativePath: 'c', bytes: 2 }
+  ]
+
+  assert.deepEqual(largestFiles(files, 2).map((file) => file.relativePath), ['b', 'c'])
+})
+
+test('largestFiles does not mutate its input', () => {
+  const files = [
+    { relativePath: 'a', bytes: 1 },
+    { relativePath: 'b', bytes: 3 }
+  ]
+
+  largestFiles(files, 2)
+
+  assert.deepEqual(files.map((file) => file.relativePath), ['a', 'b'])
+})
+
+test('formatMb reports decimal megabytes to one place', () => {
+  assert.equal(formatMb(174_828_360), '174.8 MB')
+  assert.equal(formatMb(0), '0.0 MB')
+})
+
+test('exceedsLimit compares against decimal megabytes', () => {
+  assert.equal(exceedsLimit(400 * BYTES_PER_MB, 500), false)
+  assert.equal(exceedsLimit(500 * BYTES_PER_MB, 500), false)
+  assert.equal(exceedsLimit(500 * BYTES_PER_MB + 1, 500), true)
+})
+
+test('exceedsLimit never fails when no limit is configured', () => {
+  assert.equal(exceedsLimit(10_000 * BYTES_PER_MB, null), false)
+})
+
+test('parseLimitMb treats empty and missing values as no limit', () => {
+  assert.equal(parseLimitMb(''), null)
+  assert.equal(parseLimitMb('   '), null)
+  assert.equal(parseLimitMb(undefined), null)
+  assert.equal(parseLimitMb(null), null)
+})
+
+test('parseLimitMb accepts positive numbers and rejects anything else', () => {
+  assert.equal(parseLimitMb('480'), 480)
+  assert.equal(parseLimitMb('480.5'), 480.5)
+  assert.throws(() => parseLimitMb('0'), /positive number/)
+  assert.throws(() => parseLimitMb('-1'), /positive number/)
+  assert.throws(() => parseLimitMb('abc'), /positive number/)
+})
+
+test('measure summarises a tree end to end', () => {
+  const root = makeTree({
+    'linux-x64/mod/cuda.so': 300,
+    'linux-x64/mod/vulkan.so': 200,
+    'linux-arm64/mod/vulkan.so': 100
+  })
+
+  const measurement = measure(root, { topCount: 2 })
+
+  assert.equal(measurement.fileCount, 3)
+  assert.equal(measurement.bytes, 600)
+  assert.deepEqual(measurement.byTarget, [
+    { target: 'linux-x64', bytes: 500 },
+    { target: 'linux-arm64', bytes: 100 }
+  ])
+  assert.deepEqual(measurement.largest.map((file) => file.bytes), [300, 200])
+})
+
+test('renderReport states the limit and lists targets', () => {
+  const measurement = measure(makeTree({ 'linux-x64/a.so': 2 * BYTES_PER_MB }))
+
+  const report = renderReport(measurement, 480)
+
+  assert.match(report, /Total: \*\*2\.0 MB\*\* across 1 files/)
+  assert.match(report, /Limit: 480\.0 MB\./)
+  assert.match(report, /\| `linux-x64` \| 2\.0 MB \|/)
+})
+
+test('renderReport says so when no limit is configured', () => {
+  const measurement = measure(makeTree({ 'linux-x64/a.so': 1 }))
+
+  assert.match(renderReport(measurement, null), /No limit configured \(reporting only\)\./)
+})

--- a/.github/workflows/on-pr-shared-ci-infra.yml
+++ b/.github/workflows/on-pr-shared-ci-infra.yml
@@ -36,6 +36,8 @@ jobs:
         run: node --test .github/actions/cache-models/test/*.test.mjs
       - name: Run seed-and-presign action unit tests
         run: node --test .github/actions/run-mobile-integration-tests/seed-and-presign-models/test/*.test.mjs
+      - name: Run check-prebuild-size action unit tests
+        run: node --test .github/actions/check-prebuild-size/test/*.test.mjs
 
   # The per-addon benchmark aggregators are plain Node scripts shared by the
   # benchmark-performance-*.yml workflows, which only run on demand — so without

--- a/.github/workflows/prebuilds-asr-ggml.yml
+++ b/.github/workflows/prebuilds-asr-ggml.yml
@@ -47,4 +47,5 @@ jobs:
       include-cuda: true
       platform-cmake-defines: |
         linux-x64: -D ASR_CUDA=ON
+      max-prebuild-mb: "480"
     secrets: inherit

--- a/.github/workflows/prebuilds-audiogen-ggml.yml
+++ b/.github/workflows/prebuilds-audiogen-ggml.yml
@@ -45,4 +45,5 @@ jobs:
       include-cuda: true
       platform-cmake-defines: |
         linux-x64: -D ENABLE_CUDA=ON
+      max-prebuild-mb: "480"
     secrets: inherit

--- a/.github/workflows/prebuilds-bci-whispercpp.yml
+++ b/.github/workflows/prebuilds-bci-whispercpp.yml
@@ -46,4 +46,5 @@ jobs:
       include-cuda: true
       platform-cmake-defines: |
         linux-x64: -D ENABLE_CUDA=ON
+      max-prebuild-mb: "480"
     secrets: inherit

--- a/.github/workflows/prebuilds-tts-ggml.yml
+++ b/.github/workflows/prebuilds-tts-ggml.yml
@@ -45,4 +45,5 @@ jobs:
       include-cuda: true
       platform-cmake-defines: |
         linux-x64: -D ENABLE_CUDA=ON
+      max-prebuild-mb: "480"
     secrets: inherit

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -128,6 +128,17 @@ on:
         type: string
         required: false
         default: ""
+      max-prebuild-mb:
+        description: >-
+          Fail the merge job when the assembled prebuilds tree exceeds this many
+          megabytes. The published package is roughly this plus the JS layer, and
+          npm rejects a package whose unpacked size is over its ceiling, so this
+          catches a jump in what ships (a wider GPU fatbin, a new shader payload)
+          on the PR that causes it instead of at publish time. Empty reports the
+          breakdown to the job summary without failing.
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -582,6 +593,16 @@ jobs:
           echo "::error::fabric-overlay-artifact is set but artifact-name-prefix is empty — the merge would absorb the fabric tree into the prebuilds bundle"
           exit 1
 
+      # Only for the local check-prebuild-size action below; the merged tree
+      # itself comes from the matrix artifacts, not the working tree.
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+          sparse-checkout: .github/actions/check-prebuild-size
+
       - name: Download this workflow's build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
@@ -595,6 +616,15 @@ jobs:
           pattern: ${{ inputs.artifact-name-prefix }}*
           path: prebuilds
           merge-multiple: true
+
+      # The assembled tree here is what lands in the package's prebuilds/
+      # directory, so this is the first place a jump in what ships is visible.
+      # Reports unconditionally; fails only when the caller set a limit.
+      - name: Check prebuild size
+        uses: ./.github/actions/check-prebuild-size
+        with:
+          path: prebuilds
+          max-total-mb: ${{ inputs.max-prebuild-mb }}
 
       - name: Upload merged artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0


### PR DESCRIPTION
## What problem does this PR solve?

Nothing in CI measured what the prebuilds weigh. The speech addons' linux-x64 CUDA module recently more than doubled — **77.0 MB → 174.8 MB**, taking `@qvac/asr-ggml` from **329.8 MB → 427.6 MB unpacked** — and every check stayed green. `git grep -iE 'MAX_.*SIZE|SIZE_LIMIT|prebuild.*size' -- .github` finds nothing prebuild-related; the only place the number surfaces is npm's own output *during publish*, which is after review and, on a release, after the point where npm would reject the tarball.

That is worth catching on the PR that causes it, because the ceiling is real and the margin is no longer generous.

## How does it solve it?

A `check-prebuild-size` composite action, run in `reusable-prebuilds.yml`'s **merge** job — the moment the matrix artifacts have been assembled into the tree that becomes the package's `prebuilds/` directory.

- Always writes a total, per-target and largest-file breakdown to the job summary, so the number is visible even when it passes.
- Fails the job when the total exceeds the caller's `max-prebuild-mb`, with an `::error::` naming the total, the limit, and what usually dominates (GPU fatbin architectures, shader payloads).
- `max-prebuild-mb` empty ⇒ reporting only, so **every existing caller is unaffected**.

**The four speech addons set 480 MB.** Their tree measures ~415 MB today, leaving ~65 MB of headroom — room for ordinary growth, tight enough to catch another fatbin-scale jump. Deliberately *not* set for `llm-llamacpp` or `diffusion-cpp`: those publish at **550.8 MB** and **559.7 MB** unpacked (verified live on npm), so any shared default would have failed packages that ship today. Sizes are decimal MB to match npm's own reporting.

The merge job gains a **sparse checkout** of just the action directory, since a local `uses: ./…` action needs the working tree; the merged content still comes only from the artifacts.

## Verification

- **20/20 unit tests pass**, `lunte` clean. They cover the walker (nesting, symlinks counted as zero rather than followed, empty trees), the subtotal/largest-file helpers, limit parsing (empty, whitespace, zero, negative, non-numeric) and the gate (under, over, unset, step-summary write, missing directory). Registered in `on-pr-shared-ci-infra.yml` beside the other action suites.
- Writing the tests caught a real bug before commit: `appendStepSummary` read `process.env` directly instead of the injected env, so the summary would have been silently skipped under test and worked only by accident in CI.
- **End-to-end against a tree mirroring the measured post-merge artifact** (real per-file sizes): reports `361.5 MB` with `linux-x64` at `244.7 MB` and the CUDA module top of the list; passes at 480; fails at 300 with the annotation.

## Note on the ceiling

The exact npm limit is worth pinning down separately. Team recollection is a 500 MB unpacked cap with a rejection at 502 MB, but `llm-llamacpp` (550.8 MB) and `diffusion-cpp` (559.7 MB) are live, so either the binding constraint is the packed tarball — where `asr-ggml` is now the heaviest of the set at 257.5 MB packed — or that rejection had another cause. This PR deliberately does not encode a global truth: the limit is per-caller, so it can be tuned once the real ceiling is known.

## Breaking changes

None. Callers that do not set `max-prebuild-mb` only gain a job-summary report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
