### PR TITLE
QVAC-23918 infra: rerun only previously failed SDK e2e tests via label

### DIFF
--- a/.github/actions/sdk-e2e-base-state/action.yml
+++ b/.github/actions/sdk-e2e-base-state/action.yml
@@ -1,0 +1,277 @@
+name: SDK E2E Base State
+description: >
+  Maintains the single hidden comment tracking the last *base* SDK e2e run
+  (test-e2e-smoke, test-e2e-full, or the release-branch auto-run) on a PR, which
+  `sdk-e2e-resolve-rerun` reads to plan a `test-e2e-rerun-failed` run.
+
+  phase=start marks the base run as in flight so a rerun labelled before it
+  finishes is rejected. phase=finish records the per-platform failure set from the
+  run's results-* artifacts and clears that mark; with no usable results it keeps
+  the previously recorded base rather than wiping it.
+
+  Reusable workflows share the caller's run id, so every family's artifacts are
+  visible from the caller. No-op outside PR context.
+
+inputs:
+  phase:
+    description: "start (base run beginning) or finish (base run complete)"
+    required: true
+  suite:
+    description: "Suite the base run uses (empty = full)"
+    required: false
+    default: ""
+  head-sha:
+    description: "Head SHA the base run tests"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Download base results
+      if: inputs.phase == 'finish'
+      # A run whose every job died leaves no artifacts; the recorded base is then kept as-is.
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+      with:
+        pattern: results-*
+        path: .sdk-e2e-base/results
+
+    - name: Update base state
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+      env:
+        PHASE: ${{ inputs.phase }}
+        SUITE: ${{ inputs.suite }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const pr = context.payload.pull_request?.number;
+          if (!pr) {
+            core.info('No pull_request context; skipping base state update.');
+            return;
+          }
+
+          const phase = process.env.PHASE;
+          if (phase !== 'start' && phase !== 'finish') {
+            core.setFailed(`Unknown phase: ${phase}`);
+            return;
+          }
+
+          const MARKER = '<!-- sdk-e2e-base-state -->';
+          const DATA_RE = /<!-- sdk-e2e-base-state-data:v1:([A-Za-z0-9+/=]+) -->/;
+          const MAX_TESTS = 400;
+          const resultsRoot = '.sdk-e2e-base/results';
+          const suite = process.env.SUITE || '';
+          const sha = process.env.HEAD_SHA || context.payload.pull_request?.head?.sha || '';
+          const runUrl =
+            `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+            `/actions/runs/${context.runId}`;
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr,
+            per_page: 100,
+          });
+          const existing = comments.filter((c) => (c.body || '').includes(MARKER)).pop();
+
+          let previous = null;
+          if (existing && DATA_RE.test(existing.body)) {
+            try {
+              previous = JSON.parse(
+                Buffer.from(DATA_RE.exec(existing.body)[1], 'base64').toString('utf8')
+              );
+            } catch (err) {
+              core.warning(`Ignoring undecodable base state: ${err.message}`);
+            }
+          }
+
+          // results-android / results-ios carry a single implicit platform; node
+          // families qualify the artifact name with the platform key.
+          function parseArtifactName(name) {
+            let m = /^results-(android|ios)$/.exec(name);
+            if (m) return { family: m[1], platform: m[1] };
+            m = /^results-(desktop|electron|snap)-(.+)$/.exec(name);
+            if (m) return { family: m[1], platform: m[2] };
+            return null;
+          }
+
+          // actions/download-artifact@v8 extracts a single matched artifact directly
+          // into `path` instead of `path/<artifact-name>/`, so probe both layouts.
+          function findResultFiles(artifactName) {
+            for (const dir of [path.join(resultsRoot, artifactName), resultsRoot]) {
+              if (!fs.existsSync(dir)) continue;
+              const files = fs.readdirSync(dir)
+                .filter((f) => f.startsWith('results-') && f.endsWith('.json'))
+                .map((f) => path.join(dir, f));
+              if (files.length > 0) return files;
+            }
+            return [];
+          }
+
+          async function collectPlatforms() {
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+
+            // "Re-run failed jobs" adds a second artifact under the same name; the
+            // download keeps the newest, so read each name once.
+            const byName = new Map();
+            for (const artifact of artifacts) {
+              const parsed = parseArtifactName(artifact.name);
+              if (!parsed) continue;
+              const seen = byName.get(artifact.name);
+              if (!seen || artifact.id > seen.artifact.id) byName.set(artifact.name, { artifact, parsed });
+            }
+
+            let budget = MAX_TESTS;
+            let truncated = false;
+            const platforms = [];
+
+            for (const { artifact, parsed } of byName.values()) {
+              const files = findResultFiles(artifact.name);
+              if (files.length === 0) {
+                core.warning(`Artifact ${artifact.name} contained no results-*.json.`);
+                continue;
+              }
+
+              const failed = [];
+              const seen = new Set();
+              let total = 0;
+              let passed = 0;
+              let parsedAny = false;
+
+              for (const file of files) {
+                let report;
+                try {
+                  report = JSON.parse(fs.readFileSync(file, 'utf8'));
+                } catch (err) {
+                  core.warning(`Failed to parse ${file}: ${err.message}`);
+                  continue;
+                }
+                parsedAny = true;
+                total += Number(report.summary?.total || 0);
+                passed += Number(report.summary?.passed || 0);
+                for (const test of Array.isArray(report.tests) ? report.tests : []) {
+                  if (test.outcome !== 'failure') continue;
+                  const testId = String(test.testId || '');
+                  if (!testId || seen.has(testId)) continue;
+                  seen.add(testId);
+                  if (budget <= 0) {
+                    truncated = true;
+                    continue;
+                  }
+                  budget -= 1;
+                  failed.push(testId);
+                }
+              }
+
+              if (!parsedAny) continue;
+              platforms.push({ family: parsed.family, platform: parsed.platform, total, passed, failed });
+            }
+
+            platforms.sort((a, b) =>
+              `${a.family}/${a.platform}`.localeCompare(`${b.family}/${b.platform}`));
+            return { platforms, truncated };
+          }
+
+          const recorded = previous?.recorded || null;
+          let state;
+
+          if (phase === 'start') {
+            state = { recorded, running: { runId: context.runId, runUrl, sha, suite } };
+          } else {
+            const { platforms, truncated } = await collectPlatforms();
+            if (platforms.length === 0) {
+              core.warning('No usable results on this run; keeping the previously recorded base.');
+              state = { recorded, running: null };
+            } else {
+              state = {
+                recorded: { runId: context.runId, runUrl, sha, suite, truncated, platforms },
+                running: null,
+              };
+            }
+          }
+
+          if (!state.recorded && !state.running && !existing) {
+            core.info('Nothing to record and no comment to update.');
+            return;
+          }
+
+          function describe(run) {
+            return `${run.runUrl ? `[run ${run.runId}](${run.runUrl})` : `run ${run.runId}`} · ` +
+              `suite \`${run.suite || 'full'}\`` +
+              (run.sha ? ` · sha \`${String(run.sha).substring(0, 7)}\`` : '');
+          }
+
+          const lines = [MARKER];
+
+          if (state.running) {
+            lines.push(
+              '### QVAC E2E — base run in progress',
+              `**Running:** ${describe(state.running)}`,
+              '',
+              'The `test-e2e-rerun-failed` label is rejected until this run finishes and its ' +
+              'failure set is recorded below.'
+            );
+            if (state.recorded) lines.push('', '---', '');
+          }
+
+          if (state.recorded) {
+            const totalFailed = state.recorded.platforms.reduce((sum, p) => sum + p.failed.length, 0);
+            lines.push(
+              '### QVAC E2E — base run recorded',
+              `**Base:** ${describe(state.recorded)}`,
+              '',
+              '| Platform | Passed | Total | Failed |',
+              '| --- | --- | --- | --- |',
+              ...state.recorded.platforms.map(
+                (p) => `| \`${p.family}/${p.platform}\` | ${p.passed} | ${p.total} | ${p.failed.length} |`
+              ),
+              ''
+            );
+            if (totalFailed === 0) {
+              lines.push('All recorded platforms are green — nothing for `test-e2e-rerun-failed` to re-run.');
+            } else {
+              lines.push(
+                `Apply **\`test-e2e-rerun-failed\`** to re-run just these ${totalFailed} failing ` +
+                'test(s) against the current head commit. The label clears itself, so add it again ' +
+                'for each attempt; every attempt re-runs this same set until a new ' +
+                '`test-e2e-smoke` / `test-e2e-full` run replaces this base.'
+              );
+            }
+            if (state.recorded.truncated) {
+              lines.push('', `> Only the first ${MAX_TESTS} failing test ids were recorded. Re-run the full suite instead.`);
+            }
+          } else if (!state.running) {
+            lines.push('### QVAC E2E — no base run recorded', '', 'Run `test-e2e-smoke` or `test-e2e-full` to record one.');
+          }
+
+          // Base64 keeps arbitrary test ids from closing the HTML comment early.
+          const encoded = Buffer.from(JSON.stringify(state), 'utf8').toString('base64');
+          lines.push('', `<!-- sdk-e2e-base-state-data:v1:${encoded} -->`);
+          const body = lines.join('\n');
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+            core.info(`Updated base state comment ${existing.id} (phase=${phase}).`);
+          } else {
+            const created = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });
+            core.info(`Created base state comment ${created.data.id} (phase=${phase}).`);
+          }

