### PR TITLE
QVAC-24528 feat[bc]: return batch translations as an array

### DIFF
--- a/docs/website/content/docs/ai-capabilities/translation.mdx
+++ b/docs/website/content/docs/ai-capabilities/translation.mdx
@@ -13,7 +13,7 @@ Translation input is defined by:
 - `to: string`: target language id
 - `text: string | string[]`: text to be translated
 
-`translate()` returns an object containing `text` and when streaming is enabled, a `tokenStream` for real-time output.
+`translate()` returns an object containing `translations` — one entry per input, in the order the inputs were given — and `text`, those entries joined by newlines. When streaming is enabled it returns a `tokenStream` for real-time output instead; a batch emits one whole translation per token, so the position of each token is the position of its input.
 
 For a list of supported languages and their ids (string abbreviations), see [qvac-sdk/schemas/translation-config.ts](https://github.com/tetherto/qvac/blob/main/packages/sdk/schemas/translation-config.ts).
 

--- a/packages/inference/src/api/translate.ts
+++ b/packages/inference/src/api/translate.ts
@@ -18,7 +18,8 @@ import {
  * @param params.to - Target language code
  * @param params.stream - Whether to stream tokens (true) or return complete response (false). Defaults to true.
  * @param options - Optional RPC options (timeout, profiling, force new connection, etc.).
- * @returns Object with tokenStream generator and text/stats properties
+ * @returns Object with a tokenStream generator, `translations` (one entry per
+ * input, in order), `text` (those entries joined by newlines) and stats
  * @throws {QvacErrorBase} When translation fails with an error message or when language detection fails
  * @example
  * ```typescript
@@ -54,6 +55,7 @@ export function translate(
 ): {
   tokenStream: AsyncGenerator<string>
   stats: Promise<TranslationStats | undefined>
+  translations: Promise<string[]>
   text: Promise<string>
 } {
   // Source-language auto-detection lives in the engine op
@@ -86,11 +88,10 @@ export function translate(
       }
     })()
 
-    const textPromise = Promise.resolve('')
-
     return {
       tokenStream,
-      text: textPromise,
+      translations: Promise.resolve([]),
+      text: Promise.resolve(''),
       stats: statsPromise
     }
   } else {
@@ -98,26 +99,31 @@ export function translate(
       //Empty generator for non-streaming mode
     })()
 
-    const textPromise = (async () => {
-      let buffer = ''
+    const batched = Array.isArray(params.text)
+    const translationsPromise = (async () => {
+      const collected: string[] = batched ? [] : ['']
 
       for await (const response of streamRpc(request, options)) {
         if (response.type === 'translate') {
           const streamResponse = translateResponseSchema.parse(response)
-          buffer += streamResponse.token
           if (streamResponse.done) {
             stats = streamResponse.stats
             statsResolver(stats)
+          } else if (batched) {
+            collected.push(streamResponse.token)
+          } else {
+            collected[0] += streamResponse.token
           }
         }
       }
 
-      return buffer
+      return collected
     })()
 
     return {
       tokenStream,
-      text: textPromise,
+      translations: translationsPromise,
+      text: translationsPromise.then((entries) => entries.join('\n')),
       stats: statsPromise
     }
   }

--- a/packages/inference/src/plugins/ops/translate.ts
+++ b/packages/inference/src/plugins/ops/translate.ts
@@ -163,14 +163,9 @@ export async function* translate(
       return { modelExecutionMs }
     }
 
-    // Yield each translation with a newline separator
-    for (let i = 0; i < translations.length; i++) {
+    for (const translation of translations) {
       if (ctx.signal.aborted) break
-      const translation = translations[i]!
       yield translation
-      if (i < translations.length - 1) {
-        yield '\n'
-      }
     }
 
     return { modelExecutionMs }

--- a/packages/inference/test/logging-defaults.test.ts
+++ b/packages/inference/test/logging-defaults.test.ts
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { getAppLogger, createBaseLogger } from '@/logging/logger'
+import { getAppLogger, createBaseLogger, setGlobalConsoleOutput } from '@/logging/logger'
 import { logLevelSchema } from '@/schemas/logging-stream'
 
 test('logLevelSchema: accepts off alongside the standard levels', (t) => {
@@ -33,14 +33,21 @@ test('getAppLogger: silent console by default, still feeds transports', (t) => {
   t.alike(received, ['hello'], 'transport still receives the log')
 })
 
+const CONSOLE_OUTPUT_KEY = Symbol.for('@qvac/inference:global-console-output')
+
 test('getAppLogger: enableConsole opts back into console output', (t) => {
   const original = console.info
+  const globalState = globalThis as unknown as Record<symbol, boolean | undefined>
+  const previousConsoleOutput = globalState[CONSOLE_OUTPUT_KEY]
   let printed = 0
   console.info = () => {
     printed++
   }
+  setGlobalConsoleOutput(true)
   t.teardown(() => {
     console.info = original
+    if (previousConsoleOutput === undefined) delete globalState[CONSOLE_OUTPUT_KEY]
+    else setGlobalConsoleOutput(previousConsoleOutput)
   })
 
   getAppLogger({ enableConsole: true }).info('hi')

--- a/packages/inference/test/translate-batch-results.test.ts
+++ b/packages/inference/test/translate-batch-results.test.ts
@@ -1,0 +1,56 @@
+import test from 'brittle'
+import { registerModel, unregisterModel } from '@/runtime/model-registry'
+import { ModelType } from '@/schemas'
+import { translate } from '@/plugins/ops/translate'
+import type { AnyModel } from '@/runtime/model-registry'
+
+function registerNmtBatch(modelId: string, runBatch: (texts: string[]) => Promise<string[]>) {
+  registerModel(modelId, {
+    model: { runBatch } as unknown as AnyModel,
+    path: `/tmp/${modelId}.bin`,
+    config: {},
+    modelType: ModelType.nmtcppTranslation
+  })
+}
+
+async function collect(modelId: string, texts: string[], requestId: string) {
+  const gen = translate(
+    {
+      modelId,
+      text: texts,
+      stream: false,
+      modelType: ModelType.nmtcppTranslation
+    } as never,
+    requestId
+  )
+  const yielded: string[] = []
+  const it = gen[Symbol.asyncIterator]()
+  for (let next = await it.next(); !next.done; next = await it.next()) yielded.push(next.value)
+  return yielded
+}
+
+let idCounter = 0
+function makeId(prefix: string): string {
+  idCounter++
+  return `${prefix}-${idCounter}`
+}
+
+test('translate (NMT batch): yields one whole translation per input, in order', async (t) => {
+  const modelId = makeId('nmt-batch')
+  registerNmtBatch(modelId, async (texts) => texts.map((text) => `[${text}]`))
+
+  const yielded = await collect(modelId, ['one', 'two', 'three'], makeId('req'))
+  t.alike(yielded, ['[one]', '[two]', '[three]'], 'one entry per input, no separators')
+
+  unregisterModel(modelId)
+})
+
+test('translate (NMT batch): a translation containing a newline stays one entry', async (t) => {
+  const modelId = makeId('nmt-batch-newline')
+  registerNmtBatch(modelId, async () => ['first\nsecond', 'third'])
+
+  const yielded = await collect(modelId, ['a', 'b'], makeId('req'))
+  t.alike(yielded, ['first\nsecond', 'third'], 'the newline belongs to the translation')
+
+  unregisterModel(modelId)
+})

--- a/packages/sdk/e2e/tests/shared/executors/translation-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/translation-executor.ts
@@ -33,6 +33,9 @@ export class TranslationExecutor extends AbstractModelExecutor<typeof allTests> 
       if (test.testId.endsWith('-stats')) {
         return [test.testId, this.withStats.bind(this)]
       }
+      if (test.testId.endsWith('-batch-array')) {
+        return [test.testId, this.batchArray.bind(this)]
+      }
       if (test.testId.includes('-batch-')) {
         return [test.testId, this.batch.bind(this)]
       }
@@ -178,6 +181,43 @@ export class TranslationExecutor extends AbstractModelExecutor<typeof allTests> 
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       return { passed: false, output: `Translation batch error: ${errorMsg}` }
+    }
+  }
+
+  async batchArray(params: unknown, expectation: Expectation): Promise<TestResult> {
+    const p = params as { texts: string[]; resource: string }
+    const modelId = await this.resources.ensureLoaded(p.resource)
+
+    try {
+      const result = translate({
+        modelId,
+        text: p.texts as never,
+        modelType: 'nmtcpp-translation',
+        stream: false
+      }) as unknown as { translations: Promise<string[]>; text: Promise<string> }
+      const translations = await result.translations
+
+      if (translations.length !== p.texts.length) {
+        return {
+          passed: false,
+          output: `Expected ${p.texts.length} translations, got ${translations.length}`
+        }
+      }
+
+      const emptyAt = translations.findIndex((entry) => entry.trim().length === 0)
+      if (emptyAt !== -1) {
+        return { passed: false, output: `Translation ${emptyAt + 1} of the batch is empty` }
+      }
+
+      const text = await result.text
+      if (text !== translations.join('\n')) {
+        return { passed: false, output: `text is not the newline join of translations: "${text}"` }
+      }
+
+      return ValidationHelpers.validate(translations.join(' '), expectation)
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      return { passed: false, output: `Translation batch array error: ${errorMsg}` }
     }
   }
 

--- a/packages/sdk/e2e/tests/translation-bergamot-tests.ts
+++ b/packages/sdk/e2e/tests/translation-bergamot-tests.ts
@@ -115,6 +115,20 @@ export const bergamotEnFrBatchMultiple: TestDefinition = {
   }
 }
 
+export const bergamotEnFrBatchArray: TestDefinition = {
+  testId: 'translation-bergamot-en-fr-batch-array',
+  params: {
+    texts: ['Good morning', 'The weather is nice.', 'Thank you.'],
+    resource: 'bergamot-en-fr'
+  },
+  expectation: { validation: 'contains-any', contains: ['bonjour', 'matin', 'temps', 'merci'] },
+  metadata: {
+    category: 'translation-bergamot',
+    dependency: 'bergamot-en-fr',
+    estimatedDurationMs: 20000
+  }
+}
+
 // --- EN → ES (bergamot-en-es) ---
 
 export const bergamotEnEsBasic = createBergamotTest(
@@ -182,6 +196,7 @@ export const translationBergamotTests = [
   bergamotEnFrStats,
   bergamotEnFrBatchBasic,
   bergamotEnFrBatchMultiple,
+  bergamotEnFrBatchArray,
   // EN → ES
   bergamotEnEsBasic,
   bergamotEnEsLongText,

--- a/packages/sdk/examples/translation/translation-bergamot-batch-stream.ts
+++ b/packages/sdk/examples/translation/translation-bergamot-batch-stream.ts
@@ -1,0 +1,49 @@
+import { loadModel, translate, unloadModel, BERGAMOT_EN_FR } from '@qvac/sdk'
+
+try {
+  const modelId = await loadModel({
+    modelSrc: BERGAMOT_EN_FR,
+    modelConfig: {
+      engine: 'Bergamot',
+      from: 'en',
+      to: 'fr'
+    },
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1)
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`)
+      if (p.percentage >= 100) process.stderr.write('\n')
+    }
+  })
+
+  console.log(`▸ Bergamot model loaded: ${modelId}`)
+
+  const texts = [
+    'Hello world',
+    'How are you today?',
+    'This is a test of batch translation',
+    'The weather is nice'
+  ]
+
+  console.log('▸ Streaming a batch, one translation per token:')
+
+  const result = translate({
+    modelId,
+    text: texts,
+    modelType: 'nmtcpp-translation',
+    stream: true
+  })
+
+  let index = 0
+  for await (const translation of result.tokenStream) {
+    console.log(`  ${index + 1}. ${texts[index]} -> "${translation}"`)
+    index++
+  }
+
+  console.log(`▸ Translated ${index} texts`)
+
+  await unloadModel({ modelId })
+} catch (error) {
+  console.error('✖', error)
+  process.exit(1)
+}

