### PR TITLE
QVAC-24423 QVAC-24421 bump: speech-cpp 2026-09-03#2 on the speech addons

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -32,6 +32,16 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
   runtime behavior is unchanged; the fix matters for anything that opts
   VAD into the GPU.
 
+- Raise the `speech-cpp` floor to 2026-09-03#2, which brings in ggml-speech
+  2026-09-04. Parakeet TDT decoding on CUDA and Metal runs the greedy loop
+  as fused LSTM-cell and TDT-step ops several steps per graph, the encoder
+  uses direct depthwise convolutions and view-based flash attention where
+  the backend supports them, and the mel front-end is multithreaded. At
+  steady state a 30 s clip at q8_0 transcribes about 2.5x faster on an
+  RTX 3080 and about 1.8x faster on an Apple M5, longer clips more. Metal
+  output is unchanged; CUDA output stays within WER noise of the CPU
+  reference. The `cuda` feature now builds ggml with CUDA graph capture on.
+
 ## [0.4.2] - 2026-09-01
 
 ### Changed

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require `speech-cpp` port revision `2026-09-02`, which adds the engine's
   teacher-forced LM quality scoring.
 
+- Raise the `speech-cpp` floor to 2026-09-03#2, which brings in ggml-speech
+  2026-09-04 (Metal depthwise-conv and strided-copy fast paths, CUDA norm
+  fusion and small-N MMQ tiles; the `cuda` feature now builds ggml with
+  CUDA graph capture on).
+
 ## [0.3.3] - 2026-09-01
 
 ### Added

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-02",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-02",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-02",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "audiogen",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-02",
+          "version>=": "2026-09-03#2",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-02",
+          "version>=": "2026-09-03#2",
           "default-features": false,
           "features": [
             "vulkan"

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-09-03#2, which brings in ggml-speech
+  2026-09-04 (Metal depthwise-conv and strided-copy fast paths, CUDA norm
+  fusion and small-N MMQ tiles; the `cuda` feature now builds ggml with
+  CUDA graph capture on).
+
 ## [0.8.2] - 2026-09-01
 
 ### Changed

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -23,7 +23,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -33,7 +33,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "whisper",
@@ -49,7 +49,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-01#2",
+          "version>=": "2026-09-03#2",
           "default-features": false,
           "features": [
             "cuda"

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-09-03#2, which brings in ggml-speech
+  2026-09-04 (Metal depthwise-conv and strided-copy fast paths, CUDA norm
+  fusion and small-N MMQ tiles; the `cuda` feature now builds ggml with
+  CUDA graph capture on). Two TTS CUDA crashes found by the win32/arm64
+  preflight are fixed: Chatterbox frees its time-MLP graph cache on unload
+  instead of at worker-thread exit, and Supertonic keys its capability
+  cache by device rather than backend instance.
+
 ## [0.8.1] - 2026-09-01
 
 ### Changed

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "tts",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "tts",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-03#2",
       "default-features": false,
       "features": [
         "tts",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-01#2",
+          "version>=": "2026-09-03#2",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-01#2",
+          "version>=": "2026-09-03#2",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## What problem does this PR solve?

The speech addons still floor `speech-cpp` below 2026-09-03#2, so they build against ggml-speech 2026-09-02 and miss the Parakeet TDT GPU decode path and the fused ggml ops that landed in tetherto/qvac-fabric-speech.cpp#207, tetherto/qvac-ext-ggml#81 and tetherto/qvac-registry-vcpkg#354.

## How does it solve it?

- Raise the `speech-cpp` floor to 2026-09-03#2 in `asr-ggml`, `tts-ggml`, `audiogen-ggml` and `bci-whispercpp` (`vcpkg.json` only; the registry baselines are untouched and each floor resolves the new port from the registry head).
- ggml-speech 2026-09-04 comes with it: fused LSTM cell, TDT step and gated GLU ops, Metal depthwise conv and CPY fast paths, CUDA NORM fusion and MMQ small-N tiles, and CUDA graph capture on for the `cuda` feature.
- asr-ggml: Parakeet TDT transcription of a 30 s clip at q8_0 runs about 2.5x faster on an RTX 3080 and about 1.8x faster on an Apple M5 at steady state, longer clips more. Metal output is unchanged; CUDA output stays within WER noise of the CPU reference.
- tts-ggml: the two TTS CUDA crash fixes from the win32/arm64 preflight (Chatterbox frees its time-MLP graph cache on unload; Supertonic keys its capability cache by device).
- Each package changelog gets the matching Unreleased entry.

## Breaking changes

None.