--- a/.github/actions/sdk-e2e-resolve-rerun/action.yml
+++ b/.github/actions/sdk-e2e-resolve-rerun/action.yml
@@ -1,0 +1,220 @@
+name: SDK E2E Resolve Rerun
+description: >
+  Builds the plan for a `test-e2e-rerun-failed` run from the hidden base state
+  comment maintained by `sdk-e2e-base-state`.
+
+  The plan is always anchored to the last *base* run, never to a previous rerun,
+  so every attempt answers the same question: do all the tests that failed on
+  the base pass now? Platforms that were green on the base are dropped from the
+  run entirely.
+
+  Refuses to plan while a base run is still in flight — its failure set is not
+  known yet, and planning from the previous base would re-run the wrong tests.
+
+outputs:
+  should-run:
+    description: "true when there is at least one previously failed test to re-run"
+    value: ${{ steps.resolve.outputs.should-run }}
+  targets:
+    description: "Comma-separated family list for test-sdk.yml (e.g. 'desktop,ios')"
+    value: ${{ steps.resolve.outputs.targets }}
+  rerun-plan:
+    description: "JSON {family: {platform: [testId]}} of previously failed tests"
+    value: ${{ steps.resolve.outputs.rerun-plan }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve rerun plan
+      id: resolve
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+      with:
+        script: |
+          const MARKER = '<!-- sdk-e2e-base-state -->';
+          const DATA_RE = /<!-- sdk-e2e-base-state-data:v1:([A-Za-z0-9+/=]+) -->/;
+          const PLAN_MARKER = '<!-- sdk-e2e-rerun-plan -->';
+          const FAMILY_ORDER = ['desktop', 'electron', 'snap', 'android', 'ios'];
+
+          const pr = context.payload.pull_request?.number;
+          const runUrl =
+            `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+            `/actions/runs/${context.runId}`;
+
+          let cachedComments = null;
+          async function listComments() {
+            if (!cachedComments) {
+              cachedComments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                per_page: 100,
+              });
+            }
+            return cachedComments;
+          }
+
+          async function upsertPlanComment(body) {
+            const existing = (await listComments())
+              .filter((c) => (c.body || '').includes(PLAN_MARKER))
+              .pop();
+            const args = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${PLAN_MARKER}\n${body}`,
+            };
+            if (existing) {
+              await github.rest.issues.updateComment({ ...args, comment_id: existing.id });
+            } else {
+              await github.rest.issues.createComment({ ...args, issue_number: pr });
+            }
+          }
+
+          async function stop(heading, reason) {
+            core.setOutput('should-run', 'false');
+            core.setOutput('targets', '');
+            core.setOutput('rerun-plan', '');
+            if (pr) await upsertPlanComment(`### QVAC E2E rerun — ${heading}\n\n${reason}\n\n[View run](${runUrl})`);
+            core.notice(reason);
+            core.summary.addRaw(`### QVAC E2E rerun — ${heading}\n\n${reason}\n`);
+            await core.summary.write();
+          }
+
+          // A cancelled or dead base run leaves its `running` mark behind, so trust
+          // the run's real status rather than the mark alone.
+          async function isRunInFlight(runId) {
+            try {
+              const { data } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              return data.status !== 'completed';
+            } catch (err) {
+              if (err.status === 404) return false;
+              throw err;
+            }
+          }
+
+          if (!pr) {
+            return stop('not a PR', 'A failed-test rerun is only available on pull requests.');
+          }
+
+          const NO_BASE =
+            'No SDK e2e base run recorded on this PR. Run `test-e2e-smoke` or `test-e2e-full` ' +
+            'first — `test-e2e-rerun-failed` re-runs the failures of that run.';
+
+          const stateComment = (await listComments())
+            .filter((c) => (c.body || '').includes(MARKER) && DATA_RE.test(c.body || ''))
+            .pop();
+          if (!stateComment) {
+            return stop('⚠️ no base run', NO_BASE);
+          }
+
+          let state;
+          try {
+            state = JSON.parse(Buffer.from(DATA_RE.exec(stateComment.body)[1], 'base64').toString('utf8'));
+          } catch (err) {
+            return stop(
+              '⚠️ unreadable base state',
+              `The base state comment could not be decoded (${err.message}). Re-run the full suite.`
+            );
+          }
+
+          if (state.running?.runId && (await isRunInFlight(state.running.runId))) {
+            const link = state.running.runUrl
+              ? `[run ${state.running.runId}](${state.running.runUrl})`
+              : `run ${state.running.runId}`;
+            return stop(
+              '⏳ base run still in progress',
+              `Base ${link} has not finished, so its failure set is not known yet. Wait for the ` +
+              '**QVAC E2E — base run recorded** comment, then apply the label again — it has ' +
+              'already been removed.'
+            );
+          }
+          if (state.running?.runId) {
+            core.warning(
+              `Base run ${state.running.runId} never recorded a result; planning from the last recorded base.`
+            );
+          }
+
+          const recorded = state.recorded;
+          if (!recorded || !Array.isArray(recorded.platforms) || recorded.platforms.length === 0) {
+            return stop('⚠️ no base run', NO_BASE);
+          }
+
+          const baseLabel =
+            `**Base:** ${recorded.runUrl ? `[run ${recorded.runId}](${recorded.runUrl})` : `run ${recorded.runId}`} · ` +
+            `suite \`${recorded.suite || 'full'}\`` +
+            (recorded.sha ? ` · sha \`${String(recorded.sha).substring(0, 7)}\`` : '');
+
+          const plan = {};
+          let testCount = 0;
+          for (const entry of recorded.platforms) {
+            const family = String(entry.family || '');
+            const platform = String(entry.platform || '');
+            const ids = Array.isArray(entry.failed)
+              ? [...new Set(entry.failed.map(String).filter(Boolean))]
+              : [];
+            if (ids.length === 0) continue;
+            if (!FAMILY_ORDER.includes(family) || !platform) {
+              core.warning(`Skipping unrecognised base entry: ${family}/${platform}`);
+              continue;
+            }
+            plan[family] = plan[family] || {};
+            plan[family][platform] = ids;
+            testCount += ids.length;
+          }
+
+          if (testCount === 0) {
+            return stop(
+              '✅ base is green',
+              `${baseLabel}\n\nThe recorded base run has no failing tests — nothing to re-run.`
+            );
+          }
+
+          const families = FAMILY_ORDER.filter((family) => plan[family]);
+          const headSha = context.payload.pull_request?.head?.sha || '';
+          const skipped = recorded.platforms
+            .filter((p) => !Array.isArray(p.failed) || p.failed.length === 0)
+            .map((p) => `\`${p.family}/${p.platform}\``);
+
+          const lines = [
+            `### QVAC E2E rerun — ${testCount} previously failed test(s)`,
+            baseLabel,
+            `**Now testing:** sha \`${headSha.substring(0, 7) || 'head'}\`` +
+              (headSha && headSha === recorded.sha
+                ? ' — same commit as the base, so this is a flakiness check.'
+                : ' — new commit since the base run.'),
+            `[View run](${runUrl})`,
+            '',
+            '| Platform | Tests | Test ids |',
+            '| --- | --- | --- |',
+          ];
+          for (const family of families) {
+            for (const platform of Object.keys(plan[family]).sort()) {
+              const ids = plan[family][platform];
+              const shown = ids.slice(0, 8).map((id) => `\`${id}\``).join(', ');
+              const rest = ids.length - 8;
+              lines.push(
+                `| \`${family}/${platform}\` | ${ids.length} | ${shown}${rest > 0 ? `, and ${rest} more` : ''} |`
+              );
+            }
+          }
+          lines.push('');
+          if (skipped.length > 0) lines.push(`Not re-run (green on the base): ${skipped.join(', ')}.`);
+          lines.push(
+            'This is a partial verification — it does not replace a full run, and it does not ' +
+            'apply the `e2e-tested` label.'
+          );
+          if (recorded.truncated) {
+            lines.push('', '> The base state was truncated; some failures are not covered by this rerun.');
+          }
+
+          const body = lines.join('\n');
+          await upsertPlanComment(body);
+          core.summary.addRaw(`${body}\n`);
+          await core.summary.write();
+
+          core.setOutput('should-run', 'true');
+          core.setOutput('targets', families.join(','));
+          core.setOutput('rerun-plan', JSON.stringify(plan));

--- a/.github/actions/sdk-e2e-verify-rerun/action.yml
+++ b/.github/actions/sdk-e2e-verify-rerun/action.yml
@@ -1,0 +1,133 @@
+name: SDK E2E Verify Rerun
+description: >
+  Guards a `test-e2e-rerun-failed` run against a silent pass.
+
+  `--filter` selects by testId prefix, so a planned test id that no longer exists
+  (renamed or deleted since the base run) matches nothing. A platform that ends
+  up executing zero tests would otherwise report a green summary without having
+  verified anything. This action fails the run in that case, and warns about
+  individual planned ids that matched no executed test.
+
+inputs:
+  rerun-plan:
+    description: "JSON {family: {platform: [testId]}} the run was started with"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download rerun results
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+      with:
+        pattern: results-*
+        path: .sdk-e2e-verify/results
+
+    - name: Verify planned tests actually ran
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+      env:
+        RERUN_PLAN: ${{ inputs.rerun-plan }}
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const resultsRoot = '.sdk-e2e-verify/results';
+
+          let plan;
+          try {
+            plan = JSON.parse(process.env.RERUN_PLAN || '{}');
+          } catch (err) {
+            core.setFailed(`Could not parse rerun-plan: ${err.message}`);
+            return;
+          }
+
+          function artifactName(family, platform) {
+            return family === 'android' || family === 'ios'
+              ? `results-${family}`
+              : `results-${family}-${platform}`;
+          }
+
+          // actions/download-artifact@v8 extracts a single matched artifact directly
+          // into `path` instead of `path/<artifact-name>/`, so probe both layouts.
+          function findResultFiles(name) {
+            for (const dir of [path.join(resultsRoot, name), resultsRoot]) {
+              if (!fs.existsSync(dir)) continue;
+              const files = fs.readdirSync(dir)
+                .filter((f) => f.startsWith('results-') && f.endsWith('.json'))
+                .map((f) => path.join(dir, f));
+              if (files.length > 0) return files;
+            }
+            return [];
+          }
+
+          const problems = [];
+          const rows = [];
+
+          for (const [family, platforms] of Object.entries(plan)) {
+            for (const [platform, plannedIds] of Object.entries(platforms)) {
+              const label = `${family}/${platform}`;
+              const files = findResultFiles(artifactName(family, platform));
+
+              if (files.length === 0) {
+                // report-finalize already fails on missing results; noted here for context.
+                rows.push(`| \`${label}\` | — | ⚠️ no results artifact |`);
+                continue;
+              }
+
+              const executed = new Set();
+              for (const file of files) {
+                let report;
+                try {
+                  report = JSON.parse(fs.readFileSync(file, 'utf8'));
+                } catch (err) {
+                  core.warning(`Failed to parse ${file}: ${err.message}`);
+                  continue;
+                }
+                for (const test of Array.isArray(report.tests) ? report.tests : []) {
+                  if (test.testId) executed.add(String(test.testId));
+                }
+              }
+
+              // Exact ids, never prefixes: `--filter` selects by prefix, so a deleted
+              // `model-load-llm` would otherwise look covered by the surviving
+              // `model-load-llm-load-mode-none` and this guard would stay quiet.
+              const unmatched = plannedIds.filter((id) => !executed.has(id));
+
+              if (executed.size === 0) {
+                problems.push(`${label}: the rerun executed 0 tests.`);
+                rows.push(`| \`${label}\` | 0 | ❌ nothing executed |`);
+              } else if (unmatched.length === plannedIds.length) {
+                problems.push(
+                  `${label}: none of the ${plannedIds.length} planned test id(s) ran — they no ` +
+                  `longer exist, and the ${executed.size} test(s) that did run were pulled in by ` +
+                  'prefix, so nothing planned was verified.'
+                );
+                rows.push(`| \`${label}\` | ${executed.size} | ❌ no planned id ran |`);
+              } else if (unmatched.length > 0) {
+                core.warning(
+                  `${label}: ${unmatched.length} planned test id(s) did not run and were not ` +
+                  `verified: ${unmatched.join(', ')}`
+                );
+                rows.push(`| \`${label}\` | ${executed.size} | ⚠️ ${unmatched.length} planned id(s) no longer exist |`);
+              } else {
+                rows.push(`| \`${label}\` | ${executed.size} | ✅ all planned ids covered |`);
+              }
+            }
+          }
+
+          if (rows.length > 0) {
+            core.summary.addRaw([
+              '### QVAC E2E rerun — coverage check',
+              '',
+              '| Platform | Tests executed | Status |',
+              '| --- | --- | --- |',
+              ...rows,
+              '',
+            ].join('\n'));
+            await core.summary.write();
+          }
+
+          if (problems.length > 0) {
+            core.setFailed(`Rerun did not verify anything — ${problems.join('; ')}`);
+          }

