### PR TITLE
QVAC-23890 infra: run model-fit calibration on Device Farm phones through the e2e consumer

### DIFF
--- a/.github/scripts/extract-calibration-fixture.mjs
+++ b/.github/scripts/extract-calibration-fixture.mjs
@@ -1,0 +1,115 @@
+// Pulls the model-fit calibration run out of a producer results report and
+// writes the fixture the way it should be committed:
+//
+//   node extract-calibration-fixture.mjs <reports-dir> <out-dir>
+//
+// The e2e test `calibration-model-fit` returns the whole run as its output, so
+// the results JSON is the channel off the device — no logcat parsing. Exits
+// non-zero when there is no run to extract or the held-out check failed, so
+// the job cannot go green on a fixture that must not ship; the fixture is still
+// written in the second case because a failed gate is worth auditing.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const TEST_ID = "calibration-model-fit";
+const [reportsDir = "./reports", outDir = "./calibration-fixture"] =
+  process.argv.slice(2);
+
+function annotate(level, message) {
+  console.log(`::${level}::${message}`);
+}
+
+function fail(message) {
+  annotate("error", message);
+  process.exit(1);
+}
+
+const files = fs.existsSync(reportsDir)
+  ? fs
+      .readdirSync(reportsDir)
+      .filter((f) => f.startsWith("results-") && f.endsWith(".json"))
+  : [];
+if (files.length === 0) {
+  fail(
+    `no results-*.json under ${reportsDir}: the producer did not write a report`,
+  );
+}
+
+let entry;
+for (const file of files) {
+  const report = JSON.parse(
+    fs.readFileSync(path.join(reportsDir, file), "utf8"),
+  );
+  const tests = Array.isArray(report.tests) ? report.tests : [];
+  entry = tests.find((test) => test.testId === TEST_ID);
+  if (entry) break;
+}
+if (!entry) {
+  fail(
+    `${TEST_ID} is not in the producer results; the producer needs QVAC_E2E_CALIBRATION=1 and filter=calibration`,
+  );
+}
+if (!entry.output) {
+  fail(
+    `${TEST_ID} finished ${entry.outcome} without output: ${entry.error ?? "no error recorded"}`,
+  );
+}
+
+let payload;
+try {
+  payload = JSON.parse(entry.output);
+} catch {
+  fail(`${TEST_ID} output is not JSON: ${entry.output.slice(0, 300)}`);
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(
+  path.join(outDir, "calibration-run.json"),
+  `${JSON.stringify(payload, null, 2)}\n`,
+);
+
+if (payload.aborted) {
+  fail(
+    `calibration aborted (${payload.aborted.reason}): ${payload.aborted.message}`,
+  );
+}
+if (!payload.fixtureSource || !payload.platform) {
+  fail("calibration output carries no fixture source");
+}
+
+// A GPU pass names its fixture `<platform>-<backend>`; mobile runs are always
+// system-memory, so `platform` is the fallback rather than the usual case.
+const fixturePath = path.join(
+  outDir,
+  `${payload.fixtureKey ?? payload.platform}.ts`,
+);
+fs.writeFileSync(fixturePath, payload.fixtureSource);
+console.log(`wrote ${fixturePath}`);
+
+const heldOut = payload.heldOut;
+if (heldOut) {
+  const gib = (bytes) => (bytes / 2 ** 30).toFixed(2);
+  console.log(
+    `held-out ${heldOut.model}: worst ${gib(heldOut.worstTotalBytes)} GiB vs predicted upper ${gib(heldOut.predictedUpperBytes)} GiB — ${heldOut.holds ? "PASS" : "FAIL"}`,
+  );
+}
+
+const warnings = Array.isArray(payload.warnings) ? payload.warnings : [];
+for (const warning of warnings) {
+  annotate("warning", `calibration: ${warning}`);
+}
+if (warnings.length > 0) {
+  annotate(
+    "warning",
+    "busy-host warnings above: re-run on an idle device before shipping this fixture",
+  );
+}
+if (!payload.calibration?.validated) {
+  fail(
+    "held-out check failed: the fixture is uploaded for auditing but must not ship",
+  );
+}
+console.log(
+  `validated fixture for ${payload.platform} (${payload.backend}${payload.device ? `, ${payload.device}` : ""})`,
+);

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -31,6 +31,11 @@ on:
         description: "Exclude suites (comma-separated)"
         required: false
         type: string
+      calibration:
+        description: "Model-fit calibration run: the producer loads the opt-in calibration test and the run's fixture is published as an artifact. Pair with filter=calibration."
+        required: false
+        type: boolean
+        default: false
       device-farm-timeout:
         description: "Maximum time in minutes to keep Device Farm session alive."
         required: false
@@ -729,8 +734,13 @@ jobs:
     needs: [build, wait-device-farm-running]
     runs-on: ubuntu-latest
     environment: release
-    timeout-minutes: 120
+    # A calibration run is one ~45 min test plus device boot and downloads;
+    # matches the Device Farm ceiling the dispatcher raises the job to.
+    timeout-minutes: ${{ inputs.calibration && 150 || 120 }}
     env:
+      # Loads the opt-in calibration test into the producer (see
+      # packages/sdk/e2e/tests/test-definitions.ts); empty otherwise.
+      QVAC_E2E_CALIBRATION: ${{ inputs.calibration && '1' || '' }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MQTT_PROTOCOL: ${{ secrets.MQTT_PROTOCOL }}
@@ -751,6 +761,7 @@ jobs:
             .github/actions/sdk-e2e-fail-on-failures
             .github/actions/sdk-e2e-prepare-inference
             .github/actions/sdk-e2e-prepare-test-suite
+            .github/scripts
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -893,6 +904,24 @@ jobs:
         with:
           name: results-android
           path: ${{ inputs.working-directory }}/reports/
+          retention-days: 30
+
+      # The calibration test returns the run as its output, so the fixture is
+      # lifted from the results report rather than parsed out of logcat. Fails
+      # the job on a missing run or a failed held-out check; the artifact still
+      # uploads so a failed gate can be audited.
+      - name: Extract calibration fixture
+        if: ${{ inputs.calibration && always() }}
+        working-directory: ${{ inputs.working-directory }}
+        run: node "$GITHUB_WORKSPACE/.github/scripts/extract-calibration-fixture.mjs" ./reports ./calibration-fixture
+
+      - name: Upload calibration fixture
+        if: ${{ inputs.calibration && always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: calibration-fixture-android-${{ needs.build.outputs.runId }}
+          path: ${{ inputs.working-directory }}/calibration-fixture/
+          if-no-files-found: error
           retention-days: 30
 
       - name: Download baseline (best-effort)

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -30,6 +30,11 @@ on:
         description: "Exclude suites (comma-separated)"
         required: false
         type: string
+      calibration:
+        description: "Model-fit calibration run: the producer loads the opt-in calibration test and the run's fixture is published as an artifact. Pair with filter=calibration."
+        required: false
+        type: boolean
+        default: false
       device-farm-timeout:
         description: "Maximum time in minutes to keep Device Farm session alive."
         required: false
@@ -750,8 +755,13 @@ jobs:
     needs: [build, wait-device-farm-running]
     runs-on: ubuntu-latest
     environment: release
-    timeout-minutes: 120
+    # A calibration run is one ~45 min test plus device boot and downloads;
+    # matches the Device Farm ceiling the dispatcher raises the job to.
+    timeout-minutes: ${{ inputs.calibration && 150 || 120 }}
     env:
+      # Loads the opt-in calibration test into the producer (see
+      # packages/sdk/e2e/tests/test-definitions.ts); empty otherwise.
+      QVAC_E2E_CALIBRATION: ${{ inputs.calibration && '1' || '' }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MQTT_PROTOCOL: ${{ secrets.MQTT_PROTOCOL }}
@@ -770,6 +780,7 @@ jobs:
             .github/actions/sdk-e2e-fail-on-failures
             .github/actions/sdk-e2e-prepare-inference
             .github/actions/sdk-e2e-prepare-test-suite
+            .github/scripts
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
@@ -912,6 +923,24 @@ jobs:
         with:
           name: results-ios
           path: ${{ inputs.working-directory }}/reports/
+          retention-days: 30
+
+      # The calibration test returns the run as its output, so the fixture is
+      # lifted from the results report rather than parsed out of the device
+      # log. Fails the job on a missing run or a failed held-out check; the
+      # artifact still uploads so a failed gate can be audited.
+      - name: Extract calibration fixture
+        if: ${{ inputs.calibration && always() }}
+        working-directory: ${{ inputs.working-directory }}
+        run: node "$GITHUB_WORKSPACE/.github/scripts/extract-calibration-fixture.mjs" ./reports ./calibration-fixture
+
+      - name: Upload calibration fixture
+        if: ${{ inputs.calibration && always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: calibration-fixture-ios-${{ needs.build.outputs.runId }}
+          path: ${{ inputs.working-directory }}/calibration-fixture/
+          if-no-files-found: error
           retention-days: 30
 
       - name: Download baseline (best-effort)

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -122,7 +122,7 @@ on:
       # most 25 inputs and this workflow is at the ceiling. Picking a single
       # runner is what a re-run after a busy-host warning needs anyway.
       calibration:
-        description: "Run the assessModelFit calibration harness (~30 min per platform warm; first run also downloads ~7.5 GiB of models)"
+        description: "Run the assessModelFit calibration harness (~30 min per platform warm; first run also downloads ~7.5 GiB of models). android/ios run it on a Device Farm phone through the e2e consumer (~45 min, downloads ~4.8 GB) and ignore the other platform toggles."
         type: choice
         options:
           - "off"
@@ -130,6 +130,8 @@ on:
           - qvac-macos26-arm64-gpu-calibration
           - qvac-ubuntu2204-x64-gpu-calibration
           - qvac-win25-x64-gpu-calibration
+          - android
+          - ios
         default: "off"
 
   workflow_call:
@@ -210,6 +212,10 @@ jobs:
       run-android: ${{ steps.resolve.outputs.run-android }}
       run-ios: ${{ steps.resolve.outputs.run-ios }}
       run-e2e: ${{ steps.resolve.outputs.run-e2e }}
+      filter: ${{ steps.resolve.outputs.filter }}
+      device-farm-timeout: ${{ steps.resolve.outputs.device-farm-timeout }}
+      calibration-desktop: ${{ steps.resolve.outputs.calibration-desktop }}
+      calibration-mobile: ${{ steps.resolve.outputs.calibration-mobile }}
     steps:
       - name: Resolve configuration
         id: resolve
@@ -223,6 +229,8 @@ jobs:
           RUN_ANDROID: ${{ inputs.android }}
           RUN_IOS: ${{ inputs.ios }}
           RUN_CALIBRATION: ${{ inputs.calibration }}
+          FILTER: ${{ inputs.filter }}
+          DEVICE_FARM_TIMEOUT: ${{ inputs.device-farm-timeout }}
           SUITE: ${{ inputs.suite }}
           SUITE_CUSTOM: ${{ inputs.suite-custom }}
         run: |
@@ -243,6 +251,13 @@ jobs:
           RESOLVED_SNAP=false
           RESOLVED_ANDROID=false
           RESOLVED_IOS=false
+          RESOLVED_FILTER="$FILTER"
+          RESOLVED_CALIBRATION_DESKTOP=off
+          RESOLVED_CALIBRATION_MOBILE=false
+          # Device Farm caps a job at 150 min; a mobile calibration run needs
+          # most of it (21 loads plus ~4.8 GB of downloads on a device with no
+          # model cache), so the default only rises when calibration asks.
+          RESOLVED_DEVICE_FARM_TIMEOUT="${DEVICE_FARM_TIMEOUT:-120}"
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             RESOLVED_DESKTOP="$RUN_DESKTOP"
@@ -257,6 +272,27 @@ jobs:
             if [ "${RUN_CALIBRATION:-off}" != "off" ]; then
               RESOLVED_CALIBRATION=true
             fi
+
+            # Mobile calibration rides the e2e path: the harness runs inside the
+            # consumer's calibration plugin on a Device Farm phone. That means
+            # the android/ios job, only the calibration test, no desktop runner,
+            # and the other platform toggles are ignored so the device is the
+            # run's only consumer.
+            RESOLVED_CALIBRATION_DESKTOP="${RUN_CALIBRATION:-off}"
+            case "${RUN_CALIBRATION:-off}" in
+              android|ios)
+                RESOLVED_DESKTOP=false
+                RESOLVED_ELECTRON=false
+                RESOLVED_SNAP=false
+                RESOLVED_ANDROID=false
+                RESOLVED_IOS=false
+                if [ "$RUN_CALIBRATION" = "android" ]; then RESOLVED_ANDROID=true; else RESOLVED_IOS=true; fi
+                RESOLVED_CALIBRATION_DESKTOP=off
+                RESOLVED_CALIBRATION_MOBILE=true
+                RESOLVED_FILTER=calibration
+                RESOLVED_DEVICE_FARM_TIMEOUT="${DEVICE_FARM_TIMEOUT:-150}"
+                ;;
+            esac
 
             SELECTED="${RESOLVED_DESKTOP}${RESOLVED_ELECTRON}${RESOLVED_SNAP}${RESOLVED_ANDROID}${RESOLVED_IOS}${RESOLVED_CALIBRATION}"
             if [ "$SELECTED" = "falsefalsefalsefalsefalsefalse" ]; then
@@ -322,6 +358,10 @@ jobs:
             echo "run-android=$RESOLVED_ANDROID"
             echo "run-ios=$RESOLVED_IOS"
             echo "run-e2e=$RESOLVED_E2E"
+            echo "filter=$RESOLVED_FILTER"
+            echo "device-farm-timeout=$RESOLVED_DEVICE_FARM_TIMEOUT"
+            echo "calibration-desktop=$RESOLVED_CALIBRATION_DESKTOP"
+            echo "calibration-mobile=$RESOLVED_CALIBRATION_MOBILE"
           } >> "$GITHUB_OUTPUT"
 
   prepare-inference:
@@ -580,10 +620,11 @@ jobs:
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
       consumer-timeout: ${{ fromJSON(inputs.mobile-consumer-timeout || '1200') }}
-      filter: ${{ inputs.filter }}
+      filter: ${{ needs.resolve.outputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
-      device-farm-timeout: ${{ fromJSON(inputs.device-farm-timeout || '120') }}
+      calibration: ${{ needs.resolve.outputs.calibration-mobile == 'true' }}
+      device-farm-timeout: ${{ fromJSON(needs.resolve.outputs.device-farm-timeout) }}
       device-farm-start-timeout: ${{ fromJSON(inputs.device-farm-start-timeout || '15') }}
       device-farm-project-arn: ${{ vars.SDK_DEVICE_FARM_PROJECT_ARN }}
       device-pools: ${{ vars.SDK_ANDROID_DEVICE_FARM_POOLS }}
@@ -613,10 +654,11 @@ jobs:
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
       consumer-timeout: ${{ fromJSON(inputs.mobile-consumer-timeout || '1200') }}
-      filter: ${{ inputs.filter }}
+      filter: ${{ needs.resolve.outputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}
       exclude-suite: ${{ inputs.exclude-suite }}
-      device-farm-timeout: ${{ fromJSON(inputs.device-farm-timeout || '120') }}
+      calibration: ${{ needs.resolve.outputs.calibration-mobile == 'true' }}
+      device-farm-timeout: ${{ fromJSON(needs.resolve.outputs.device-farm-timeout) }}
       device-farm-start-timeout: ${{ fromJSON(inputs.device-farm-start-timeout || '15') }}
       device-farm-project-arn: ${{ vars.SDK_DEVICE_FARM_PROJECT_ARN }}
       ios-device-pools: ${{ vars.SDK_IOS_DEVICE_FARM_POOLS }}
@@ -646,15 +688,18 @@ jobs:
   # GITHUB_JOB), and the run holds the whole host, so dispatch during off-peak
   # windows. The harness's busy-host warnings remain as a backstop — do not
   # ship a fixture from a warned run.
+  # android/ios resolve to `off` here: those run through android-tests /
+  # ios-tests with `calibration: true` instead.
   calibration:
-    if: github.event_name == 'workflow_dispatch' && inputs.calibration != 'off'
+    needs: resolve
+    if: github.event_name == 'workflow_dispatch' && needs.resolve.outputs.calibration-desktop != 'off'
     strategy:
       fail-fast: false
       matrix:
         platform: >-
-          ${{ fromJSON(inputs.calibration == 'all'
+          ${{ fromJSON(needs.resolve.outputs.calibration-desktop == 'all'
             && '["qvac-macos26-arm64-gpu-calibration", "qvac-ubuntu2204-x64-gpu-calibration", "qvac-win25-x64-gpu-calibration"]'
-            || format('["{0}"]', inputs.calibration)) }}
+            || format('["{0}"]', needs.resolve.outputs.calibration-desktop)) }}
     runs-on: ${{ matrix.platform }}
     # Expected completion: ~30 min warm (validated darwin-arm64 runs measured
     # ~15 min for the 21 loads, plus install and build) — the first run on a

--- a/packages/sdk/docs/assess-model-fit.md
+++ b/packages/sdk/docs/assess-model-fit.md
@@ -129,8 +129,13 @@ verdicts on those. Audio
 workloads still return `unknown` on every platform: their coefficients await
 the harness's whisper pass, and the estimator refuses the unmeasured
 placeholders rather than consuming them. Every other platform returns `unknown`
-until its own run lands. See
-`@qvac/inference`'s `src/resources/model-fit/calibration/METHODOLOGY.md`.
+until its own run lands. `android-arm64` and `ios-arm64` are measured through
+the SDK e2e consumer on a Device Farm phone (the test-sdk dispatch's
+`calibration: android|ios`), since the harness has to run where the engine
+does. A fixture is all Android needs; iOS also needs the `process-memory`
+budget's `os_proc_available_memory()` term, and returns `unknown` until that
+native metric exists however good its fixture is. See `@qvac/inference`'s
+`src/resources/model-fit/calibration/METHODOLOGY.md`.
 
 **Discrete-GPU desktops.** The engine executes the model in the GPU's own
 memory there, which system RAM cannot bound, so those platforms' `platforms`

--- a/packages/sdk/e2e/README.md
+++ b/packages/sdk/e2e/README.md
@@ -134,6 +134,14 @@ the same way a real app would add a third-party or in-repo custom plugin. `Plugi
 own client wrapper (`custom-echo-plugin/client`) for the happy-path tests, mirroring how a real consumer would
 use a custom plugin rather than calling `invokePlugin` directly.
 
+[`fixtures/calibration-plugin/`](./fixtures/calibration-plugin) uses the same mechanism for a different job: its
+`calibrate` handler runs `@qvac/inference`'s model-fit calibration harness (via `@qvac/sdk/model-fit-calibration`)
+inside the worker, streams progress, and returns the run. `CalibrationExecutor` turns that into the
+`calibration-model-fit` test's output, which is how a fixture leaves a Device Farm phone. The test is opt-in —
+the producer only loads it with `QVAC_E2E_CALIBRATION=1` (`--filter=calibration` to run nothing else) — because
+it takes ~45 minutes and wants the device to itself. The test-sdk dispatch's `calibration: android|ios` does all
+of that and publishes `calibration-fixture-<platform>-<runId>`.
+
 Both `qvac.config.*` files list built-in plugins explicitly, not just `custom-echo-plugin/plugin`: an empty
 or missing `plugins` array bundles all built-ins by default, but as soon as it's non-empty only the listed
 plugins are included (see `resolvePluginSpecifiers` in `@qvac/sdk/commands/bundle`). Omitting the built-ins here

--- a/packages/sdk/e2e/fixtures/calibration-plugin/client.d.ts
+++ b/packages/sdk/e2e/fixtures/calibration-plugin/client.d.ts
@@ -1,0 +1,64 @@
+export interface CalibrationByteRange {
+  lower: number
+  upper: number
+}
+
+export interface CalibrationCoefficients {
+  weightUpperCoeff: number
+  fixedOverheadBytes: CalibrationByteRange
+  computeBufferBytesPerToken: CalibrationByteRange
+  audioWindowBytes: CalibrationByteRange
+  audioStreamingBytes: CalibrationByteRange
+  validated: boolean
+  measuredAt?: string
+  measuredOn?: { backend: string; device?: string; kvElementBytes: number }
+  notes?: readonly string[]
+}
+
+export interface CalibrationRunSummary {
+  platform: string
+  /** `<platform>` for a system-memory run, `<platform>-<backend>` for a GPU one. */
+  fixtureKey: string
+  gpuPass: boolean
+  profile: {
+    name: 'desktop' | 'mobile'
+    contexts: readonly [number, number]
+    fitModels: readonly string[]
+    heldOutModel: string
+  }
+  loadMode?: 'none'
+  backend: string
+  device?: string
+  cpuForced: boolean
+  measurements: readonly {
+    name: string
+    contextTokens: number
+    artifactBytes: number
+    persistentBytes: number
+    workingBytes: number
+    kvBytes: number
+  }[]
+  fit: {
+    weightRatio: number
+    fixedBytes: number
+    perTokenBytes: number
+    worstExcessBytes: number
+  }
+  calibration: CalibrationCoefficients
+  heldOut: {
+    model: string
+    contextTokens: number
+    worstTotalBytes: number
+    predictedUpperBytes: number
+    holds: boolean
+  }
+  warnings: readonly string[]
+  fixtureSource: string
+}
+
+export type CalibrationChunk =
+  | { type: 'log'; line: string }
+  | { type: 'aborted'; reason: string; message: string }
+  | { type: 'result'; run: CalibrationRunSummary }
+
+export declare function calibrate(modelId: string): AsyncGenerator<CalibrationChunk>

--- a/packages/sdk/e2e/fixtures/calibration-plugin/client.js
+++ b/packages/sdk/e2e/fixtures/calibration-plugin/client.js
@@ -1,0 +1,12 @@
+import { invokePluginStream } from '@qvac/sdk'
+
+export async function* calibrate(modelId) {
+  const stream = invokePluginStream({
+    modelId,
+    handler: 'calibrate',
+    params: {}
+  })
+  for await (const chunk of stream) {
+    yield chunk
+  }
+}

--- a/packages/sdk/e2e/fixtures/calibration-plugin/package.json
+++ b/packages/sdk/e2e/fixtures/calibration-plugin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "custom-calibration-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Runs the @qvac/inference model-fit calibration harness inside the SDK worker (e2e only)",
+  "exports": {
+    "./plugin": "./plugin.js",
+    "./client": {
+      "types": "./client.d.ts",
+      "default": "./client.js"
+    }
+  },
+  "peerDependencies": {
+    "@qvac/sdk": "*",
+    "zod": "*"
+  }
+}

--- a/packages/sdk/e2e/fixtures/calibration-plugin/plugin.js
+++ b/packages/sdk/e2e/fixtures/calibration-plugin/plugin.js
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+import { definePlugin, defineHandler } from '@qvac/sdk'
+import { CalibrationAbortedError, runModelFitCalibration } from '@qvac/sdk/model-fit-calibration'
+
+// Runs the model-fit calibration harness where the engine lives — inside the
+// worker — and streams its progress out so the consumer can log it while the
+// run is in flight. The final chunk carries the whole run: the e2e test
+// returns it as its output, which is how the fixture leaves a phone.
+
+const requestSchema = z.object({}).passthrough()
+
+const chunkSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('log'), line: z.string() }),
+  z.object({ type: z.literal('aborted'), reason: z.string(), message: z.string() }),
+  z.object({ type: z.literal('result'), run: z.object({}).passthrough() })
+])
+
+// Measurements carry the GGUF facts of every load; the fixture does not need
+// them and the test output should stay readable.
+function summarize(run) {
+  return {
+    platform: run.platform,
+    fixtureKey: run.fixtureKey,
+    profile: run.profile,
+    gpuPass: run.gpuPass,
+    ...(run.loadMode ? { loadMode: run.loadMode } : {}),
+    backend: run.backend,
+    ...(run.device ? { device: run.device } : {}),
+    cpuForced: run.cpuForced,
+    measurements: run.measurements.map((m) => ({
+      name: m.name,
+      contextTokens: m.contextTokens,
+      artifactBytes: m.artifactBytes,
+      persistentBytes: m.persistentBytes,
+      workingBytes: m.workingBytes,
+      kvBytes: m.kvBytes
+    })),
+    fit: run.fit,
+    calibration: run.calibration,
+    heldOut: run.heldOut,
+    warnings: run.warnings,
+    fixtureSource: run.fixtureSource
+  }
+}
+
+const calibrationPlugin = definePlugin({
+  modelType: 'calibration',
+  displayName: 'Model-fit calibration (e2e)',
+  addonPackage: 'custom-calibration-plugin',
+  skipPrimaryModelPathValidation: true,
+  loadConfigSchema: z.object({}).passthrough(),
+
+  createModel() {
+    return {
+      model: {
+        async load() {},
+        unload() {}
+      }
+    }
+  },
+
+  handlers: {
+    calibrate: defineHandler({
+      requestSchema,
+      responseSchema: chunkSchema,
+      streaming: true,
+      async *handler() {
+        // The harness reports through a callback; bridge it into this
+        // generator so every line is yielded as soon as it is logged.
+        const queue = []
+        let wake = null
+        let settled = false
+        let run = null
+        let failure = null
+
+        function push(item) {
+          queue.push(item)
+          if (wake) {
+            wake()
+            wake = null
+          }
+        }
+
+        runModelFitCalibration({ log: (line) => push({ type: 'log', line }) })
+          .then((result) => {
+            run = result
+            settled = true
+            push(null)
+          })
+          .catch((error) => {
+            failure = error
+            settled = true
+            push(null)
+          })
+
+        while (true) {
+          while (queue.length > 0) {
+            const item = queue.shift()
+            if (item) yield item
+          }
+          if (settled) break
+          await new Promise((resolve) => {
+            wake = resolve
+          })
+        }
+
+        if (failure) {
+          if (failure instanceof CalibrationAbortedError) {
+            yield { type: 'aborted', reason: failure.reason, message: failure.message }
+            return
+          }
+          throw failure
+        }
+        yield { type: 'result', run: summarize(run) }
+      }
+    })
+  }
+})
+
+export default calibrationPlugin

--- a/packages/sdk/e2e/fixtures/qvac.config.e2e.json
+++ b/packages/sdk/e2e/fixtures/qvac.config.e2e.json
@@ -12,7 +12,8 @@
     "@qvac/sdk/audiogen-ggml/plugin",
     "@qvac/sdk/ggml-vla/plugin",
     "@qvac/sdk/ggml-classification/plugin",
-    "custom-echo-plugin/plugin"
+    "custom-echo-plugin/plugin",
+    "custom-calibration-plugin/plugin"
   ],
   "registryDownloadMaxRetries": 10,
   "registryStreamTimeoutMs": 600000

--- a/packages/sdk/e2e/fixtures/qvac.config.electron.json
+++ b/packages/sdk/e2e/fixtures/qvac.config.electron.json
@@ -9,7 +9,8 @@
     "@qvac/sdk/tts-ggml/plugin",
     "@qvac/sdk/ggml-ocr/plugin",
     "@qvac/sdk/ggml-classification/plugin",
-    "custom-echo-plugin/plugin"
+    "custom-echo-plugin/plugin",
+    "custom-calibration-plugin/plugin"
   ],
   "loggerLevel": "debug",
   "loggerConsoleOutput": true

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@qvac/sdk": "file:..",
     "@qvac/test-suite": "^0.11.0",
+    "custom-calibration-plugin": "file:./fixtures/calibration-plugin",
     "custom-echo-plugin": "file:./fixtures/echo-plugin",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",

--- a/packages/sdk/e2e/tests/calibration-tests.ts
+++ b/packages/sdk/e2e/tests/calibration-tests.ts
@@ -1,0 +1,24 @@
+import type { TestDefinition } from '@qvac/test-suite'
+
+// Runs the assessModelFit calibration harness inside the SDK worker and
+// returns the run — coefficients, held-out check, warnings and the
+// `<platform>.ts` fixture source — as the test output. Opt-in only: the
+// producer loads it when QVAC_E2E_CALIBRATION=1 (see test-definitions.ts),
+// because it takes the better part of an hour and wants the device to itself.
+//
+// The estimate sizes both timeouts the framework derives from it (consumer 2×,
+// producer 3×): the mobile profile is 21 loads plus ~4.8 GB of model downloads
+// on a device with no cache.
+export const calibrationModelFit: TestDefinition = {
+  testId: 'calibration-model-fit',
+  params: {},
+  expectation: { validation: 'type', expectedType: 'string' },
+  suites: ['calibration'],
+  metadata: {
+    category: 'calibration',
+    dependency: 'calibration',
+    estimatedDurationMs: 45 * 60 * 1000
+  }
+}
+
+export const calibrationTests = [calibrationModelFit] as const

--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -102,6 +102,7 @@ import { NoLingeringBareExecutor } from '../shared/executors/node/no-lingering-b
 import { MultiGpuExecutor } from '../shared/executors/multi-gpu-executor.js'
 import { NodeCancellationExecutor } from '../shared/executors/node/cancellation-executor.js'
 import { PluginExecutor } from '../shared/executors/plugin-executor.js'
+import { CalibrationExecutor } from '../shared/executors/calibration-executor.js'
 
 const resources = new ResourceManager({
   downloadTarget: 'desktop'
@@ -248,6 +249,12 @@ resources.define('classification', {
 
 resources.define('echo', {
   type: 'echo',
+  modelSrc: '',
+  skipPreDownload: true
+})
+
+resources.define('calibration', {
+  type: 'calibration',
   modelSrc: '',
   skipPreDownload: true
 })
@@ -737,7 +744,8 @@ export const executor = createExecutor({
     new NoLingeringBareExecutor(),
     new MultiGpuExecutor(resources),
     new NodeCancellationExecutor(resources),
-    new PluginExecutor(resources)
+    new PluginExecutor(resources),
+    new CalibrationExecutor(resources)
   ],
   profiling: {
     init: () => profiler.enable({ mode: 'summary', includeServerBreakdown: true }),

--- a/packages/sdk/e2e/tests/electron/consumer.ts
+++ b/packages/sdk/e2e/tests/electron/consumer.ts
@@ -91,6 +91,7 @@ import { MultiGpuExecutor } from '../shared/executors/multi-gpu-executor.js'
 import { BatchCompletionExecutor } from '../shared/executors/batch-completion-executor.js'
 import { NodeCancellationExecutor } from '../shared/executors/node/cancellation-executor.js'
 import { PluginExecutor } from '../shared/executors/plugin-executor.js'
+import { CalibrationExecutor } from '../shared/executors/calibration-executor.js'
 import { SnapStorageExecutor } from '../shared/executors/node/snap-storage-executor.js'
 import { runSnapRefreshProbe as executeSnapRefreshProbe } from './snap-refresh-probe.js'
 
@@ -196,6 +197,12 @@ resources.define('classification', {
 
 resources.define('echo', {
   type: 'echo',
+  modelSrc: '',
+  skipPreDownload: true
+})
+
+resources.define('calibration', {
+  type: 'calibration',
   modelSrc: '',
   skipPreDownload: true
 })
@@ -609,7 +616,8 @@ export const executor = createExecutor({
     new ConfigExecutor(),
     new MultiGpuExecutor(resources),
     new NodeCancellationExecutor(resources),
-    new PluginExecutor(resources)
+    new PluginExecutor(resources),
+    new CalibrationExecutor(resources)
   ],
   profiling: {
     init: () => profiler.enable({ mode: 'summary', includeServerBreakdown: true }),

--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -73,6 +73,7 @@ import { SystemResourcesExecutor } from '../shared/executors/system-resources-ex
 import { ConfigExecutor } from '../shared/executors/config-executor.js'
 import { MobileCancellationExecutor } from './executors/cancellation-executor.js'
 import { PluginExecutor } from '../shared/executors/plugin-executor.js'
+import { CalibrationExecutor } from '../shared/executors/calibration-executor.js'
 
 const resources = new ResourceManager({
   downloadTarget: 'mobile',
@@ -177,6 +178,12 @@ resources.define('classification', {
 
 resources.define('echo', {
   type: 'echo',
+  modelSrc: '',
+  skipPreDownload: true
+})
+
+resources.define('calibration', {
+  type: 'calibration',
   modelSrc: '',
   skipPreDownload: true
 })
@@ -699,7 +706,8 @@ export const executor = createExecutor({
     new SystemResourcesExecutor(),
     new ConfigExecutor(),
     new MobileCancellationExecutor(resources),
-    new PluginExecutor(resources)
+    new PluginExecutor(resources),
+    new CalibrationExecutor(resources)
   ],
   profiling: {
     init: () => profiler.enable({ mode: 'summary', includeServerBreakdown: true }),

--- a/packages/sdk/e2e/tests/shared/executors/calibration-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/calibration-executor.ts
@@ -1,0 +1,60 @@
+import type { TestResult, Expectation } from '@qvac/test-suite'
+import { calibrate, type CalibrationRunSummary } from 'custom-calibration-plugin/client'
+import { AbstractModelExecutor } from './abstract-model-executor.js'
+import { calibrationTests, calibrationModelFit } from '../../calibration-tests.js'
+
+/**
+ * Drives `custom-calibration-plugin` (`fixtures/calibration-plugin/`), which
+ * runs the @qvac/inference model-fit harness inside the worker. Progress is
+ * relayed to the console as it streams; the run itself becomes the test
+ * output, so the producer's results JSON carries the fixture off the device.
+ * The fixture is also echoed between markers for anyone reading the device
+ * log directly.
+ */
+export class CalibrationExecutor extends AbstractModelExecutor<typeof calibrationTests> {
+  pattern = /^calibration-/
+
+  protected handlers = {
+    [calibrationModelFit.testId]: this.modelFit.bind(this)
+  }
+
+  async modelFit(_params: Record<string, never>, _expectation: Expectation): Promise<TestResult> {
+    try {
+      const modelId = await this.resources.ensureLoaded('calibration')
+      let run: CalibrationRunSummary | undefined
+      let aborted: { reason: string; message: string } | undefined
+
+      for await (const chunk of calibrate(modelId)) {
+        if (chunk.type === 'log') {
+          console.log(`[calibration] ${chunk.line}`)
+        } else if (chunk.type === 'aborted') {
+          aborted = { reason: chunk.reason, message: chunk.message }
+        } else {
+          run = chunk.run
+        }
+      }
+
+      if (aborted) {
+        console.log(`[calibration] aborted (${aborted.reason}): ${aborted.message}`)
+        return { passed: false, output: JSON.stringify({ aborted }) }
+      }
+      if (!run) {
+        return { passed: false, output: 'calibration stream ended without a result' }
+      }
+
+      console.log(`----- BEGIN CALIBRATION FIXTURE ${run.platform}.ts -----`)
+      console.log(run.fixtureSource)
+      console.log(`----- END CALIBRATION FIXTURE ${run.platform}.ts -----`)
+      for (const warning of run.warnings) {
+        console.log(`[calibration] warning: ${warning}`)
+      }
+
+      // A failed held-out check still returns the run: coefficients that did
+      // not validate are worth auditing even though they must not ship.
+      return { passed: run.calibration.validated, output: JSON.stringify(run) }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      return { passed: false, output: `Calibration failed: ${msg}` }
+    }
+  }
+}

--- a/packages/sdk/e2e/tests/test-definitions.ts
+++ b/packages/sdk/e2e/tests/test-definitions.ts
@@ -42,6 +42,17 @@ import { vlaTests } from './vla-tests.js'
 import { pluginTests } from './plugin-tests.js'
 import { snapStorageTests } from './snap-storage-tests.js'
 import { systemResourcesTests } from './system-resources-tests.js'
+import { calibrationTests } from './calibration-tests.js'
+
+// Model-fit calibration is opt-in: it runs for the better part of an hour and
+// wants the device to itself, so a full run never loads it. The producer opts
+// in with QVAC_E2E_CALIBRATION=1; read through globalThis because this module
+// is also bundled into the consumers, where `process` may not exist.
+function includeCalibration() {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    ?.env
+  return env?.['QVAC_E2E_CALIBRATION'] === '1'
+}
 
 // Model loading tests
 export const modelLoadLlm: TestDefinition = {
@@ -372,6 +383,8 @@ export const tests = [
 
   // Local hardware capabilities and on-demand usage sampling
   ...systemResourcesTests,
+  // Model-fit calibration harness (opt-in via QVAC_E2E_CALIBRATION=1)
+  ...(includeCalibration() ? calibrationTests : []),
 
   // Additional model tests
   modelSwitchLlm,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -127,6 +127,10 @@
       "types": "./dist/src/plugin-utils.d.ts",
       "import": "./dist/src/plugin-utils.js"
     },
+    "./model-fit-calibration": {
+      "types": "./dist/src/model-fit-calibration.d.ts",
+      "import": "./dist/src/model-fit-calibration.js"
+    },
     "./schemas": {
       "types": "./dist/src/schemas/public.d.ts",
       "import": "./dist/src/schemas/public.js",

--- a/packages/sdk/src/model-fit-calibration.ts
+++ b/packages/sdk/src/model-fit-calibration.ts
@@ -1,0 +1,5 @@
+// `@qvac/sdk/model-fit-calibration` subpath. The harness lives in
+// @qvac/inference; the SDK re-exports it so a worker-side plugin (the e2e
+// consumer's calibration plugin) reaches the engine's own copy instead of
+// resolving @qvac/inference itself and risking a second instance.
+export * from '@qvac/inference/model-fit-calibration'


### PR DESCRIPTION
Draft: needs an `@qvac/inference` release carrying #4245, plus the version bump in `packages/sdk/package.json`. The dispatch can be exercised before that with `inference-source: branch`.

Stacked on #4245 → #4238.

## 🎯 What problem does this PR solve?

- `assessModelFit` returns `unknown` on `android-arm64` and `ios-arm64` because no fixture exists, and nothing can measure one: the harness has to run where the engine does, and on a phone that is inside the worker.

## 📝 How does it solve it?

- `@qvac/sdk/model-fit-calibration` re-exports the harness so a worker-side plugin reaches the engine's own `@qvac/inference` copy.
- The e2e consumer bundles `custom-calibration-plugin`: one streaming handler runs the harness in the worker and relays log lines; `CalibrationExecutor` drives it for the `calibration-model-fit` test and returns the whole run as the test output, so the fixture leaves the device in `results-<runId>.json` rather than via logcat.
- The test is loaded only when the producer has `QVAC_E2E_CALIBRATION=1`; a normal e2e run never includes it.
- `test-sdk.yml`'s `calibration` input gains `android`/`ios`, routing to the mobile workflows with `filter=calibration` and a 150-minute Device Farm ceiling. Both mobile workflows gain a `calibration` boolean, and after the results upload run `.github/scripts/extract-calibration-fixture.mjs`, publishing `calibration-fixture-<platform>-<runId>`.
- The extractor exits non-zero on a missing run, an abort, or a failed held-out check, so the job cannot go green on a fixture that must not ship. The fixture still uploads on a failed gate for auditing.

## 🧪 How was it tested?

- Extractor exercised against synthetic producer reports: validated, backend-keyed fixture name, failed held-out gate (exit 1, fixture still written, warnings annotated), abort (exit 1, run JSON only), test absent, and test present with no output. All behave as intended.
- `actionlint` on the three workflows (only pre-existing shellcheck infos), `tsc --noEmit` on the SDK and the e2e consumer, `lunte`, prettier.
- No Device Farm dispatch has run yet — that is the next step once #4245 is in a release.

**Scope note.** A fixture is all `android-arm64` needs. `ios-arm64` assesses on the `process-memory` basis, whose budget needs `os_proc_available_memory()`; with no native source `resolveBudget` returns `unknown` before calibration is consulted, so an iOS run measures real coefficients but buys no verdicts until that metric exists.
