### PR TITLE
chore[notask]: release @qvac/cli 0.13.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,142 @@
 # Changelog
 
+## [0.13.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.13.0
+
+`qvac serve` becomes a host for mounted surfaces rather than a single OpenAI server, so the QVAC-native API and the OpenAI-compatible API can run together or apart. Translation is now a served endpoint, `qvac configure` prompts for every model type instead of only llamacpp, and worker startup failures finally report the reason they failed. This release also clears a HIGH-severity advisory reachable through the `/docs` route.
+
+## Breaking Changes
+
+### `qvac serve` now serves the QVAC surface by default
+
+`qvac serve` used to print help and do nothing; the only real server was `qvac serve openai`. Serving is now the default, and the OpenAI-compatible surface is a flag rather than a subcommand.
+
+**Before:**
+
+```bash
+qvac serve            # prints help
+qvac serve openai     # serves /v1/*
+```
+
+**After:**
+
+```bash
+qvac serve                          # serves the QVAC surface only
+qvac serve --openai                 # QVAC + /v1/*
+qvac serve --openai --no-default    # /v1/* only
+```
+
+`qvac serve openai` still works, keeps every flag it had, and behaves identically — it prints a deprecation warning on start. Migrate by replacing the `openai` subcommand with `--openai --no-default` if you want the previous surface set exactly.
+
+`qvac openai spec` emits the same paths, schemas, and tags as before. Two `info` fields change, because the document now names the surfaces it mounts:
+
+```
+BEFORE: "title": "QVAC OpenAI-compatible API"
+        "description": "OpenAI-compatible REST API served by `qvac serve openai`."
+AFTER:  "title": "QVAC API"
+        "description": "Mounted surfaces: openai (OpenAI-compatible REST API)."
+```
+
+Configuration is unchanged: `serve.models` and every existing key keep their meaning. OpenAI-specific keys move under `serve.openai`, and an unknown `serve.*` key now logs a warning instead of being dropped in silence.
+
+## New APIs
+
+### Text translation over HTTP
+
+The QVAC surface serves translation at `POST /qvac/v1/translate`. Configure a translation model the same way as any other served model:
+
+```json
+// qvac.config.json
+{
+  "serve": {
+    "models": {
+      "de-en": {
+        "model": "BERGAMOT_DE_EN",
+        "config": { "engine": "Bergamot", "from": "de", "to": "en" }
+      }
+    }
+  }
+}
+```
+
+```bash
+curl localhost:11434/qvac/v1/translate \
+  -H 'content-type: application/json' \
+  -d '{ "model": "de-en", "text": ["Guten Morgen", "Vielen Dank"] }'
+```
+
+```json
+{
+  "object": "translation",
+  "model": "de-en",
+  "translations": ["Good morning", "Thank you very much"]
+}
+```
+
+Batches stream item by item when you ask for a stream, so long batches report progress instead of blocking to the end:
+
+```
+data: {"object":"translation.item","index":0,"text":"Good morning", ...}
+data: {"object":"translation.item","index":1,"text":"Thank you very much", ...}
+data: {"object":"translation.done", ...}
+data: [DONE]
+```
+
+## New Configuration
+
+### Worker handshake timeout is configurable, and startup failures say why
+
+A worker that never completed its RPC handshake produced `RPC_INIT_TIMEOUT` and nothing else — no way to tell a slow cold start from a worker that died on a missing native library. The timeout is now tunable, and every pre-handshake failure carries a typed cause:
+
+```json
+// qvac.config.json
+{ "rpcInitTimeoutMs": 120000 }
+```
+
+```bash
+# Takes precedence over the config file, and also raises `qvac doctor`'s probe
+QVAC_RPC_INIT_TIMEOUT_MS=120000 qvac serve
+```
+
+The typed cause distinguishes the two cases that used to look identical — a worker that exited (raising the timeout will not help) from one that is still running but never connected (a longer timeout may help) — and carries the worker's stderr tail.
+
+## Improvements
+
+### `qvac configure` prompts for every model type
+
+Schema-driven prompts previously covered only llamacpp chat and embedding entries; every other model type fell back to a generic entry you had to finish by hand. `qvac configure` now reads each model type's config schema from the SDK, so type hints, field descriptions, and per-field validation come from the same source the runtime validates against — for all model types, including addons added after this release.
+
+## Bug Fixes
+
+### Preload failures report the real cause, and can refuse to start
+
+On a preload failure `qvac serve` logged only `err.message` (for example "RPC initialization timed out") and discarded `err.cause`, which is where the worker stderr — the actual reason, such as a missing addon or a bad `.so` — lives. The full error cause chain is now logged.
+
+With lazy loading off, preloaded models are the only ones that can serve, yet the server still opened its port when every preload had failed: healthy-looking, serving nothing. `--no-lazy-load` now exits non-zero if every preload model fails. With lazy loading on (the default) the server still starts, because a failed preload retries on the next request, so ordinary and mixed configurations are unaffected.
+
+### A model lazy-loaded over a POST body can now load at all
+
+With `cancelOnDisconnect` on (the default), the first request that lazy-loaded a model through a POST body was cancelled before the load began, returning `503 model_load_failed` ("cancelled before start"). The load left the model unloaded, so every retry hit the same path and such a model could never load.
+
+The disconnect check watched the request stream, which closes as soon as the body is read — and Fastify reads the body before the load starts, so the abort fired immediately. It now watches the response stream, which closes only when the client actually disconnects during the load. A real mid-load disconnect still cancels the in-flight load.
+
+### `qvac serve` builds again
+
+`serve/lib/tool-dialect.ts` still read `isDelegated` from loaded-model info, a field removed when delegated inference was dropped from the SDK, which broke typecheck and build. The stale guard is gone.
+
+## Security
+
+### HIGH-severity advisory cleared on the `/docs` route
+
+`serve --docs` serves Swagger UI through `@fastify/static`, pulled in transitively by `@fastify/swagger-ui@5`, which resolved to a vulnerable version. That exposed [GHSA-83w8-p2f5-377r](https://github.com/advisories/GHSA-83w8-p2f5-377r) (route-guard bypass via path traversal, HIGH, CVSS 7.5) and [GHSA-8pvw-jcv7-9cmj](https://github.com/advisories/GHSA-8pvw-jcv7-9cmj) (authorization bypass, moderate) through the `/docs` route.
+
+`@fastify/swagger-ui` moves to `^6.1.1`, which depends on `@fastify/static ^10.1.0` — past both fix versions — and `fastify-plugin` moves to `^6` to match that chain and avoid a duplicate install. There are no source changes; `npm audit` reports zero vulnerabilities after the bump.
+
+## Requirements
+
+This release requires `@qvac/sdk@^0.19.0`. Both the configurable handshake timeout and `qvac configure`'s schema-driven prompts for every model type read APIs that 0.19.0 is the first SDK release to export.
+
 ## [0.12.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.12.0

--- a/packages/cli/NOTICE
+++ b/packages/cli/NOTICE
@@ -16,48 +16,50 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperswarm-secret-stream
   @qvac/asr-ggml@0.3.3
     https://github.com/tetherto/qvac
-  @qvac/audiogen-ggml@0.2.4
+  @qvac/audiogen-ggml@0.3.3
     https://github.com/tetherto/qvac
-  @qvac/bci-whispercpp@0.7.2
+  @qvac/bci-whispercpp@0.8.2
     https://github.com/tetherto/qvac
-  @qvac/classification-ggml@0.20.0
+  @qvac/classification-ggml@0.23.0
     https://github.com/tetherto/qvac
   @qvac/decoder-audio@0.5.0
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/diffusion-cpp@0.18.0
+  @qvac/diffusion-cpp@0.21.0
     https://github.com/tetherto/qvac
-  @qvac/embed-llamacpp@0.34.0
+  @qvac/embed-llamacpp@0.37.0
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
-  @qvac/fabric@0.6.0
+  @qvac/fabric@0.10.0
     https://github.com/tetherto/qvac
   @qvac/infer-base@0.4.2
     https://github.com/tetherto/qvac
   @qvac/infer-base@0.6.2
     https://github.com/tetherto/qvac
+  @qvac/inference@0.19.0
+    https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.45.0
+  @qvac/llm-llamacpp@0.49.1
     https://github.com/tetherto/qvac
   @qvac/logging@0.1.1
     https://github.com/tetherto/qvac
-  @qvac/ocr-ggml@0.18.0
+  @qvac/ocr-ggml@0.21.0
     https://github.com/tetherto/qvac
-  @qvac/rag@0.6.4
+  @qvac/rag@0.8.0
     https://github.com/tetherto/qvac
   @qvac/registry-client@0.6.1
     https://github.com/tetherto/qvac
   @qvac/registry-schema@0.3.0
     https://github.com/tetherto/qvac
-  @qvac/sdk@0.18.2
+  @qvac/sdk@0.19.0
     https://github.com/tetherto/qvac
-  @qvac/translation-nmtcpp@0.10.1
+  @qvac/translation-nmtcpp@0.13.0
     https://github.com/tetherto/qvac
-  @qvac/tts-ggml@0.7.5
+  @qvac/tts-ggml@0.8.1
     https://github.com/tetherto/qvac
-  @qvac/vla-ggml@0.21.1
+  @qvac/vla-ggml@0.24.0
     https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
@@ -123,17 +125,17 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-mime
   bare-module@6.4.0
     https://github.com/holepunchto/bare-module
-  bare-module-lexer@1.6.5
+  bare-module-lexer@1.6.6
     https://github.com/holepunchto/bare-module-lexer
-  bare-module-resolve@1.12.4
+  bare-module-resolve@1.12.5
     https://github.com/holepunchto/bare-module-resolve
-  bare-module-traverse@2.4.4
+  bare-module-traverse@2.5.2
     https://github.com/holepunchto/bare-module-traverse
   bare-net@2.3.3
     https://github.com/holepunchto/bare-net
   bare-os@3.9.3
     https://github.com/holepunchto/bare-os
-  bare-pack@2.2.1
+  bare-pack@2.2.2
     https://github.com/holepunchto/bare-pack
   bare-path@3.1.2
     https://github.com/holepunchto/bare-path
@@ -147,9 +149,9 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-process
   bare-rpc@1.3.8
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.31.0
+  bare-runtime@1.32.0
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.31.0
+  bare-runtime-darwin-arm64@1.32.0
     https://github.com/holepunchto/bare-runtime
   bare-semver@1.1.0
     https://github.com/holepunchto/bare-semver
@@ -177,7 +179,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.1
     https://github.com/holepunchto/bare-type
-  bare-type-stripper@0.1.5
+  bare-type-stripper@0.1.6
     https://github.com/holepunchto/bare-type-stripper
   bare-url@2.5.4
     https://github.com/holepunchto/bare-url
@@ -192,7 +194,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/blind-relay
   brittle@3.19.1
     https://github.com/holepunchto/brittle
-  compact-encoding@3.3.2
+  compact-encoding@3.4.0
     https://github.com/holepunchto/compact-encoding
   compact-encoding-bitfield@1.1.0
     https://github.com/compact-encoding/compact-encoding-bitfield
@@ -222,7 +224,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdb
   hyperdht-address@1.1.1
     https://github.com/holepunchto/hyperdht-address
-  hyperdht-stats@1.10.0
+  hyperdht-stats@1.11.0
     https://github.com/holepunchto/hyperdht-stats
   hyperdispatch@1.6.0
     https://github.com/holepunchto/hyperdispatch
@@ -342,8 +344,6 @@ JavaScript Dependencies
     https://github.com/fastify/accept-negotiator
   @fastify/ajv-compiler@4.0.6
     https://github.com/fastify/ajv-compiler
-  @fastify/autoload@6.5.0
-    https://github.com/fastify/fastify-autoload
   @fastify/busboy@3.2.2
     https://github.com/fastify/busboy
   @fastify/cors@11.3.0
@@ -450,7 +450,7 @@ JavaScript Dependencies
     https://github.com/thlorenz/convert-source-map
   cookie@1.1.1
     https://github.com/jshttp/cookie
-  corestore@7.12.2
+  corestore@7.12.3
     https://github.com/holepunchto/corestore
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
@@ -486,7 +486,7 @@ JavaScript Dependencies
     https://github.com/fabiospampinato/fast-string-width
   fast-wrap-ansi@0.2.2
     https://github.com/43081j/fast-wrap-ansi
-  fastify@5.12.1
+  fastify@5.12.3
     https://github.com/fastify/fastify
   fastify-plugin@5.1.0
     https://github.com/fastify/fastify-plugin
@@ -508,11 +508,11 @@ JavaScript Dependencies
     https://github.com/jshttp/http-errors
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.35.2
+  hypercore@11.35.4
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.33.2
+  hyperdht@6.34.0
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm

--- a/packages/cli/changelog/0.13.0/CHANGELOG.md
+++ b/packages/cli/changelog/0.13.0/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog v0.13.0
+
+Release Date: 2026-09-04
+
+## 🔌 API
+
+- Configurable worker RPC init timeout and typed startup failure cause. (see PR [#4159](https://github.com/tetherto/qvac/pull/4159)) - See [API changes](./api.md)
+- Serve text translation on /qvac/v1/translate. (see PR [#4165](https://github.com/tetherto/qvac/pull/4165)) - See [API changes](./api.md)
+- Surface modelConfig descriptions for every model type in qvac configure. (see PR [#4172](https://github.com/tetherto/qvac/pull/4172)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Assemble CLI workspace SDK against local inference. (see PR [#4043](https://github.com/tetherto/qvac/pull/4043))
+- Drop removed isDelegated check in serve tool-dialect. (see PR [#4117](https://github.com/tetherto/qvac/pull/4117))
+- Surface preload failure cause and refuse to start when all preloads fail. (see PR [#4129](https://github.com/tetherto/qvac/pull/4129))
+- Cancel model load on client disconnect, not request-body end. (see PR [#4130](https://github.com/tetherto/qvac/pull/4130))
+
+## 🧹 Chores
+
+- Mount the serve surfaces as extensions. (see PR [#4164](https://github.com/tetherto/qvac/pull/4164)) - See [breaking changes](./breaking.md)
+- Build the cli with tsc-alias and use @ imports. (see PR [#4187](https://github.com/tetherto/qvac/pull/4187))
+- Typecheck the whole cli test tree. (see PR [#4188](https://github.com/tetherto/qvac/pull/4188))
+- Split the cli entry into per-command modules. (see PR [#4189](https://github.com/tetherto/qvac/pull/4189))
+- Bump @fastify/swagger-ui to 6 to clear @fastify/static HIGH CVE. (see PR [#4219](https://github.com/tetherto/qvac/pull/4219))

--- a/packages/cli/changelog/0.13.0/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.13.0/CHANGELOG_LLM.md
@@ -1,0 +1,136 @@
+# QVAC CLI v0.13.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.13.0
+
+`qvac serve` becomes a host for mounted surfaces rather than a single OpenAI server, so the QVAC-native API and the OpenAI-compatible API can run together or apart. Translation is now a served endpoint, `qvac configure` prompts for every model type instead of only llamacpp, and worker startup failures finally report the reason they failed. This release also clears a HIGH-severity advisory reachable through the `/docs` route.
+
+## Breaking Changes
+
+### `qvac serve` now serves the QVAC surface by default
+
+`qvac serve` used to print help and do nothing; the only real server was `qvac serve openai`. Serving is now the default, and the OpenAI-compatible surface is a flag rather than a subcommand.
+
+**Before:**
+
+```bash
+qvac serve            # prints help
+qvac serve openai     # serves /v1/*
+```
+
+**After:**
+
+```bash
+qvac serve                          # serves the QVAC surface only
+qvac serve --openai                 # QVAC + /v1/*
+qvac serve --openai --no-default    # /v1/* only
+```
+
+`qvac serve openai` still works, keeps every flag it had, and behaves identically — it prints a deprecation warning on start. Migrate by replacing the `openai` subcommand with `--openai --no-default` if you want the previous surface set exactly.
+
+`qvac openai spec` emits the same paths, schemas, and tags as before. Two `info` fields change, because the document now names the surfaces it mounts:
+
+```
+BEFORE: "title": "QVAC OpenAI-compatible API"
+        "description": "OpenAI-compatible REST API served by `qvac serve openai`."
+AFTER:  "title": "QVAC API"
+        "description": "Mounted surfaces: openai (OpenAI-compatible REST API)."
+```
+
+Configuration is unchanged: `serve.models` and every existing key keep their meaning. OpenAI-specific keys move under `serve.openai`, and an unknown `serve.*` key now logs a warning instead of being dropped in silence.
+
+## New APIs
+
+### Text translation over HTTP
+
+The QVAC surface serves translation at `POST /qvac/v1/translate`. Configure a translation model the same way as any other served model:
+
+```json
+// qvac.config.json
+{
+  "serve": {
+    "models": {
+      "de-en": {
+        "model": "BERGAMOT_DE_EN",
+        "config": { "engine": "Bergamot", "from": "de", "to": "en" }
+      }
+    }
+  }
+}
+```
+
+```bash
+curl localhost:11434/qvac/v1/translate \
+  -H 'content-type: application/json' \
+  -d '{ "model": "de-en", "text": ["Guten Morgen", "Vielen Dank"] }'
+```
+
+```json
+{
+  "object": "translation",
+  "model": "de-en",
+  "translations": ["Good morning", "Thank you very much"]
+}
+```
+
+Batches stream item by item when you ask for a stream, so long batches report progress instead of blocking to the end:
+
+```
+data: {"object":"translation.item","index":0,"text":"Good morning", ...}
+data: {"object":"translation.item","index":1,"text":"Thank you very much", ...}
+data: {"object":"translation.done", ...}
+data: [DONE]
+```
+
+## New Configuration
+
+### Worker handshake timeout is configurable, and startup failures say why
+
+A worker that never completed its RPC handshake produced `RPC_INIT_TIMEOUT` and nothing else — no way to tell a slow cold start from a worker that died on a missing native library. The timeout is now tunable, and every pre-handshake failure carries a typed cause:
+
+```json
+// qvac.config.json
+{ "rpcInitTimeoutMs": 120000 }
+```
+
+```bash
+# Takes precedence over the config file, and also raises `qvac doctor`'s probe
+QVAC_RPC_INIT_TIMEOUT_MS=120000 qvac serve
+```
+
+The typed cause distinguishes the two cases that used to look identical — a worker that exited (raising the timeout will not help) from one that is still running but never connected (a longer timeout may help) — and carries the worker's stderr tail.
+
+## Improvements
+
+### `qvac configure` prompts for every model type
+
+Schema-driven prompts previously covered only llamacpp chat and embedding entries; every other model type fell back to a generic entry you had to finish by hand. `qvac configure` now reads each model type's config schema from the SDK, so type hints, field descriptions, and per-field validation come from the same source the runtime validates against — for all model types, including addons added after this release.
+
+## Bug Fixes
+
+### Preload failures report the real cause, and can refuse to start
+
+On a preload failure `qvac serve` logged only `err.message` (for example "RPC initialization timed out") and discarded `err.cause`, which is where the worker stderr — the actual reason, such as a missing addon or a bad `.so` — lives. The full error cause chain is now logged.
+
+With lazy loading off, preloaded models are the only ones that can serve, yet the server still opened its port when every preload had failed: healthy-looking, serving nothing. `--no-lazy-load` now exits non-zero if every preload model fails. With lazy loading on (the default) the server still starts, because a failed preload retries on the next request, so ordinary and mixed configurations are unaffected.
+
+### A model lazy-loaded over a POST body can now load at all
+
+With `cancelOnDisconnect` on (the default), the first request that lazy-loaded a model through a POST body was cancelled before the load began, returning `503 model_load_failed` ("cancelled before start"). The load left the model unloaded, so every retry hit the same path and such a model could never load.
+
+The disconnect check watched the request stream, which closes as soon as the body is read — and Fastify reads the body before the load starts, so the abort fired immediately. It now watches the response stream, which closes only when the client actually disconnects during the load. A real mid-load disconnect still cancels the in-flight load.
+
+### `qvac serve` builds again
+
+`serve/lib/tool-dialect.ts` still read `isDelegated` from loaded-model info, a field removed when delegated inference was dropped from the SDK, which broke typecheck and build. The stale guard is gone.
+
+## Security
+
+### HIGH-severity advisory cleared on the `/docs` route
+
+`serve --docs` serves Swagger UI through `@fastify/static`, pulled in transitively by `@fastify/swagger-ui@5`, which resolved to a vulnerable version. That exposed [GHSA-83w8-p2f5-377r](https://github.com/advisories/GHSA-83w8-p2f5-377r) (route-guard bypass via path traversal, HIGH, CVSS 7.5) and [GHSA-8pvw-jcv7-9cmj](https://github.com/advisories/GHSA-8pvw-jcv7-9cmj) (authorization bypass, moderate) through the `/docs` route.
+
+`@fastify/swagger-ui` moves to `^6.1.1`, which depends on `@fastify/static ^10.1.0` — past both fix versions — and `fastify-plugin` moves to `^6` to match that chain and avoid a duplicate install. There are no source changes; `npm audit` reports zero vulnerabilities after the bump.
+
+## Requirements
+
+This release requires `@qvac/sdk@^0.19.0`. Both the configurable handshake timeout and `qvac configure`'s schema-driven prompts for every model type read APIs that 0.19.0 is the first SDK release to export.

--- a/packages/cli/changelog/0.13.0/api.md
+++ b/packages/cli/changelog/0.13.0/api.md
@@ -1,0 +1,90 @@
+# 🔌 API Changes v0.13.0
+
+## Configurable worker RPC init timeout and typed startup failure cause
+
+PR: [#4159](https://github.com/tetherto/qvac/pull/4159)
+
+```typescript
+// 1. Configurable handshake timeout — qvac.config.json
+{
+  "rpcInitTimeoutMs": 120000
+}
+// or, taking precedence over the config file (and also raising `qvac doctor`'s probe):
+//   QVAC_RPC_INIT_TIMEOUT_MS=120000 node app.js
+
+// 2. Typed pre-handshake failure, always attached as the cause of RPC_INIT_TIMEOUT
+import { WorkerStartupError, loadModel } from '@qvac/sdk'
+
+try {
+  await loadModel({ modelSrc, modelType: 'llamacpp-completion' })
+} catch (error) {
+  const cause = (error as Error).cause
+  if (cause instanceof WorkerStartupError) {
+    if (cause.workerExited) {
+      // Dead, not slow — raising the timeout will not help.
+      console.error(`worker died: code=${cause.exitCode} signal=${cause.exitSignal}`)
+    } else {
+      // Still running, just never connected — a longer rpcInitTimeoutMs may help.
+      console.error('worker still running but never connected')
+    }
+    if (cause.stderrTail) console.error(cause.stderrTail)
+  }
+}
+```
+
+---
+
+## Serve text translation on /qvac/v1/translate
+
+PR: [#4165](https://github.com/tetherto/qvac/pull/4165)
+
+```bash
+# qvac.config.json
+# {
+#   "serve": {
+#     "models": {
+#       "de-en": {
+#         "model": "BERGAMOT_DE_EN",
+#         "config": { "engine": "Bergamot", "from": "de", "to": "en" }
+#       }
+#     }
+#   }
+# }
+
+curl localhost:11434/qvac/v1/translate \
+  -H 'content-type: application/json' \
+  -d '{ "model": "de-en", "text": ["Guten Morgen", "Vielen Dank"] }'
+```
+
+```json
+{
+  "object": "translation",
+  "model": "de-en",
+  "translations": ["Good morning", "Thank you very much"]
+}
+```
+
+```
+data: {"object":"translation.item","index":0,"text":"Good morning", ...}
+data: {"object":"translation.item","index":1,"text":"Thank you very much", ...}
+data: {"object":"translation.done", ...}
+data: [DONE]
+```
+
+---
+
+## Surface modelConfig descriptions for every model type in qvac configure
+
+PR: [#4172](https://github.com/tetherto/qvac/pull/4172)
+
+```typescript
+import { configSchemaForModelType } from '@qvac/sdk/schemas'
+
+// Resolve a model type's modelConfig schema by canonical name, alias, or engine string
+const schema = configSchemaForModelType('whisper') // 'tts-ggml', 'llm', 'diffusion', ...
+
+// z.toJSONSchema(schema) surfaces each field's .describe() text as `description`,
+// so tools (e.g. the CLI's `qvac configure`) can document config without a per-addon list.
+```
+
+---

--- a/packages/cli/changelog/0.13.0/breaking.md
+++ b/packages/cli/changelog/0.13.0/breaking.md
@@ -1,0 +1,36 @@
+# 💥 Breaking Changes v0.13.0
+
+## Mount the serve surfaces as extensions
+
+PR: [#4164](https://github.com/tetherto/qvac/pull/4164)
+
+**BEFORE:**
+
+```bash
+qvac serve            # prints help
+qvac serve openai     # serves /v1/*
+```
+
+**AFTER:**
+
+```bash
+qvac serve                          # serves the QVAC surface only
+qvac serve --openai                 # QVAC + /v1/*
+qvac serve --openai --no-default    # /v1/* only
+qvac serve openai                   # same as above, warns that it is deprecated
+```
+
+`qvac serve openai` keeps every flag it had and the same behaviour. It prints a deprecation warning on start.
+
+`qvac openai spec` emits the same paths, schemas and tags as before. Two `info` lines change, because the document now names the mounted surfaces:
+
+```
+BEFORE: "title": "QVAC OpenAI-compatible API"
+        "description": "OpenAI-compatible REST API served by `qvac serve openai`."
+AFTER:  "title": "QVAC API"
+        "description": "Mounted surfaces: openai (OpenAI-compatible REST API)."
+```
+
+Config is unchanged: `serve.models` and all existing keys keep their meaning. OpenAI-specific keys move under `serve.openai`, and an unknown `serve.*` key now logs a warning instead of being silently dropped.
+
+---

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -59,7 +59,7 @@
     "@fastify/swagger": "^9.0.0",
     "@fastify/swagger-ui": "^6.1.1",
     "@inquirer/prompts": "8.5.2",
-    "@qvac/sdk": "^0.18.1",
+    "@qvac/sdk": "^0.19.0",
     "close-with-grace": "^2.1.0",
     "commander": "^14.0.3",
     "fastify": "^5.0.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Cuts the `@qvac/cli` 0.13.0 release: version bump, changelog, NOTICE, and the `@qvac/sdk` dependency range the release actually needs.
- 12 PRs have landed on `main` since 0.12.0, including a breaking change to `qvac serve` and a HIGH-severity advisory fix reachable through the `/docs` route. None of it is released.

## 📝 How does it solve it?

- `packages/cli/package.json`: `0.12.0` → `0.13.0`.
- `packages/cli/package.json`: `@qvac/sdk` `^0.18.1` → `^0.19.0`. `packages/cli/src/configure/param-schemas.ts` imports `configSchemaForModelType` from `@qvac/sdk/schemas`, and #4159 added `rpcInitTimeoutMs`. Neither exists in `@qvac/sdk@0.18.2`; both ship in 0.19.0, now published.
- Adds `packages/cli/changelog/0.13.0/` (`CHANGELOG.md`, `breaking.md`, `api.md`, `CHANGELOG_LLM.md`) and rebuilds the root `packages/cli/CHANGELOG.md`.
- Regenerates `packages/cli/NOTICE` against the 0.19.0 tree: `@qvac/sdk` 0.18.2 → 0.19.0, `@qvac/inference@0.19.0` added, `@fastify/autoload` dropped, plus transitive addon and holepunch bumps. 321 production dependencies, 0 generator warnings.

### Changelog base

The generator's base here is `3ba4d3547`, not `cli-v0.12.0`:

- `cli-v0.12.0` is not an ancestor of `main` — backmerges are squash-merged, so no `cli-v*` tag ever lands on `main` — and the generator fail-stops on a non-ancestor base.
- The 0.12.0 fork point (`9e48cf15a`) does pass the check, but re-lists #3492 and #3953. Both are already documented in the 0.12.0 changelog and their source shipped in the 0.12.0 tarball.
- `3ba4d3547` drops those two and keeps #4043 onward: 12 PRs, with the `[skiplog]` backmerge #3991 excluded.

## 🧪 How was it tested?

From `packages/cli` against the published `@qvac/sdk@0.19.0`:

- `npm run format` (prettier) — clean
- `npm run lint` (lunte) — no issues
- `npm run typecheck` — clean
- `npm run build` — clean
- `npm audit` — 0 vulnerabilities, confirming the `@fastify/static` / `@fastify/swagger-ui@6.1.1` advisory fix holds in the resolved tree
- Changelog markdown prettier-clean; root `CHANGELOG.md` regenerated deterministically (`## [0.13.0]`, 14 versions, descending, no duplicates)
- `SDK Pod Checks` green on this PR

`cli-v0.13.0` is created automatically by the `create-tag` job after a successful npm publish; there is no GitHub Release for cli by the SDK-only releases policy.
