### PR TITLE
QVAC-23890 feat[api]: model-fit calibration harness as a module with a mobile profile

### DIFF
--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/models/registry/resource-profiles.d.ts",
       "import": "./dist/models/registry/resource-profiles.js"
     },
+    "./model-fit-calibration": {
+      "types": "./dist/resources/model-fit/calibration/harness.d.ts",
+      "import": "./dist/resources/model-fit/calibration/harness.js"
+    },
     "./llamacpp-completion/plugin": {
       "types": "./dist/plugins/builtin/llamacpp-completion/plugin.d.ts",
       "import": "./dist/plugins/builtin/llamacpp-completion/plugin.js"

--- a/packages/inference/scripts/calibrate-model-fit.ts
+++ b/packages/inference/scripts/calibrate-model-fit.ts
@@ -1,8 +1,10 @@
-// Calibration harness for assessModelFit.
+// Calibration harness for assessModelFit — desktop entry point.
 //
-// Loads representative catalog models, measures resident and peak memory around
-// real operations, and derives the coefficients in
-// `src/resources/model-fit/calibration/<platform>.ts`.
+// The procedure lives in `src/resources/model-fit/calibration/harness.ts`
+// (exported as `@qvac/inference/model-fit-calibration`); this script registers
+// the LLM plugin, runs it on the current host, and writes the fixture. On a
+// phone the same procedure runs inside the SDK e2e consumer's calibration
+// plugin instead — see METHODOLOGY.md, "Mobile".
 //
 // Run from the package root, on the platform being calibrated, with bare ≥ 1.30
 // (which runs TypeScript directly via type-stripping — the version the
@@ -11,585 +13,72 @@
 //   npm run build
 //   bare scripts/calibrate-model-fit.ts            # measure and print
 //   bare scripts/calibrate-model-fit.ts --write    # also rewrite the fixture
+//   bare scripts/calibrate-model-fit.ts --gpu      # GPU-resident pass instead
 //
 // Models are downloaded on first run and cached, so the first pass is slow and
 // needs registry access. See calibration/METHODOLOGY.md for what the numbers
-// mean and how the held-out check works, and "Windows" there for why that
-// platform loads weights with `load_mode: 'none'`.
+// mean and how the held-out check works, and "RSS and mmap" there for why the
+// CPU-forced platforms load weights with `load_mode: 'none'`.
 
 import os from 'bare-os'
 import fs from 'bare-fs'
 import path from 'bare-path'
-import {
-  registerPlugin,
-  loadModel,
-  completion,
-  unloadModel,
-  getSystemResources
-} from '../dist/index.js'
-import * as catalog from '../dist/models/registry/index.js'
-import { MODEL_RESOURCE_PROFILES } from '../dist/models/registry/resource-profiles.js'
-import { kvElementBytes, kvCacheBytesForWidth } from '../dist/resources/model-fit/estimators/llm.js'
-import { fitResidentMemory, kvObservation } from '../dist/resources/model-fit/calibration/fit.js'
+import { registerPlugin } from '../dist/index.js'
 import { llmPlugin } from '../dist/plugins/builtin/llamacpp-completion/plugin.js'
-import type { GgufFacts } from '../dist/schemas/model-resource-profile.js'
-import type { PlatformCalibration } from '../dist/resources/model-fit/types.js'
+import {
+  CalibrationAbortedError,
+  runModelFitCalibration
+} from '../dist/resources/model-fit/calibration/harness.js'
 
 declare const Bare: { argv: string[]; exit(code?: number): never }
-
-const SAMPLE_INTERVAL_MS = 25
-const SETTLE_MS = 250
-
-// Two contexts per model so fixed overhead and the per-token compute buffer can
-// be separated; a single point cannot tell them apart.
-const CONTEXTS = [512, 8192]
-
-// Every point is measured this many times. Single-shot loads were observed to
-// vary by up to ~100 MiB run to run; all repeats enter the fit, and the upper
-// bound is floored at the worst point seen.
-const REPEATS = 3
-
-// llama.cpp allocates the whole context at load — KV cache, engine overhead
-// and compute buffers included — so the RSS delta during a completion should
-// be near zero. A working delta above this threshold means the engine's
-// allocation behaviour changed and this methodology needs re-checking.
-const WORKING_DRIFT_WARN_BYTES = 64 * 1024 * 1024
-
-// The KV cache grows by a known amount between the two contexts, so the deltas
-// must too. A shortfall means the wrong KV width, or a counter missing memory.
-const KV_OBSERVATION_FLOOR = 0.9
-
-// Small, medium, large — plus one held out of the fit entirely, used only to
-// check that the derived upper bound actually holds.
-const FIT_MODELS = ['QWEN3_600M_INST_Q4', 'LLAMA_3_2_1B_INST_Q4_0', 'QWEN3_4B_INST_Q4_K_M']
-const HELD_OUT_MODEL = 'QWEN3_8B_INST_Q4_K_M'
-
-interface Measurement {
-  name: string
-  contextTokens: number
-  artifactBytes: number
-  facts: GgufFacts
-  persistentBytes: number
-  workingBytes: number
-}
-
-interface FitPoint extends Measurement {
-  kvBytes: number
-}
-
-function rssBytes() {
-  const usage = os.memoryUsage()
-  return usage && usage.rss > 0 ? usage.rss : 0
-}
-
-// Load anonymously wherever the CPU backend is forced. It copies mapped weights
-// into its own buffers, so RSS counts them twice — linux read 1.7x the artifact
-// — while win32 prefetches to the standby list and counts almost none. The
-// anonymous copy is the memory the system must actually find; the mapped pages
-// the default keeps are file-backed and evictable.
-function calibrationLoadMode(platform: string) {
-  return forcesCpu(platform) ? 'none' : undefined
-}
-
-function createSampler() {
-  const samples: number[] = []
-  let timer: ReturnType<typeof setTimeout> | null = null
-  let running = false
-
-  function tick() {
-    if (!running) return
-    const rss = rssBytes()
-    if (rss > 0) samples.push(rss)
-    timer = setTimeout(tick, SAMPLE_INTERVAL_MS)
-    if (timer && typeof timer.unref === 'function') timer.unref()
-  }
-
-  return {
-    start() {
-      running = true
-      tick()
-    },
-    stop() {
-      running = false
-      if (timer) clearTimeout(timer)
-      const rss = rssBytes()
-      if (rss > 0) samples.push(rss)
-      return samples.length > 0 ? Math.max(...samples) : 0
-    }
-  }
-}
-
-function settle() {
-  return new Promise((resolve) => setTimeout(resolve, SETTLE_MS))
-}
-
-// A stalled download or a wedged engine call would otherwise run to the job
-// timeout while holding an exclusive drained host, so every phase is bounded.
-const LOAD_TIMEOUT_MS = 30 * 60 * 1000
-const COMPLETION_TIMEOUT_MS = 15 * 60 * 1000
-const UNLOAD_TIMEOUT_MS = 5 * 60 * 1000
-
-function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs: number, hint: string) {
-  let timer: ReturnType<typeof setTimeout>
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error(`${label} did not finish within ${timeoutMs / 60000} minutes; ${hint}`))
-    }, timeoutMs)
-    if (timer && typeof timer.unref === 'function') timer.unref()
-  })
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
-}
-
-function metricValue(metric: unknown) {
-  const m = metric as { status?: string; value?: unknown } | undefined
-  return m?.status === 'supported' ? m.value : undefined
-}
-
-// Largest dedicated GPU first. The win25 runner reports an Intel iGPU ahead of
-// its RTX 4000, and first-wins named the iGPU as the device on every fixture.
-function byCapability(gpuList: readonly Record<string, unknown>[]) {
-  return [...gpuList].sort((a, b) => {
-    const dedicated = (gpu: Record<string, unknown>) =>
-      metricValue(gpu.unifiedMemory) === false ? 1 : 0
-    const memory = (gpu: Record<string, unknown>) =>
-      (metricValue(gpu.memoryTotalBytes) as number) ?? 0
-    return dedicated(b) - dedicated(a) || memory(b) - memory(a)
-  })
-}
-
-// Bytes resident on the GPU the engine would pick. Read through the collector
-// so the calibration and the estimator agree on which device counts and on
-// whether its readings are device-scoped at all.
-async function readGpuUsedBytes() {
-  // `sample: true` is required: the default response carries capabilities only.
-  const resources = await getSystemResources({ sample: true })
-  const gpus = resources.capabilities.gpus
-  const samples = resources.sample?.gpus
-  if (gpus.status !== 'supported' || samples?.status !== 'supported') {
-    throw new Error('no GPU sample is available, so a GPU pass cannot be measured')
-  }
-
-  for (const gpu of byCapability(gpus.value as unknown as Record<string, unknown>[])) {
-    const sample = samples.value.find((entry) => entry.id === (gpu.id as string))
-    if (sample?.memoryUsedBytes.status === 'supported') return sample.memoryUsedBytes.value
-  }
-
-  // Returning 0 here would read as "nothing allocated" and quietly fit garbage.
-  throw new Error(
-    'no GPU reports device-scoped used memory, so this host cannot be calibrated for GPU residency'
-  )
-}
-
-// The driver frees device memory asynchronously, so a fixed settle can read a
-// baseline that still holds the previous load: one repeat measured 1781 MiB
-// against 690 for the same model. Wait for two readings to agree instead.
-const GPU_SETTLE_TOLERANCE_BYTES = 16 * 1024 * 1024
-const GPU_SETTLE_ATTEMPTS = 40
-
-async function settledGpuUsedBytes() {
-  let previous = await readGpuUsedBytes()
-  for (let attempt = 0; attempt < GPU_SETTLE_ATTEMPTS; attempt++) {
-    await settle()
-    const current = await readGpuUsedBytes()
-    if (Math.abs(current - previous) <= GPU_SETTLE_TOLERANCE_BYTES) return current
-    previous = current
-  }
-  throw new Error(
-    `GPU memory did not settle within ${(GPU_SETTLE_ATTEMPTS * SETTLE_MS) / 1000}s; the device is not idle enough to calibrate`
-  )
-}
-
-// Label for the backend in play, recorded with the coefficients because the
-// buffers they measure are allocated by the backend, and used as the GPU
-// fixture key. Must stay in step with `GPU_BACKENDS` in `assess.ts`: the
-// estimator derives the same key the same way, and a fixture filed under a
-// backend the engine does not use would be served to hosts it never measured.
-function detectBackend(gpuList: readonly Record<string, unknown>[]) {
-  for (const gpu of byCapability(gpuList)) {
-    const drivers = (gpu.drivers ?? {}) as Record<
-      string,
-      { status: string; value?: unknown } | undefined
-    >
-    for (const name of ['metal', 'vulkan', 'rocm', 'cuda', 'levelZero', 'opencl']) {
-      if (drivers[name]?.status === 'supported' && drivers[name].value) return name
-    }
-  }
-  return 'cpu'
-}
-
-function gpuName(gpuList: readonly Record<string, unknown>[]) {
-  for (const gpu of byCapability(gpuList)) {
-    const name = metricValue(gpu.name)
-    if (typeof name === 'string' && name) return name
-  }
-  return undefined
-}
-
-/**
- * KV-cache bytes the engine allocated for one model at one context, computed
- * by the estimator's own exported accounting rather than a local copy — a copy
- * drifted from `estimators/llm.ts` once already.
- *
- * The residuals this harness fits describe everything *except* the cache, so a
- * cache whose size the file does not state exactly (an engine-owned layer
- * pattern or hybrid block choice) cannot be subtracted. That surfaces as a
- * non-degenerate range, and the harness stops: calibration models must be
- * dense.
- */
-function exactKvBytes(
-  name: string,
-  facts: GgufFacts,
-  contextTokens: number,
-  bytesPerElement: number
-) {
-  const kv = kvCacheBytesForWidth(facts, contextTokens, bytesPerElement)
-  if (kv.lower !== kv.upper) {
-    throw new Error(
-      `${name}'s KV cache is not exactly determined by the file (bounds span ${kv.lower}–${kv.upper} bytes); part of its layout is engine-owned, so it cannot be subtracted from a measurement. Use a dense model for calibration.`
-    )
-  }
-  return kv.lower
-}
-
-// RSS cannot observe VRAM, so these platforms calibrate CPU-resident execution.
-// Must be `device`, not `gpu_layers: 0`: the addon takes its KV default from the
-// backend `device` selects, so a GPU device builds q8_0 against a subtracted f16.
-function forcesCpu(platform: string) {
-  return platform.startsWith('linux') || platform.startsWith('win32') || platform === 'darwin-x64'
-}
-
-async function measure(
-  name: string,
-  contextTokens: number,
-  cpuForced: boolean,
-  loadMode: 'none' | undefined,
-  gpuPass: boolean
-): Promise<Measurement> {
-  const model = (catalog as Record<string, { sha256Checksum: string } | undefined>)[name]
-  if (!model) throw new Error(`unknown catalog constant: ${name}`)
-
-  const profile = MODEL_RESOURCE_PROFILES[model.sha256Checksum]
-  if (!profile?.ggufFacts) throw new Error(`no GGUF facts for ${name}`)
-
-  await settle()
-  const before = gpuPass ? await settledGpuUsedBytes() : rssBytes()
-
-  const modelId = await withTimeout(
-    loadModel({
-      modelSrc: model,
-      modelConfig: {
-        ctx_size: contextTokens,
-        ...(cpuForced && { device: 'cpu' }),
-        ...(loadMode && { load_mode: loadMode })
-      }
-    }),
-    `loading ${name}`,
-    LOAD_TIMEOUT_MS,
-    "a registry download has likely stalled. Check the registry's reachability from this host."
-  )
-
-  await settle()
-  const afterLoad = gpuPass ? await settledGpuUsedBytes() : rssBytes()
-
-  // The RSS sampler cannot follow device memory — that counter is only readable
-  // through an async collector call. It costs nothing to skip: llama.cpp
-  // allocates the whole context at load, and every CPU point measured a working
-  // delta of 0.
-  const sampler = gpuPass ? undefined : createSampler()
-  sampler?.start()
-  let peak = afterLoad
-  try {
-    const result = completion({
-      modelId,
-      history: [{ role: 'user', content: 'Summarize the history of cartography.' }],
-      stream: false,
-      params: { maxTokens: 128 }
-    })
-    await withTimeout(
-      result.response,
-      `completion for ${name}`,
-      COMPLETION_TIMEOUT_MS,
-      'the weights loaded, so this is a wedged engine call rather than a download stall.'
-    )
-  } finally {
-    if (sampler) peak = sampler.stop()
-  }
-
-  await withTimeout(
-    unloadModel({ modelId }),
-    `unloading ${name}`,
-    UNLOAD_TIMEOUT_MS,
-    'the engine call is wedged.'
-  )
-  await settle()
-
-  return {
-    name,
-    contextTokens,
-    artifactBytes: profile.artifactBytes,
-    facts: profile.ggufFacts,
-    persistentBytes: Math.max(0, afterLoad - before),
-    workingBytes: Math.max(0, peak - afterLoad)
-  }
-}
-
-function fixtureSource(platform: string, calibration: PlatformCalibration) {
-  // Unquote the keys only. Values stay JSON-quoted, which is already valid
-  // TypeScript; replacing every quote breaks any value containing one, and
-  // prettier settles the house quote style afterwards anyway.
-  const json = JSON.stringify(calibration, null, 2).replace(/"([a-zA-Z]+)":/g, '$1:')
-  return `import type { PlatformCalibration } from '@/resources/model-fit/types'
-
-/**
- * ${platform} coefficients.
- *
- * Generated by \`scripts/calibrate-model-fit.ts\`; see \`METHODOLOGY.md\` next
- * to this file for how the numbers are derived and validated.
- */
-export const ${platform.toUpperCase().replace(/-/g, '_')}_CALIBRATION: PlatformCalibration = ${json}
-`
-}
 
 async function main() {
   const write = Bare.argv.includes('--write')
   // `--gpu` calibrates the same models resident on the GPU instead: no device
   // override, the SDK's own load mode, and device memory as the counter.
   const gpuPass = Bare.argv.includes('--gpu')
-  const platform = `${os.platform()}-${os.arch()}`
-  console.log(`calibrating ${platform}${gpuPass ? ' (GPU-resident)' : ''}`)
-
-  const loadMode = gpuPass ? undefined : calibrationLoadMode(platform)
-  if (loadMode) {
-    console.log(`weights loaded with load_mode '${loadMode}' — see METHODOLOGY.md, "Windows"`)
-  }
 
   registerPlugin(llmPlugin)
 
-  // The fit subtracts the KV cache from each load's persistent delta, so the
-  // cache subtracted has to be the one the engine actually allocated. A fixed
-  // f16 assumption over-subtracts by nearly 2x on a Metal or Vulkan backend —
-  // and since the error scales with context, it lands in the per-token slope
-  // rather than the intercept, corrupting the very coefficient the two-context
-  // design exists to isolate.
-  const resources = await getSystemResources()
-  const gpus = resources.capabilities.gpus
-  const gpuList = gpus.status === 'supported' ? gpus.value : []
-  const cpuForced = !gpuPass && forcesCpu(platform)
-  // `device: 'cpu'` selects the CPU backend, and with it the f16 KV default.
-  const hasGpu = gpuList.length > 0 && !cpuForced
-  const backend = cpuForced ? 'cpu' : detectBackend(gpuList)
-  const device = gpuName(gpuList)
-  console.log(
-    `backend: ${backend}${device ? ` (${device})` : ''}${cpuForced ? ' — GPU offload disabled for calibration' : ''}`
-  )
+  const run = await runModelFitCalibration({ gpuPass, log: (line) => console.log(line) })
 
-  const mib = (n: number) => (n / 1024 / 1024).toFixed(0)
-
-  // The first load in a process reads high — arenas and caches that later loads
-  // reuse — and these coefficients describe warm loads. Left in, it landed as a
-  // 30% spread the repeat check reported as a busy host, and skewed the linux
-  // weight ratio to 1.7. Warm up on the smallest model and throw it away.
-  console.log('warm-up load (not measured)')
-  await measure(FIT_MODELS[0]!, CONTEXTS[0]!, cpuForced, loadMode, gpuPass)
-
-  const elementWidths = new Set<number>()
-  const measurements: FitPoint[] = []
-  for (const name of FIT_MODELS) {
-    for (const contextTokens of CONTEXTS) {
-      for (let repeat = 0; repeat < REPEATS; repeat++) {
-        const measurement = await measure(name, contextTokens, cpuForced, loadMode, gpuPass)
-        // `.lower` is the width a GPU backend defaults to (q8_0), and equals
-        // f16 when no GPU is reported — what the engine allocates in each
-        // case, not an optimistic bound borrowed from the estimator's range.
-        const bytesPerElement = kvElementBytes(measurement.facts, hasGpu).bytes.lower
-        elementWidths.add(bytesPerElement)
-        const kvBytes = exactKvBytes(name, measurement.facts, contextTokens, bytesPerElement)
-        measurements.push({ ...measurement, kvBytes })
-        console.log(
-          `  ${name} @ ${contextTokens} (${repeat + 1}/${REPEATS}): persistent ${mib(measurement.persistentBytes)} MiB, working ${mib(measurement.workingBytes)} MiB, kv ${mib(kvBytes)} MiB`
-        )
-        if (measurement.workingBytes > WORKING_DRIFT_WARN_BYTES) {
-          console.log(
-            `    warning: working delta is ${mib(measurement.workingBytes)} MiB — the engine no longer allocates everything at load, so the persistent-based fit under-describes the peak`
-          )
-        }
-      }
-    }
-  }
-
-  if (elementWidths.size > 1) {
+  if (run.warnings.length > 0) {
     console.log(
-      `\nwarning: the fit mixes KV element widths (${[...elementWidths].join(', ')} bytes), so the points do not describe a single cache type`
+      `\n${run.warnings.length} warning(s) above — re-run on a quiet host before shipping this fixture`
     )
-  }
-
-  // Judge the counter before the fit: the KV cache grows by an exactly known
-  // amount between the two contexts, and every sound counter has to see it.
-  const observation = kvObservation(measurements)
-  console.log('\nKV growth between contexts, computed vs observed:')
-  for (const growth of observation.models) {
-    const model = measurements.find((m) => m.artifactBytes === growth.artifactBytes)
-    console.log(
-      `  ${model?.name ?? mib(growth.artifactBytes) + ' MiB'}: kv +${mib(growth.kvDeltaBytes)} MiB, persistent +${mib(growth.observedDeltaBytes)} MiB (${((growth.observedDeltaBytes / growth.kvDeltaBytes) * 100).toFixed(0)}%)`
-    )
-  }
-  if (observation.ratio < KV_OBSERVATION_FLOOR) {
-    // The same shortfall read against the other width the engine could have
-    // chosen: a ratio near 1 there names the cause outright.
-    const width = Math.max(...elementWidths)
-    const other = kvElementBytes(measurements[0]!.facts, !hasGpu).bytes.lower
-    const otherRatio = (observation.ratio * width) / other
-    console.log(
-      `\nthe persistent deltas grew by ${(observation.ratio * 100).toFixed(0)}% of the KV cache computed at ${width} bytes per element (floor ${KV_OBSERVATION_FLOOR * 100}%); at ${other} bytes per element the same growth reads as ${(otherRatio * 100).toFixed(0)}%. Either the engine built a different cache type than the one subtracted, or RSS is missing allocation; nothing fitted on these points is an upper bound. No fixture written.`
-    )
-    Bare.exit(1)
-  }
-
-  // Fail loudly rather than fitting nonsense: a load that measured smaller
-  // than the KV cache it supposedly allocated means the assumed cache type
-  // does not match what the engine did.
-  const negative = measurements.filter((m) => m.persistentBytes - m.kvBytes < 0)
-  if (negative.length > 0) {
-    // Weights far below artifact size with a GPU present means the model went
-    // to discrete GPU memory, which process RSS cannot observe; RSS-based
-    // calibration only works on unified-memory or CPU-resident hosts.
-    const offloaded = hasGpu && measurements.some((m) => m.persistentBytes < m.artifactBytes / 2)
-    console.log(
-      offloaded
-        ? `\n${negative.length} of ${measurements.length} points measured less persistent memory than the KV cache being subtracted: the model is in discrete GPU memory, which process RSS cannot observe. This methodology only calibrates unified-memory or CPU-resident hosts. No fixture written.`
-        : `\n${negative.length} of ${measurements.length} points measured less persistent memory than the KV cache being subtracted: the assumed cache type does not match what the engine allocated. No fixture written.`
-    )
-    Bare.exit(1)
-  }
-
-  const fit = fitResidentMemory(measurements)
-  if (!fit) {
-    console.log(
-      '\nthe measurement design cannot separate the weight ratio, fixed overhead and per-token slope (degenerate fit). No fixture written.'
-    )
-    Bare.exit(1)
-  }
-  console.log(
-    `\nfit: weightRatio ${fit.weightRatio.toFixed(3)}, fixed ${mib(fit.fixedBytes)} MiB, perToken ${fit.perTokenBytes.toFixed(0)} B, worst excess ${mib(fit.worstExcessBytes)} MiB`
-  )
-
-  // Busy-host tripwires. Co-scheduled work cannot inflate this process's RSS,
-  // but memory pressure can evict its mapped pages and DEFLATE the persistent
-  // deltas — the dangerous direction for an upper bound. Deflation shows up as
-  // a weight ratio well below 1 (quiet-host runs measured ~1.0) or as repeats
-  // of the same point disagreeing; neither aborts, because a platform could
-  // legitimately page weights lazily, but a fixture from a warned run should
-  // not ship without a quiet re-run.
-  if (fit.weightRatio < 0.9) {
-    console.log(
-      `\nwarning: weightRatio ${fit.weightRatio.toFixed(3)} — resident weights landed well below artifact size. Either this platform pages weights lazily, or the host was under memory pressure during the run. Re-run on an idle host before trusting this fixture.`
-    )
-  }
-  for (const name of FIT_MODELS) {
-    for (const contextTokens of CONTEXTS) {
-      const repeats = measurements.filter(
-        (m) => m.name === name && m.contextTokens === contextTokens
-      )
-      const values = repeats.map((m) => m.persistentBytes)
-      const spread = Math.max(...values) - Math.min(...values)
-      const mean = values.reduce((total, v) => total + v, 0) / values.length
-      if (mean > 0 && spread / mean > 0.15) {
-        console.log(
-          `\nwarning: ${name} @ ${contextTokens} repeats spread ${mib(spread)} MiB (${((spread / mean) * 100).toFixed(0)}% of mean) — the host does not look idle. Re-run on a quiet machine before trusting this fixture.`
-        )
-      }
-    }
-  }
-
-  const calibration: PlatformCalibration = {
-    weightUpperCoeff: Number(Math.max(1, fit.weightRatio).toFixed(3)),
-    fixedOverheadBytes: {
-      lower: Math.round(fit.fixedBytes * 0.8),
-      // Floored at the worst point observed: an upper bound that does not
-      // cover a measurement is not an upper bound.
-      upper: Math.round((fit.fixedBytes + fit.worstExcessBytes) * 1.2)
-    },
-    computeBufferBytesPerToken: {
-      lower: Math.round(fit.perTokenBytes * 0.8),
-      upper: Math.round(fit.perTokenBytes * 1.2)
-    },
-    // Audio coefficients need a whisper pass; left at zero until that runs.
-    // `estimateWhisper` refuses to consume the zeros, so audio workloads
-    // assess as unknown rather than as a confident under-estimate.
-    audioWindowBytes: { lower: 0, upper: 0 },
-    audioStreamingBytes: { lower: 0, upper: 0 },
-    validated: false,
-    ...(loadMode && {
-      notes: [
-        `weights were loaded with load_mode '${loadMode}' so RSS counted them in full at load; a mapped weight set keeps at most the artifact size resident, so weightUpperCoeff remains an upper bound for the default mmap load`
-      ]
-    }),
-    measuredAt: new Date().toISOString().slice(0, 10),
-    measuredOn: {
-      backend,
-      ...(device ? { device } : {}),
-      kvElementBytes: Math.max(...elementWidths)
-    }
-  }
-
-  console.log('\nderived:', JSON.stringify(calibration, null, 2))
-
-  // Predict with the width this run actually allocated, not the estimator's f16
-  // upper end. Using f16 here on a q8_0 backend would pad the prediction by the
-  // whole cache-type spread and let weak coefficients through the gate; the
-  // point is to test the fit, not the conservatism of the range. The held-out
-  // model is measured as many times as a fit point, against the worst total.
-  let heldOutWorstTotal = 0
-  let heldOutKv = 0
-  let heldOutArtifactBytes = 0
-  for (let repeat = 0; repeat < REPEATS; repeat++) {
-    const heldOut = await measure(HELD_OUT_MODEL, CONTEXTS[1]!, cpuForced, loadMode, gpuPass)
-    const heldOutWidth = kvElementBytes(heldOut.facts, hasGpu).bytes.lower
-    heldOutKv = exactKvBytes(HELD_OUT_MODEL, heldOut.facts, CONTEXTS[1]!, heldOutWidth)
-    heldOutArtifactBytes = heldOut.artifactBytes
-    heldOutWorstTotal = Math.max(heldOutWorstTotal, heldOut.persistentBytes + heldOut.workingBytes)
-  }
-  const predictedUpper =
-    heldOutArtifactBytes * calibration.weightUpperCoeff +
-    calibration.fixedOverheadBytes.upper +
-    calibration.computeBufferBytesPerToken.upper * CONTEXTS[1]! +
-    heldOutKv
-  const holds = heldOutWorstTotal <= predictedUpper
-
-  console.log(
-    `\nheld-out ${HELD_OUT_MODEL}: worst measured ${(heldOutWorstTotal / 2 ** 30).toFixed(2)} GiB vs predicted upper ${(predictedUpper / 2 ** 30).toFixed(2)} GiB — ${holds ? 'PASS' : 'FAIL'}`
-  )
-  calibration.validated = holds
-  if (!holds) {
-    console.log('the held-out peak exceeded the upper bound; do not ship these coefficients')
   }
 
   if (write) {
-    // A GPU pass is keyed by backend as well as platform, so it neither
-    // overwrites the CPU fixture nor claims to cover another backend.
-    const fixtureKey = gpuPass ? `${platform}-${backend}` : platform
     const target = path.join(
       os.cwd(),
       'src',
       'resources',
       'model-fit',
       'calibration',
-      `${fixtureKey}.ts`
+      `${run.fixtureKey}.ts`
     )
-    fs.writeFileSync(target, fixtureSource(fixtureKey, calibration))
+    fs.writeFileSync(target, run.fixtureSource)
     console.log(`\nwrote ${target}`)
     console.log('remember to add the platform to calibration/index.ts and run prettier')
   } else {
-    console.log('\nre-run with --write to update the fixture')
+    console.log(`\n----- BEGIN CALIBRATION FIXTURE ${run.fixtureKey}.ts -----`)
+    console.log(run.fixtureSource)
+    console.log(`----- END CALIBRATION FIXTURE ${run.fixtureKey}.ts -----`)
+    console.log('re-run with --write to update the fixture in place')
   }
 
   // Exit explicitly either way. The registry client keeps handles open, so a
   // returning main() leaves the process alive until the job times out — and the
-  // fixture, already written, never reaches the upload step.
-  Bare.exit(holds ? 0 : 1)
+  // fixture, already written, never reaches the upload step. Non-zero on a
+  // failed gate so the CI job cannot rot green.
+  Bare.exit(run.heldOut.holds ? 0 : 1)
 }
 
 main().catch((error) => {
-  console.error('calibration failed:', error)
+  if (error instanceof CalibrationAbortedError) {
+    console.error(`calibration aborted (${error.reason}): ${error.message} No fixture written.`)
+  } else {
+    console.error('calibration failed:', error)
+  }
   Bare.exit(1)
 })

--- a/packages/inference/src/resources/model-fit/calibration/METHODOLOGY.md
+++ b/packages/inference/src/resources/model-fit/calibration/METHODOLOGY.md
@@ -24,17 +24,28 @@ for the per-layer accounting.
 
 ## Procedure
 
-`scripts/calibrate-model-fit.ts` on the platform being calibrated (bare ≥ 1.30
-runs it directly via type-stripping):
+The procedure is `calibration/harness.ts`, exported as
+`@qvac/inference/model-fit-calibration`. On desktop,
+`scripts/calibrate-model-fit.ts` runs it on the platform being calibrated (bare
+≥ 1.30 runs the script directly via type-stripping) and writes the fixture. On
+a phone the same module runs inside the SDK e2e consumer's calibration plugin
+and the fixture comes back as the test output — see "Mobile" below.
 
 llama.cpp allocates **everything at load** — weights, KV cache, engine
 overhead and the context-scaled compute buffers — so a load's RSS delta is the
-whole cost and the delta during a completion is ~0. The first real runs on
-Apple silicon confirmed this, which is why the fit reads persistent deltas
-rather than working samples. The harness still samples RSS across one
-completion per point and warns if that working delta grows past 64 MiB: that
-would mean the engine's allocation behaviour changed and this methodology
-needs re-checking.
+whole cost and the delta during a completion should be ~0, which is why the fit
+reads persistent deltas rather than working samples. The harness still samples
+RSS across one 128-token completion per point and warns if that working delta
+grows past 64 MiB: that would mean the engine's allocation behaviour changed
+and this methodology needs re-checking. The script that measured every fixture
+below awaited `response`, which `CompletionRun` does not expose, and passed
+`maxTokens`, which is not a generation parameter — so its samplers covered no
+generation and the ~0 working delta they printed was not evidence. The module
+awaits `run.text` with `generationParams.predict`; the working term stays
+unmeasured on each platform until it is re-run. Persistent deltas are read
+before generation starts and are unaffected, and so is the GPU pass, which
+reads device memory and never sampled — though the "every CPU point measured 0"
+it rests on comes from those same empty samplers.
 
 On platforms where a GPU means discrete device memory (linux, windows,
 darwin-x64) the harness loads with `device: 'cpu'`: RSS cannot observe VRAM,
@@ -50,10 +61,15 @@ Vulkan-capable GPU still builds a `q8_0` cache while every layer runs on the
 CPU, and the `f16` subtracted for a CPU run would be twice what the engine
 allocated. The first Windows run failed exactly that way (see "Windows").
 
-1. For each of three models (small, medium, large) at two contexts (512 and
-   8192 tokens), **three times each**: settle, read RSS, load, settle, read RSS
-   again — the difference is **persistent**. Single-shot loads were observed to
-   vary by up to ~100 MiB run to run, so every repeat enters the fit.
+1. For each of three models (small, medium, large) at two contexts, **three
+   times each**: settle, read RSS, load, settle, read RSS again — the
+   difference is **persistent**. Single-shot loads were observed to vary by up
+   to ~100 MiB run to run, so every repeat enters the fit. The model set and
+   contexts come from a per-platform-family profile in the harness: desktop
+   uses 600M/1B/4B at 512/8192 with 8B held out; mobile uses 600M/1B/1.7B at
+   512/4096 with 4B held out, because every load must stay well under a phone's
+   per-process ceiling — iOS jetsam kills near it, and a killed harness
+   measures nothing (needs a device with at least 6 GB of RAM).
 2. Subtract the KV cache from each persistent delta — the cache the engine
    _actually allocated_, taken from the estimator's own `kvElementBytes` rather
    than assumed. On a Metal or Vulkan backend the default is `q8_0`, so a fixed
@@ -164,6 +180,46 @@ Measured under `device: 'gpu'` linux reads ~1.0 (2415 MiB for the same
 artifact), because no CPU-backend copy exists there. That number does not
 transfer to a CPU-forced run, and reading it across cost a calibration round.
 
+## Mobile
+
+A phone has no shell to run the script from, and `@qvac/sdk` reaches the
+engine only through its worker, so the harness runs where the engine lives:
+the SDK e2e consumer bundles a `custom-calibration-plugin` whose single
+streaming handler calls `runModelFitCalibration` inside the worker and relays
+its log lines and result. The e2e test `calibration-model-fit` (category
+`calibration`) drives it and returns the run — coefficients, held-out check,
+warnings and the `<platform>.ts` source — as its output, so the producer's
+`results-<runId>.json` carries the fixture off the device without parsing
+logcat. The test is only loaded when the producer runs with
+`QVAC_E2E_CALIBRATION=1`; a full e2e run never includes it.
+
+Two hosts run that test: `npx qvac-test run:local:android|ios` against an idle
+physical device plugged in with a registry-reachable network, or the test-sdk
+dispatch with `calibration: android|ios`, which builds the consumer, uploads it
+to a Device Farm pool, runs only that test, and publishes the fixture as a
+`calibration-fixture-<platform>-<runId>` artifact. Device Farm gives each run
+a device to itself, so there is no equivalent of the desktop drain-stop hook to
+arrange; the busy-host warnings still apply and a warned fixture still does not
+ship.
+
+What RSS means there differs by OS. Android's counter is the same Linux RSS as
+desktop. On iOS `uv_resident_set_memory` reads `task_info` resident size, which
+counts touched file-backed pages; jetsam's budget is `phys_footprint`, which
+does not. RSS therefore reads at or above what jetsam charges for the same
+load, so a fixture measured on it stays an upper bound for the per-process
+budget `assessModelFit` compares against on iOS — conservative, not
+optimistic. Per-process measurement also means the app hosting the worker is
+part of the baseline; every delta subtracts a settled reading taken in the same
+process, so the host's own footprint cancels.
+
+A calibrated iOS fixture is necessary but not sufficient. iOS assesses on the
+`process-memory` basis, whose budget is `os_proc_available_memory()` plus the
+current footprint, and no native source supplies the first term today —
+`resolveBudget` returns `unknown` before calibration is ever consulted. So an
+iOS run here is worth doing (the coefficients are what they will be), but iOS
+keeps returning `unknown` until that native metric lands. Android has no such
+gap: it assesses on `system-memory`, and only the fixture is missing.
+
 ## Scope of a fixture
 
 Coefficients are keyed by **platform**, while several of the buffers they cover
@@ -187,12 +243,14 @@ one.
 
 ## Status
 
-| Platform            | Coefficients                                         | Validated |
-| ------------------- | ---------------------------------------------------- | --------- |
-| darwin-arm64        | measured 2026-08-31 (Metal, Apple M4 Pro)            | yes       |
-| linux-x64           | measured 2026-09-03 (CPU-forced, RTX 4000 SFF host)  | yes       |
-| win32-x64           | measured 2026-09-03 (CPU-forced, RTX 4000 SFF host)  | yes       |
-| linux-x64 \| vulkan | measured 2026-09-03 (GPU-resident, RTX 4000 SFF Ada) | yes       |
+| Platform            | Coefficients                                           | Validated |
+| ------------------- | ------------------------------------------------------ | --------- |
+| darwin-arm64        | measured 2026-08-31 (Metal, Apple M4 Pro)              | yes       |
+| linux-x64           | measured 2026-09-03 (CPU-forced, RTX 4000 SFF host)    | yes       |
+| win32-x64           | measured 2026-09-03 (CPU-forced, RTX 4000 SFF host)    | yes       |
+| linux-x64 \| vulkan | measured 2026-09-03 (GPU-resident, RTX 4000 SFF Ada)   | yes       |
+| android-arm64       | pending: run via the e2e calibration plugin ("Mobile") | no        |
+| ios-arm64           | pending: run via the e2e calibration plugin ("Mobile") | no        |
 
 `darwin-arm64` was measured on an Apple M4 Pro against the Metal backend
 (`q8_0` KV cache): held-out Qwen3-8B landed at 5.28 GiB against a predicted
@@ -210,5 +268,7 @@ There is no `win32-x64` GPU entry: Windows reports per-process GPU memory
 (DXGI `CurrentUsage` and `Budget`), which cannot bound a device. LLM workloads return real verdicts there; audio workloads
 still return `unknown` because the harness has no whisper pass yet, and
 `estimateWhisper` refuses the zeroed audio coefficients rather than consuming
-them. Adding a platform means: run the harness with `--write`, add the module
-to `calibration/index.ts`, run prettier, and update the table above.
+them. Adding a platform means: run the harness with `--write` (on a phone, copy
+the `<platform>.ts` out of the e2e run's `calibration-fixture-*` artifact
+verbatim), add the module to `calibration/index.ts`, run prettier, and update
+the table above.

--- a/packages/inference/src/resources/model-fit/calibration/harness.ts
+++ b/packages/inference/src/resources/model-fit/calibration/harness.ts
@@ -1,0 +1,786 @@
+// Calibration harness for assessModelFit, as a module.
+//
+// Loads representative catalog models, measures resident memory around real
+// operations, and derives the coefficients that live in
+// `calibration/<platform>.ts`. Two hosts run it: `scripts/calibrate-model-fit.ts`
+// on a desktop runner (which registers the LLM plugin, then writes the fixture),
+// and the SDK e2e consumer's calibration plugin inside the worker on a phone
+// (where the plugins are already registered and the result travels back as the
+// test output). Neither host is assumed here: the caller registers plugins,
+// decides what to do with the result, and owns process exit.
+//
+// See METHODOLOGY.md next to this file for what the numbers mean.
+
+import os from 'bare-os'
+import { loadModel } from '@/api/load-model'
+import { completion } from '@/api/completion-stream'
+import { unloadModel } from '@/api/unload-model'
+import { getSystemResources } from '@/api/get-system-resources'
+import * as catalog from '@/models/registry/index'
+import { MODEL_RESOURCE_PROFILES } from '@/models/registry/resource-profiles'
+import { kvElementBytes, kvCacheBytesForWidth } from '@/resources/model-fit/estimators/llm'
+import {
+  fitResidentMemory,
+  kvObservation,
+  type ResidentFit
+} from '@/resources/model-fit/calibration/fit'
+import type { GgufFacts } from '@/schemas/model-resource-profile'
+import type { ModelDescriptor } from '@/schemas/model-src-utils'
+import type { GPUResourceCapabilities } from '@/schemas/system-resources'
+import type { PlatformCalibration } from '@/resources/model-fit/types'
+
+const SAMPLE_INTERVAL_MS = 25
+const SETTLE_MS = 250
+
+// Every point is measured this many times. Single-shot loads were observed to
+// vary by up to ~100 MiB run to run; all repeats enter the fit, and the upper
+// bound is floored at the worst point seen.
+const REPEATS = 3
+
+// llama.cpp allocates the whole context at load — KV cache, engine overhead
+// and compute buffers included — so the RSS delta during a completion should
+// be near zero. A working delta above this threshold means the engine's
+// allocation behaviour changed and this methodology needs re-checking.
+const WORKING_DRIFT_WARN_BYTES = 64 * 1024 * 1024
+
+// The KV cache grows by a known amount between the two contexts, so the deltas
+// must too. A shortfall means the wrong KV width, or a counter missing memory.
+const KV_OBSERVATION_FLOOR = 0.9
+
+// A stalled download or a wedged engine call would otherwise run to the job
+// timeout while holding an exclusive drained host, so every phase is bounded.
+const DEFAULT_LOAD_TIMEOUT_MS = 30 * 60 * 1000
+const COMPLETION_TIMEOUT_MS = 15 * 60 * 1000
+const UNLOAD_TIMEOUT_MS = 5 * 60 * 1000
+
+/**
+ * What one platform family's run measures: two contexts per model so fixed
+ * overhead and the per-token slope can be separated (a single point cannot
+ * tell them apart), fit models spanning small–large artifact sizes to pin the
+ * weight ratio, and one model held out of the fit entirely to check that the
+ * derived upper bound actually holds.
+ */
+export interface CalibrationProfile {
+  name: 'desktop' | 'mobile'
+  contexts: readonly [number, number]
+  fitModels: readonly string[]
+  heldOutModel: string
+}
+
+export const DESKTOP_CALIBRATION_PROFILE: CalibrationProfile = {
+  name: 'desktop',
+  contexts: [512, 8192],
+  fitModels: ['QWEN3_600M_INST_Q4', 'LLAMA_3_2_1B_INST_Q4_0', 'QWEN3_4B_INST_Q4_K_M'],
+  heldOutModel: 'QWEN3_8B_INST_Q4_K_M'
+}
+
+// Everything must stay well under a phone's per-process ceiling (iOS jetsam
+// kills near it, and a killed harness measures nothing): smaller models, and
+// the upper context halved so the held-out 4B load stays inside what a 6 GB
+// device grants.
+export const MOBILE_CALIBRATION_PROFILE: CalibrationProfile = {
+  name: 'mobile',
+  contexts: [512, 4096],
+  fitModels: ['QWEN3_600M_INST_Q4', 'LLAMA_3_2_1B_INST_Q4_0', 'QWEN3_1_7B_INST_Q4'],
+  heldOutModel: 'QWEN3_4B_INST_Q4_K_M'
+}
+
+/** The `<platform>-<arch>` key fixtures are named after, for the running process. */
+export function calibrationPlatform() {
+  return `${os.platform()}-${os.arch()}`
+}
+
+export function isMobileCalibrationPlatform(platform: string) {
+  return platform.startsWith('android') || platform.startsWith('ios')
+}
+
+export function calibrationProfileFor(platform: string): CalibrationProfile {
+  return isMobileCalibrationPlatform(platform)
+    ? MOBILE_CALIBRATION_PROFILE
+    : DESKTOP_CALIBRATION_PROFILE
+}
+
+// RSS cannot observe VRAM, so these platforms calibrate CPU-resident execution.
+// Must be `device`, not `gpu_layers: 0`: the addon takes its KV default from the
+// backend `device` selects, so a GPU device builds q8_0 against a subtracted f16.
+// Apple silicon and mobile are unified memory and keep the GPU.
+export function forcesCpu(platform: string) {
+  return platform.startsWith('linux') || platform.startsWith('win32') || platform === 'darwin-x64'
+}
+
+// Load anonymously wherever the CPU backend is forced. It copies mapped weights
+// into its own buffers, so RSS counts them twice — linux read 1.7x the artifact
+// — while win32 prefetches to the standby list and counts almost none. The
+// anonymous copy is the memory the system must actually find; the mapped pages
+// the default keeps are file-backed and evictable.
+export function calibrationLoadMode(platform: string) {
+  return forcesCpu(platform) ? 'none' : undefined
+}
+
+export type CalibrationAbortReason =
+  | 'unknown-model'
+  | 'no-gguf-facts'
+  | 'kv-not-exact'
+  | 'kv-observation-shortfall'
+  | 'negative-residual'
+  | 'degenerate-fit'
+  | 'timeout'
+  | 'gpu-counter-unavailable'
+  | 'gpu-not-settled'
+
+/**
+ * The run stopped before producing coefficients. Every reason is a methodology
+ * tripwire, not a transient: re-running without changing something will abort
+ * again. `reason` is stable for callers; `message` says what to change.
+ */
+export class CalibrationAbortedError extends Error {
+  readonly reason: CalibrationAbortReason
+
+  constructor(reason: CalibrationAbortReason, message: string) {
+    super(message)
+    this.name = 'CalibrationAbortedError'
+    this.reason = reason
+  }
+}
+
+export interface CalibrationMeasurement {
+  name: string
+  contextTokens: number
+  artifactBytes: number
+  facts: GgufFacts
+  persistentBytes: number
+  workingBytes: number
+  kvBytes: number
+}
+
+export interface HeldOutCheck {
+  model: string
+  contextTokens: number
+  worstTotalBytes: number
+  predictedUpperBytes: number
+  holds: boolean
+}
+
+export interface CalibrationRun {
+  platform: string
+  /**
+   * What the fixture module is named: `platform` for a system-memory run,
+   * `<platform>-<backend>` for a GPU-resident one, so the two never collide
+   * and neither claims to cover a backend it did not measure.
+   */
+  fixtureKey: string
+  profile: CalibrationProfile
+  /** Device memory was the counter, not RSS. */
+  gpuPass: boolean
+  /** `'none'` when weights were loaded anonymously; absent for the default mmap load. */
+  loadMode?: 'none'
+  backend: string
+  device?: string
+  cpuForced: boolean
+  measurements: readonly CalibrationMeasurement[]
+  fit: ResidentFit
+  calibration: PlatformCalibration
+  heldOut: HeldOutCheck
+  /** Busy-host and methodology warnings. A fixture from a warned run should not ship. */
+  warnings: readonly string[]
+  /** The `<platform>.ts` module source, ready to commit verbatim. */
+  fixtureSource: string
+}
+
+export interface CalibrationRunOptions {
+  /** Defaults to the running process's platform. */
+  platform?: string
+  /** Defaults to the profile for `platform`. */
+  profile?: CalibrationProfile
+  /**
+   * Calibrate the models resident on the GPU against device memory instead of
+   * RSS: no `device` override, the SDK's own load mode, and a fixture keyed by
+   * backend. Only meaningful where a GPU has device-scoped memory readings.
+   */
+  gpuPass?: boolean
+  /** Receives progress and warnings as they happen; the run is long and silent otherwise. */
+  log?: (line: string) => void
+  loadTimeoutMs?: number
+}
+
+function rssBytes() {
+  const usage = os.memoryUsage()
+  return usage && usage.rss > 0 ? usage.rss : 0
+}
+
+function createSampler() {
+  const samples: number[] = []
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let running = false
+
+  function tick() {
+    if (!running) return
+    const rss = rssBytes()
+    if (rss > 0) samples.push(rss)
+    timer = setTimeout(tick, SAMPLE_INTERVAL_MS)
+    if (timer && typeof timer.unref === 'function') timer.unref()
+  }
+
+  return {
+    start() {
+      running = true
+      tick()
+    },
+    stop() {
+      running = false
+      if (timer) clearTimeout(timer)
+      const rss = rssBytes()
+      if (rss > 0) samples.push(rss)
+      return samples.length > 0 ? Math.max(...samples) : 0
+    }
+  }
+}
+
+function settle() {
+  return new Promise<void>((resolve) => setTimeout(() => resolve(), SETTLE_MS))
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs: number, hint: string) {
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new CalibrationAbortedError(
+          'timeout',
+          `${label} did not finish within ${timeoutMs / 60000} minutes; ${hint}`
+        )
+      )
+    }, timeoutMs)
+    if (timer && typeof timer.unref === 'function') timer.unref()
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+// Largest dedicated GPU first. The win25 runner reports an Intel iGPU ahead of
+// its RTX 4000, and first-wins named the iGPU as the device on every fixture.
+function byCapability(gpuList: readonly GPUResourceCapabilities[]) {
+  function dedicated(gpu: GPUResourceCapabilities) {
+    return gpu.unifiedMemory.status === 'supported' && gpu.unifiedMemory.value === false ? 1 : 0
+  }
+  function memory(gpu: GPUResourceCapabilities) {
+    return gpu.memoryTotalBytes.status === 'supported' ? gpu.memoryTotalBytes.value : 0
+  }
+  return [...gpuList].sort((a, b) => dedicated(b) - dedicated(a) || memory(b) - memory(a))
+}
+
+/**
+ * Label for the backend in play, recorded with the coefficients because the
+ * buffers they measure are allocated by the backend, and used as the GPU
+ * fixture key. Must stay in step with `GPU_BACKENDS` in `assess.ts`: the
+ * estimator derives the same key the same way, and a fixture filed under a
+ * backend the engine does not use would be served to hosts it never measured.
+ */
+function detectBackend(gpuList: readonly GPUResourceCapabilities[]) {
+  for (const gpu of byCapability(gpuList)) {
+    const drivers = gpu.drivers as Record<string, { status: string; value?: unknown } | undefined>
+    for (const name of ['metal', 'vulkan', 'rocm', 'cuda', 'levelZero', 'opencl']) {
+      if (drivers[name]?.status === 'supported' && drivers[name].value) return name
+    }
+  }
+  return 'cpu'
+}
+
+function gpuName(gpuList: readonly GPUResourceCapabilities[]) {
+  for (const gpu of byCapability(gpuList)) {
+    if (gpu.name.status === 'supported' && gpu.name.value) return gpu.name.value
+  }
+  return undefined
+}
+
+/**
+ * Bytes resident on the GPU the engine would pick. Read through the collector
+ * so the calibration and the estimator agree on which device counts and on
+ * whether its readings are device-scoped at all.
+ */
+async function readGpuUsedBytes() {
+  // `sample: true` is required: the default response carries capabilities only.
+  const resources = await getSystemResources({ sample: true })
+  const gpus = resources.capabilities.gpus
+  const samples = resources.sample?.gpus
+  if (gpus.status !== 'supported' || samples?.status !== 'supported') {
+    throw new CalibrationAbortedError(
+      'gpu-counter-unavailable',
+      'no GPU sample is available, so a GPU pass cannot be measured.'
+    )
+  }
+
+  for (const gpu of byCapability(gpus.value)) {
+    const sample = samples.value.find((entry) => entry.id === gpu.id)
+    if (sample?.memoryUsedBytes.status === 'supported') return sample.memoryUsedBytes.value
+  }
+
+  // Returning 0 here would read as "nothing allocated" and quietly fit garbage.
+  throw new CalibrationAbortedError(
+    'gpu-counter-unavailable',
+    'no GPU reports device-scoped used memory, so this host cannot be calibrated for GPU residency.'
+  )
+}
+
+// The driver frees device memory asynchronously, so a fixed settle can read a
+// baseline that still holds the previous load: one repeat measured 1781 MiB
+// against 690 for the same model. Wait for two readings to agree instead.
+const GPU_SETTLE_TOLERANCE_BYTES = 16 * 1024 * 1024
+const GPU_SETTLE_ATTEMPTS = 40
+
+async function settledGpuUsedBytes() {
+  let previous = await readGpuUsedBytes()
+  for (let attempt = 0; attempt < GPU_SETTLE_ATTEMPTS; attempt++) {
+    await settle()
+    const current = await readGpuUsedBytes()
+    if (Math.abs(current - previous) <= GPU_SETTLE_TOLERANCE_BYTES) return current
+    previous = current
+  }
+  throw new CalibrationAbortedError(
+    'gpu-not-settled',
+    `GPU memory did not settle within ${(GPU_SETTLE_ATTEMPTS * SETTLE_MS) / 1000}s; the device is not idle enough to calibrate.`
+  )
+}
+
+/**
+ * KV-cache bytes the engine allocated for one model at one context, computed
+ * by the estimator's own exported accounting rather than a local copy — a copy
+ * drifted from `estimators/llm.ts` once already.
+ *
+ * The residuals this harness fits describe everything *except* the cache, so a
+ * cache whose size the file does not state exactly (an engine-owned layer
+ * pattern or hybrid block choice) cannot be subtracted. That surfaces as a
+ * non-degenerate range, and the harness stops: calibration models must be
+ * dense.
+ */
+function exactKvBytes(
+  name: string,
+  facts: GgufFacts,
+  contextTokens: number,
+  bytesPerElement: number
+) {
+  const kv = kvCacheBytesForWidth(facts, contextTokens, bytesPerElement)
+  if (kv.lower !== kv.upper) {
+    throw new CalibrationAbortedError(
+      'kv-not-exact',
+      `${name}'s KV cache is not exactly determined by the file (bounds span ${kv.lower}–${kv.upper} bytes); part of its layout is engine-owned, so it cannot be subtracted from a measurement. Use a dense model for calibration.`
+    )
+  }
+  return kv.lower
+}
+
+type CatalogModel = ModelDescriptor & { sha256Checksum: string }
+
+function catalogModel(name: string): CatalogModel {
+  const entry = (catalog as Record<string, unknown>)[name]
+  if (
+    !entry ||
+    typeof entry !== 'object' ||
+    typeof (entry as Partial<CatalogModel>).sha256Checksum !== 'string'
+  ) {
+    throw new CalibrationAbortedError('unknown-model', `unknown catalog constant: ${name}`)
+  }
+  return entry as CatalogModel
+}
+
+interface MeasureContext {
+  cpuForced: boolean
+  loadMode: 'none' | undefined
+  loadTimeoutMs: number
+  /** Measure device memory instead of RSS, for the GPU-resident pass. */
+  gpuPass: boolean
+}
+
+async function measure(name: string, contextTokens: number, ctx: MeasureContext) {
+  const model = catalogModel(name)
+  const profile = MODEL_RESOURCE_PROFILES[model.sha256Checksum]
+  if (!profile?.ggufFacts) {
+    throw new CalibrationAbortedError('no-gguf-facts', `no GGUF facts for ${name}`)
+  }
+
+  await settle()
+  const before = ctx.gpuPass ? await settledGpuUsedBytes() : rssBytes()
+
+  const modelId = await withTimeout(
+    loadModel({
+      modelSrc: model,
+      modelType: 'llamacpp-completion',
+      modelConfig: {
+        ctx_size: contextTokens,
+        ...(ctx.cpuForced && { device: 'cpu' }),
+        ...(ctx.loadMode && { load_mode: ctx.loadMode })
+      }
+    }),
+    `loading ${name}`,
+    ctx.loadTimeoutMs,
+    "a registry download has likely stalled. Check the registry's reachability from this host."
+  )
+
+  await settle()
+  const afterLoad = ctx.gpuPass ? await settledGpuUsedBytes() : rssBytes()
+
+  // Wait for the generation to actually finish before reading the peak: the
+  // sampler only sees what happens while the run is in flight. The GPU pass
+  // has no sampler — device memory is only readable through an async collector
+  // call, which cannot be polled on an interval the way RSS can.
+  const sampler = ctx.gpuPass ? undefined : createSampler()
+  sampler?.start()
+  let peak = afterLoad
+  try {
+    const run = completion({
+      modelId,
+      history: [{ role: 'user', content: 'Summarize the history of cartography.' }],
+      stream: false,
+      generationParams: { predict: 128 }
+    })
+    await withTimeout(
+      run.text,
+      `completion for ${name}`,
+      COMPLETION_TIMEOUT_MS,
+      'the weights loaded, so this is a wedged engine call rather than a download stall.'
+    )
+  } finally {
+    if (sampler) peak = sampler.stop()
+  }
+
+  await withTimeout(
+    unloadModel({ modelId }),
+    `unloading ${name}`,
+    UNLOAD_TIMEOUT_MS,
+    'the engine call is wedged.'
+  )
+  await settle()
+
+  return {
+    name,
+    contextTokens,
+    artifactBytes: profile.artifactBytes,
+    facts: profile.ggufFacts,
+    persistentBytes: Math.max(0, afterLoad - before),
+    workingBytes: Math.max(0, peak - afterLoad)
+  }
+}
+
+export function fixtureSource(platform: string, calibration: PlatformCalibration) {
+  // Unquote the keys only. Values stay JSON-quoted, which is already valid
+  // TypeScript; replacing every quote breaks any value containing one, and
+  // prettier settles the house quote style afterwards anyway.
+  const json = JSON.stringify(calibration, null, 2).replace(/"([a-zA-Z]+)":/g, '$1:')
+  // Assembled so tsc-alias leaves it alone: it rewrites `@/` specifiers inside
+  // string literals too, and the fixture must import the alias, not a path
+  // relative to wherever this module compiled to.
+  const typesModule = ['@', 'resources', 'model-fit', 'types'].join('/')
+  return `import type { PlatformCalibration } from '${typesModule}'
+
+/**
+ * ${platform} coefficients.
+ *
+ * Generated by the calibration harness; see \`METHODOLOGY.md\` next to this
+ * file for how the numbers are derived and validated.
+ */
+export const ${platform.toUpperCase().replace(/-/g, '_')}_CALIBRATION: PlatformCalibration = ${json}
+`
+}
+
+const mib = (n: number) => (n / 1024 / 1024).toFixed(0)
+
+/**
+ * Turns a fit into shippable coefficients: ±20% bounds, with the fixed-overhead
+ * upper bound floored at the worst point observed above the fitted plane.
+ * `validated` starts false; the held-out check decides it.
+ */
+export function deriveCalibration(
+  fit: ResidentFit,
+  provenance: {
+    backend: string
+    device?: string
+    kvElementBytes: number
+    loadMode?: 'none'
+  }
+): PlatformCalibration {
+  return {
+    weightUpperCoeff: Number(Math.max(1, fit.weightRatio).toFixed(3)),
+    fixedOverheadBytes: {
+      lower: Math.round(fit.fixedBytes * 0.8),
+      // Floored at the worst point observed: an upper bound that does not
+      // cover a measurement is not an upper bound.
+      upper: Math.round((fit.fixedBytes + fit.worstExcessBytes) * 1.2)
+    },
+    computeBufferBytesPerToken: {
+      lower: Math.round(fit.perTokenBytes * 0.8),
+      upper: Math.round(fit.perTokenBytes * 1.2)
+    },
+    // Audio coefficients need a whisper pass; left at zero until that runs.
+    // `estimateWhisper` refuses to consume the zeros, so audio workloads
+    // assess as unknown rather than as a confident under-estimate.
+    audioWindowBytes: { lower: 0, upper: 0 },
+    audioStreamingBytes: { lower: 0, upper: 0 },
+    validated: false,
+    ...(provenance.loadMode && {
+      notes: [
+        `weights were loaded with load_mode '${provenance.loadMode}' so RSS counted them in full at load; a mapped weight set keeps at most the artifact size resident, so weightUpperCoeff remains an upper bound for the default mmap load`
+      ]
+    }),
+    measuredAt: new Date().toISOString().slice(0, 10),
+    measuredOn: {
+      backend: provenance.backend,
+      ...(provenance.device ? { device: provenance.device } : {}),
+      kvElementBytes: provenance.kvElementBytes
+    }
+  }
+}
+
+/** The upper bound the coefficients predict for one load, as the estimator would compute it. */
+export function predictedUpperBytes(
+  calibration: PlatformCalibration,
+  artifactBytes: number,
+  contextTokens: number,
+  kvBytes: number
+) {
+  return (
+    artifactBytes * calibration.weightUpperCoeff +
+    calibration.fixedOverheadBytes.upper +
+    calibration.computeBufferBytesPerToken.upper * contextTokens +
+    kvBytes
+  )
+}
+
+/**
+ * Runs the whole procedure on this host and returns the coefficients with
+ * everything needed to judge them. The LLM plugin must already be registered.
+ *
+ * Aborts throw `CalibrationAbortedError`; a failed held-out check does not —
+ * it returns with `validated: false`, because the coefficients are still
+ * worth auditing even though they must not ship.
+ */
+export async function runModelFitCalibration(
+  options: CalibrationRunOptions = {}
+): Promise<CalibrationRun> {
+  const log = options.log ?? (() => {})
+  const platform = options.platform ?? calibrationPlatform()
+  const profile = options.profile ?? calibrationProfileFor(platform)
+  const loadTimeoutMs = options.loadTimeoutMs ?? DEFAULT_LOAD_TIMEOUT_MS
+  const warnings: string[] = []
+  const warn = (line: string) => {
+    warnings.push(line)
+    log(`warning: ${line}`)
+  }
+
+  const gpuPass = options.gpuPass ?? false
+
+  log(
+    `calibrating ${platform}${gpuPass ? ' (GPU-resident)' : ''} (${profile.name} profile; fit: ${profile.fitModels.join(', ')}; held out: ${profile.heldOutModel}; contexts: ${profile.contexts.join('/')})`
+  )
+
+  // A GPU pass keeps the SDK's own load mode: the anonymous copy exists to make
+  // weights visible to RSS, and device memory sees them either way.
+  const loadMode = gpuPass ? undefined : calibrationLoadMode(platform)
+  if (loadMode) {
+    log(`weights loaded with load_mode '${loadMode}' — see METHODOLOGY.md, "RSS and mmap"`)
+  }
+
+  // The fit subtracts the KV cache from each load's persistent delta, so the
+  // cache subtracted has to be the one the engine actually allocated. A fixed
+  // f16 assumption over-subtracts by nearly 2x on a Metal or Vulkan backend —
+  // and since the error scales with context, it lands in the per-token slope
+  // rather than the intercept, corrupting the very coefficient the two-context
+  // design exists to isolate.
+  const resources = await getSystemResources()
+  const gpus = resources.capabilities.gpus
+  const gpuList = gpus.status === 'supported' ? gpus.value : []
+  const cpuForced = !gpuPass && forcesCpu(platform)
+  // `device: 'cpu'` selects the CPU backend, and with it the f16 KV default.
+  const hasGpu = gpuList.length > 0 && !cpuForced
+  const backend = cpuForced ? 'cpu' : detectBackend(gpuList)
+  const device = gpuName(gpuList)
+  log(
+    `backend: ${backend}${device ? ` (${device})` : ''}${cpuForced ? ' — GPU offload disabled for calibration' : ''}`
+  )
+
+  // A GPU pass is keyed by backend as well as platform, so it neither
+  // overwrites the CPU fixture nor claims to cover another backend.
+  const fixtureKey = gpuPass ? `${platform}-${backend}` : platform
+
+  const ctx: MeasureContext = { cpuForced, loadMode, loadTimeoutMs, gpuPass }
+
+  // The first load in a process reads high — arenas and caches that later loads
+  // reuse — and these coefficients describe warm loads. Left in, it landed as a
+  // 30% spread the repeat check reported as a busy host, and skewed the linux
+  // weight ratio to 1.7. Warm up on the smallest model and throw it away.
+  const warmUpModel = profile.fitModels[0]
+  if (warmUpModel) {
+    log('warm-up load (not measured)')
+    await measure(warmUpModel, profile.contexts[0], ctx)
+  }
+
+  const elementWidths = new Set<number>()
+  const measurements: CalibrationMeasurement[] = []
+  for (const name of profile.fitModels) {
+    for (const contextTokens of profile.contexts) {
+      for (let repeat = 0; repeat < REPEATS; repeat++) {
+        const measurement = await measure(name, contextTokens, ctx)
+        // `.lower` is the width a GPU backend defaults to (q8_0), and equals
+        // f16 when no GPU is reported — what the engine allocates in each
+        // case, not an optimistic bound borrowed from the estimator's range.
+        const bytesPerElement = kvElementBytes(measurement.facts, hasGpu).bytes.lower
+        elementWidths.add(bytesPerElement)
+        const kvBytes = exactKvBytes(name, measurement.facts, contextTokens, bytesPerElement)
+        measurements.push({ ...measurement, kvBytes })
+        log(
+          `  ${name} @ ${contextTokens} (${repeat + 1}/${REPEATS}): persistent ${mib(measurement.persistentBytes)} MiB, working ${mib(measurement.workingBytes)} MiB, kv ${mib(kvBytes)} MiB`
+        )
+        if (measurement.workingBytes > WORKING_DRIFT_WARN_BYTES) {
+          warn(
+            `working delta is ${mib(measurement.workingBytes)} MiB for ${name} @ ${contextTokens} — the engine no longer allocates everything at load, so the persistent-based fit under-describes the peak`
+          )
+        }
+      }
+    }
+  }
+
+  if (elementWidths.size > 1) {
+    warn(
+      `the fit mixes KV element widths (${[...elementWidths].join(', ')} bytes), so the points do not describe a single cache type`
+    )
+  }
+
+  // Judge the counter before the fit: the KV cache grows by an exactly known
+  // amount between the two contexts, and every sound counter has to see it.
+  const observation = kvObservation(measurements)
+  log('KV growth between contexts, computed vs observed:')
+  for (const growth of observation.models) {
+    const model = measurements.find((m) => m.artifactBytes === growth.artifactBytes)
+    log(
+      `  ${model?.name ?? mib(growth.artifactBytes) + ' MiB'}: kv +${mib(growth.kvDeltaBytes)} MiB, persistent +${mib(growth.observedDeltaBytes)} MiB (${((growth.observedDeltaBytes / growth.kvDeltaBytes) * 100).toFixed(0)}%)`
+    )
+  }
+  if (observation.ratio < KV_OBSERVATION_FLOOR) {
+    // The same shortfall read against the other width the engine could have
+    // chosen: a ratio near 1 there names the cause outright.
+    const width = Math.max(...elementWidths)
+    const other = kvElementBytes(measurements[0]!.facts, !hasGpu).bytes.lower
+    const otherRatio = (observation.ratio * width) / other
+    throw new CalibrationAbortedError(
+      'kv-observation-shortfall',
+      `the persistent deltas grew by ${(observation.ratio * 100).toFixed(0)}% of the KV cache computed at ${width} bytes per element (floor ${KV_OBSERVATION_FLOOR * 100}%); at ${other} bytes per element the same growth reads as ${(otherRatio * 100).toFixed(0)}%. Either the engine built a different cache type than the one subtracted, or RSS is missing allocation; nothing fitted on these points is an upper bound.`
+    )
+  }
+
+  // Fail loudly rather than fitting nonsense: a load that measured smaller
+  // than the KV cache it supposedly allocated means the assumed cache type
+  // does not match what the engine did.
+  const negative = measurements.filter((m) => m.persistentBytes - m.kvBytes < 0)
+  if (negative.length > 0) {
+    // Weights far below artifact size with a GPU present means the model went
+    // to discrete GPU memory, which process RSS cannot observe; RSS-based
+    // calibration only works on unified-memory or CPU-resident hosts.
+    const offloaded = hasGpu && measurements.some((m) => m.persistentBytes < m.artifactBytes / 2)
+    throw new CalibrationAbortedError(
+      'negative-residual',
+      offloaded
+        ? `${negative.length} of ${measurements.length} points measured less persistent memory than the KV cache being subtracted: the model is in discrete GPU memory, which process RSS cannot observe. This methodology only calibrates unified-memory or CPU-resident hosts.`
+        : `${negative.length} of ${measurements.length} points measured less persistent memory than the KV cache being subtracted: the assumed cache type does not match what the engine allocated.`
+    )
+  }
+
+  const fit = fitResidentMemory(measurements)
+  if (!fit) {
+    throw new CalibrationAbortedError(
+      'degenerate-fit',
+      'the measurement design cannot separate the weight ratio, fixed overhead and per-token slope (degenerate fit).'
+    )
+  }
+  log(
+    `fit: weightRatio ${fit.weightRatio.toFixed(3)}, fixed ${mib(fit.fixedBytes)} MiB, perToken ${fit.perTokenBytes.toFixed(0)} B, worst excess ${mib(fit.worstExcessBytes)} MiB`
+  )
+
+  // Busy-host tripwires. Co-scheduled work cannot inflate this process's RSS,
+  // but memory pressure can evict its mapped pages and DEFLATE the persistent
+  // deltas — the dangerous direction for an upper bound. Deflation shows up as
+  // a weight ratio well below 1 (quiet-host runs measured ~1.0) or as repeats
+  // of the same point disagreeing; neither aborts, because a platform could
+  // legitimately page weights lazily, but a fixture from a warned run should
+  // not ship without a quiet re-run.
+  if (fit.weightRatio < 0.9) {
+    warn(
+      `weightRatio ${fit.weightRatio.toFixed(3)} — resident weights landed well below artifact size. Either this platform pages weights lazily, or the host was under memory pressure during the run. Re-run on an idle host before trusting this fixture.`
+    )
+  }
+  for (const name of profile.fitModels) {
+    for (const contextTokens of profile.contexts) {
+      const repeats = measurements.filter(
+        (m) => m.name === name && m.contextTokens === contextTokens
+      )
+      const values = repeats.map((m) => m.persistentBytes)
+      const spread = Math.max(...values) - Math.min(...values)
+      const mean = values.reduce((total, v) => total + v, 0) / values.length
+      if (mean > 0 && spread / mean > 0.15) {
+        warn(
+          `${name} @ ${contextTokens} repeats spread ${mib(spread)} MiB (${((spread / mean) * 100).toFixed(0)}% of mean) — the host does not look idle. Re-run on a quiet machine before trusting this fixture.`
+        )
+      }
+    }
+  }
+
+  const calibration = deriveCalibration(fit, {
+    backend,
+    ...(device ? { device } : {}),
+    kvElementBytes: Math.max(...elementWidths),
+    ...(loadMode ? { loadMode } : {})
+  })
+  log(`derived: ${JSON.stringify(calibration)}`)
+
+  // Predict with the width this run actually allocated, not the estimator's f16
+  // upper end. Using f16 here on a q8_0 backend would pad the prediction by the
+  // whole cache-type spread and let weak coefficients through the gate; the
+  // point is to test the fit, not the conservatism of the range. The held-out
+  // model is measured as many times as a fit point, against the worst total.
+  const heldOutContext = profile.contexts[1]
+  let worstTotalBytes = 0
+  let heldOutKv = 0
+  let heldOutArtifactBytes = 0
+  for (let repeat = 0; repeat < REPEATS; repeat++) {
+    const heldOut = await measure(profile.heldOutModel, heldOutContext, ctx)
+    const width = kvElementBytes(heldOut.facts, hasGpu).bytes.lower
+    heldOutKv = exactKvBytes(profile.heldOutModel, heldOut.facts, heldOutContext, width)
+    heldOutArtifactBytes = heldOut.artifactBytes
+    worstTotalBytes = Math.max(worstTotalBytes, heldOut.persistentBytes + heldOut.workingBytes)
+    log(
+      `  held-out ${profile.heldOutModel} @ ${heldOutContext} (${repeat + 1}/${REPEATS}): persistent ${mib(heldOut.persistentBytes)} MiB, working ${mib(heldOut.workingBytes)} MiB`
+    )
+  }
+  const predicted = predictedUpperBytes(
+    calibration,
+    heldOutArtifactBytes,
+    heldOutContext,
+    heldOutKv
+  )
+  const holds = worstTotalBytes <= predicted
+  log(
+    `held-out ${profile.heldOutModel}: worst measured ${(worstTotalBytes / 2 ** 30).toFixed(2)} GiB vs predicted upper ${(predicted / 2 ** 30).toFixed(2)} GiB — ${holds ? 'PASS' : 'FAIL'}`
+  )
+  if (!holds) log('the held-out peak exceeded the upper bound; do not ship these coefficients')
+  calibration.validated = holds
+
+  return {
+    platform,
+    fixtureKey,
+    profile,
+    gpuPass,
+    ...(loadMode ? { loadMode } : {}),
+    backend,
+    ...(device ? { device } : {}),
+    cpuForced,
+    measurements,
+    fit,
+    calibration,
+    heldOut: {
+      model: profile.heldOutModel,
+      contextTokens: heldOutContext,
+      worstTotalBytes,
+      predictedUpperBytes: predicted,
+      holds
+    },
+    warnings,
+    fixtureSource: fixtureSource(fixtureKey, calibration)
+  }
+}