--- a/.github/scripts/lib/sdk-e2e-rerun.mjs
+++ b/.github/scripts/lib/sdk-e2e-rerun.mjs
@@ -1,0 +1,294 @@
+/**
+ * Test harness for the SDK e2e failed-test rerun chain.
+ *
+ * The logic under test is embedded in workflow / composite-action YAML, so these
+ * helpers extract the real scripts and run them against fixtures — the shipped
+ * code, not a copy. That is the only pre-merge net available: `on-pr-test-sdk.yml`
+ * is `pull_request_target`, so it and its local actions always load from the base
+ * branch and cannot be exercised on the PR that changes them.
+ *
+ * Node built-ins only: `policy-tests` runs `node --test` with no dependency
+ * install, so no YAML library is available. The extractor is a line parser over a
+ * narrow known shape — same trade-off as `parseRunnersYaml` in ./runner-names.mjs.
+ */
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+const scriptRequire = createRequire(import.meta.url)
+const BLOCK_KEYS = new Set(['script', 'run', 'group'])
+
+function indentOf(line) {
+  return line.length - line.trimStart().length
+}
+
+/**
+ * Returns the block-scalar body of `key` under the line whose trimmed text is
+ * `anchor` (a `- name: <step>` or a mapping key like `concurrency:`).
+ *
+ * Lines are dedented by the block's own indent and joined with newlines, which
+ * reproduces YAML for a literal `|` block and for the one folded `>-` value read
+ * here (every continuation line is extra-indented, so folding is a no-op).
+ *
+ * Throws when the anchor or key is missing, so a YAML restructure fails the tests
+ * loudly instead of handing back an empty script that passes vacuously.
+ */
+export function extractBlockScalar(source, { anchor, key }) {
+  if (!BLOCK_KEYS.has(key)) throw new Error(`unsupported block key: ${key}`)
+
+  const lines = source.split('\n')
+  const anchorIndex = lines.findIndex((line) => line.trim() === anchor)
+  if (anchorIndex === -1) throw new Error(`anchor not found: ${anchor}`)
+  const anchorIndent = indentOf(lines[anchorIndex])
+
+  let keyIndex = -1
+  for (let i = anchorIndex + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.trim() === '') continue
+    // Any dedent to the anchor's own column ends its block, whether that is a
+    // sibling list item or the next mapping key.
+    if (indentOf(line) <= anchorIndent) break
+    if (line.trim() === `${key}: |` || line.trim() === `${key}: >-`) {
+      keyIndex = i
+      break
+    }
+  }
+  if (keyIndex === -1) throw new Error(`key "${key}" not found under: ${anchor}`)
+
+  const keyIndent = indentOf(lines[keyIndex])
+  const body = []
+  for (let i = keyIndex + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.trim() === '') {
+      body.push('')
+      continue
+    }
+    if (indentOf(line) <= keyIndent) break
+    body.push(line)
+  }
+  while (body.length > 0 && body[body.length - 1] === '') body.pop()
+  if (body.length === 0) throw new Error(`empty block for "${key}" under: ${anchor}`)
+
+  const blockIndent = Math.min(...body.filter((line) => line !== '').map(indentOf))
+  return body.map((line) => (line === '' ? '' : line.slice(blockIndent))).join('\n')
+}
+
+export function readRepoFile(relativePath) {
+  return readFileSync(join(repoRoot, relativePath), 'utf8')
+}
+
+export function actionScript(actionDir, stepName) {
+  return extractBlockScalar(readRepoFile(`.github/actions/${actionDir}/action.yml`), {
+    anchor: `- name: ${stepName}`,
+    key: 'script',
+  })
+}
+
+export function workflowStepRun(workflowFile, stepName) {
+  return extractBlockScalar(readRepoFile(`.github/workflows/${workflowFile}`), {
+    anchor: `- name: ${stepName}`,
+    key: 'run',
+  })
+}
+
+export function concurrencyGroup(workflowFile) {
+  return extractBlockScalar(readRepoFile(`.github/workflows/${workflowFile}`), {
+    anchor: 'concurrency:',
+    key: 'group',
+  })
+}
+
+export function makeCore() {
+  const outputs = {}
+  const notices = []
+  const warnings = []
+  const failures = []
+  return {
+    outputs,
+    notices,
+    warnings,
+    failures,
+    api: {
+      setOutput: (key, value) => { outputs[key] = value },
+      info: () => {},
+      notice: (message) => notices.push(message),
+      warning: (message) => warnings.push(message),
+      setFailed: (message) => failures.push(message),
+      summary: { addRaw: () => {}, write: async () => {} },
+    },
+  }
+}
+
+export function makeContext({ runId, prNumber = 7, headSha }) {
+  return {
+    runId,
+    serverUrl: 'https://github.com',
+    repo: { owner: 'tetherto', repo: 'qvac' },
+    payload: { pull_request: { number: prNumber, head: { sha: headSha } } },
+  }
+}
+
+/**
+ * `comments` is mutated in place, standing in for the PR's comment list.
+ * `runStatuses` maps a run id to its Actions API status; a missing id 404s.
+ */
+export function makeGithub({ comments = [], artifacts = [], runStatuses = {} } = {}) {
+  return {
+    paginate: async (fn) => fn(),
+    rest: {
+      actions: {
+        listWorkflowRunArtifacts: async () => artifacts,
+        getWorkflowRun: async ({ run_id: runId }) => {
+          const status = runStatuses[runId]
+          if (status === undefined) {
+            const error = new Error('Not Found')
+            error.status = 404
+            throw error
+          }
+          return { data: { status } }
+        },
+      },
+      issues: {
+        listComments: async () => comments,
+        createComment: async ({ body }) => {
+          const id = comments.length + 1
+          comments.push({ id, body })
+          return { data: { id } }
+        },
+        updateComment: async ({ comment_id: commentId, body }) => {
+          const index = comments.findIndex((comment) => comment.id === commentId)
+          if (index >= 0) comments[index] = { ...comments[index], body }
+        },
+      },
+    },
+  }
+}
+
+/** Runs a github-script body the way the action runtime does. */
+export async function runGithubScript(script, { github, context, core, env = {} }) {
+  const previous = {}
+  for (const [key, value] of Object.entries(env)) {
+    previous[key] = process.env[key]
+    process.env[key] = value
+  }
+  try {
+    const fn = new AsyncFunction('github', 'context', 'core', 'require', 'Buffer', 'process', script)
+    await fn(github, context, core.api, scriptRequire, Buffer, process)
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
+}
+
+export function makeWorkspace() {
+  const dir = mkdtempSync(join(tmpdir(), 'sdk-e2e-rerun-'))
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+function readOutputs(outputPath) {
+  const outputs = {}
+  for (const line of readFileSync(outputPath, 'utf8').split('\n')) {
+    const separator = line.indexOf('=')
+    if (separator > 0) outputs[line.slice(0, separator)] = line.slice(separator + 1)
+  }
+  return outputs
+}
+
+function runStep({ command, extension, code, cwd, env }) {
+  const scriptPath = join(cwd, `step.${extension}`)
+  const outputPath = join(cwd, 'step-output.txt')
+  writeFileSync(scriptPath, code)
+  writeFileSync(outputPath, '')
+  const result = spawnSync(command, [scriptPath], {
+    env: { ...process.env, ...env, GITHUB_OUTPUT: outputPath },
+    encoding: 'utf8',
+  })
+  return { status: result.status, stdout: result.stdout, outputs: readOutputs(outputPath) }
+}
+
+/** Runs a `shell: node {0}` step body; a non-zero exit is a test failure. */
+export function runNodeStep(code, { cwd, env = {} }) {
+  const result = runStep({ command: process.execPath, extension: 'cjs', code, cwd, env })
+  if (result.status !== 0) throw new Error(`node step exited ${result.status}:\n${result.stdout}`)
+  return result
+}
+
+/** Runs a `shell: bash` step body; the caller asserts on `status`. */
+export function runBashStep(code, { cwd, env = {} }) {
+  return runStep({ command: 'bash', extension: 'sh', code, cwd, env })
+}
+
+/**
+ * Writes results-*.json fixtures. `flatten` reproduces
+ * actions/download-artifact@v8 dropping a lone matched artifact straight into
+ * `path` with no per-artifact subdirectory.
+ */
+export function writeResults(root, artifacts, { flatten = false } = {}) {
+  for (const [name, spec] of Object.entries(artifacts)) {
+    const dir = flatten ? root : join(root, name)
+    mkdirSync(dir, { recursive: true })
+    const passedIds = spec.passedIds || []
+    const failedIds = spec.failed || []
+    const tests = passedIds.map((testId) => ({ testId, outcome: 'success' }))
+    for (let i = passedIds.length; i < spec.passed; i++) {
+      tests.push({ testId: `filler-${i}`, outcome: 'success' })
+    }
+    for (const testId of failedIds) tests.push({ testId, outcome: 'failure', error: 'boom' })
+    writeFileSync(
+      join(dir, 'results-run.json'),
+      JSON.stringify({
+        summary: { total: spec.total, passed: spec.passed, failed: failedIds.length },
+        tests,
+      }),
+    )
+  }
+}
+
+export function planSize(planJson) {
+  return Object.values(JSON.parse(planJson))
+    .flatMap((family) => Object.values(family))
+    .flat()
+    .length
+}
+
+/** The decoded base-state payload from the PR's hidden comment. */
+export function readBaseState(comments) {
+  const comment = comments.filter((c) => c.body.includes('<!-- sdk-e2e-base-state -->')).pop()
+  if (!comment) return null
+  const match = /<!-- sdk-e2e-base-state-data:v1:([A-Za-z0-9+/=]+) -->/.exec(comment.body)
+  if (!match) throw new Error('base-state comment carries no data payload')
+  return { body: comment.body, data: JSON.parse(Buffer.from(match[1], 'base64').toString('utf8')) }
+}
+
+export function readPlanComment(comments) {
+  return comments.filter((c) => c.body.includes('<!-- sdk-e2e-rerun-plan -->')).pop()
+}
+
+/**
+ * Evaluates a GitHub expression template. GitHub's `&&` / `||` return the operand
+ * and treat '' as falsy, matching JS, so the body evaluates directly once the
+ * context lookups are rewritten. Throws on a lookup this shim does not map.
+ */
+export function evaluateExpression(template, context) {
+  return template.replace(/\$\{\{([\s\S]*?)\}\}/g, (_, expression) => {
+    const js = expression
+      .replace(/format\(/g, '__format(')
+      .replace(/github\.event\.pull_request\.number/g, '__ctx.prNumber')
+      .replace(/github\.event\.action/g, '__ctx.action')
+      .replace(/github\.event\.label\.name/g, '__ctx.label')
+      .replace(/github\.workflow/g, '__ctx.workflow')
+      .replace(/github\.ref/g, '__ctx.ref')
+    if (/github\./.test(js)) throw new Error(`unmapped context lookup in: ${expression.trim()}`)
+    const format = (spec, ...args) => spec.replace(/\{(\d+)\}/g, (__, index) => args[index])
+    const value = new Function('__ctx', '__format', `return (${js});`)(context, format)
+    return value === null || value === undefined || value === false ? '' : String(value)
+  })
+}

--- a/.github/scripts/test/sdk-e2e-rerun.test.mjs
+++ b/.github/scripts/test/sdk-e2e-rerun.test.mjs
@@ -1,0 +1,544 @@
+/**
+ * Behaviour of the `test-e2e-rerun-failed` chain, exercising the real scripts
+ * embedded in the workflow / action YAML. `on-pr-test-sdk.yml` is
+ * `pull_request_target`, so it and its composite actions always load from the
+ * base branch: this suite is the only check that can run before a change to them
+ * merges.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  actionScript,
+  concurrencyGroup,
+  evaluateExpression,
+  extractBlockScalar,
+  makeContext,
+  makeCore,
+  makeGithub,
+  makeWorkspace,
+  planSize,
+  readBaseState,
+  readPlanComment,
+  runBashStep,
+  runGithubScript,
+  runNodeStep,
+  workflowStepRun,
+  writeResults,
+} from '../lib/sdk-e2e-rerun.mjs'
+
+const BASE_STATE = actionScript('sdk-e2e-base-state', 'Update base state')
+const RESOLVE_RERUN = actionScript('sdk-e2e-resolve-rerun', 'Resolve rerun plan')
+const VERIFY_RERUN = actionScript('sdk-e2e-verify-rerun', 'Verify planned tests actually ran')
+const APPLY_PLAN = workflowStepRun('test-sdk.yml', 'Apply rerun plan')
+const LEG_FILTER = workflowStepRun('test-node-sdk.yml', 'Resolve test filter for this platform')
+const RESOLVE_CONFIG = workflowStepRun('test-sdk.yml', 'Resolve configuration')
+
+const HEAD_SHA = 'cafe0000000000000000000000000000000000ba'
+const OTHER_SHA = 'beef1111111111111111111111111111111111aa'
+
+const DESKTOP_RUNNERS = '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu"]'
+const ELECTRON_RUNNERS = '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]'
+const SNAP_RUNNERS = '["qvac-ubuntu2204-x64-gpu"]'
+
+// A base full run: one failure on windows, one on linux, everything else green.
+const DESKTOP_BASE = {
+  'results-desktop-windows': { total: 120, passed: 119, failed: ['completion-stream-abort'] },
+  'results-desktop-linux': { total: 120, passed: 119, failed: ['ocr-pdf-multipage'] },
+  'results-desktop-macos': { total: 120, passed: 120, failed: [] },
+  'results-android': { total: 90, passed: 90, failed: [] },
+  'results-ios': { total: 90, passed: 90, failed: [] },
+}
+
+// The extracted scripts read their downloaded artifacts from paths relative to
+// the workspace. `node --test` runs each file in its own process, so this cwd is
+// not shared with other suites.
+const workspace = makeWorkspace()
+process.chdir(workspace.dir)
+process.on('exit', workspace.cleanup)
+
+async function baseState({
+  phase,
+  runId,
+  comments,
+  artifacts = {},
+  flatten = false,
+  suite = '',
+  sha = HEAD_SHA,
+  artifactNames,
+}) {
+  rmSync(join(workspace.dir, '.sdk-e2e-base'), { recursive: true, force: true })
+  if (phase === 'finish') {
+    writeResults(join(workspace.dir, '.sdk-e2e-base/results'), artifacts, { flatten })
+  }
+  const core = makeCore()
+  await runGithubScript(BASE_STATE, {
+    github: makeGithub({
+      comments,
+      artifacts: artifactNames
+        ?? Object.keys(artifacts).map((name, index) => ({ id: index + 1, name })),
+    }),
+    context: makeContext({ runId, headSha: HEAD_SHA }),
+    core,
+    env: { PHASE: phase, SUITE: suite, HEAD_SHA: sha },
+  })
+  return core
+}
+
+async function resolveRerun({ comments, runStatuses = {}, runId = 999, headSha = HEAD_SHA }) {
+  const core = makeCore()
+  await runGithubScript(RESOLVE_RERUN, {
+    github: makeGithub({ comments, runStatuses }),
+    context: makeContext({ runId, headSha }),
+    core,
+  })
+  return core
+}
+
+async function verifyRerun({ plan, artifacts, flatten = false }) {
+  rmSync(join(workspace.dir, '.sdk-e2e-verify'), { recursive: true, force: true })
+  writeResults(join(workspace.dir, '.sdk-e2e-verify/results'), artifacts, { flatten })
+  const core = makeCore()
+  await runGithubScript(VERIFY_RERUN, {
+    github: makeGithub({}),
+    context: makeContext({ runId: 888, headSha: HEAD_SHA }),
+    core,
+    env: { RERUN_PLAN: plan },
+  })
+  return core
+}
+
+function applyPlan(rerunPlan) {
+  return runNodeStep(APPLY_PLAN, {
+    cwd: workspace.dir,
+    env: {
+      RERUN_PLAN: rerunPlan,
+      DESKTOP_PLATFORMS: DESKTOP_RUNNERS,
+      ELECTRON_PLATFORMS: ELECTRON_RUNNERS,
+      SNAP_PLATFORMS: SNAP_RUNNERS,
+    },
+  }).outputs
+}
+
+function legFilter({ plan, consumer, runner, baseFilter = '' }) {
+  return runNodeStep(LEG_FILTER, {
+    cwd: workspace.dir,
+    env: { RERUN_PLAN: plan, BASE_FILTER: baseFilter, CONSUMER: consumer, RUNNER_LABEL: runner },
+  }).outputs
+}
+
+function resolveConfig(targets) {
+  return runBashStep(RESOLVE_CONFIG, {
+    cwd: workspace.dir,
+    env: {
+      EVENT_NAME: 'workflow_call',
+      TARGETS: targets,
+      SUITE: '',
+      SUITE_CUSTOM: '',
+      RUN_DESKTOP: '',
+      RUN_ELECTRON: '',
+      RUN_SNAP: '',
+      RUN_ANDROID: '',
+      RUN_IOS: '',
+      RUN_CALIBRATION: 'off',
+    },
+  })
+}
+
+test('the embedded scripts are extracted, not silently empty', () => {
+  assert.match(BASE_STATE, /sdk-e2e-base-state-data:v1:/)
+  assert.match(RESOLVE_RERUN, /base run still in progress/)
+  assert.match(VERIFY_RERUN, /executed 0 tests/)
+  assert.match(APPLY_PLAN, /desktop-platforms/)
+  assert.match(LEG_FILTER, /RERUN_PLAN/)
+  assert.match(RESOLVE_CONFIG, /run-e2e=/)
+})
+
+test('a missing anchor or key throws instead of returning nothing', () => {
+  const source = ['      - name: Real step', '        run: |', '          echo hi', ''].join('\n')
+  assert.equal(extractBlockScalar(source, { anchor: '- name: Real step', key: 'run' }), 'echo hi')
+  assert.throws(
+    () => extractBlockScalar(source, { anchor: '- name: Absent step', key: 'run' }),
+    /anchor not found/,
+  )
+  assert.throws(
+    () => extractBlockScalar(source, { anchor: '- name: Real step', key: 'script' }),
+    /not found under/,
+  )
+})
+
+test('the extractor stops at the end of its own block', () => {
+  // Jobs start at indent 2 with no leading dash, so a search for a key the step
+  // does not have must not run on into a later job and match its script.
+  const source = [
+    '  first-job:',
+    '    steps:',
+    '      - name: Target',
+    '        run: |',
+    '          echo mine',
+    '',
+    '  second-job:',
+    '    steps:',
+    '      - name: Other',
+    '        with:',
+    '          script: |',
+    '            echo not mine',
+    '',
+  ].join('\n')
+  assert.equal(extractBlockScalar(source, { anchor: '- name: Target', key: 'run' }), 'echo mine')
+  assert.throws(
+    () => extractBlockScalar(source, { anchor: '- name: Target', key: 'script' }),
+    /not found under/,
+  )
+})
+
+test('a base run records its failures and the rerun narrows to them', async () => {
+  const comments = []
+
+  await baseState({ phase: 'start', runId: 100, comments })
+  const started = readBaseState(comments)
+  assert.equal(started.data.running.runId, 100)
+  assert.match(started.body, /base run in progress/)
+
+  // Labelling mid-run must not plan from a half-finished base.
+  const midRun = await resolveRerun({ comments, runStatuses: { 100: 'in_progress' } })
+  assert.equal(midRun.outputs['should-run'], 'false')
+  assert.match(readPlanComment(comments).body, /still in progress/)
+
+  await baseState({ phase: 'finish', runId: 100, comments, artifacts: DESKTOP_BASE })
+  const recorded = readBaseState(comments)
+  assert.equal(recorded.data.running, null)
+  assert.equal(recorded.data.recorded.platforms.length, 5)
+  assert.equal(
+    comments.filter((comment) => comment.body.includes('<!-- sdk-e2e-base-state -->')).length,
+    1,
+    'the base state lives in exactly one comment',
+  )
+
+  const core = await resolveRerun({ comments, runStatuses: { 100: 'completed' } })
+  assert.equal(core.outputs['should-run'], 'true')
+  assert.equal(core.outputs.targets, 'desktop')
+  assert.equal(planSize(core.outputs['rerun-plan']), 2)
+
+  const narrowed = applyPlan(core.outputs['rerun-plan'])
+  assert.deepEqual(
+    JSON.parse(narrowed['desktop-platforms']),
+    ['qvac-win25-x64-gpu', 'qvac-ubuntu2204-x64-gpu'],
+    'the green macOS runner is dropped from the matrix',
+  )
+  assert.equal(narrowed['electron-platforms'], '[]')
+  assert.equal(narrowed['snap-platforms'], '[]')
+  assert.equal(narrowed['filter-android'], '')
+  assert.equal(narrowed['filter-ios'], '')
+
+  const plan = core.outputs['rerun-plan']
+  assert.equal(
+    legFilter({ plan, consumer: 'desktop', runner: 'qvac-win25-x64-gpu' }).filter,
+    'completion-stream-abort',
+  )
+  assert.equal(
+    legFilter({ plan, consumer: 'desktop', runner: 'qvac-ubuntu2204-x64-gpu' }).filter,
+    'ocr-pdf-multipage',
+  )
+
+  const verified = await verifyRerun({
+    plan,
+    artifacts: {
+      'results-desktop-windows': {
+        total: 1, passed: 1, passedIds: ['completion-stream-abort'], failed: [],
+      },
+      'results-desktop-linux': {
+        total: 1, passed: 1, passedIds: ['ocr-pdf-multipage'], failed: [],
+      },
+    },
+  })
+  assert.deepEqual(verified.failures, [])
+  assert.deepEqual(verified.warnings, [])
+})
+
+test('mobile-only failures skip desktop entirely', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 200,
+    comments,
+    artifacts: {
+      'results-desktop-windows': { total: 10, passed: 10, failed: [] },
+      'results-android': { total: 10, passed: 8, failed: ['tts-long-text', 'diffusion-sdxl'] },
+      'results-ios': { total: 10, passed: 9, failed: ['tts-long-text'] },
+    },
+  })
+
+  const core = await resolveRerun({ comments, runStatuses: { 200: 'completed' } })
+  assert.equal(core.outputs.targets, 'android,ios')
+  assert.equal(planSize(core.outputs['rerun-plan']), 3)
+
+  const narrowed = applyPlan(core.outputs['rerun-plan'])
+  assert.equal(narrowed['desktop-platforms'], '[]')
+  assert.equal(narrowed['filter-android'], 'tts-long-text,diffusion-sdxl')
+  assert.equal(narrowed['filter-ios'], 'tts-long-text')
+})
+
+test('without a plan the run keeps every runner and the incoming filter', () => {
+  const full = applyPlan('')
+  assert.equal(JSON.parse(full['desktop-platforms']).length, 3)
+  assert.equal(JSON.parse(full['electron-platforms']).length, 3)
+  assert.equal(full['filter-android'], '')
+
+  const leg = legFilter({
+    plan: '', consumer: 'desktop', runner: 'qvac-macos26-arm64-gpu', baseFilter: 'completion-',
+  })
+  assert.equal(leg.filter, 'completion-')
+})
+
+test('every reusable target still resolves, and keeps run-e2e true', () => {
+  const cases = [
+    ['desktop + mobile', 'true,false,false,true,true'],
+    ['all', 'true,false,false,true,true'],
+    ['mobile', 'false,false,false,true,true'],
+    ['desktop', 'true,false,false,false,false'],
+    ['ios', 'false,false,false,false,true'],
+    // Comma-separated family lists come from a rerun plan.
+    ['android,ios', 'false,false,false,true,true'],
+    ['desktop,android', 'true,false,false,true,false'],
+    ['desktop,electron,snap,android,ios', 'true,true,true,true,true'],
+  ]
+  for (const [targets, expected] of cases) {
+    const result = resolveConfig(targets)
+    assert.equal(result.status, 0, `"${targets}" should resolve: ${result.stdout}`)
+    const flags = [
+      result.outputs['run-desktop'], result.outputs['run-electron'], result.outputs['run-snap'],
+      result.outputs['run-android'], result.outputs['run-ios'],
+    ].join(',')
+    assert.equal(flags, expected, `"${targets}"`)
+    // prepare-inference / prepare-test-suite are gated on run-e2e.
+    assert.equal(result.outputs['run-e2e'], 'true', `"${targets}" run-e2e`)
+  }
+})
+
+test('a malformed target is rejected', () => {
+  for (const targets of ['bogus', 'desktop,bogus', ',']) {
+    assert.notEqual(resolveConfig(targets).status, 0, `"${targets}" should fail`)
+  }
+})
+
+test('with no base recorded the rerun explains itself instead of running', async () => {
+  const comments = []
+  const core = await resolveRerun({ comments })
+  assert.equal(core.outputs['should-run'], 'false')
+  assert.match(readPlanComment(comments).body, /no base run/)
+  assert.ok(
+    core.notices.some((notice) => notice.includes('test-e2e-smoke')),
+    'the reason reaches the run log, not just the PR comment',
+  )
+})
+
+test('a green base has nothing to re-run', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 300,
+    comments,
+    artifacts: { 'results-desktop-linux': { total: 10, passed: 10, failed: [] } },
+  })
+  const core = await resolveRerun({ comments, runStatuses: { 300: 'completed' } })
+  assert.equal(core.outputs['should-run'], 'false')
+  assert.match(readPlanComment(comments).body, /base is green/)
+})
+
+test('a run with no results keeps the previously recorded base', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 400,
+    comments,
+    artifacts: { 'results-desktop-linux': { total: 10, passed: 9, failed: ['still-relevant'] } },
+  })
+
+  await baseState({ phase: 'start', runId: 401, comments })
+  const started = readBaseState(comments)
+  assert.equal(started.data.recorded.runId, 400, 'start preserves the recorded base')
+  assert.equal(started.data.running.runId, 401)
+
+  await baseState({ phase: 'finish', runId: 401, comments, artifacts: {} })
+  const after = readBaseState(comments)
+  assert.equal(after.data.recorded.runId, 400)
+  assert.equal(after.data.running, null, 'the in-flight mark is cleared')
+
+  const core = await resolveRerun({ comments, runStatuses: { 400: 'completed', 401: 'completed' } })
+  assert.match(core.outputs['rerun-plan'], /still-relevant/)
+})
+
+test('a cancelled base run leaves a stale mark that is ignored, not obeyed', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 500,
+    comments,
+    artifacts: { 'results-desktop-linux': { total: 10, passed: 9, failed: ['old-but-valid'] } },
+  })
+  // 501 was cancelled, so record-base never ran and `running` was never cleared.
+  await baseState({ phase: 'start', runId: 501, comments })
+
+  const core = await resolveRerun({ comments, runStatuses: { 500: 'completed', 501: 'completed' } })
+  assert.equal(core.outputs['should-run'], 'true')
+  assert.match(core.outputs['rerun-plan'], /old-but-valid/)
+  assert.ok(core.warnings.some((warning) => warning.includes('never recorded')))
+})
+
+test('a newer base run replaces the older record', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 600,
+    comments,
+    artifacts: { 'results-desktop-linux': { total: 10, passed: 9, failed: ['old-failure'] } },
+  })
+  await baseState({
+    phase: 'finish',
+    runId: 601,
+    comments,
+    artifacts: { 'results-desktop-linux': { total: 10, passed: 9, failed: ['new-failure'] } },
+  })
+
+  const core = await resolveRerun({ comments, runStatuses: { 601: 'completed' } })
+  assert.match(core.outputs['rerun-plan'], /new-failure/)
+  assert.doesNotMatch(core.outputs['rerun-plan'], /old-failure/)
+})
+
+test('a lone artifact flattened into path is still read', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 700,
+    comments,
+    flatten: true,
+    artifacts: { 'results-ios': { total: 10, passed: 9, failed: ['tts-long-text'] } },
+  })
+  const core = await resolveRerun({ comments, runStatuses: { 700: 'completed' } })
+  assert.equal(core.outputs.targets, 'ios')
+
+  const verified = await verifyRerun({
+    plan: core.outputs['rerun-plan'],
+    flatten: true,
+    artifacts: {
+      'results-ios': { total: 1, passed: 1, passedIds: ['tts-long-text'], failed: [] },
+    },
+  })
+  assert.deepEqual(verified.failures, [])
+  assert.deepEqual(verified.warnings, [])
+})
+
+test('duplicate artifact names from a job re-run are deduped to the newest', async () => {
+  const comments = []
+  await baseState({
+    phase: 'finish',
+    runId: 800,
+    comments,
+    artifacts: {
+      'results-desktop-linux': { total: 10, passed: 9, failed: ['second-attempt-failure'] },
+    },
+    // Attempt 1 has the lower id; the download keeps the newest, so the name must
+    // be read once, not twice.
+    artifactNames: [
+      { id: 1, name: 'results-desktop-linux' },
+      { id: 9, name: 'results-desktop-linux' },
+    ],
+  })
+  const state = readBaseState(comments)
+  assert.equal(state.data.recorded.platforms.length, 1)
+  assert.deepEqual(state.data.recorded.platforms[0].failed, ['second-attempt-failure'])
+})
+
+test('a leg that executed nothing fails the rerun', async () => {
+  const comments = []
+  await baseState({ phase: 'finish', runId: 900, comments, artifacts: DESKTOP_BASE })
+  const core = await resolveRerun({ comments, runStatuses: { 900: 'completed' } })
+
+  const verified = await verifyRerun({
+    plan: core.outputs['rerun-plan'],
+    artifacts: {
+      'results-desktop-windows': { total: 0, passed: 0, failed: [] },
+      'results-desktop-linux': {
+        total: 1, passed: 1, passedIds: ['ocr-pdf-multipage'], failed: [],
+      },
+    },
+  })
+  assert.equal(verified.failures.length, 1)
+  assert.match(verified.failures[0], /executed 0 tests/)
+})
+
+test('a planned id covered only by a prefix sibling does not count as verified', async () => {
+  // `--filter=model-load-llm` also selects `model-load-llm-load-mode-none`, so a
+  // prefix comparison would call the deleted id covered and stay silent.
+  const plan = JSON.stringify({ desktop: { linux: ['model-load-llm'] } })
+  const verified = await verifyRerun({
+    plan,
+    artifacts: {
+      'results-desktop-linux': {
+        total: 1, passed: 1, passedIds: ['model-load-llm-load-mode-none'], failed: [],
+      },
+    },
+  })
+  assert.equal(verified.failures.length, 1, 'nothing planned ran, so the rerun must fail')
+  assert.match(verified.failures[0], /none of the 1 planned test id/)
+})
+
+test('a partially renamed plan warns but still reports the tests that ran', async () => {
+  const plan = JSON.stringify({ desktop: { linux: ['renamed-away', 'ocr-pdf-multipage'] } })
+  const verified = await verifyRerun({
+    plan,
+    artifacts: {
+      'results-desktop-linux': {
+        total: 1, passed: 1, passedIds: ['ocr-pdf-multipage'], failed: [],
+      },
+    },
+  })
+  assert.deepEqual(verified.failures, [])
+  assert.equal(verified.warnings.length, 1)
+  assert.match(verified.warnings[0], /renamed-away/)
+})
+
+test('the plan comment distinguishes a flakiness check from a fix verification', async () => {
+  const sameCommit = []
+  await baseState({ phase: 'finish', runId: 1000, comments: sameCommit, artifacts: DESKTOP_BASE })
+  await resolveRerun({ comments: sameCommit, runStatuses: { 1000: 'completed' } })
+  assert.match(readPlanComment(sameCommit).body, /flakiness check/)
+
+  const newCommit = []
+  await baseState({
+    phase: 'finish', runId: 1001, comments: newCommit, artifacts: DESKTOP_BASE, sha: OTHER_SHA,
+  })
+  await resolveRerun({ comments: newCommit, runStatuses: { 1001: 'completed' } })
+  assert.match(readPlanComment(newCommit).body, /new commit since the base run/)
+})
+
+test('each kind of run gets its own concurrency group', () => {
+  const template = concurrencyGroup('on-pr-test-sdk.yml')
+  assert.doesNotMatch(
+    template.replace(/\$\{\{[\s\S]*?\}\}/g, ''),
+    /\n/,
+    'a literal newline outside an interpolation would land in the group name',
+  )
+
+  const base = { workflow: 'w', prNumber: 4200, ref: 'refs/pull/4200/merge', label: null }
+  const groupFor = (context) => evaluateExpression(template, { ...base, ...context })
+
+  const baseGroup = groupFor({ action: 'labeled', label: 'test-e2e-smoke' })
+  assert.equal(groupFor({ action: 'labeled', label: 'test-e2e-full' }), baseGroup)
+  assert.equal(
+    groupFor({ action: 'synchronize' }),
+    baseGroup,
+    'a push still supersedes an in-flight base run',
+  )
+
+  // Neither a rerun nor a label this workflow ignores may cancel a base run.
+  assert.notEqual(groupFor({ action: 'labeled', label: 'test-e2e-rerun-failed' }), baseGroup)
+  assert.notEqual(groupFor({ action: 'labeled', label: 'safe-to-test' }), baseGroup)
+  assert.notEqual(
+    groupFor({ action: 'labeled', label: 'safe-to-test' }),
+    groupFor({ action: 'labeled', label: 'verify' }),
+    'two ignored labels must not cancel each other either',
+  )
+})

--- a/.github/workflows/on-pr-test-sdk.yml
+++ b/.github/workflows/on-pr-test-sdk.yml
@@ -3,9 +3,15 @@
 # Triggers SDK e2e tests via test-sdk.yml when:
 #   - "test-e2e-smoke" label applied: runs smoke suite on desktop + mobile
 #   - "test-e2e-full" label applied: runs full suite on desktop + mobile
+#   - "test-e2e-rerun-failed" label applied: re-runs only the tests that failed
+#     on the last smoke/full run, on the platforms where they failed
 #   - PR opened/updated targeting release-* branch with SDK/inference changes: runs full suite
 #
-# On success, applies "e2e-tested" label to the PR.
+# Smoke/full/release runs are "base" runs: they record their per-platform failure
+# set (sdk-e2e-base-state) and, on success, apply the "e2e-tested" label. Reruns
+# are anchored to that base — every attempt re-runs the same set until a new base
+# run replaces it — never apply "e2e-tested", and are rejected while a base run
+# is still in flight, since its failure set is not known until it finishes.
 #
 # Uses pull_request_target for secrets access (Device Farm, MQTT).
 # Authorization gate prevents untrusted fork PRs from running.
@@ -28,7 +34,16 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # One group per kind of run, so cancel-in-progress only supersedes a run of the
+  # same kind: a rerun must not cancel the base run whose failure set it consumes,
+  # and a label this workflow ignores must not cancel anything at all.
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{
+      github.event.action != 'labeled' && 'base'
+      || (github.event.label.name == 'test-e2e-rerun-failed' && 'rerun')
+      || (github.event.label.name == 'test-e2e-smoke' && 'base')
+      || (github.event.label.name == 'test-e2e-full' && 'base')
+      || format('ignored-{0}', github.event.label.name) }}
   cancel-in-progress: true
 
 jobs:
@@ -46,6 +61,7 @@ jobs:
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       suite: ${{ steps.check.outputs.suite }}
+      mode: ${{ steps.check.outputs.mode }}
     steps:
       - name: Checkout authorize-pr (default branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -72,43 +88,188 @@ jobs:
           LABEL: ${{ github.event.label.name }}
           TARGET: ${{ github.base_ref }}
         run: |
+          SHOULD_RUN=false
+          SUITE=
+          MODE=
+
           if [ "$EVENT" = "labeled" ]; then
-            if [ "$LABEL" = "test-e2e-smoke" ]; then
-              echo "should-run=true" >> "$GITHUB_OUTPUT"
-              echo "suite=smoke" >> "$GITHUB_OUTPUT"
-            elif [ "$LABEL" = "test-e2e-full" ]; then
-              echo "should-run=true" >> "$GITHUB_OUTPUT"
-              echo "suite=" >> "$GITHUB_OUTPUT"
-            else
-              echo "::notice::Ignoring unrelated label: $LABEL"
-              echo "should-run=false" >> "$GITHUB_OUTPUT"
-            fi
+            case "$LABEL" in
+              test-e2e-smoke)
+                SHOULD_RUN=true
+                SUITE=smoke
+                MODE=base
+                ;;
+              test-e2e-full)
+                SHOULD_RUN=true
+                MODE=base
+                ;;
+              test-e2e-rerun-failed)
+                echo "::notice::Re-running the tests that failed on the last base run"
+                SHOULD_RUN=true
+                MODE=rerun
+                ;;
+              *)
+                echo "::notice::Ignoring unrelated label: $LABEL"
+                ;;
+            esac
           elif echo "$TARGET" | grep -q '^release-'; then
             # Path filter already ensures SDK or inference changes exist.
             echo "::notice::Release branch PR with SDK/inference changes — running full suite"
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            echo "suite=" >> "$GITHUB_OUTPUT"
-          else
-            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            SHOULD_RUN=true
+            MODE=base
           fi
+
+          {
+            echo "should-run=$SHOULD_RUN"
+            echo "suite=$SUITE"
+            echo "mode=$MODE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Release the rerun label
+        if: steps.check.outputs.mode == 'rerun'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
+        with:
+          script: |
+            // GitHub only emits `labeled` when the label is not already present,
+            // so the label has to come back off for the next attempt to trigger.
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'test-e2e-rerun-failed',
+              });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              core.info('Label already removed.');
+            }
+
+  # Marks the base run as in flight so a rerun labelled before it finishes is
+  # rejected. Deliberately not a dependency of run-tests: the base run should
+  # start even if this bookkeeping fails.
+  mark-base-running:
+    needs: [resolve-config]
+    if: >-
+      needs.resolve-config.outputs.should-run == 'true'
+      && needs.resolve-config.outputs.mode == 'base'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          sparse-checkout: .github/actions/sdk-e2e-base-state
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - uses: ./.github/actions/sdk-e2e-base-state
+        with:
+          phase: start
+          suite: ${{ needs.resolve-config.outputs.suite }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+
+  resolve-rerun:
+    needs: [resolve-config]
+    if: >-
+      needs.resolve-config.outputs.should-run == 'true'
+      && needs.resolve-config.outputs.mode == 'rerun'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.plan.outputs.should-run }}
+      targets: ${{ steps.plan.outputs.targets }}
+      rerun-plan: ${{ steps.plan.outputs.rerun-plan }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          sparse-checkout: .github/actions/sdk-e2e-resolve-rerun
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Build rerun plan from the recorded base run
+        id: plan
+        uses: ./.github/actions/sdk-e2e-resolve-rerun
 
   run-tests:
     needs:
       - fork-approval
       - resolve-config
-    if: (needs.resolve-config.outputs.should-run == 'true')
+      - resolve-rerun
+    if: >-
+      !cancelled()
+      && needs.fork-approval.result == 'success'
+      && needs.resolve-config.result == 'success'
+      && needs.resolve-config.outputs.should-run == 'true'
+      && (needs.resolve-config.outputs.mode != 'rerun'
+          || (needs.resolve-rerun.result == 'success'
+              && needs.resolve-rerun.outputs.should-run == 'true'))
     uses: ./.github/workflows/test-sdk.yml
     with:
-      targets: desktop + mobile
+      targets: ${{ needs.resolve-rerun.outputs.targets || 'desktop + mobile' }}
       suite: ${{ needs.resolve-config.outputs.suite }}
+      rerun-plan: ${{ needs.resolve-rerun.outputs.rerun-plan }}
       test-version: ${{ github.event.pull_request.head.sha }}
       inference-source: branch
       test-suite-source: branch
     secrets: inherit
 
+  record-base:
+    # mark-base-running is a dependency purely for ordering: both jobs
+    # read-modify-write the same comment, and this one must write last.
+    needs: [resolve-config, mark-base-running, run-tests]
+    if: >-
+      !cancelled()
+      && needs.resolve-config.outputs.mode == 'base'
+      && (needs.run-tests.result == 'success' || needs.run-tests.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          sparse-checkout: .github/actions/sdk-e2e-base-state
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Record base failure set
+        uses: ./.github/actions/sdk-e2e-base-state
+        with:
+          phase: finish
+          suite: ${{ needs.resolve-config.outputs.suite }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+
+  verify-rerun:
+    needs: [resolve-config, resolve-rerun, run-tests]
+    if: >-
+      !cancelled()
+      && needs.resolve-config.outputs.mode == 'rerun'
+      && (needs.run-tests.result == 'success' || needs.run-tests.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          sparse-checkout: .github/actions/sdk-e2e-verify-rerun
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Verify the rerun covered the planned tests
+        uses: ./.github/actions/sdk-e2e-verify-rerun
+        with:
+          rerun-plan: ${{ needs.resolve-rerun.outputs.rerun-plan }}
+
   apply-label:
-    needs: run-tests
-    if: success()
+    needs: [resolve-config, run-tests]
+    # Only a base run earns "e2e-tested" — a rerun verifies a subset, not the suite.
+    if: success() && needs.resolve-config.outputs.mode == 'base'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -102,6 +102,15 @@ jobs:
           node --test
           .github/scripts/test/mobile-prebuild-registry.test.mjs
 
+      # on-pr-test-sdk.yml is pull_request_target, so it and its composite actions
+      # always load from the base branch — no run on this PR exercises an edit to
+      # the failed-test rerun chain. This suite extracts those scripts and runs
+      # them against fixtures, which is the only pre-merge check on them.
+      - name: Run SDK e2e rerun tests
+        run: >-
+          node --test
+          .github/scripts/test/sdk-e2e-rerun.test.mjs
+
       # The trust-policy suite asserts on workflow *text*, so it stays green even
       # when an edit destroys a job graph. on-merge-*/on-publish-* never run on a
       # PR, and pull_request_target workflows load from the base branch, so this

--- a/.github/workflows/test-node-sdk.yml
+++ b/.github/workflows/test-node-sdk.yml
@@ -40,6 +40,14 @@ on:
         description: "Exclude suites (comma-separated)"
         required: false
         type: string
+      rerun-plan:
+        description: >-
+          JSON {family: {platform: [testId]}} of previously failed tests. When set,
+          each matrix leg replaces `filter` with the list recorded for its own
+          platform. Empty = normal run.
+        required: false
+        type: string
+        default: ""
       test-version:
         description: "Git ref to checkout (branch, tag, or SHA). Defaults to trigger ref."
         required: false
@@ -160,7 +168,7 @@ jobs:
           family: ${{ inputs.consumer }}
           platforms: ${{ steps.keys.outputs.platforms }}
           suite: ${{ inputs.suite }}
-          filter: ${{ inputs.filter }}
+          filter: ${{ inputs.rerun-plan != '' && 'rerun of previously failed tests' || inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
           inference-provenance: ${{ inputs.inference-provenance }}
           test-suite-provenance: ${{ inputs.test-suite-provenance }}
@@ -206,6 +214,49 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:
           bun-version: latest
+
+      # A failed-test rerun carries a different test list per platform, so the
+      # effective filter is resolved inside the matrix leg rather than passed in.
+      - name: Resolve test filter for this platform
+        id: leg-filter
+        shell: node {0}
+        env:
+          RERUN_PLAN: ${{ inputs.rerun-plan }}
+          BASE_FILTER: ${{ inputs.filter }}
+          CONSUMER: ${{ inputs.consumer }}
+          RUNNER_LABEL: ${{ matrix.os }}
+        run: |
+          const fs = require('fs');
+
+          const label = String(process.env.RUNNER_LABEL || '').toLowerCase();
+          let platform = 'linux';
+          if (label.includes('win')) platform = 'windows';
+          else if (label.includes('mac') || label.includes('darwin')) platform = 'macos';
+
+          let filter = process.env.BASE_FILTER || '';
+          const raw = (process.env.RERUN_PLAN || '').trim();
+
+          if (raw) {
+            let plan;
+            try {
+              plan = JSON.parse(raw);
+            } catch (err) {
+              console.log(`::error::Invalid rerun-plan JSON: ${err.message}`);
+              process.exit(1);
+            }
+            const family = process.env.CONSUMER;
+            const ids = plan && plan[family] && plan[family][platform];
+            if (!Array.isArray(ids) || ids.length === 0) {
+              console.log(
+                `::error::rerun-plan has no tests for ${family}/${platform}; this leg should not have started.`
+              );
+              process.exit(1);
+            }
+            filter = ids.join(',');
+          }
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `filter=${filter}\n`);
+          console.log(`${platform}: filter=${filter || '(none)'}`);
 
       - name: Configure npm registries
         shell: node {0}
@@ -458,7 +509,7 @@ jobs:
         if: inputs.consumer == 'snap'
         shell: node {0}
         env:
-          TEST_FILTER: ${{ inputs.filter }}
+          TEST_FILTER: ${{ steps.leg-filter.outputs.filter }}
         run: |
           const fs = require('fs');
           const filters = (process.env.TEST_FILTER || '')
@@ -574,12 +625,15 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         timeout-minutes: 60
         shell: node {0}
+        env:
+          TEST_FILTER: ${{ steps.leg-filter.outputs.filter }}
         run: |
           (async () => {
             const { spawn, spawnSync } = require('child_process');
             const fs = require('fs');
 
-            const filter = '${{ inputs.filter }}';
+            // Read via env: a rerun filter is a long comma-separated test-id list.
+            const filter = process.env.TEST_FILTER || '';
             const filterArgs = filter ? ['--filter=' + filter] : [];
             const suite = '${{ inputs.suite }}';
             const suiteArgs = suite ? ['--suite=' + suite] : [];
@@ -875,7 +929,7 @@ jobs:
           platforms: ${{ needs.report-start.outputs.platform-keys }}
           comment-ids: ${{ needs.report-start.outputs.comment-ids }}
           suite: ${{ inputs.suite }}
-          filter: ${{ inputs.filter }}
+          filter: ${{ inputs.rerun-plan != '' && 'rerun of previously failed tests' || inputs.filter }}
           exclude-suite: ${{ inputs.exclude-suite }}
           inference-provenance: ${{ inputs.inference-provenance }}
           test-suite-provenance: ${{ inputs.test-suite-provenance }}

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -176,6 +176,13 @@ on:
       electron-platforms:
         type: string
         default: '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]'
+      rerun-plan:
+        description: >-
+          JSON {family: {platform: [testId]}} of previously failed tests. When set,
+          the run is narrowed to exactly these platforms and each platform receives
+          its own test filter. Empty = normal run.
+        type: string
+        default: ""
       test-version:
         type: string
       inference-source:
@@ -215,6 +222,11 @@ jobs:
       run-android: ${{ steps.resolve.outputs.run-android }}
       run-ios: ${{ steps.resolve.outputs.run-ios }}
       run-e2e: ${{ steps.resolve.outputs.run-e2e }}
+      desktop-platforms: ${{ steps.plan.outputs.desktop-platforms }}
+      electron-platforms: ${{ steps.plan.outputs.electron-platforms }}
+      snap-platforms: ${{ steps.plan.outputs.snap-platforms }}
+      filter-android: ${{ steps.plan.outputs.filter-android }}
+      filter-ios: ${{ steps.plan.outputs.filter-ios }}
     steps:
       - name: Resolve configuration
         id: resolve
@@ -305,8 +317,34 @@ jobs:
                 RESOLVED_IOS=true
                 ;;
               *)
-                echo "::error::Unsupported reusable target: $TARGETS"
-                exit 1
+                # Comma-separated family list (e.g. "desktop,ios"), used by
+                # failed-test reruns where the families come from the base run.
+                REST="$TARGETS"
+                MATCHED=false
+                while [ -n "$REST" ]; do
+                  ITEM="${REST%%,*}"
+                  if [ "$ITEM" = "$REST" ]; then
+                    REST=""
+                  else
+                    REST="${REST#*,}"
+                  fi
+                  case "$ITEM" in
+                    desktop) RESOLVED_DESKTOP=true; MATCHED=true ;;
+                    electron) RESOLVED_ELECTRON=true; MATCHED=true ;;
+                    snap) RESOLVED_SNAP=true; MATCHED=true ;;
+                    android) RESOLVED_ANDROID=true; MATCHED=true ;;
+                    ios) RESOLVED_IOS=true; MATCHED=true ;;
+                    "") ;;
+                    *)
+                      echo "::error::Unsupported reusable target: $TARGETS"
+                      exit 1
+                      ;;
+                  esac
+                done
+                if [ "$MATCHED" != "true" ]; then
+                  echo "::error::Unsupported reusable target: $TARGETS"
+                  exit 1
+                fi
                 ;;
             esac
           fi
