### PR TITLE
QVAC-24420 asr-ggml: consume the silero VAD GPU crash fix (speech-cpp 2026-09-03)

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -14,6 +14,18 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ## [Unreleased]
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-09-03. Silero VAD now honors
+  `use_gpu`: the compute backends match the weight placement, fixing the
+  ggml_backend_sched abort ("pre-allocated tensor in a buffer that cannot
+  run the operation") that killed every `use_gpu=true` VAD context init on
+  GPU builds (Metal, Vulkan, CUDA, HIP), and the VAD LSTM input is made
+  contiguous to satisfy the CUDA mul-mat-vec kernel's stride requirement.
+  The addon creates its VAD context with the default (CPU) parameters, so
+  runtime behavior is unchanged; the fix matters for anything that opts
+  VAD into the GPU.
+
 ## [0.4.2] - 2026-09-01
 
 ### Changed

--- a/packages/asr-ggml/vcpkg-configuration.json
+++ b/packages/asr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "dca20a940d85d6741285c888b53bd10da29c0723",
+    "baseline": "57a0ca7717124b662f6a94dfd4d5e00850ff4471",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/asr-ggml/vcpkg-configuration.json
+++ b/packages/asr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "57a0ca7717124b662f6a94dfd4d5e00850ff4471",
+    "baseline": "c05d1f85f013632f8b164f01a9c1802ddfcc35c2",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/asr-ggml/vcpkg-configuration.json
+++ b/packages/asr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "c05d1f85f013632f8b164f01a9c1802ddfcc35c2",
+    "baseline": "dca20a940d85d6741285c888b53bd10da29c0723",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03",
       "default-features": false,
       "features": [
         "whisper",
@@ -24,7 +24,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03",
       "default-features": false,
       "features": [
         "whisper",
@@ -36,7 +36,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03",
       "default-features": false,
       "features": [
         "whisper",
@@ -61,7 +61,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-01#2",
+          "version>=": "2026-09-03",
           "default-features": false,
           "features": [
             "cuda"


### PR DESCRIPTION
Consume the silero VAD GPU crash fix: bumps the `speech-cpp` pin to `2026-09-03` (tetherto/qvac-fabric-speech.cpp#203 via tetherto/qvac-registry-vcpkg#351, merged as `c05d1f85`). The registry baseline is untouched per review; the `version>=` floor resolves the new port version on its own, and the bump is recorded in the package changelog.

silero VAD now honors `use_gpu` — the compute backends match the weight placement, fixing the `ggml_backend_sched` abort ("pre-allocated tensor in a buffer that cannot run the operation") that killed every `use_gpu=true` VAD init on GPU builds — and the VAD LSTM input is made contiguous for the CUDA mul-mat-vec kernel's stride requirement. The default stays CPU, so asr-ggml sees no behavior change unless it opts in.

Verified upstream of this PR on every GPU backend, each with Pratik's repro (`whisper-vad-speech-segments --use-gpu`, silero-v5.1.2, jfk.wav; previously exit 134, now exit 0 with CPU-identical segments) plus the `test-vad-gpu` contract test:

| Backend | Hardware |
|---|---|
| CUDA | RTX 5090 (x86), NVIDIA GB10 Spark (arm64) |
| Vulkan | RTX 5090, AMD RADV iGPU, Radeon 8060S (Strix) |
| Metal | Apple M3 Ultra |
| HIP | Radeon 8060S (Strix, gfx1151) |

On Metal and HIP the parent commit `bcd7dbd5` was also rebuilt on the same machines and reproduces the exact abort, confirming the fix is causal.

Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218052115546696
  - https://app.asana.com/0/0/1218052115546685
  - https://app.asana.com/0/0/1218052115546692

Replaces #4239 (same branch content, moved off the fork so the on-pr workflows run without the fork-approval gate). Review feedback from there is already applied: the registry baseline is untouched and the floor bump is recorded in the package changelog.