--- a/packages/inference/test/calibration-harness.test.ts
+++ b/packages/inference/test/calibration-harness.test.ts
@@ -1,0 +1,154 @@
+import test from 'brittle'
+import {
+  CalibrationAbortedError,
+  DESKTOP_CALIBRATION_PROFILE,
+  MOBILE_CALIBRATION_PROFILE,
+  calibrationLoadMode,
+  calibrationProfileFor,
+  deriveCalibration,
+  fixtureSource,
+  forcesCpu,
+  isMobileCalibrationPlatform,
+  predictedUpperBytes
+} from '@/resources/model-fit/calibration/harness'
+import type { ResidentFit } from '@/resources/model-fit/calibration/fit'
+
+const MIB = 1024 * 1024
+
+const FIT: ResidentFit = {
+  weightRatio: 0.95,
+  fixedBytes: 100 * MIB,
+  perTokenBytes: 1000,
+  worstExcessBytes: 20 * MIB
+}
+
+test('mobile platforms get the mobile profile, everything else the desktop one', (t) => {
+  t.is(calibrationProfileFor('android-arm64'), MOBILE_CALIBRATION_PROFILE)
+  t.is(calibrationProfileFor('ios-arm64'), MOBILE_CALIBRATION_PROFILE)
+  t.is(calibrationProfileFor('darwin-arm64'), DESKTOP_CALIBRATION_PROFILE)
+  t.is(calibrationProfileFor('linux-x64'), DESKTOP_CALIBRATION_PROFILE)
+  t.ok(isMobileCalibrationPlatform('android-arm64'))
+  t.absent(isMobileCalibrationPlatform('darwin-arm64'))
+})
+
+test('mobile profile keeps every load below a phone budget', (t) => {
+  // The held-out model is the largest load of the run; 4B Q4 at 4096 tokens
+  // stays under the ~3 GiB iOS per-process ceiling with room for the app.
+  t.is(MOBILE_CALIBRATION_PROFILE.heldOutModel, 'QWEN3_4B_INST_Q4_K_M')
+  t.is(MOBILE_CALIBRATION_PROFILE.contexts[1], 4096)
+  t.absent(MOBILE_CALIBRATION_PROFILE.fitModels.includes('QWEN3_8B_INST_Q4_K_M'))
+})
+
+test('discrete-GPU platforms force CPU, unified-memory ones keep the GPU', (t) => {
+  t.ok(forcesCpu('linux-x64'))
+  t.ok(forcesCpu('win32-x64'))
+  t.ok(forcesCpu('darwin-x64'))
+  t.absent(forcesCpu('darwin-arm64'))
+  t.absent(forcesCpu('android-arm64'))
+  t.absent(forcesCpu('ios-arm64'))
+})
+
+test('the anonymous load follows the forced CPU backend, not the OS', (t) => {
+  t.is(calibrationLoadMode('linux-x64'), 'none')
+  t.is(calibrationLoadMode('win32-x64'), 'none')
+  t.is(calibrationLoadMode('darwin-x64'), 'none')
+  t.is(calibrationLoadMode('darwin-arm64'), undefined, 'unified memory keeps the mapped load')
+  t.is(calibrationLoadMode('android-arm64'), undefined)
+  t.is(calibrationLoadMode('ios-arm64'), undefined)
+})
+
+test('deriveCalibration widens the fit into bounds and floors the ratio at 1', (t) => {
+  const calibration = deriveCalibration(FIT, {
+    backend: 'metal',
+    device: 'Apple A18',
+    kvElementBytes: 1.0625
+  })
+
+  t.is(calibration.weightUpperCoeff, 1, 'a ratio below 1 is not an upper bound')
+  t.is(calibration.fixedOverheadBytes.lower, Math.round(80 * MIB))
+  t.is(
+    calibration.fixedOverheadBytes.upper,
+    Math.round(120 * MIB * 1.2),
+    'upper floored at the worst observed excess before widening'
+  )
+  t.is(calibration.computeBufferBytesPerToken.lower, 800)
+  t.is(calibration.computeBufferBytesPerToken.upper, 1200)
+  t.is(calibration.validated, false, 'the held-out check decides validation, not the fit')
+  t.alike(calibration.audioWindowBytes, { lower: 0, upper: 0 })
+  t.is(calibration.measuredOn?.backend, 'metal')
+  t.is(calibration.measuredOn?.device, 'Apple A18')
+  t.is(calibration.measuredOn?.kvElementBytes, 1.0625)
+  t.is(calibration.notes, undefined, 'a default mmap load needs no note')
+})
+
+test('deriveCalibration records an anonymous weight load', (t) => {
+  const calibration = deriveCalibration(
+    { ...FIT, weightRatio: 1.02 },
+    { backend: 'cpu', kvElementBytes: 2, loadMode: 'none' }
+  )
+
+  t.is(calibration.weightUpperCoeff, 1.02)
+  t.is(calibration.measuredOn?.device, undefined)
+  t.is(calibration.notes?.length, 1)
+  t.ok(calibration.notes?.[0]?.includes("load_mode 'none'"))
+})
+
+test('predictedUpperBytes is the estimator upper bound for one load', (t) => {
+  const calibration = deriveCalibration(FIT, { backend: 'cpu', kvElementBytes: 2 })
+  const artifact = 2 * 1024 * MIB
+  const kv = 512 * MIB
+  const expected =
+    artifact * calibration.weightUpperCoeff +
+    calibration.fixedOverheadBytes.upper +
+    calibration.computeBufferBytesPerToken.upper * 4096 +
+    kv
+  t.is(predictedUpperBytes(calibration, artifact, 4096, kv), expected)
+})
+
+test('fixtureSource is a committable module named after the platform', (t) => {
+  const calibration = deriveCalibration(FIT, {
+    backend: 'vulkan',
+    kvElementBytes: 2
+  })
+  const source = fixtureSource('android-arm64', calibration)
+
+  t.ok(source.includes('export const ANDROID_ARM64_CALIBRATION: PlatformCalibration = {'))
+  // Spelled in pieces so tsc-alias does not rewrite the expected specifier.
+  const typesModule = ['@', 'resources', 'model-fit', 'types'].join('/')
+  t.ok(
+    source.includes(`import type { PlatformCalibration } from '${typesModule}'`),
+    'the fixture imports through the alias, not a compiled relative path'
+  )
+  t.ok(source.includes('backend: "vulkan"'), 'values stay JSON-quoted; prettier settles the style')
+  t.absent(source.includes('"backend":'), 'keys are unquoted')
+})
+
+test('a GPU fixture is keyed by backend so it cannot overwrite the CPU one', (t) => {
+  const calibration = deriveCalibration(FIT, { backend: 'vulkan', kvElementBytes: 1.0625 })
+  const source = fixtureSource('linux-x64-vulkan', calibration)
+
+  t.ok(source.includes('export const LINUX_X64_VULKAN_CALIBRATION: PlatformCalibration = {'))
+  t.absent(source.includes('LINUX_X64_CALIBRATION:'), 'the CPU fixture keeps its own constant')
+})
+
+test('fixtureSource leaves quotes inside a value alone', (t) => {
+  const calibration = deriveCalibration(FIT, {
+    backend: 'cpu',
+    kvElementBytes: 2,
+    loadMode: 'none'
+  })
+  const source = fixtureSource('linux-x64', calibration)
+
+  t.ok(
+    source.includes("load_mode 'none'"),
+    'unquoting every quote would have closed the note early'
+  )
+})
+
+test('CalibrationAbortedError carries a stable reason', (t) => {
+  const error = new CalibrationAbortedError('degenerate-fit', 'cannot separate the coefficients')
+  t.ok(error instanceof Error)
+  t.is(error.name, 'CalibrationAbortedError')
+  t.is(error.reason, 'degenerate-fit')
+  t.is(error.message, 'cannot separate the coefficients')
+})


