### PR TITLE
QVAC-24254 chore: bump llm-llamacpp to 0.49.1

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.49.1] - 2026-09-02
 
 ### Fixed
 
@@ -57,7 +57,8 @@
   projects f16 where this addon now applies q8_0 (over-estimating KV by ~2× and trimming `ctx_size` further
   than needed), and its Adreno 800+/Vulkan guard reports as supported a configuration this addon now
   rejects. `model-fit`'s own CHANGELOG statement that *"`flash-attn` is recognised as enabled on `on` only,
-  as `llm-llamacpp` does"* is stale as of this entry.
+  as `llm-llamacpp` does"* is stale as of this entry. Tracked in
+  [#4223](https://github.com/tetherto/qvac/pull/4223), open as of this release.
 
 - **Grok on a GPU backend fails to load, and this change does not fix it.** qvac-fabric force-disables flash
   attention for Grok, then rejects the quantized V cache the q8_0 default just applied, so context creation

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 Problem

#4216 merged (`c4d4686ea`) with its changelog under `## [Unreleased]` and `package.json` untouched, per
the repo's convention that a bump is a separate post-merge act. `@qvac/llm-llamacpp` therefore still
carries `0.49.0` on `main` while `main`'s code is past it, so the fix cannot be consumed from npm.

#4216 is the only unreleased change for this package — `git log 27102dc3f..main -- packages/llm-llamacpp`
returns it alone, and the `## [0.49.0]` heading was written by #4121.

## 📝 How

Two files, nothing else:

- `package.json`: `0.49.0` → `0.49.1`.
- `CHANGELOG.md`: `## [Unreleased]` → `## [0.49.1] - 2026-09-02`. Entry text is #4216's, unchanged.

`vcpkg.json` declares no version of its own, so there is nothing to bump there.

**Patch, not minor.** `packages/rag` pins `@qvac/llm-llamacpp: ^0.49.0` (#4207), and a caret on `0.x` is
minor-locked — a patch is what that range picks up, so no consumer dependency bump is needed alongside
this. Worth flagging for reviewers: the release *is* behaviour-changing (truthy synonyms now project a
q8_0 KV cache, and `'auto'` plus quantized KV on Adreno 800+/Vulkan is now rejected), and the comparable
release in #4167 took a minor bump on that reasoning. Patch here is deliberate.

### One line of entry text changed

The `### Known follow-ups` block says `packages/model-fit` "must widen in lockstep and has not yet".
That is still true, and this release freezes it into history, so it now names the PR that tracks it —
[#4223](https://github.com/tetherto/qvac/pull/4223), open at time of writing. No other entry text moved.

## 🧪 Tested

Metadata only — no code, no tests, no build inputs touched. `main`'s own CI on #4216 is the verification
for the code being released.

- Confirmed `0.49.0` is what `main` carries and that #4216 left `package.json` alone.
- Confirmed `packages/llm-llamacpp/vcpkg.json` has no `version` field.
- Grepped the tree for pinned `0.49.0` references: only `packages/rag/package.json:77`, which a patch
  satisfies.

## ⚠️ Breaking

None from this PR. The behavioural changes are #4216's and are already on `main`; this only makes them
installable. They are catalogued under `## [0.49.1]`.