@@ -328,6 +366,78 @@ jobs:
             echo "run-ios=$RESOLVED_IOS"
             echo "run-e2e=$RESOLVED_E2E"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Apply rerun plan
+        id: plan
+        shell: node {0}
+        env:
+          RERUN_PLAN: ${{ inputs.rerun-plan }}
+          DESKTOP_PLATFORMS: ${{ inputs.desktop-platforms || '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu"]' }}
+          ELECTRON_PLATFORMS: ${{ inputs.electron-platforms || '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]' }}
+          SNAP_PLATFORMS: ${{ inputs.snap-platforms || '["qvac-ubuntu2204-x64-gpu"]' }}
+        run: |
+          const fs = require('fs');
+
+          const raw = (process.env.RERUN_PLAN || '').trim();
+          let plan = null;
+          if (raw) {
+            try {
+              plan = JSON.parse(raw);
+            } catch (err) {
+              console.log(`::error::Invalid rerun-plan JSON: ${err.message}`);
+              process.exit(1);
+            }
+          }
+
+          // Same runner-label -> platform-key mapping as test-node-sdk.yml.
+          function platformKey(label) {
+            const s = String(label).toLowerCase();
+            if (s.includes('win')) return 'windows';
+            if (s.includes('mac') || s.includes('darwin')) return 'macos';
+            return 'linux';
+          }
+
+          function narrow(family, rawRunners) {
+            const runners = JSON.parse(rawRunners);
+            if (!plan) return runners;
+
+            const wanted = plan[family];
+            if (!wanted) return [];
+
+            const kept = runners.filter((runner) => Array.isArray(wanted[platformKey(runner)]));
+            const missing = Object.keys(wanted).filter(
+              (key) => !runners.some((runner) => platformKey(runner) === key)
+            );
+            if (missing.length > 0) {
+              console.log(
+                `::warning::No ${family} runner is configured for: ${missing.join(', ')} — ` +
+                'those previously failed tests will not be re-run.'
+              );
+            }
+            if (kept.length === 0) {
+              console.log(`::error::Rerun plan targets ${family} but no configured runner matches it.`);
+              process.exit(1);
+            }
+            return kept;
+          }
+
+          function filterFor(family, platform) {
+            const ids = plan && plan[family] && plan[family][platform];
+            return Array.isArray(ids) ? ids.join(',') : '';
+          }
+
+          const outputs = {
+            'desktop-platforms': JSON.stringify(narrow('desktop', process.env.DESKTOP_PLATFORMS)),
+            'electron-platforms': JSON.stringify(narrow('electron', process.env.ELECTRON_PLATFORMS)),
+            'snap-platforms': JSON.stringify(narrow('snap', process.env.SNAP_PLATFORMS)),
+            'filter-android': filterFor('android', 'android'),
+            'filter-ios': filterFor('ios', 'ios'),
+          };
+
+          for (const [key, value] of Object.entries(outputs)) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+            console.log(`${key}=${value}`);
+          }
 
   prepare-inference:
     name: Resolve inference source
