### PR TITLE
fix[notask]: pin bare-module-lexer to 1.6.5 in check-bundler-requires

### DIFF
--- a/scripts/ci/check-bundler-requires.mjs
+++ b/scripts/ci/check-bundler-requires.mjs
@@ -21,6 +21,15 @@ const LEXER_PACKAGE = 'bare-module-lexer'
 // picks up whatever version happens to be hoisted nearby, and the desync this
 // check hunts for differs between lexer releases.
 const BUNDLER_SPEC = 'bare-pack@^1.4.7'
+// bare-module-lexer 1.6.6 prebuilds reference node_api_is_sharedarraybuffer,
+// which Node 18 (the sanity-checks runtime) does not export, so requiring the
+// lexer kills the node process at dynamic-link time — not a catchable error.
+// Pin the last release that loads under Node 18. The pin satisfies bare-pack's
+// ^1.6.0 range, so npm hoists one copy and the scan still uses the lexer
+// bare-pack resolves; assertPinnedLexer turns any future range drift into a
+// visible infrastructure failure instead of a silently ignored pin. Drop the
+// pin once the runner moves off Node 18 or a lexer release loads there again.
+const LEXER_SPEC = 'bare-module-lexer@1.6.5'
 const REQUIRE_PATTERN = /require\(\s*['"]([^'"]+)['"]\s*\)/g
 // Directory names that never enter a mobile bundle. Generators under `scripts/`
 // and fixtures under `test/` embed require-looking strings in output text
@@ -70,23 +79,34 @@ function installBundler() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bundler-requires-'))
   const result = spawnSync(
     'npm',
-    ['install', '--no-save', '--no-audit', '--no-fund', '--prefix', root, BUNDLER_SPEC],
+    ['install', '--no-save', '--no-audit', '--no-fund', '--prefix', root, BUNDLER_SPEC, LEXER_SPEC],
     { encoding: 'utf8' }
   )
   if (result.status !== 0) {
-    throw new Error(`failed to install ${BUNDLER_SPEC}: ${result.stderr || result.stdout}`)
+    throw new Error(`failed to install ${BUNDLER_SPEC} ${LEXER_SPEC}: ${result.stderr || result.stdout}`)
   }
   return path.join(root, 'node_modules', 'bare-pack', 'package.json')
+}
+
+function assertPinnedLexer(version) {
+  const pinned = LEXER_SPEC.slice(LEXER_SPEC.lastIndexOf('@') + 1)
+  if (version !== pinned) {
+    throw new Error(
+      `${BUNDLER_SPEC} resolved ${LEXER_PACKAGE}@${version} instead of the pinned ${LEXER_SPEC}; ` +
+        'the pin no longer satisfies bare-pack and must be revisited'
+    )
+  }
 }
 
 function loadLexer() {
   const bundlerManifest = installBundler()
   const lexerPath = createRequire(bundlerManifest).resolve(LEXER_PACKAGE)
-  const lexer = createRequire(import.meta.url)(lexerPath)
   const version = JSON.parse(
     fs.readFileSync(path.join(path.dirname(lexerPath), 'package.json'), 'utf8')
   ).version
-  process.stdout.write(`Using ${LEXER_PACKAGE}@${version} as resolved by ${BUNDLER_SPEC}.\n`)
+  assertPinnedLexer(version)
+  const lexer = createRequire(import.meta.url)(lexerPath)
+  process.stdout.write(`Using ${LEXER_PACKAGE}@${version} (pinned; resolved via ${BUNDLER_SPEC}).\n`)
   return lexer
 }
 


### PR DESCRIPTION
Unblocks every PR going through the shared `sanity-checks` action, all red since ~12:17 UTC today.

## Problem

`check-bundler-requires.mjs` installs `bare-pack@^1.4.7` unpinned, and its transitive `bare-module-lexer ^1.6.0` now resolves **1.6.6 (published 2026-09-03 12:17 UTC)**, whose linux-x64 prebuild references `node_api_is_sharedarraybuffer` — a symbol Node 18 (the sanity-checks runtime, `node-version: 18.x`) does not export. Requiring it kills the node process at dynamic-link time:

```
node: symbol lookup error: .../bare-module-lexer/prebuilds/linux-x64/bare-module-lexer.node: undefined symbol: node_api_is_sharedarraybuffer
```

That bypasses the script's own error handling (no catchable JS error), so the composite reports "check-bundler-requires could not run (infrastructure failure, not a hidden require)" and fails the job. Timeline confirms causality: the last green run (feature-on-merge-nx, 10:38 UTC) resolved 1.6.5; every run after the 1.6.6 publish fails identically — e.g. both red sanity jobs on #4247.

## Fix

- Install `bare-module-lexer@1.6.5` (the last release that loads under Node 18) in the same temp prefix. It satisfies bare-pack's `^1.6.0`, so npm hoists a single copy and the scan still uses the lexer bare-pack resolves — the check's original invariant holds.
- Assert the resolved version against the pin **before** requiring the lexer, so future bare-pack range drift surfaces as a clear infrastructure error instead of a silently inert pin (or another linker abort).

Verified locally: the patched check resolves 1.6.5 and scans `packages/asr-ggml` clean (`Checked 14 script(s) ... 0 require(s) hidden`, rc=0). 1.6.5-under-Node-18 is proven by this morning's green CI runs, which resolved it on the same runners.

## Follow-ups (out of scope here)

- Move the sanity-checks job off Node 18 (EOL) to 20/22 — the proper fix; the prebuild loads fine on Node 22. The pin carries a comment saying to drop it then.
- No test added: the script is a self-executing CI entry point with no existing harness (same shape as its previous change in #4185); the version assert makes the failure mode self-reporting.

Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218141990723827