### PR TITLE
QVAC-24215 feat[api]: assess Windows GPUs against the budget DXGI grants

### DIFF
--- a/packages/inference/src/resources/collector.ts
+++ b/packages/inference/src/resources/collector.ts
@@ -34,8 +34,12 @@ const GPU_UNIFIED_MEMORY_REASON =
 // DXGI reports CurrentUsage and Budget, which are what this process is using
 // and may use — not what the device holds. An idle machine makes Budget look
 // like VRAM, so no value-level check can separate them; only the platform can.
-const GPU_PROCESS_SCOPE_REASON =
-  'Windows reports per-process GPU usage and budget, not device-wide memory'
+// Reported under the `budget` scope rather than discarded: what a process may
+// allocate is exactly what an admission decision needs.
+const gpuBudgetProvenance = {
+  source: GPU_SOURCE,
+  scope: 'budget'
+} as const
 
 // A sampled total that matches what the device declares for itself is
 // describing that device's own pool. Measured: a discrete card agrees within a
@@ -106,14 +110,15 @@ function normalizeDeclaredGPUMemory(value: unknown, unified: unknown): ResourceM
 
 function normalizeSampledGPUMemory(
   value: unknown,
-  deviceScoped: boolean,
+  scope: 'device' | 'budget' | undefined,
   reason: string
 ): ResourceMetric<number> {
   if (value === undefined || value === null) return unavailableMetric()
-  const normalized = normalizeNonNegativeMetric(value, gpuDeviceProvenance)
+  const provenance = scope === 'budget' ? gpuBudgetProvenance : gpuDeviceProvenance
+  const normalized = normalizeNonNegativeMetric(value, provenance)
   if (normalized.status !== 'supported') return normalized
 
-  return deviceScoped ? normalized : unverifiedMetric(reason)
+  return scope ? normalized : unverifiedMetric(reason)
 }
 
 function normalizeDriverCapabilities(drivers: NativeGPUCapabilities['drivers']) {
@@ -196,11 +201,16 @@ function normalizeGPUSample(
   device: GPUMemoryFacts | undefined,
   platform: string
 ) {
-  const processScoped = platform === 'win32'
-  const deviceScoped =
-    !processScoped &&
-    gpuMemoryIsDeviceScoped(device?.declaredMemory, device?.unifiedMemory, usage.memoryTotal)
-  const scopeReason = processScoped ? GPU_PROCESS_SCOPE_REASON : GPU_MEMORY_SCOPE_REASON
+  // win32 values come from DXGI's per-process query, so they describe this
+  // process's budget rather than the device — real, but a different quantity.
+  const scope: 'device' | 'budget' | undefined =
+    platform === 'win32'
+      ? device?.unifiedMemory === false
+        ? 'budget'
+        : undefined
+      : gpuMemoryIsDeviceScoped(device?.declaredMemory, device?.unifiedMemory, usage.memoryTotal)
+        ? 'device'
+        : undefined
 
   return {
     id,
@@ -209,10 +219,10 @@ function normalizeGPUSample(
     decode: normalizeUtilizationMetric(usage.decode, gpuDeviceProvenance),
     memoryUsedBytes: normalizeSampledGPUMemory(
       usage.memoryUsed,
-      deviceScoped,
-      processScoped ? GPU_PROCESS_SCOPE_REASON : 'GPU memory usage scope is unverified'
+      scope,
+      'GPU memory usage scope is unverified'
     ),
-    memoryTotalBytes: normalizeSampledGPUMemory(usage.memoryTotal, deviceScoped, scopeReason),
+    memoryTotalBytes: normalizeSampledGPUMemory(usage.memoryTotal, scope, GPU_MEMORY_SCOPE_REASON),
     powerWatts: normalizeNonNegativeMetric(usage.power, gpuDeviceProvenance),
     temperatureCelsius: normalizeNonNegativeMetric(usage.temperature, gpuDeviceProvenance)
   } satisfies GPUResourceSample

--- a/packages/inference/src/resources/model-fit/assess.ts
+++ b/packages/inference/src/resources/model-fit/assess.ts
@@ -96,7 +96,11 @@ export function assessModelFitFromResources(options: AssessModelFitOptions): Ass
   const gpuMode = gpuTarget !== undefined && gpuCalibration !== undefined
   const effectiveCalibration = gpuMode ? gpuCalibration : calibration
 
-  const basis: ModelFitBasis = gpuMode ? 'device-memory' : resolveBasis(platform)
+  const basis: ModelFitBasis = gpuMode
+    ? gpuTarget!.scope === 'budget'
+      ? 'device-budget'
+      : 'device-memory'
+    : resolveBasis(platform)
   const reasons: string[] = []
   const assumptions: string[] = [
     `execution mode '${execution}' is a declared assumption used for aggregation only; the SDK does not schedule, serialize, or reserve anything`,
@@ -119,6 +123,9 @@ export function assessModelFitFromResources(options: AssessModelFitOptions): Ass
     gpuMode && gpuTarget
       ? gpuBudget(gpuTarget, platform)
       : resolveBudget(resources, platform, basis, reasons)
+
+  // A GPU load also consumes system RAM, so the system budget bounds it too.
+  const alsoBoundBy = gpuMode ? resolveBudget(resources, platform, 'system-memory', []) : undefined
 
   if (!platform) {
     reasons.push('the runtime platform is not one this assessment covers')
@@ -143,7 +150,7 @@ export function assessModelFitFromResources(options: AssessModelFitOptions): Ass
   }
 
   const modelResults: ModelFitModelResult[] = evaluated.map(({ candidate, result }) =>
-    toModelResult(candidate, result, budget)
+    toModelResult(candidate, result, budget, alsoBoundBy)
   )
 
   const estimates = evaluated
@@ -160,7 +167,13 @@ export function assessModelFitFromResources(options: AssessModelFitOptions): Ass
   }
 
   const verdict: ModelFitVerdict =
-    !budget || !combined ? 'unknown' : compare(combined, budget.availableAfterReserveBytes)
+    !budget || !combined ? 'unknown' : verdictAgainst(combined, budget, alsoBoundBy)
+
+  if (gpuMode && combined && alsoBoundBy) {
+    reasons.push(
+      'a GPU load is also paid for in system RAM, so every verdict is the more pessimistic of the GPU and system budgets'
+    )
+  }
 
   if (budget && combined) {
     reasons.push(
@@ -323,12 +336,28 @@ function hasGpu(resources: SystemResources): boolean {
   return gpus.status === 'supported' && gpus.value.length > 0
 }
 
-/** The GPU the engine would execute on, when its memory is device-scoped. */
+/** The GPU the engine would execute on, when its memory can carry a budget. */
 interface GpuTarget {
   backend: string
   totalBytes: number
   usedBytes: number
+  /** `device` is the card's own memory; `budget` is this process's allowance. */
+  scope: 'device' | 'budget'
   device?: string
+}
+
+// An adapter too small to hold any model we assess is not a candidate for one.
+// Windows classifies the Intel iGPU as dedicated because it declares 128 MiB of
+// its own, which is otherwise indistinguishable from a real card by type.
+const MIN_USABLE_GPU_BYTES = GIB
+
+// Only excludes a card when the declared memory says so. An unreported total
+// leaves it counted, so an unknown device makes the choice ambiguous rather
+// than silently disappearing from it.
+function tooSmallToHostAModel(gpu: GPUResourceCapabilities) {
+  return (
+    gpu.memoryTotalBytes.status === 'supported' && gpu.memoryTotalBytes.value < MIN_USABLE_GPU_BYTES
+  )
 }
 
 // Ordered by the backends the addon actually builds, not by what the device's
@@ -367,9 +396,12 @@ function resolveGpuTarget(resources: SystemResources): GpuTarget | undefined {
   // Count the cards first. Filtering on the readings would let a GPU with a
   // failed sample drop out of the count, leaving its neighbour looking like the
   // only candidate — while the engine remains free to use the one that dropped.
-  const candidates = gpus.value.filter(
-    (gpu) => gpu.unifiedMemory.status === 'supported' && !gpu.unifiedMemory.value
-  )
+  // Only a device property may exclude a card from the count, never a reading:
+  // an adapter that cannot hold a model is not a rival for one.
+  const candidates = gpus.value.filter((gpu) => {
+    if (gpu.unifiedMemory.status !== 'supported' || gpu.unifiedMemory.value) return false
+    return !tooSmallToHostAModel(gpu)
+  })
   if (candidates.length !== 1) return undefined
 
   const gpu = candidates[0]!
@@ -383,10 +415,13 @@ function resolveGpuTarget(resources: SystemResources): GpuTarget | undefined {
   if (sample.memoryTotalBytes.value <= 0) return undefined
   if (sample.memoryUsedBytes.value > sample.memoryTotalBytes.value) return undefined
 
+  const scope = sample.memoryTotalBytes.provenance.scope === 'budget' ? 'budget' : 'device'
+
   return {
     backend,
     totalBytes: sample.memoryTotalBytes.value,
     usedBytes: sample.memoryUsedBytes.value,
+    scope,
     ...(gpu.name.status === 'supported' && { device: gpu.name.value })
   }
 }
@@ -401,12 +436,30 @@ function gpuBudget(target: GpuTarget, platform: ModelFitPlatform | undefined) {
   }
 }
 
-// Windows is deliberately absent from the GPU basis: its GPU readings are
-// per-process (DXGI CurrentUsage and Budget), so the collector never grades
-// them device-scoped and no GPU target resolves there. When it does become
-// available, note that a GPU load there is also paid for in system RAM —
-// loading a 2382 MiB model onto the card raised RSS by 2918 MiB, against
-// 868 MiB on linux — so it will need both bounds, on every verdict.
+/**
+ * A verdict against the GPU budget and, when one applies, system memory too.
+ *
+ * A GPU load is paid for in system RAM as well — a 2382 MiB model raised RSS
+ * by 2918 MiB on win32 and 868 MiB on linux — so a host with the card for it
+ * but not the RAM must not read as a fit. Applied to every verdict, per model
+ * and combined alike, so the two can never disagree.
+ */
+function verdictAgainst(
+  estimate: ByteRange,
+  budget: NonNullable<AssessModelFitResult['budget']>,
+  alsoBoundBy: AssessModelFitResult['budget']
+): ModelFitVerdict {
+  const primary = compare(estimate, budget.availableAfterReserveBytes)
+  if (!alsoBoundBy) return primary
+  return worst(primary, compare(estimate, alsoBoundBy.availableAfterReserveBytes))
+}
+
+/** The more pessimistic of two verdicts. */
+function worst(a: ModelFitVerdict, b: ModelFitVerdict): ModelFitVerdict {
+  if (a === 'likely-too-large' || b === 'likely-too-large') return 'likely-too-large'
+  if (a === 'unknown' || b === 'unknown') return 'unknown'
+  return 'likely-fits'
+}
 
 /**
  * Picks the budget basis for a platform.
@@ -425,6 +478,7 @@ function resolveBasis(platform: ModelFitPlatform | undefined): ModelFitBasis {
 function basisEvidence(basis: ModelFitBasis) {
   if (basis === 'process-memory') return 'this process’s own memory ceiling'
   if (basis === 'device-memory') return 'the GPU’s own memory'
+  if (basis === 'device-budget') return 'the GPU memory this process is budgeted'
   return 'system memory'
 }
 
@@ -541,7 +595,8 @@ function compare(estimate: ByteRange, budget: number): ModelFitVerdict {
 function toModelResult(
   candidate: ModelFitCandidate,
   result: EstimatorResult,
-  budget: AssessModelFitResult['budget']
+  budget: AssessModelFitResult['budget'],
+  alsoBoundBy: AssessModelFitResult['budget']
 ): ModelFitModelResult {
   if (result.kind === 'unknown') {
     return {
@@ -558,7 +613,7 @@ function toModelResult(
 
   return {
     name: candidate.model.name,
-    verdict: budget ? compare(total, budget.availableAfterReserveBytes) : 'unknown',
+    verdict: budget ? verdictAgainst(total, budget, alsoBoundBy) : 'unknown',
     estimate: { lowerBoundBytes: total.lower, upperBoundBytes: total.upper },
     estimatorVersion: result.estimatorVersion,
     reasons: budget

--- a/packages/inference/src/schemas/assess-model-fit.ts
+++ b/packages/inference/src/schemas/assess-model-fit.ts
@@ -114,7 +114,12 @@ const byteRangeSchema = z.object({
  *   on its per-process footprint against a limit well below device RAM, so a
  *   system-wide budget there would defend verdicts the OS does not honor.
  */
-export const modelFitBasisSchema = z.enum(['system-memory', 'process-memory', 'device-memory'])
+export const modelFitBasisSchema = z.enum([
+  'system-memory',
+  'process-memory',
+  'device-memory',
+  'device-budget'
+])
 
 export const modelFitBudgetSchema = z.object({
   totalBytes: z
@@ -145,7 +150,7 @@ export const modelFitModelResultSchema = z.object({
 export const assessModelFitResultSchema = z.object({
   verdict: modelFitVerdictSchema.describe('Combined verdict across every candidate.'),
   basis: modelFitBasisSchema.describe(
-    'The evidence the budget was derived from — system RAM, the per-process ceiling on iOS, or a discrete GPU’s own memory when the model executes there and that GPU’s readings are device-scoped.'
+    'The evidence the budget was derived from — system RAM, the per-process ceiling on iOS, a discrete GPU’s own memory, or on Windows the GPU memory budget the OS grants this process. The two device bases also require the system-memory budget to hold.'
   ),
   execution: modelFitExecutionSchema.describe('The declared execution mode this result assumed.'),
   budget: modelFitBudgetSchema.optional().describe('Absent when memory evidence was unusable.'),

--- a/packages/inference/test/assess-model-fit.test.ts
+++ b/packages/inference/test/assess-model-fit.test.ts
@@ -1010,8 +1010,9 @@ function discreteGpuResources(options: {
   vramUsedBytes: number
   systemTotalBytes?: number
   systemUsedBytes?: number
+  gpuScope?: 'device' | 'budget'
 }) {
-  const provenance = { source: 'test', scope: 'device' as const }
+  const provenance = { source: 'test', scope: options.gpuScope ?? ('device' as const) }
   const system = { source: 'test', scope: 'system' as const }
   const total = options.systemTotalBytes ?? 64 * GIB
   const used = options.systemUsedBytes ?? 16 * GIB
@@ -1176,6 +1177,103 @@ test('assess: unverified GPU samples cannot form a device budget', (t) => {
 
   t.is(result.verdict, 'unknown')
   t.is(result.basis, 'system-memory')
+})
+
+// DXGI gives a per-process budget, not the device's memory. It still answers
+// the question admission asks — what may this process allocate — so it gets
+// its own basis rather than being discarded.
+test('assess: windows budgets against the GPU allowance it is granted', (t) => {
+  const result = assessModelFitFromResources({
+    models: [candidate()],
+    execution: 'sequential',
+    resources: discreteGpuResources({
+      vramTotalBytes: 20 * GIB,
+      vramUsedBytes: 1 * GIB,
+      gpuScope: 'budget'
+    }),
+    platform: 'win32-x64',
+    calibration: calibration(),
+    resolveGpuCalibration: () => calibration(),
+    resolveProfile: () => profile()
+  })
+
+  t.is(result.basis, 'device-budget')
+  t.is(result.verdict, 'likely-fits')
+  t.ok(result.models[0]!.estimate)
+})
+
+// The bound that a GPU load also costs system RAM has to reach the per-model
+// verdicts, not just the combined one, or the two contradict each other.
+test('assess: the system bound reaches per-model verdicts as well as the combined one', (t) => {
+  const result = assessModelFitFromResources({
+    models: [candidate()],
+    execution: 'sequential',
+    resources: discreteGpuResources({
+      vramTotalBytes: 20 * GIB,
+      vramUsedBytes: 1 * GIB,
+      systemTotalBytes: 8 * GIB,
+      systemUsedBytes: 7 * GIB,
+      gpuScope: 'budget'
+    }),
+    platform: 'win32-x64',
+    calibration: calibration(),
+    resolveGpuCalibration: () => calibration(),
+    resolveProfile: () => profile()
+  })
+
+  t.is(result.verdict, 'likely-too-large', 'plenty of VRAM, no system RAM')
+  t.is(result.models[0]!.verdict, 'likely-too-large', 'and the model agrees with the whole')
+  t.ok(result.reasons.some((r) => r.includes('system RAM')))
+})
+
+// Windows classifies the Intel iGPU as dedicated because it declares 128 MiB
+// of its own, so the count alone would refuse a host with one real card.
+test('assess: an adapter too small to hold a model is not a rival candidate', (t) => {
+  const resources = discreteGpuResources({
+    vramTotalBytes: 20 * GIB,
+    vramUsedBytes: 1 * GIB,
+    gpuScope: 'budget'
+  })
+  const gpus = resources.capabilities.gpus
+  const samples = resources.sample!.gpus
+  if (gpus.status === 'supported' && samples.status === 'supported') {
+    gpus.value.push({
+      ...gpus.value[0]!,
+      id: 'igpu',
+      memoryTotalBytes: {
+        status: 'supported',
+        value: 128 * 1024 * 1024,
+        provenance: { source: 'test', scope: 'device' }
+      }
+    })
+    samples.value.push({
+      ...samples.value[0]!,
+      id: 'igpu',
+      memoryTotalBytes: {
+        status: 'supported',
+        value: 128 * 1024 * 1024,
+        provenance: { source: 'test', scope: 'budget' }
+      },
+      memoryUsedBytes: {
+        status: 'supported',
+        value: 0,
+        provenance: { source: 'test', scope: 'budget' }
+      }
+    })
+  }
+
+  const result = assessModelFitFromResources({
+    models: [candidate()],
+    execution: 'sequential',
+    resources,
+    platform: 'win32-x64',
+    calibration: calibration(),
+    resolveGpuCalibration: () => calibration(),
+    resolveProfile: () => profile()
+  })
+
+  t.is(result.basis, 'device-budget', 'the real card still resolves')
+  t.is(result.budget?.totalBytes, 20 * GIB)
 })
 
 // A card whose reading failed is still a card the engine can use, so it must

--- a/packages/inference/test/resource-collector-fixtures.test.ts
+++ b/packages/inference/test/resource-collector-fixtures.test.ts
@@ -331,10 +331,11 @@ test('rejects sampled GPU memory that disagrees with the declared memory', (t) =
   }
 })
 
-// DXGI reports what this process uses and may use, not what the device holds.
-// On an idle machine Budget looks exactly like VRAM, so the agreement check
-// cannot catch it — only the platform can.
-test('rejects sampled GPU memory on windows however well it agrees', (t) => {
+// DXGI reports what this process uses and may use, so the readings are real
+// but describe a budget rather than the device. Reported under that scope
+// instead of discarded — the agreement check cannot separate them, because on
+// an idle machine Budget looks exactly like VRAM.
+test('scopes sampled GPU memory as a budget on windows', (t) => {
   const collector = createSystemResourceCollector(
     createFixture({
       platform: 'win32',
@@ -347,10 +348,23 @@ test('rejects sampled GPU memory on windows however well it agrees', (t) => {
   t.is(gpus.status, 'supported')
   if (gpus.status === 'supported') {
     t.alike(gpus.value[0]?.memoryTotalBytes, {
-      status: 'unverified',
-      reason: 'Windows reports per-process GPU usage and budget, not device-wide memory'
+      status: 'supported',
+      value: 8_000,
+      provenance: { source: 'bare-gpu-info', scope: 'budget' }
     })
-    t.is(gpus.value[0]?.memoryUsedBytes.status, 'unverified')
+    t.is(gpus.value[0]?.memoryUsedBytes.status, 'supported')
+  }
+})
+
+test('keeps windows unified-memory GPUs unverified', (t) => {
+  const collector = createSystemResourceCollector(
+    createFixture({ platform: 'win32', gpuUnifiedMemory: true }).dependencies
+  )
+  const { gpus } = collector.sample()
+
+  t.is(gpus.status, 'supported')
+  if (gpus.status === 'supported') {
+    t.is(gpus.value[0]?.memoryTotalBytes.status, 'unverified')
   }
 })
 

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
@@ -133,6 +133,7 @@ class AssessModelFitResponseBasis(Enum):
     system_memory = "system-memory"
     process_memory = "process-memory"
     device_memory = "device-memory"
+    device_budget = "device-budget"
 
 
 class AssessModelFitResponseExecution(Enum):
@@ -233,7 +234,7 @@ class AssessModelFitResponse(GeneratedBaseModel):
     basis: Annotated[
         AssessModelFitResponseBasis,
         Field(
-            description="The evidence the budget was derived from — system RAM, the per-process ceiling on iOS, or a discrete GPU’s own memory when the model executes there and that GPU’s readings are device-scoped.",
+            description="The evidence the budget was derived from — system RAM, the per-process ceiling on iOS, a discrete GPU’s own memory, or on Windows the GPU memory budget the OS grants this process. The two device bases also require the system-memory budget to hold.",
             title="AssessModelFitResponseBasis",
         ),
     ]

--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -400,8 +400,8 @@
         },
         "basis": {
           "type": "string",
-          "enum": ["system-memory", "process-memory", "device-memory"],
-          "description": "The evidence the budget was derived from — system RAM, the per-process ceiling on iOS, or a discrete GPU’s own memory when the model executes there and that GPU’s readings are device-scoped.",
+          "enum": ["system-memory", "process-memory", "device-memory", "device-budget"],
+          "description": "The evidence the budget was derived from — system RAM, the per-process ceiling on iOS, a discrete GPU’s own memory, or on Windows the GPU memory budget the OS grants this process. The two device bases also require the system-memory budget to hold.",
           "title": "AssessModelFitResponseBasis"
         },
         "execution": {

--- a/packages/sdk/docs/assess-model-fit.md
+++ b/packages/sdk/docs/assess-model-fit.md
@@ -139,16 +139,22 @@ switches to a `device-memory` basis and the backend's own coefficients — today
 `linux-x64` on Vulkan — and reports the GPU's total, used and reserve in
 `budget` as usual.
 
-It returns `unknown` instead whenever that evidence is not defensible:
+On Windows the readings are per-process rather than device-wide (DXGI
+`CurrentUsage` and `Budget`), so the basis is `device-budget` instead: the GPU
+memory the OS grants _this process_. It answers the same admission question.
 
-- **Windows.** GPU memory there is per-process (DXGI `CurrentUsage` and
-  `Budget`), not device-wide, so no VRAM budget can be formed. Note that a GPU
-  load on Windows also consumes system RAM — a 2382 MiB model raised RSS by
-  2918 MiB, against 868 MiB on linux — so a future device budget there will
-  need both bounds.
-- **More than one dedicated GPU.** The engine takes the first eligible ggml
+Both device bases additionally require the **system-memory** budget to hold, on
+every verdict — a GPU load is paid for in system RAM too (a 2382 MiB model
+raised RSS by 2918 MiB on Windows, 868 MiB on linux), so a machine with the
+card for it but not the RAM does not read as a fit.
+
+It returns `unknown` instead whenever the evidence is not defensible:
+
+- **More than one usable GPU.** The engine takes the first eligible ggml
   device, an order the SDK cannot observe, so the card cannot be identified.
-- **An uncalibrated backend**, or a GPU whose readings are not device-scoped.
+  Adapters too small to hold any model are not counted as rivals — Windows
+  classifies an Intel iGPU as dedicated because it declares 128 MiB of its own.
+- **An uncalibrated backend**, or a GPU whose readings carry no usable scope.
 
 Apple silicon is unaffected: its memory is unified, so a GPU allocation is
 system RAM and the system basis already covers it.

--- a/packages/sdk/docs/system-resources-support-matrix.md
+++ b/packages/sdk/docs/system-resources-support-matrix.md
@@ -87,10 +87,16 @@ itself, per device, and reports `unverified` wherever it cannot:
   system RAM, which the memory budget already accounts for. Apple readings are
   `unverified` for this reason, and are a working-set recommendation rather
   than a device pool (an M4 Max reports 81% of system RAM).
-- Otherwise a sample is trusted only when its total agrees with the memory the
-  device declares for itself, within 10%. A discrete card agrees (measured 1.00
-  and 0.96); an Intel iGPU declares 128 MiB and samples half of system RAM,
-  because it is reporting the shared pool.
+- On Windows the values come from DXGI's `QueryVideoMemoryInfo` — `CurrentUsage`
+  and `Budget`, which are what this process uses and may use. They are reported
+  under the `budget` scope rather than discarded: what a process is allowed to
+  allocate is what an admission decision needs. They are not device totals, and
+  on an idle machine `Budget` is indistinguishable from VRAM, so no value-level
+  check can separate them.
+- Otherwise a sample is trusted as `device` only when its total agrees with the
+  memory the device declares for itself, within 10%. A discrete card agrees
+  (measured 1.00 and 0.96); an Intel iGPU declares 128 MiB and samples half of
+  system RAM, because it is reporting the shared pool.
 
 Declared memory (`capabilities`) is therefore `supported` on any non-unified
 GPU, while the per-sample readings additionally require that agreement.


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Windows returns `unknown` for every GPU host, which is most Windows desktops with a discrete card. #4238 discarded the readings as `unverified` because DXGI reports per-process values.
- Those values are real, though — `Budget` is what the OS grants *this process*, and whether this process may allocate the model is exactly what admission asks.

## 📝 How does it solve it?

- **`budget` scope**: win32 GPU samples are reported `supported` with the existing `budget` scope instead of discarded, on non-unified GPUs. Their meaning is stated rather than guessed at.
- **`device-budget` basis**: a Windows GPU host is budgeted against that allowance. `device-memory` still means the card's own memory, unchanged.
- **System bound on every verdict**: both device bases now also require the system-memory budget, applied to per-model verdicts as well as the combined one so the two cannot disagree. A GPU load is paid for in system RAM too — 2918 MiB of RSS for a 2382 MiB model on win32, against 868 MiB on linux.
- **Usable-GPU filter**: a candidate must be able to hold a model. Windows classifies the Intel iGPU as `DEDICATED` because it declares 128 MiB of its own, and neither `type` nor `unifiedMemory` separates it from a real card — so without this, the multi-GPU refusal would reject every Windows host that has one.

## 🔌 API Changes

`assessModelFit` gains a fourth `basis`, `device-budget`. `getSystemResources()` GPU samples on win32 change from `unverified` to `supported` with `provenance.scope: 'budget'`.

```typescript
const { basis, budget } = await assessModelFit({ models, execution: 'sequential' })
// Windows + discrete GPU: basis === 'device-budget',
// budget.totalBytes is the DXGI budget for this process, not the card's VRAM.
```

## 🧪 How was it tested?

- New tests: budget scoping on win32, unified GPUs still unverified there, the `device-budget` basis, per-model and combined agreeing under the system bound, and a small adapter not counting as a rival candidate.
- Assess and collector suites pass; typecheck, prettier clean; contract and Python client regenerated.
- **Not yet measured on hardware.** There is no `win32-x64` GPU fixture in this PR, so Windows GPU hosts still return `unknown` until a calibration run lands — the plumbing is what changes here.

Stacked on #4238.