@@ -504,7 +614,8 @@ jobs:
       consumer: desktop
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
-      platforms: ${{ inputs.desktop-platforms || '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu"]' }}
+      platforms: ${{ needs.resolve.outputs.desktop-platforms }}
+      rerun-plan: ${{ inputs.rerun-plan }}
       consumer-timeout: ${{ fromJSON(inputs.desktop-consumer-timeout || '60') }}
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
@@ -529,7 +640,8 @@ jobs:
       consumer: electron
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
-      platforms: ${{ inputs.electron-platforms || '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]' }}
+      platforms: ${{ needs.resolve.outputs.electron-platforms }}
+      rerun-plan: ${{ inputs.rerun-plan }}
       consumer-timeout: ${{ fromJSON(inputs.desktop-consumer-timeout || '60') }}
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
@@ -554,7 +666,8 @@ jobs:
       consumer: snap
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
-      platforms: ${{ inputs.snap-platforms || '["qvac-ubuntu2204-x64-gpu"]' }}
+      platforms: ${{ needs.resolve.outputs.snap-platforms }}
+      rerun-plan: ${{ inputs.rerun-plan }}
       consumer-timeout: ${{ fromJSON(inputs.desktop-consumer-timeout || '60') }}
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
@@ -585,7 +698,7 @@ jobs:
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
       consumer-timeout: ${{ fromJSON(inputs.mobile-consumer-timeout || '1200') }}