### PR DESCRIPTION
Stacked on #4238. Review that first.

## 🎯 What problem does this PR solve?

- The calibration procedure lives in a `bare` script, so it can only run on a desktop shell — a phone has no shell, and `@qvac/sdk` reaches the engine only through its worker. `android-arm64` and `ios-arm64` cannot be calibrated at all.
- `scripts/` is in no tsconfig, so the procedure is never typechecked. Two API misuses have been riding along: it awaits `result.response`, which `CompletionRun` does not expose, and passes `params: { maxTokens }`, which is not in `CompletionParams` (the field is `generationParams.predict`).

## 📝 How does it solve it?

- Move the procedure into `calibration/harness.ts` — inside `src/`, so it typechecks — exported as `@qvac/inference/model-fit-calibration`. The caller registers plugins, owns process exit and decides what to do with the run; aborts throw `CalibrationAbortedError` with a stable `reason` instead of calling `Bare.exit`.
- `scripts/calibrate-model-fit.ts` is now a thin desktop entry point over it: same flags including `--gpu`, same output, same exit codes.
- Add a mobile profile (600M/1B/1.7B at 512/4096, 4B held out) selected for android/ios, sized so every load stays under a phone's per-process ceiling.
- The GPU-resident pass carries across as a `gpuPass` option; the run reports `fixtureKey` (`<platform>` or `<platform>-<backend>`) so callers write the right module name.
- Await `run.text` with `generationParams: { predict: 128 }`.