--- a/packages/sdk/examples/translation/translation-bergamot-batch.ts
+++ b/packages/sdk/examples/translation/translation-bergamot-batch.ts
@@ -41,14 +41,11 @@ try {
     stream: false
   })
 
-  const translatedText = await result.text
-  const translations = translatedText.split('\n')
+  const translations = await result.translations
 
   console.log('▸ Translations:')
   translations.forEach((translation, i) => {
-    if (i < texts.length) {
-      console.log(`  ${i + 1}. ${texts[i]} -> "${translation}"`)
-    }
+    console.log(`  ${i + 1}. ${texts[i]} -> "${translation}"`)
   })
 
   await unloadModel({ modelId })

--- a/packages/sdk/src/client/api/translate.ts
+++ b/packages/sdk/src/client/api/translate.ts
@@ -19,7 +19,8 @@ import {
  * @param params.to - Target language code
  * @param params.stream - Whether to stream tokens (true) or return complete response (false). Defaults to true.
  * @param options - Optional RPC options (timeout, profiling, force new connection, etc.).
- * @returns Object with tokenStream generator and text/stats properties
+ * @returns Object with a tokenStream generator, `translations` (one entry per
+ * input, in order), `text` (those entries joined by newlines) and stats
  * @throws {QvacErrorBase} When translation fails with an error message or when language detection fails
  * @example
  * ```typescript
@@ -55,6 +56,7 @@ export function translate(
 ): {
   tokenStream: AsyncGenerator<string>
   stats: Promise<TranslationStats | undefined>
+  translations: Promise<string[]>
   text: Promise<string>
   requestId: string
 } {
@@ -99,11 +101,10 @@ export function translate(
       }
     })()
 
-    const textPromise = Promise.resolve('')
-
     return {
       tokenStream,
-      text: textPromise,
+      translations: Promise.resolve([]),
+      text: Promise.resolve(''),
       stats: statsPromise,
       requestId
     }
@@ -112,17 +113,21 @@ export function translate(
       //Empty generator for non-streaming mode
     })()
 
-    const textPromise = (async () => {
-      let buffer = ''
+    const batched = Array.isArray(params.text)
+    const translationsPromise = (async () => {
+      const collected: string[] = batched ? [] : ['']
 
       try {
         for await (const response of streamRpc(request, options)) {
           if (response.type === 'translate') {
             const streamResponse = translateResponseSchema.parse(response)
-            buffer += streamResponse.token
             if (streamResponse.done) {
               stats = streamResponse.stats
               statsResolver(stats)
+            } else if (batched) {
+              collected.push(streamResponse.token)
+            } else {
+              collected[0] += streamResponse.token
             }
           }
         }
@@ -132,12 +137,13 @@ export function translate(
         statsResolver(stats)
       }
 
-      return buffer
+      return collected
     })()
 
     return {
       tokenStream,
-      text: textPromise,
+      translations: translationsPromise,
+      text: translationsPromise.then((entries) => entries.join('\n')),
       stats: statsPromise,
       requestId
     }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `translate()` with an array of texts returned one string with the translations joined by `\n`. Callers had to split it back apart, and a translation that itself contains a newline made that split wrong.
- The streaming path had the same problem: entries were separated by a `'\n'` token, so a consumer could not tell a separator from part of a translation.
- While at it, fix a flaky test: `getAppLogger: enableConsole` passed alone and failed in the full inference suite.

## 📝 How does it solve it?

- `translate()` returns `translations: Promise<string[]>`, one entry per input in input order. `text` stays, now defined as those entries joined by `\n`.
- The plugin stops emitting `'\n'` tokens between entries, so a streaming batch emits one whole translation per token and a token's position is its input's position.
- Same change in `@qvac/inference` and `@qvac/sdk`, so both keep the one API.
- The download tests set the global console-output flag to `false`, which every later logger picked up. The logging test now sets that flag itself and restores it.

## 🧪 How was it tested?

- Two inference tests: one whole translation per input in order, and a translation containing a newline stays one entry.
- New e2e test `translation-bergamot-en-fr-batch-array` on desktop, checking entry count, no empty entries, and `text === translations.join('\n')`.
- Full pod checks: inference 1617/1617, SDK typecheck, build, unit tests, contract check.
- Real bergamot model via the SDK examples, batch and streaming batch, E2E suite of translation.

## 💥 Breaking Changes

**BEFORE:**

```typescript
const result = translate({ modelId, text: ['Good morning', 'Good night'], stream: false })
const translations = (await result.text).split('\n')

// streaming: entries arrive separated by a '\n' token
for await (const token of stream.tokenStream) {
  if (token === '\n') next()
  else current += token
}
```

**AFTER:**

```typescript
const result = translate({ modelId, text: ['Good morning', 'Good night'], stream: false })
const translations = await result.translations

// streaming: one whole translation per token, in input order
let i = 0
for await (const translation of stream.tokenStream) {
  console.log(texts[i++], '->', translation)
}
```

## 🔌 API Changes

```typescript
const result = translate({
  modelId,
  text: ['Good morning', 'The weather is nice.', 'Thank you.'],
  modelType: 'nmtcpp-translation',
  stream: false
})

const translations = await result.translations // ['Bonjour', 'Le temps est agréable.', 'Merci.']
const text = await result.text // translations.join('\n')
```