### PR TITLE
test[notask]: verify impact-based smoke expansion (do not merge)

### DIFF
--- a/packages/sdk/e2e/tests/shared/executors/system-resources-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/system-resources-executor.ts
@@ -76,6 +76,7 @@ function assertSample(resources: SystemResources) {
 }
 
 export class SystemResourcesExecutor extends BaseExecutor<typeof systemResourcesTests> {
+  // Matches the ids declared in system-resources-tests.ts.
   pattern = /^system-resources-/
 
   protected handlers = {

--- a/packages/sdk/e2e/tests/system-resources-tests.ts
+++ b/packages/sdk/e2e/tests/system-resources-tests.ts
@@ -1,5 +1,8 @@
 import type { TestDefinition } from '@qvac/test-suite'
 
+// These probe locally reported hardware capabilities, so they load no model
+// (`dependency: 'none'`) and stay in the seconds range.
+
 export const systemResourcesCapabilities = {
   testId: 'system-resources-capabilities',
   params: { sample: false },


### PR DESCRIPTION
**Throwaway PR — do not merge.** It exists to verify the impact-based smoke expansion from `infra/e2e-smoke-impacted-tests`, and targets that branch so `pull_request_target` loads the workflow from it rather than from `main`.

## What this changes

Comment-only edits to two files, chosen so the impact set is non-empty but nearly free to run:

- `tests/system-resources-tests.ts` — declares `system-resources-capabilities`, `-sample`, `-invalid-input`
- `tests/shared/executors/system-resources-executor.ts` — `pattern = /^system-resources-/`

Those three tests carry **no `smoke` tag** and are `dependency: 'none'`, so they load no model and take ~5 s each.

## What should happen

A plain `test-e2e-smoke` run covers 106 of 513 tests and would skip all three. With the expansion, the run should be **106 + 3**.

The mapper predicts, run locally against the base branch:

```
catalog 513 tests, smoke 106
changed files in scope: 2
affected: 3 (0 already in smoke)
adding: 3 (~0.3 min)
  executor pattern                  3  tests/shared/executors/system-resources-executor.ts
  definitions (whole file)          3  tests/system-resources-tests.ts
```

Both relations are exercised: the executor's `pattern` regex, and the testIds a definitions file declares.

## Pass criteria

- a **QVAC E2E — tests changed by this PR** comment appears, reporting 3 affected / 0 in smoke / 3 added
- the producer log shows `➕ Also running 3 explicitly requested test(s)` and `109` selected tests
- `system-resources-capabilities`, `system-resources-sample`, and `system-resources-invalid-input` appear in the per-platform results

## Note on draft state

`authorize-pr` blocks draft PRs (`Draft PR — blocked until ready-for-review`), and the workflow triggers only on `labeled`, `opened`, and `synchronize` — not `ready_for_review`. So the run starts only after the PR is marked ready **and** the `test-e2e-smoke` label is re-applied.
