### PR TITLE
fix[notask]: support the streamed file-upload input in the AI SDK provider

### DIFF
--- a/packages/ai-sdk-provider/src/files.ts
+++ b/packages/ai-sdk-provider/src/files.ts
@@ -1,4 +1,8 @@
-import type { FilesV4, FilesV4UploadFileCallOptions } from '@ai-sdk/provider'
+import {
+  UnsupportedFunctionalityError,
+  type FilesV4,
+  type FilesV4UploadFileCallOptions
+} from '@ai-sdk/provider'
 import {
   createStatusCodeErrorResponseHandler,
   postFormDataToApi,
@@ -17,10 +21,32 @@ function multipartHeaders(headers: Record<string, string>): Record<string, strin
   )
 }
 
-function bytesFor(data: FilesV4UploadFileCallOptions['data']): Uint8Array {
-  if (data.type === 'text') return new TextEncoder().encode(data.text)
-  if (typeof data.data === 'string') return Uint8Array.from(Buffer.from(data.data, 'base64'))
-  return data.data
+/**
+ * A `stream` input is drained into bytes instead of being forwarded as a
+ * streaming request body: `POST /v1/files` buffers the whole upload into
+ * serve's in-memory ephemeral store, so streaming the request would add a
+ * `duplex: 'half'` requirement on the caller's `fetch` without any consumer
+ * on the other end.
+ *
+ * The `default` branch keeps a future `@ai-sdk/provider` data variant a
+ * runtime error for the one unsupported call rather than a build failure for
+ * the whole package.
+ */
+async function bytesFor(data: FilesV4UploadFileCallOptions['data']): Promise<Uint8Array> {
+  switch (data.type) {
+    case 'text':
+      return new TextEncoder().encode(data.text)
+    case 'data':
+      return typeof data.data === 'string'
+        ? Uint8Array.from(Buffer.from(data.data, 'base64'))
+        : data.data
+    case 'stream':
+      return new Uint8Array(await new Response(data.stream).arrayBuffer())
+    default:
+      throw new UnsupportedFunctionalityError({
+        functionality: `file upload data type '${(data as { type: string }).type}'`
+      })
+  }
 }
 
 /** AI SDK v4 files interface backed by QVAC serve's local ephemeral file store. */
@@ -36,9 +62,9 @@ export function createQvacFiles(options: QvacFilesOptions): FilesV4 {
   return {
     specificationVersion: 'v4',
     provider: 'qvac',
-    async uploadFile({ data, mediaType, filename, providerOptions }) {
+    async uploadFile({ data, mediaType, filename, providerOptions, abortSignal }) {
       const form = new FormData()
-      const bytes = bytesFor(data)
+      const bytes = await bytesFor(data)
       const body = bytes.slice().buffer as ArrayBuffer
       form.append('file', new Blob([body], { type: mediaType }), filename ?? 'upload.bin')
       const purpose = providerOptions?.['qvac']?.['purpose']
@@ -50,6 +76,7 @@ export function createQvacFiles(options: QvacFilesOptions): FilesV4 {
         formData: form,
         failedResponseHandler,
         successfulResponseHandler,
+        ...(abortSignal !== undefined && { abortSignal }),
         ...(options.fetch !== undefined && { fetch: options.fetch })
       })
       const result = response.value

--- a/packages/ai-sdk-provider/src/files.ts
+++ b/packages/ai-sdk-provider/src/files.ts
@@ -9,6 +9,8 @@ import {
   type ResponseHandler
 } from '@ai-sdk/provider-utils'
 
+import { mergeHeaders } from './headers.js'
+
 export interface QvacFilesOptions {
   readonly baseURL: string
   readonly headers: Record<string, string>
@@ -62,7 +64,7 @@ export function createQvacFiles(options: QvacFilesOptions): FilesV4 {
   return {
     specificationVersion: 'v4',
     provider: 'qvac',
-    async uploadFile({ data, mediaType, filename, providerOptions, abortSignal }) {
+    async uploadFile({ data, mediaType, filename, providerOptions, abortSignal, headers }) {
       const form = new FormData()
       const bytes = await bytesFor(data)
       const body = bytes.slice().buffer as ArrayBuffer
@@ -72,7 +74,7 @@ export function createQvacFiles(options: QvacFilesOptions): FilesV4 {
 
       const response = await postFormDataToApi({
         url: `${options.baseURL.replace(/\/+$/, '')}/files`,
-        headers: multipartHeaders(options.headers),
+        headers: multipartHeaders(mergeHeaders(options.headers, headers)),
         formData: form,
         failedResponseHandler,
         successfulResponseHandler,

--- a/packages/ai-sdk-provider/test/provider.test.ts
+++ b/packages/ai-sdk-provider/test/provider.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { APICallError } from '@ai-sdk/provider'
+import { APICallError, UnsupportedFunctionalityError } from '@ai-sdk/provider'
 
 import { DEFAULT_API_KEY, DEFAULT_BASE_URL } from '../src/defaults.js'
 import { createQvac, qvac } from '../src/provider.js'
@@ -170,6 +170,83 @@ test('uploadFile returns a qvac reference and language models resolve it through
     'http://127.0.0.1:55555/v1/chat/completions'
   ])
   assert.match(JSON.stringify(chatBody), /data:image\/png;base64,iVBORw0KGgo=/)
+})
+
+test('uploadFile accepts every file data variant and forwards the abort signal', async () => {
+  const uploaded: Array<{ bytes: Uint8Array; signal?: AbortSignal | null }> = []
+  const customFetch: typeof fetch = async (_input, init) => {
+    assert.ok(init?.body instanceof FormData)
+    const file = init.body.get('file')
+    assert.ok(file instanceof Blob)
+    uploaded.push({
+      bytes: new Uint8Array(await file.arrayBuffer()),
+      ...(init.signal !== undefined && { signal: init.signal })
+    })
+    return Response.json({ id: `file-${uploaded.length}` })
+  }
+  const files = createQvac({
+    baseURL: 'http://127.0.0.1:55555/v1',
+    fetch: customFetch
+  }).files()
+
+  const raw = await files.uploadFile({
+    data: { type: 'data', data: Uint8Array.from([1, 2, 3]) },
+    mediaType: 'application/octet-stream'
+  })
+  assert.deepEqual(raw.providerReference, { qvac: 'file-1' })
+
+  await files.uploadFile({
+    data: { type: 'data', data: 'AQID' },
+    mediaType: 'application/octet-stream'
+  })
+
+  await files.uploadFile({ data: { type: 'text', text: 'hi' }, mediaType: 'text/plain' })
+
+  const abort = new AbortController()
+  await files.uploadFile({
+    data: {
+      type: 'stream',
+      stream: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([1, 2]))
+          controller.enqueue(Uint8Array.from([3]))
+          controller.close()
+        }
+      })
+    },
+    mediaType: 'application/octet-stream',
+    abortSignal: abort.signal
+  })
+
+  assert.deepEqual(
+    uploaded.map(({ bytes }) => Array.from(bytes)),
+    [
+      [1, 2, 3],
+      [1, 2, 3],
+      [104, 105],
+      [1, 2, 3]
+    ]
+  )
+  assert.equal(uploaded[0]?.signal ?? null, null)
+  assert.equal(uploaded[3]?.signal, abort.signal)
+})
+
+test('uploadFile rejects an unknown file data variant without a build-time break', async () => {
+  const files = createQvac({
+    baseURL: 'http://127.0.0.1:55555/v1',
+    fetch: () => assert.fail('unknown data variants must not reach the network')
+  }).files()
+
+  await assert.rejects(
+    async () =>
+      await files.uploadFile({
+        data: { type: 'holo-tape' } as unknown as Parameters<typeof files.uploadFile>[0]['data'],
+        mediaType: 'application/octet-stream'
+      }),
+    (error: unknown) =>
+      UnsupportedFunctionalityError.isInstance(error) &&
+      error.functionality === "file upload data type 'holo-tape'"
+  )
 })
 
 test('native HTTP adapters expose structured APICallError details and retryability', async () => {

--- a/packages/ai-sdk-provider/test/provider.test.ts
+++ b/packages/ai-sdk-provider/test/provider.test.ts
@@ -172,20 +172,26 @@ test('uploadFile returns a qvac reference and language models resolve it through
   assert.match(JSON.stringify(chatBody), /data:image\/png;base64,iVBORw0KGgo=/)
 })
 
-test('uploadFile accepts every file data variant and forwards the abort signal', async () => {
-  const uploaded: Array<{ bytes: Uint8Array; signal?: AbortSignal | null }> = []
+test('uploadFile accepts every file data variant and forwards per-call options', async () => {
+  const uploaded: Array<{
+    bytes: Uint8Array
+    headers: Headers
+    signal?: AbortSignal | null
+  }> = []
   const customFetch: typeof fetch = async (_input, init) => {
     assert.ok(init?.body instanceof FormData)
     const file = init.body.get('file')
     assert.ok(file instanceof Blob)
     uploaded.push({
       bytes: new Uint8Array(await file.arrayBuffer()),
+      headers: new Headers(init.headers),
       ...(init.signal !== undefined && { signal: init.signal })
     })
     return Response.json({ id: `file-${uploaded.length}` })
   }
   const files = createQvac({
     baseURL: 'http://127.0.0.1:55555/v1',
+    headers: { 'Content-Type': 'application/x-invalid-global-default', 'x-configured': 'provider' },
     fetch: customFetch
   }).files()
 
@@ -215,7 +221,8 @@ test('uploadFile accepts every file data variant and forwards the abort signal',
       })
     },
     mediaType: 'application/octet-stream',
-    abortSignal: abort.signal
+    abortSignal: abort.signal,
+    headers: { 'x-trace-id': 'upload-4' }
   })
 
   assert.deepEqual(
@@ -229,6 +236,14 @@ test('uploadFile accepts every file data variant and forwards the abort signal',
   )
   assert.equal(uploaded[0]?.signal ?? null, null)
   assert.equal(uploaded[3]?.signal, abort.signal)
+
+  // The configured Content-Type must never survive: fetch has to pick the
+  // multipart boundary itself.
+  assert.equal(uploaded[0]?.headers.get('content-type'), null)
+  assert.equal(uploaded[0]?.headers.get('x-configured'), 'provider')
+  assert.equal(uploaded[0]?.headers.get('x-trace-id'), null)
+  assert.equal(uploaded[3]?.headers.get('content-type'), null)
+  assert.equal(uploaded[3]?.headers.get('x-trace-id'), 'upload-4')
 })
 
 test('uploadFile rejects an unknown file data variant without a build-time break', async () => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@ai-sdk/provider` 4.0.10 added a third `uploadFile` data variant, `{ type: 'stream', stream }`. `packages/ai-sdk-provider` has no lockfile in git and depends on `^4.0.0`, so every fresh install now resolves 4.0.10 and `src/files.ts` stops compiling:

```
src/files.ts(22,19): error TS2339: Property 'data' does not exist on type 'SharedV4FileDataData | FilesV4UploadFileStreamData'.
```

- `[ai-sdk-provider] typecheck` and `[ai-sdk-provider] build` both fail, which fails **SDK Pod Checks** and therefore `qvac-merge-guard / validate-pr` on **every open PR**, not just ones touching this package. Example: [run 33762929624](https://github.com/tetherto/qvac/actions/runs/33762929624/job/100673593217).
- It is also a live consumer crash, not only a build break. `ai`'s `uploadFile` passes a stream input straight through to the provider (`ai@7.0.92`, `dist/index.js:19347`), and the old `bytesFor` fell through to `return data.data` → `undefined` → `TypeError` on `bytes.slice()`.
- Two more per-call options that `ai` already passes were being dropped on the floor: `abortSignal` (uploads could not be cancelled) and `headers` (every other adapter in this package merges them).

## 📝 How does it solve it?

- `bytesFor` is now an exhaustive switch over the tagged union and handles `stream` by draining it into bytes.
- The stream is drained rather than forwarded as a streaming request body: `POST /v1/files` buffers the whole upload into serve's in-memory ephemeral store (`multipartToBody` → `part.toBuffer()`), so `postMultipartStreamToApi` would only impose a `duplex: 'half'` requirement on the caller's `fetch` with no streaming consumer on the other end.
- A `default` branch throws `UnsupportedFunctionalityError`. The next variant upstream adds will fail the one unsupported call instead of breaking the package build — and with it every PR's merge guard.
- `abortSignal` is forwarded to `postFormDataToApi`; `headers` are merged with `mergeHeaders(options.headers, headers)`, keeping the existing content-type strip so `fetch` still picks the multipart boundary.

Pinning `@ai-sdk/provider` to 4.0.9 was the alternative. Not taken: it holds us off upstream patches, the same break returns whenever the pin is lifted, and the streamed input is one the AI SDK already sends us.

## 🧪 How was it tested?

All five checks CI runs for this package, against a clean `bun install` resolving `@ai-sdk/provider@4.0.10`:

| check | result |
| --- | --- |
| `bun run typecheck` | clean (fails on `main`) |
| `bun run build` | clean (fails on `main`) |
| `bun run test:unit` | 103 tests, 0 failures (2 pre-existing managed-integration skips) |
| `bun run format` | clean |
| `bun run lint` | clean |

Two tests added to `test/provider.test.ts`:

- `uploadFile` across all four data variants (`data` as bytes, `data` as base64, `text`, `stream`), asserting the exact bytes that reach the multipart body, that `abortSignal` is forwarded and absent when not passed, that per-call headers arrive, and that the configured `Content-Type` never survives.
- An unknown variant rejects with `UnsupportedFunctionalityError` and never reaches the network.