## 🧪 How was it tested?

- `test/calibration-harness.test.ts`, 11/11: profile selection, CPU forcing and load mode, `deriveCalibration` bounds and notes, `predictedUpperBytes`, GPU fixture keying, and `fixtureSource` (including a value containing a quote, which the old unquoting broke).
- `npm run lint`, `tsc --noEmit` on both tsconfigs, prettier, `npm run build`, `npm run build:test`.
- No behavioural change to a run: the module is the same procedure with the same constants. Full harness runs remain the calibration CI job.

**On the existing fixtures.** Their coefficients are unaffected — persistent deltas are read after load and before generation. But the working term was sampled across a window that closed immediately, so `worstTotalBytes = persistent + working` used `working ≈ 0` in every held-out check, and the 64 MiB drift tripwire has never had a chance to fire. Re-measuring the desktop fixtures is worth considering separately.

## 🔌 API Changes

```typescript
import {
  runModelFitCalibration,
  CalibrationAbortedError
} from '@qvac/inference/model-fit-calibration'

// plugins already registered by the host
const run = await runModelFitCalibration({ log: (line) => console.log(line) })
run.fixtureKey // 'linux-x64', or 'linux-x64-vulkan' for a gpuPass run
run.fixtureSource // the module, ready to commit
run.heldOut.holds // false means the coefficients must not ship
```