-      filter: ${{ inputs.filter }}
+      filter: ${{ needs.resolve.outputs.filter-android || inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
       device-farm-timeout: ${{ fromJSON(inputs.device-farm-timeout || '120') }}
@@ -618,7 +731,7 @@ jobs:
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
       consumer-timeout: ${{ fromJSON(inputs.mobile-consumer-timeout || '1200') }}
-      filter: ${{ inputs.filter }}
+      filter: ${{ needs.resolve.outputs.filter-ios || inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
       device-farm-timeout: ${{ fromJSON(inputs.device-farm-timeout || '120') }}

--- a/docs/ci/LABELS.md
+++ b/docs/ci/LABELS.md
@@ -57,7 +57,8 @@ The `verified` label is **no longer used to authorize CI**. It may still appear 
 | `tier1`, `tier2` | Approval-bot review-tier groupings. | `approval-check-worker.yml` | The bot uses these to compute whether a PR has met its required approval tier. |
 | `test-e2e-smoke` | Runs the smoke E2E suite (currently SDK-only). | E2E test workflows | Faster subset; prefer for PR feedback. |
 | `test-e2e-full` | Runs the full E2E suite (currently SDK-only). | E2E workflows | Long-running; use for release branches and major changes. |
-| `e2e-tested` | Set automatically by the E2E workflow once a run has completed against the PR. | E2E workflows | Status indicator only; does not pass/fail by itself — see linked run. |
+| `test-e2e-rerun-failed` | Re-runs only the tests that failed on the last smoke/full run, on the platforms where they failed. | `on-pr-test-sdk.yml` | Self-clearing — removed as soon as the run consumes it, so it can be applied again for each attempt. See [Re-running failed SDK e2e tests](#re-running-failed-sdk-e2e-tests). |
+| `e2e-tested` | Set automatically once a **base** E2E run has completed against the PR. | E2E workflows | Status indicator only; does not pass/fail by itself — see linked run. A `test-e2e-rerun-failed` run never sets it. |
 | `NLP` | Marks PRs touching `packages/llm-llamacpp/` or `packages/embed-llamacpp/`. | Routing in approval workflows | Casing matters: it's `NLP`, not `nlp`. |
 | `prebuilds`, `run-cpp-addon-tests`, `run-desktop-addon-tests`, `run-mobile-addon-tests` | Select expensive CI stages on addon PR workflows. | `ci-router` composite in `on-pr-*` workflows | External forks can use these after `fork-ci` approval; internal same-repo PRs skip the fork-ci gate. |
 
@@ -69,6 +70,27 @@ The `verified` label is **no longer used to authorize CI**. It may still appear 
 > future re-enable; do not rely on it to launch a per-addon mobile run.
 
 Standard GitHub labels (`bug`, `documentation`, `enhancement`, `good first issue`, `help wanted`, `question`, `wontfix`, `duplicate`, `invalid`) and Dependabot/CodeQL labels (`dependencies`, `javascript`, `github_actions`) are unchanged.
+
+---
+
+## Re-running failed SDK e2e tests
+
+`test-e2e-smoke`, `test-e2e-full`, and the release-branch auto-run are **base runs**. Each one records its per-platform failure set into a single hidden state comment on the PR (`sdk-e2e-base-state`), and posts a visible **QVAC E2E — base run recorded** summary alongside it.
+
+`test-e2e-rerun-failed` consumes that record and re-runs **only** those tests, **only** on the platforms that had failures. One failure on Windows and one on Linux means two tests on two runners; macOS, Android, and iOS never start.
+
+| | |
+|---|---|
+| **Needs a new commit?** | No. The rerun always tests the current PR HEAD, so it verifies a pushed fix or, on an unchanged commit, checks for flakiness. The PR comment says which. |
+| **Anchoring** | Always the last **base** run, never the previous rerun. Every attempt re-runs the same set until a new smoke/full run replaces the base — so a later fix cannot quietly break a test an earlier rerun had already turned green. |
+| **Re-applying** | The label is removed automatically once the run picks it up. Just add it again for the next attempt — GitHub only fires `labeled` when the label is absent, which is why it has to come back off. |
+| **`e2e-tested`** | Never applied by a rerun. A partial run does not verify the suite; only a base run can mark the PR as e2e-tested. |
+| **Base run still in flight** | Rejected. The base failure set is not known until every family finishes, so the rerun refuses rather than planning from a stale record. Wait for the **base run recorded** comment. Reruns run in their own concurrency group, so labelling early cannot cancel the base run. |
+| **No base recorded / base fully green** | Nothing runs, and a PR comment says why. Apply `test-e2e-smoke` or `test-e2e-full` first. |
+| **Base run cancelled or died** | The previously recorded base is kept, not wiped, and the "in flight" mark is ignored once the run is no longer running. |
+| **Test renamed or deleted since the base** | Warned in the job summary. If that leaves a platform with zero tests to run, the rerun **fails** rather than reporting a green summary that verified nothing. |
+
+Implementation: [`on-pr-test-sdk.yml`](../../.github/workflows/on-pr-test-sdk.yml) plus the `sdk-e2e-base-state`, `sdk-e2e-resolve-rerun`, and `sdk-e2e-verify-rerun` actions.
 
 ---
 

--- a/packages/sdk/e2e/README.md
+++ b/packages/sdk/e2e/README.md
@@ -171,6 +171,32 @@ See [`.github/workflows/on-pr-test-sdk.yml`](../../../.github/workflows/on-pr-te
 - Release-branch PRs with SDK or inference changes auto-run the same desktop and mobile suite.
 - Success applies the `e2e-tested` label.
 
+These three are **base runs**: each records its per-platform failure set into a hidden state
+comment on the PR, which is what the rerun label below consumes.
+
+### Re-running only the tests that failed
+
+- `test-e2e-rerun-failed` — re-runs just the tests that failed on the last base run, on the
+  platforms where they failed. A platform that was green is not started at all: one failure
+  on Windows and one on Linux means two tests on two runners, with macOS, Android, and iOS
+  skipped entirely.
+
+The label needs no new commit — the rerun always tests the current PR HEAD, so it verifies a
+pushed fix or, on an unchanged commit, checks for flakiness. It is removed automatically once
+the run picks it up, so the next attempt is a single click, and it never applies `e2e-tested`.
+
+Wait for the **QVAC E2E — base run recorded** comment before applying it. The base failure set
+is not known until every family finishes, so a rerun labelled while the base run is still going
+is rejected with a comment saying so (it cannot cancel the base run — reruns use their own
+concurrency group).
+
+The plan is anchored to the base run, not to the previous rerun: every attempt re-runs the
+same set until a new `test-e2e-smoke` / `test-e2e-full` run replaces the base.
+
+See [Re-running failed SDK e2e tests](../../../docs/ci/LABELS.md#re-running-failed-sdk-e2e-tests)
+for the full behaviour table, including what happens when no base is recorded, the base is
+green, or a recorded test no longer exists.
+
 ### Manual runs
 
 Open [Actions → QVAC Tests (sdk) → Run workflow](https://github.com/tetherto/qvac/actions/workflows/test-sdk.yml)


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- After an SDK e2e run leaves a handful of failures, there is no way to re-verify just those tests. Re-triggering always starts a fresh smoke or full catalog across desktop and Device Farm, and GitHub's "Re-run failed jobs" re-runs whole jobs, not the failed test cases.
- Follow-up verification therefore costs a full run — hours of self-hosted runners and Device Farm time — to confirm two or three tests.
- The existing per-test retry flag only retries inside a single run for diagnostics; it cannot carry failures across commits.

## 📝 How does it solve it?

Adds a **`test-e2e-rerun-failed`** label that re-runs only the tests that failed on the last base run, on only the platforms where they failed. One failure on Windows and one on Linux means two tests on two runners — macOS, Android, and iOS never start.

- **Base runs record their failures.** `test-e2e-smoke`, `test-e2e-full`, and the release-branch auto-run now write their per-platform failure set into a single hidden PR comment (`sdk-e2e-base-state`), alongside a visible **base run recorded** table.
- **The plan is anchored to the base, not to the previous rerun.** Every attempt re-runs the same set until a new smoke/full run replaces the base. This keeps the question stable — *do all the tests that failed on the base pass now?* — and stops a later fix from silently breaking a test an earlier rerun had turned green.
- **No commit required.** The rerun always tests the current PR HEAD, so it verifies a pushed fix or, on an unchanged commit, checks for flakiness. The PR comment states which.
- **Per-platform narrowing** reuses the existing plumbing: `test-sdk.yml` drops green platforms from the runner matrix, and each `test-node-sdk.yml` matrix leg resolves its own `--filter` from the plan.
- **The label clears itself** as soon as a run consumes it, so the next attempt is one click. GitHub only emits `labeled` when the label is absent, which is why it has to come back off.

Requirement 2 of the ticket — an explicit option to re-run the whole suite — is already served by the existing `test-e2e-full` label, so both paths are available.

### Guards against false confidence

- A rerun **never applies `e2e-tested`**; only a base run can, since a partial run does not verify the suite.
- A rerun labelled **while a base run is still in flight is rejected** — the base failure set is not known until every family finishes.
- **Each kind of run gets its own concurrency group.** A rerun, or a label this workflow ignores such as `safe-to-test`, can no longer cancel an in-flight base run; a push still supersedes one. This also closes a pre-existing hole: before, any label event landed in the single per-PR group and killed a base run mid-flight.
- **A recorded test id that no longer exists cannot look like coverage.** `--filter` selects by prefix, so a deleted `model-load-llm` would be "covered" by the surviving `model-load-llm-load-mode-none`. `sdk-e2e-verify-rerun` compares ids exactly: it warns on a partial rename, and **fails the run** when a platform executed nothing or when no planned id ran at all.
- A base run that is cancelled or dies **keeps the previously recorded base** instead of wiping it, and its stale "in flight" mark is resolved against the run's real status via the Actions API.

## 🧪 How was it tested?

### Unit — the script logic

A `policy-tests` suite that **extracts the real embedded scripts from the YAML and
runs them against fixtures**, so it exercises the shipped code rather than a
reimplementation. 20 tests, Node built-ins only (that job installs no
dependencies).

- [`.github/scripts/test/sdk-e2e-rerun.test.mjs`](.github/scripts/test/sdk-e2e-rerun.test.mjs)
- [`.github/scripts/lib/sdk-e2e-rerun.mjs`](.github/scripts/lib/sdk-e2e-rerun.mjs) — extractor, `github`/`context`/`core` mocks, step runners, fixtures
- runs on every PR as the `Run SDK e2e rerun tests` step in `security-baseline.yml`

Covered: the headline flow (one Windows + one Linux failure → a 2-test, 2-runner
rerun with the green platforms dropped, each leg getting only its own id);
non-rerun runs unchanged; mobile-only failures; no base recorded / base green;
rerun refused while a base run is `in_progress`, and a stale mark from a
cancelled run ignored instead; a run with no usable results keeping the previous
base; `actions/download-artifact` flattening a lone artifact; duplicate artifact
names from "Re-run failed jobs"; the coverage guard on both failure paths; the
`concurrency.group` expression over every event shape; the `targets` parser; and
the extractor itself, so a YAML restructure fails loudly instead of passing
vacuously.

### Real CI — the selection half

Verified on a throwaway branch via `workflow_dispatch`, which does run the
selected ref's version of a workflow:
**[run 34360843971, attempt 1](https://github.com/tetherto/qvac/actions/runs/34360843971/attempts/1)**.
Dispatched with **three** desktop runners and a fixed plan of
`{"desktop":{"windows":["error-invalid-model-id"],"linux":["error-structured-error-code"]}}`:

| | |
|---|---|
| `Apply rerun plan` | `desktop-platforms=["qvac-win25-x64-gpu","qvac-ubuntu2204-x64-gpu"]`, `electron-platforms=[]`, `snap-platforms=[]`, mobile filters empty — the macOS leg never materialises |
| `report-start` | derives its platform keys from the narrowed array, so comments are posted only for the platforms that run |
| `Resolve test filter` (Windows leg) | `windows: filter=error-invalid-model-id` — its own id, not Linux's |
| `results-desktop-windows` | `total: 1, passed: 1` → `error-invalid-model-id`. Exactly one test: not the five `error-*` siblings a prefix filter would drag in, and not the other platform's |

The Linux leg was cancelled to free the runner; it is the same code path with a
different plan entry. `actionlint` also lints every changed
`.github/workflows/**` and `.github/actions/**` file on this PR and is clean.

### What no pre-merge run can reach

`record-base`, `resolve-rerun`, `verify-rerun` and the label event itself live in
`on-pr-test-sdk.yml`, and **`pull_request_target` loads a workflow from the
repository's default branch** — not from the PR's base branch. Verified: a
throwaway PR whose base branch carried all eight jobs still executed only main's
four (`fork-approval`, `resolve-config`, `run-tests`, `apply-label`). Those parts
become reachable only once this lands on `main`.

## Follow-up (not in this PR)

- Because `pull_request_target` resolves from the default branch, the label works
  on PRs against any base as soon as this is on `main` — no `release-*` backport
  is needed for the workflow itself.
- A comment in `security-baseline.yml:117` states that `pull_request_target`
  workflows load from the base branch. That is wrong, and worth a follow-up
  correction — its conclusion still holds, since the default branch is no more
  the PR's own edited copy than the base branch is.
