### PR TITLE
chore[notask]: drop CUDA from published speech addon linux-x64 prebuilds

### DIFF
--- a/.github/workflows/integration-test-asr-ggml.yml
+++ b/.github/workflows/integration-test-asr-ggml.yml
@@ -182,19 +182,11 @@ jobs:
             no_gpu: 'true'
             benchmark_matrix_json: >-
               [{"engine":"whisper","modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"engine":"parakeet","modelType":"tdt","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"tdt","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"tdt","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"ctc","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"ctc","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"ctc","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"eou","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"eou","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"eou","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"sortformer","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"q4_0","useGPU":false}]
-          # The linux-x64 prebuild bundles the CUDA and Vulkan backend modules
-          # and ggml registers CUDA first, so the GPU backend is decided by
-          # whether the CUDA module's cudart/cuBLAS DT_NEEDED entries resolve.
-          # cuda_libs points this row's test steps at the runner's CUDA
-          # toolkit (kept outside ldconfig), giving it end-to-end CUDA
-          # coverage; qvac-ubuntu2404-x64-gpu leaves the CUDA module
-          # unresolvable, so ggml skips it and that row keeps dedicated
-          # Vulkan coverage plus the fallback path itself.
+          # Linux GPU runners exercise the published Vulkan desktop backend.
           - os: ubuntu-22.04
             platform: linux
             arch: x64
             runner: ${{ needs.runner_names.outputs.linux_ubuntu2204_x64_gpu }}
-            cuda_libs: /usr/local/cuda/lib64
             benchmark_matrix_json: >-
               [{"engine":"whisper","modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"engine":"whisper","modelFile":"ggml-base.bin","useGPU":true,"backendHint":"vulkan"},{"engine":"whisper","modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"engine":"whisper","modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"vulkan"},{"engine":"whisper","modelFile":"ggml-small.bin","useGPU":true,"backendHint":"vulkan"},{"engine":"whisper","modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"engine":"whisper","modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"tdt","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"tdt","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"tdt","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"ctc","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"ctc","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"ctc","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"eou","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"eou","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"eou","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"sortformer","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"f16","useGPU":false},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"q8_0","useGPU":false},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"q4_0","useGPU":false},{"engine":"parakeet","modelType":"tdt","quant":"f16","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"tdt","quant":"q8_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"tdt","quant":"q4_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"ctc","quant":"f16","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"ctc","quant":"q8_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"ctc","quant":"q4_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"eou","quant":"f16","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"eou","quant":"q8_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"eou","quant":"q4_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"sortformer","quant":"f16","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"sortformer","quant":"q8_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"sortformer","quant":"q4_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"f16","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"q8_0","useGPU":true,"backendHint":"vulkan"},{"engine":"parakeet","modelType":"sortformer-streaming","quant":"q4_0","useGPU":true,"backendHint":"vulkan"}]
           - os: ubuntu-24.04
@@ -418,9 +410,7 @@ jobs:
           INTEGRATION_TEST_TIMEOUT: ${{ matrix.platform == 'win32' && '1800' || '600' }}
           # ggml backend .so/.dylib files load transitively from the prebuilds
           # dir (parakeet's transitive-.so gotcha) — keep for the merged addon.
-          # matrix.cuda_libs additionally resolves the CUDA module's
-          # cudart/cuBLAS dependencies on the CUDA-lane runner.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/asr-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.cuda_libs && format(':{0}', matrix.cuda_libs) || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/asr-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/asr-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
 
       - name: Run integration test (Windows)
@@ -445,7 +435,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NO_GPU: ${{ matrix.no_gpu_whisper || matrix.no_gpu || 'false' }}
           INTEGRATION_TEST_TIMEOUT: ${{ matrix.platform == 'win32' && '1800' || '600' }}
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/asr-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.cuda_libs && format(':{0}', matrix.cuda_libs) || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/asr-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/asr-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
 
       - name: Run integration GPU test (Windows)

--- a/.github/workflows/integration-test-audiogen-ggml.yml
+++ b/.github/workflows/integration-test-audiogen-ggml.yml
@@ -94,19 +94,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The linux-x64 prebuild bundles the CUDA and Vulkan backend modules
-          # and the engine prefers CUDA, so the GPU backend is decided by
-          # whether the CUDA module's cudart/cuBLAS DT_NEEDED entries resolve.
-          # cuda_libs points this row's test steps at the runner's CUDA
-          # toolkit (kept outside ldconfig), giving it end-to-end CUDA
-          # coverage; qvac-ubuntu2404-x64-gpu leaves the CUDA module
-          # unresolvable, so ggml skips it and that row keeps dedicated
-          # Vulkan coverage plus the fallback path itself.
+          # Linux GPU runners exercise the published Vulkan desktop backend.
           - os: ubuntu-22.04
             platform: linux
             arch: x64
             runner: ${{ needs.runner_names.outputs.linux_ubuntu2204_x64_gpu }}
-            cuda_libs: /usr/local/cuda/lib64
           - os: ubuntu-24.04
             platform: linux
             arch: x64
@@ -252,9 +244,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_TIMEOUT: ${{ matrix.platform == 'win32' && '3600' || '1800' }}
-          # matrix.cuda_libs additionally resolves the CUDA module's
-          # cudart/cuBLAS dependencies on the CUDA-lane runner.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/audiogen-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.cuda_libs && format(':{0}', matrix.cuda_libs) || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/audiogen-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/audiogen-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
 
       # Benchmark leg (run_rtf_benchmarks=true, set by

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -94,21 +94,14 @@ jobs:
       matrix:
         include:
           # Linux x64 on the GPU runners (no_gpu unset -> NO_GPU=false ->
-          # gpu-smoke runs + asserts GPU). The linux-x64 prebuild bundles the
-          # CUDA and Vulkan backend modules and ggml registers CUDA first, so
-          # the GPU backend is decided by whether the CUDA module's
-          # cudart/cuBLAS DT_NEEDED entries resolve. cuda_libs points the
-          # 2204 row's test steps at the runner's CUDA toolkit (kept outside
-          # ldconfig), giving it end-to-end CUDA coverage; the 2404 row leaves
-          # the CUDA module unresolvable, so ggml skips it and that row keeps
-          # dedicated Vulkan coverage plus the fallback path itself. BCI ships
-          # a single registry model, so the benchmark sweeps platform ×
+          # gpu-smoke runs + asserts GPU). The published linux-x64 prebuild
+          # ships Vulkan; both GPU rows exercise that backend. BCI ships a
+          # single registry model, so the benchmark sweeps platform ×
           # CPU/GPU backend (no quant dimension).
           - os: ubuntu-22.04
             platform: linux
             arch: x64
             runner: ${{ needs.runner_names.outputs.linux_ubuntu2204_x64_gpu }}
-            cuda_libs: /usr/local/cuda/lib64
             benchmark_matrix_json: >-
               [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
           - os: ubuntu-24.04
@@ -323,9 +316,6 @@ jobs:
         run: npm run test:integration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Resolves the CUDA module's cudart/cuBLAS dependencies on the
-          # CUDA-lane runner; empty everywhere else.
-          LD_LIBRARY_PATH: ${{ matrix.cuda_libs }}
 
       - name: Run integration test (Windows)
         if: ${{ matrix.platform == 'win32' && inputs.run_integration_tests != false }}

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -96,15 +96,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both linux GPU runners carry an NVIDIA card and a prebuild that
-          # bundles the CUDA and Vulkan backends; pin one runner per backend so
-          # each keeps dedicated coverage instead of both resolving to the
-          # engine's CUDA-first preference.
+          # Both linux GPU runners carry an NVIDIA card; the published
+          # linux-x64 prebuild ships Vulkan only, so both rows pin vulkan.
           - os: ubuntu-22.04
             platform: linux
             arch: x64
             runner: ${{ needs.runner_names.outputs.linux_ubuntu2204_x64_gpu }}
-            gpu_backend: cuda
+            gpu_backend: vulkan
           - os: ubuntu-24.04
             platform: linux
             arch: x64
@@ -254,11 +252,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INTEGRATION_TEST_TIMEOUT: ${{ matrix.platform == 'win32' && '1800' || '600' }}
-          # /usr/local/cuda/lib64: the self-hosted linux GPU runners keep the
-          # CUDA toolkit there without registering it in ldconfig; the CUDA
-          # backend module's cudart/cuBLAS DT_NEEDED entries resolve from it.
-          # Harmless where the directory does not exist.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.platform == 'linux' && ':/usr/local/cuda/lib64' || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
 
       # Benchmark leg (run_rtf_benchmarks=true, set by
@@ -288,11 +282,7 @@ jobs:
           QVAC_TTS_GGML_BENCHMARK_MATRIX_OVERRIDE: ${{ inputs.benchmark_matrix_json }}
           QVAC_TTS_GGML_BENCHMARK_DEVICE: ${{ matrix.runner || matrix.os }}
           QVAC_TTS_GGML_BENCHMARK_RUNNER: ${{ matrix.runner || matrix.os }}
-          # /usr/local/cuda/lib64: the self-hosted linux GPU runners keep the
-          # CUDA toolkit there without registering it in ldconfig; the CUDA
-          # backend module's cudart/cuBLAS DT_NEEDED entries resolve from it.
-          # Harmless where the directory does not exist.
-          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.platform == 'linux' && ':/usr/local/cuda/lib64' || '' }}
+          LD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/packages/tts-ggml/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/prebuilds-asr-ggml.yml
+++ b/.github/workflows/prebuilds-asr-ggml.yml
@@ -44,7 +44,4 @@ jobs:
       linux-extra-packages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev libopenblas-dev liblapack-dev libfftw3-dev
       setup-python-on-windows: true
       include-vulkan-sdk: true
-      include-cuda: true
-      platform-cmake-defines: |
-        linux-x64: -D ASR_CUDA=ON
     secrets: inherit

--- a/.github/workflows/prebuilds-audiogen-ggml.yml
+++ b/.github/workflows/prebuilds-audiogen-ggml.yml
@@ -42,7 +42,4 @@ jobs:
       linux-extra-packages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
       setup-python-on-windows: true
       include-vulkan-sdk: true
-      include-cuda: true
-      platform-cmake-defines: |
-        linux-x64: -D ENABLE_CUDA=ON
     secrets: inherit

--- a/.github/workflows/prebuilds-bci-whispercpp.yml
+++ b/.github/workflows/prebuilds-bci-whispercpp.yml
@@ -43,7 +43,4 @@ jobs:
       linux-extra-packages: libopenblas-dev liblapack-dev libfftw3-dev
       mac-brew-packages: openblas lapack fftw
       include-vulkan-sdk: true
-      include-cuda: true
-      platform-cmake-defines: |
-        linux-x64: -D ENABLE_CUDA=ON
     secrets: inherit

--- a/.github/workflows/prebuilds-tts-ggml.yml
+++ b/.github/workflows/prebuilds-tts-ggml.yml
@@ -42,7 +42,4 @@ jobs:
       linux-extra-packages: pkg-config libx11-dev libxcb1-dev libxkbcommon-dev
       setup-python-on-windows: true
       include-vulkan-sdk: true
-      include-cuda: true
-      platform-cmake-defines: |
-        linux-x64: -D ENABLE_CUDA=ON
     secrets: inherit

--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -18,6 +18,10 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ### Changed
 
+- Drop CUDA from the published linux-x64 prebuild so the npm tarball stays
+  under the registry size limit. `use_gpu` / `useGPU: true` uses Vulkan on
+  Linux. CUDA remains opt-in at build time via `ASR_CUDA=ON`.
+
 - Raise the `speech-cpp` floor to 2026-09-01#2, which brings in ggml-speech
   2026-09-02. The CUDA backend now skips, at registration, GPUs whose
   compute capability has no compiled code in the fatbin, so a

--- a/packages/asr-ggml/README.md
+++ b/packages/asr-ggml/README.md
@@ -503,14 +503,13 @@ that ends mid-sample is rejected.
 GPU backends are selected per platform via `vcpkg.json` features; no
 `bare-make generate` flag is needed:
 
-- **Linux / Windows** — Vulkan (needs the [Vulkan SDK](https://vulkan.lunarg.com/) on the build host); the linux-x64 prebuild additionally bundles CUDA, see below
+- **Linux / Windows** — Vulkan (needs the [Vulkan SDK](https://vulkan.lunarg.com/) on the build host)
 - **Android** — Vulkan + OpenCL (Adreno) as dynamically-loaded `.so` backends shipped beside the prebuild
 - **macOS / iOS** — Metal, statically linked
 
 **CUDA (Linux / Windows on NVIDIA)** needs `nvcc` on the build host, so it is
 gated behind the `ASR_CUDA` CMake option. The published linux-x64 prebuild
-turns it on (the prebuild workflow installs the CUDA toolkit); elsewhere build
-it yourself with `npm run build:cuda` (or
+does not enable it; build it yourself with `npm run build:cuda` (or
 `bare-make generate -D ASR_CUDA=ON`), which adds the `cuda` feature to the
 `speech-cpp` dependency and turns on `GGML_CUDA`. On linux-x64 the cuda
 feature flips ggml into hybrid dynamically-loaded backend mode: the
@@ -526,7 +525,7 @@ CUDA when a supported device is present and falls back to Vulkan otherwise.
 Both engines report the winner through `getBackendInfo()` as `backendId: 2`
 (`BackendId.CUDA`).
 
-The prebuilt CUDA module targets **compute capability 7.5 and newer**, with
+A CUDA build's module targets **compute capability 7.5 and newer**, with
 native code for Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6),
 Ada (8.9), Hopper (9.0) and Blackwell (12.0, 12.1). Anything newer JIT-compiles
 from the bundled 8.0 PTX on first use, a one-off compile the driver caches.

--- a/packages/asr-ggml/README.md
+++ b/packages/asr-ggml/README.md
@@ -120,7 +120,7 @@ SDK code — see [Engine Selection](#engine-selection).
 |----------|-------------|-------------|--------|-------------|
 | macOS | arm64, x64 | 14.0+ | ✅ Tier 1 | Metal |
 | iOS | arm64 | 17.0+ | ✅ Tier 1 | Metal |
-| Linux | arm64, x64 | Ubuntu-22+ | ✅ Tier 1 | Vulkan; CUDA (x64 prebuild) |
+| Linux | arm64, x64 | Ubuntu-22+ | ✅ Tier 1 | Vulkan; CUDA via `build:cuda` / `ASR_CUDA=ON` |
 | Android | arm64 | 12+ | ✅ Tier 1 | Vulkan, OpenCL (Adreno) |
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
 

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -56,7 +56,7 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable the CUDA GPU backend for both engines (Linux / Windows on NVIDIA). Off by default; the published linux-x64 prebuild enables it, and building it elsewhere needs nvcc on the build host, so opt in with `bare-make generate -D ASR_CUDA=ON`. At runtime CUDA engages only where the NVIDIA driver and the CUDA 13 runtime libraries (cudart, cuBLAS) both resolve; hosts without them skip the CUDA backend and fall back to Vulkan or CPU.",
+      "description": "Enable the CUDA GPU backend for both engines (Linux / Windows on NVIDIA). Off by default; building it needs nvcc on the build host, so opt in with `bare-make generate -D ASR_CUDA=ON`. At runtime CUDA engages only where the NVIDIA driver and the CUDA 13 runtime libraries (cudart, cuBLAS) both resolve; hosts without them skip the CUDA backend and fall back to Vulkan or CPU.",
       "supports": "!(osx | ios | android)",
       "dependencies": [
         {

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Drop CUDA from the published linux-x64 prebuild so the npm tarball stays
+  under the registry size limit. `useGPU: true` uses Vulkan on Linux. CUDA
+  remains opt-in at build time via `ENABLE_CUDA=ON`.
+
 - Raise the `speech-cpp` floor to 2026-08-31, which brings in the ACE-Step
   Multi-Track (lego) task and base-model guided sampling.
 - Raise the `speech-cpp` floor further to 2026-09-01#2, which brings in

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -40,17 +40,17 @@ Android arm64, and iOS arm64. You also need the model GGUFs on disk (see
 [Models](#models)); point the addon at the folder that holds them.
 MiniMax-Music3 is available only in the Linux, macOS, and Windows prebuilds.
 
-The linux-x64 prebuild bundles the CUDA backend next to Vulkan: ggml runs in
-hybrid dynamically-loaded backend mode, the CPU-variant, Vulkan, and CUDA
-backends ship as `.so` modules beside the addon, and only the CUDA module
-depends on the CUDA runtime. Engaging CUDA needs the NVIDIA driver plus the
-CUDA 13 runtime libraries (cudart and cuBLAS) resolvable at load time; hosts that
-cannot resolve them skip the module and fall back to Vulkan or CPU. The engine
-prefers CUDA when both GPU backends are usable. Elsewhere the CUDA backend is
-opt-in at build time via `bare-make generate -D ENABLE_CUDA=ON` (needs `nvcc`
-on the build host).
+The published linux-x64 prebuild ships Vulkan. CUDA is opt-in at build time
+via `bare-make generate -D ENABLE_CUDA=ON` (needs `nvcc` on the build host).
+When CUDA is compiled in, ggml runs in hybrid dynamically-loaded backend
+mode: the CPU-variant, Vulkan, and CUDA backends ship as `.so` modules beside
+the addon, and only the CUDA module depends on the CUDA runtime. Engaging
+CUDA needs the NVIDIA driver plus the CUDA 13 runtime libraries (cudart and
+cuBLAS) resolvable at load time; hosts that cannot resolve them skip the
+module and fall back to Vulkan or CPU. The engine prefers CUDA when both GPU
+backends are usable.
 
-The prebuilt CUDA module targets **compute capability 7.5 and newer**, with
+A CUDA build's module targets **compute capability 7.5 and newer**, with
 native code for Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6),
 Ada (8.9), Hopper (9.0) and Blackwell (12.0, 12.1). Anything newer JIT-compiles
 from the bundled 8.0 PTX on first use, a one-off compile the driver caches.

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Drop CUDA from the published linux-x64 prebuild so the npm tarball stays
+  under the registry size limit. `use_gpu: true` uses Vulkan on Linux. CUDA
+  remains opt-in at build time via `ENABLE_CUDA=ON`.
+
 - Raise the `speech-cpp` floor to 2026-09-01#2, which brings in ggml-speech
   2026-09-02. The CUDA backend now skips, at registration, GPUs whose
   compute capability has no compiled code in the fatbin, so a

--- a/packages/bci-whispercpp/README.md
+++ b/packages/bci-whispercpp/README.md
@@ -83,8 +83,7 @@ VCPKG_ROOT=/path/to/vcpkg npm run build
 
 **CUDA (Linux / Windows on NVIDIA)** needs `nvcc` on the build host, so it is
 gated behind the `ENABLE_CUDA` CMake option. The published linux-x64 prebuild
-turns it on (the prebuild workflow installs the CUDA toolkit); elsewhere
-build it yourself with `npm run build:cuda` (or
+does not enable it; build it yourself with `npm run build:cuda` (or
 `bare-make generate -D ENABLE_CUDA=ON`), which adds the `cuda` feature to
 the `speech-cpp` dependency. On linux-x64 that
 flips ggml into hybrid dynamically-loaded backend mode: the CPU-variant,
@@ -95,7 +94,7 @@ CUDA 13 runtime libraries (cudart, cuBLAS — from a CUDA toolkit install) are
 needed at runtime; ggml registers CUDA ahead of Vulkan, so `use_gpu: true`
 prefers CUDA when a supported device is present.
 
-The prebuilt CUDA module targets **compute capability 7.5 and newer**, with
+A CUDA build's module targets **compute capability 7.5 and newer**, with
 native code for Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6),
 Ada (8.9), Hopper (9.0) and Blackwell (12.0, 12.1). Anything newer JIT-compiles
 from the bundled 8.0 PTX on first use, a one-off compile the driver caches.
@@ -361,7 +360,7 @@ These keys back the `whisper_context`. Changing any of them between jobs forces 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `model` | string | Optional override; usually set via `args.files.model`. |
-| `use_gpu` | boolean | Enable GPU acceleration. Enabled by default (whisper.cpp default); set `false` to force CPU. The GPU backend is chosen per platform at build time: Metal on macOS/iOS, Vulkan on Linux/Windows (plus CUDA on the linux-x64 prebuild and on `build:cuda` builds, preferred when an NVIDIA device and the CUDA runtime are present), OpenCL/Vulkan on Android. |
+| `use_gpu` | boolean | Enable GPU acceleration. Enabled by default (whisper.cpp default); set `false` to force CPU. The GPU backend is chosen per platform at build time: Metal on macOS/iOS, Vulkan on Linux/Windows (plus CUDA on `build:cuda` builds, preferred when an NVIDIA device and the CUDA runtime are present), OpenCL/Vulkan on Android. |
 | `flash_attn` | boolean | Enable flash attention. |
 | `gpu_device` | number | Select a non-default GPU device. |
 

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -44,7 +44,7 @@
   ],
   "features": {
     "cuda": {
-      "description": "Enable the CUDA GPU backend (Linux / Windows on NVIDIA). Off by default; the published linux-x64 prebuild enables it, and building it elsewhere needs nvcc on the build host, so opt in with `bare-make generate -D ENABLE_CUDA=ON`. At runtime CUDA engages only where the NVIDIA driver and the CUDA 13 runtime libraries (cudart, cuBLAS) both resolve; hosts without them skip the CUDA backend and fall back to Vulkan or CPU.",
+      "description": "Enable the CUDA GPU backend (Linux / Windows on NVIDIA). Off by default; building it needs nvcc on the build host, so opt in with `bare-make generate -D ENABLE_CUDA=ON`. At runtime CUDA engages only where the NVIDIA driver and the CUDA 13 runtime libraries (cudart, cuBLAS) both resolve; hosts without them skip the CUDA backend and fall back to Vulkan or CPU.",
       "supports": "!(osx | ios | android)",
       "dependencies": [
         {

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Drop CUDA from the published linux-x64 prebuild so the npm tarball stays
+  under the registry size limit. `useGPU: true` uses Vulkan on Linux. CUDA
+  remains opt-in at build time via `ENABLE_CUDA=ON`.
+
 - Raise the `speech-cpp` floor to 2026-09-01#2, which brings in ggml-speech
   2026-09-02. The CUDA backend now skips, at registration, GPUs whose
   compute capability has no compiled code in the fatbin, so a

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -556,7 +556,7 @@ host's policy:
 | Platform                | Default backend when `useGPU: true`          |
 |-------------------------|----------------------------------------------|
 | macOS / iOS             | Metal                                        |
-| Linux x64 — NVIDIA      | CUDA (the linux-x64 prebuild bundles CUDA and Vulkan; CUDA wins the cascade) |
+| Linux x64 — NVIDIA      | Vulkan (CUDA is opt-in at build via `ENABLE_CUDA`; CUDA then wins the cascade) |
 | Linux — other / Windows | Vulkan                                       |
 | Android — Adreno 700+   | OpenCL                                       |
 | Android — Mali / others | Vulkan                                       |
@@ -567,11 +567,12 @@ On hosts where more than one backend is usable, `TTS_CPP_GPU_BACKEND`
 and fails loudly when that backend cannot be resolved; unset (or empty)
 keeps the automatic preference above.
 
-The linux-x64 CUDA backend ships as a runtime-loaded module: engaging it
-requires the NVIDIA driver plus the CUDA 13 runtime libraries (cudart and
-cuBLAS, from a CUDA toolkit install) resolvable at load time. On hosts
-without them — including CPU-only and non-NVIDIA machines — the module is
-skipped and the addon behaves exactly as before (Vulkan or CPU).
+When the addon is built with `ENABLE_CUDA`, the CUDA backend ships as a
+runtime-loaded module: engaging it requires the NVIDIA driver plus the CUDA
+13 runtime libraries (cudart and cuBLAS, from a CUDA toolkit install)
+resolvable at load time. On hosts without them — including CPU-only and
+non-NVIDIA machines — the module is skipped and the addon behaves exactly as
+before (Vulkan or CPU).
 
 The module targets **compute capability 7.5 and newer**: native code for
 Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6), Ada (8.9), Hopper
@@ -1004,8 +1005,7 @@ baseline commit.
 GPU backends are controlled by the `speech-cpp` port's vcpkg features:
 `metal` (default on osx/ios), `vulkan` (default on
 linux/windows/android), `opencl` (default on android), and `cuda`
-(opt-in via the addon's `ENABLE_CUDA` cmake option; the published
-linux-x64 prebuilds enable it).
+(opt-in via the addon's `ENABLE_CUDA` cmake option).
 On Android the port is configured with
 `GGML_BACKEND_DL=ON` + `GGML_CPU_ALL_VARIANTS=ON`, so the build
 produces per-arch CPU + Vulkan + OpenCL `.so` files alongside the

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -21,7 +21,7 @@ Vulkan / OpenCL on Android) is **opt-in** via `config: { useGPU: true }`;
 the default is CPU.  On
 Android `useGPU` flows through to `tts-cpp`, which picks the GPU
 backend per its own per-vendor allowlist (Adreno → OpenCL,
-Xclipse/Mali → Vulkan). Parler supports Apple/Metal, linux CUDA, and the
+Xclipse/Mali → Vulkan). Parler supports Apple/Metal and the
 validated Android paths, including Vulkan on ARM Mali (see
 [Backends & GPU acceleration](#backends--gpu-acceleration)). Audio8 supports
 CUDA/Vulkan offload on Linux and Vulkan on Windows.
@@ -587,7 +587,7 @@ or CPU.
 > Mali for the Chatterbox / S3Gen graph and fell back to CPU there.)
 >
 > Parler also opts into ARM Mali Vulkan on Android. Its GPU smoke test is
-> strict on Apple, Android, and the linux CUDA lane; desktop Vulkan remains
+> strict on Apple and Android; desktop Vulkan remains
 > outside that test until dedicated Linux and Windows validation is available.
 >
 > CosyVoice3's GPU path covers Metal (macOS / iOS), CUDA and Vulkan on desktop
@@ -829,7 +829,7 @@ a one-off encode when a new reference recording is supplied.
 | `openclCacheDir`          | string     | unset      | Android-only: directory where the OpenCL backend persists its compiled program-binary cache.  Setting it across runs avoids re-JITing the kernels on every fresh process |
 | `vulkanCacheDir`          | string     | unset      | Supertonic + `useGPU: true` only: writable directory where the Vulkan backend persists its compiled pipeline cache (`GGML_VK_PIPELINE_CACHE_DIR`).  Moves the one-time first-dispatch pipeline-compile cost (seconds on Mali) off the first `run()` — paid once per install instead of once per process — and enables a load-time pre-warm.  Fully opt-in: unset -> no cross-process cache, no pre-warm, behaviour unchanged |
 | `config.language`         | string     | `"en"`     | Chatterbox MTL accepts `es/fr/de/pt/it/zh/ja/ko/...`; turbo & Supertonic are English |
-| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / CUDA / Vulkan / OpenCL if available. Honored for Chatterbox/Supertonic on GPU-capable hosts (including Android, per `tts-cpp`'s per-vendor allowlist); Parler is validated on Apple/Metal, linux CUDA, and Android/ARM Mali Vulkan; CosyVoice3 and Audio8 offload on Apple/Metal, desktop linux CUDA/Vulkan, Windows Vulkan, and Android OpenCL/Adreno. Unsupported backends fall back to CPU. See [Backends & GPU acceleration](#backends--gpu-acceleration) |
+| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / CUDA / Vulkan / OpenCL if available. Honored for Chatterbox/Supertonic on GPU-capable hosts (including Android, per `tts-cpp`'s per-vendor allowlist); Parler is validated on Apple/Metal and Android/ARM Mali Vulkan; CosyVoice3 and Audio8 offload on Apple/Metal, desktop linux CUDA/Vulkan, Windows Vulkan, and Android OpenCL/Adreno. Unsupported backends fall back to CPU. See [Backends & GPU acceleration](#backends--gpu-acceleration) |
 | `config.outputSampleRate` | number     | — (engine-native) | Resample the output to this rate (8000–192000 Hz). Omit to keep the engine-native rate (Chatterbox 24 kHz, Supertonic / Parler / Audio8 44.1 kHz, CosyVoice3 24 kHz, enhancer 48 kHz). Parler native chunk streaming accepts a non-native rate only with the enhancer active |
 | `opts.stats`              | boolean    | `false`    | Populate `response.stats` with RTF, `backendDevice` (0=CPU, 1=GPU), `backendId` (0=CPU, 1=Metal, 2=CUDA, 3=Vulkan, 4=OpenCL, 99=other), and — when an enhancer is active — `enhancerBackendDevice` / `enhancerBackendId` |
 | `exclusiveRun`            | boolean    | `false`    | **Top-level** option (not under `opts`): serialize overlapping streaming runs |

--- a/packages/tts-ggml/test/integration/audio8.test.js
+++ b/packages/tts-ggml/test/integration/audio8.test.js
@@ -28,9 +28,8 @@ const platform = os.platform()
 const arch = os.arch()
 const isDesktopGpu = (platform === 'linux' || platform === 'win32') && arch === 'x64'
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
-// CI rows that pin the engine's GPU cascade (linux prebuilds bundle CUDA and
-// Vulkan) export TTS_CPP_GPU_BACKEND; the desktop assertion expects the pinned
-// backend and defaults to Vulkan when unset.
+// CI rows that pin the engine's GPU cascade export TTS_CPP_GPU_BACKEND; the
+// desktop assertion expects the pinned backend and defaults to Vulkan when unset.
 const pinnedGpuBackend = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 const expectedDesktopBackend = pinnedGpuBackend === 'cuda' ? CUDA_BACKEND : VULKAN_BACKEND
 const expectedDesktopBackendName = pinnedGpuBackend === 'cuda' ? 'CUDA' : 'Vulkan'

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -54,10 +54,9 @@ const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
 // the assertions expect whatever the row pinned and fall back to the
 // platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
-// Parler GPU coverage is validated on Apple, the Android Device Farm, and the
-// linux CUDA lane. Keep desktop Vulkan out until dedicated runs prove it there.
-const isParlerGpuPlatform =
-  isApple || platform === 'android' || (platform === 'linux' && PINNED_GPU_BACKEND === 'cuda')
+// Parler GPU coverage is validated on Apple and the Android Device Farm.
+// Keep desktop Vulkan out until dedicated Linux and Windows runs prove it.
+const isParlerGpuPlatform = isApple || platform === 'android'
 // CosyVoice3's tts-cpp allowlist is Metal (Apple), OpenCL/Adreno (Android),
 // and Vulkan on desktop hosts, so the strict GPU leg runs everywhere the
 // desktop and mobile GPU runners exist. On Android the engine keeps its

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -50,10 +50,9 @@ const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 const isApple = platform === 'darwin' || platform === 'ios'
 const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
-// CI rows whose prebuild bundles more than one usable GPU backend (the linux
-// runners carry CUDA and Vulkan) pin the engine cascade through
-// TTS_CPP_GPU_BACKEND; the assertions expect whatever the row pinned and fall
-// back to the platform's cascade default when unset.
+// CI rows that pin the engine's GPU cascade export TTS_CPP_GPU_BACKEND;
+// the assertions expect whatever the row pinned and fall back to the
+// platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 // Parler GPU coverage is validated on Apple, the Android Device Farm, and the
 // linux CUDA lane. Keep desktop Vulkan out until dedicated runs prove it there.
@@ -94,7 +93,7 @@ function backendIdToName(id) {
 // Which platforms wire up a GPU backend in the speech-cpp vcpkg port
 // today (features in qvac-registry-vcpkg/ports/speech-cpp/vcpkg.json):
 //   - darwin / ios:        metal
-//   - linux / win32:       vulkan (linux-x64 prebuilds also bundle cuda)
+//   - linux / win32:       vulkan (CUDA only when built with ENABLE_CUDA)
 //   - android:             vulkan + opencl
 function expectsGpu() {
   return (

--- a/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
+++ b/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
@@ -41,10 +41,9 @@ const isMobile = platform === 'ios' || platform === 'android'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 const GPU_BACKEND_IDS = { metal: 1, cuda: 2, vulkan: 3, opencl: 4 }
-// CI rows whose prebuild bundles more than one usable GPU backend (the linux
-// runners carry CUDA and Vulkan) pin the engine cascade through
-// TTS_CPP_GPU_BACKEND; the enhancer assertion expects whatever the row pinned
-// and falls back to the platform's cascade default when unset.
+// CI rows that pin the engine's GPU cascade export TTS_CPP_GPU_BACKEND; the
+// enhancer assertion expects whatever the row pinned and falls back to the
+// platform's cascade default when unset.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 
 const ENHANCED_RATE = 48000
@@ -78,8 +77,8 @@ function backendIdToName(id) {
 }
 
 // Platforms that wire a GPU backend into tts-cpp's vcpkg port:
-// darwin/ios -> metal; linux/win32 -> vulkan (linux-x64 prebuilds also bundle
-// cuda); android -> vulkan + opencl.
+// darwin/ios -> metal; linux/win32 -> vulkan (CUDA only when built with
+// ENABLE_CUDA); android -> vulkan + opencl.
 function expectsGpu() {
   return (
     platform === 'darwin' ||

--- a/packages/tts-ggml/test/utils/kvCacheMatrix.js
+++ b/packages/tts-ggml/test/utils/kvCacheMatrix.js
@@ -51,8 +51,7 @@ const RELAX = !!(proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1')
 // to validate that follow-up fix once it ships.
 const PROBE_UNSAFE = !!(proc.env && proc.env.QVAC_TTS_KV_PROBE_UNSAFE === '1')
 
-// CI rows that pin the engine's GPU cascade (linux prebuilds bundle CUDA and
-// Vulkan) export TTS_CPP_GPU_BACKEND.
+// CI rows that pin the engine's GPU cascade export TTS_CPP_GPU_BACKEND.
 const PINNED_GPU_BACKEND = (proc.env && proc.env.TTS_CPP_GPU_BACKEND) || ''
 
 // KV dtypes every GPU backend wired into tts-cpp can actually *run the whole


### PR DESCRIPTION
## What problem does this PR solve?

- npm rejected `@qvac/tts-ggml@0.8.1` with HTTP 413 (tarball 232.1 MB). The CUDA fatbin in the linux-x64 prebuild pushed the package over the registry upload limit, so the already-bumped speech addons could not be published.

## How does it solve it?

- Stop compiling CUDA into the published linux-x64 prebuilds for `tts-ggml`, `asr-ggml`, `audiogen-ggml`, and `bci-whispercpp`. `useGPU: true` uses Vulkan on Linux; CUDA stays opt-in via `ENABLE_CUDA=ON` / `ASR_CUDA=ON`.
- Align integration-test GPU lanes with the Vulkan-only prebuild, and record the change in the unpublished patch changelogs (not `[Unreleased]`).

## How was it tested?

- `asr-ggml` CUDA wiring tests (`scripts/__tests__/build-backends.test.js`) still pass: default build stays CUDA-off, `build:cuda` remains opt-in.
- Prebuild size and publish will be confirmed by CI after merge (the failing publish path is the tts-ggml linux-x64 tarball).

CI Runs:
[AudioGen GGML](https://github.com/tetherto/qvac/actions/runs/33638241148)
[ASR GGML](https://github.com/tetherto/qvac/actions/runs/33638246404)
[TTS GGML](https://github.com/tetherto/qvac/actions/runs/33638253758)
[BCI Whispercpp](https://github.com/tetherto/qvac/actions/runs/33638259736)