### PR TITLE
chore[notask]: release @qvac/ai-sdk-provider 0.6.2

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.6.2]
+
+Release Date: 2026-09-04
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.2
+
+## Streamed File Uploads Work Again
+
+`@ai-sdk/provider` 4.0.10 added a third `uploadFile` data variant, `{ type: 'stream', stream }`, and the AI SDK hands it straight to the provider whenever a caller uploads from a stream. Version 0.6.1 did not recognise it and threw a `TypeError` instead of uploading. `uploadFile` now drains the stream and posts the bytes.
+
+The stream is drained rather than forwarded as a streaming request body on purpose: `POST /v1/files` buffers the whole upload into serve's in-memory ephemeral store, so a streaming request would only require `duplex: 'half'` support from the caller's `fetch` without anything streaming on the other end.
+
+An unrecognised data variant now rejects with `UnsupportedFunctionalityError`, naming the variant, so a future addition upstream fails the one unsupported call with a clear error.
+
+## Upload Calls Honour `abortSignal` and `headers`
+
+Both options are part of the files interface and the AI SDK already passed them, but the QVAC adapter dropped them:
+
+- `abortSignal` is now forwarded, so an in-flight upload can be cancelled.
+- Per-call `headers` are now merged over the configured provider headers, matching the behaviour of every other adapter in this package. The configured `Content-Type` is still stripped so `fetch` picks the multipart boundary itself.
+
+Callers already passing `abortSignal` will see uploads actually abort where they previously ran to completion.
+
+No provider API surface changed in this patch release.
+
 ## [0.6.1]
 
 Release Date: 2026-08-21

--- a/packages/ai-sdk-provider/changelog/0.6.2/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.6.2/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog v0.6.2
+
+Release Date: 2026-09-04
+
+## 🐞 Fixes
+
+- Accept the streamed file-upload input. `uploadFile` now handles the `{ type: 'stream' }` data variant that `@ai-sdk/provider` 4.0.10 added and the AI SDK passes straight through, instead of throwing a `TypeError` on it.
+- Forward the per-call `abortSignal` to the upload request, so an in-flight upload can be cancelled.
+- Forward per-call `headers` to the upload request, matching every other adapter in the provider.
+- Reject an unrecognised upload data variant with `UnsupportedFunctionalityError` rather than failing at an arbitrary point in the request.

--- a/packages/ai-sdk-provider/changelog/0.6.2/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.6.2/CHANGELOG_LLM.md
@@ -1,0 +1,24 @@
+# QVAC AI SDK Provider v0.6.2 Release Notes
+
+Release Date: 2026-09-04
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.6.2
+
+## Streamed File Uploads Work Again
+
+`@ai-sdk/provider` 4.0.10 added a third `uploadFile` data variant, `{ type: 'stream', stream }`, and the AI SDK hands it straight to the provider whenever a caller uploads from a stream. Version 0.6.1 did not recognise it and threw a `TypeError` instead of uploading. `uploadFile` now drains the stream and posts the bytes.
+
+The stream is drained rather than forwarded as a streaming request body on purpose: `POST /v1/files` buffers the whole upload into serve's in-memory ephemeral store, so a streaming request would only require `duplex: 'half'` support from the caller's `fetch` without anything streaming on the other end.
+
+An unrecognised data variant now rejects with `UnsupportedFunctionalityError`, naming the variant, so a future addition upstream fails the one unsupported call with a clear error.
+
+## Upload Calls Honour `abortSignal` and `headers`
+
+Both options are part of the files interface and the AI SDK already passed them, but the QVAC adapter dropped them:
+
+- `abortSignal` is now forwarded, so an in-flight upload can be cancelled.
+- Per-call `headers` are now merged over the configured provider headers, matching the behaviour of every other adapter in this package. The configured `Content-Type` is still stripped so `fetch` picks the multipart boundary itself.
+
+Callers already passing `abortSignal` will see uploads actually abort where they previously ran to completion.
+
+No provider API surface changed in this patch release.

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Cuts `@qvac/ai-sdk-provider` 0.6.2 so the streamed-upload fix reaches consumers.

The published 0.6.1 throws a `TypeError` on any stream upload: `@ai-sdk/provider` 4.0.10 added a `{ type: 'stream', stream }` data variant and `ai` passes it straight through to the provider. The fix landed on `main` in #4279 (`1f13e8f0b`).

**Patch, not minor, on purpose:** `^0.6.1` resolves `>=0.6.1 <0.7.0`, so a 0.7.0 would not reach anyone already depending on the provider. This closes a live crash, so it needs to.

## 📝 How does it solve it?

- `packages/ai-sdk-provider/package.json` → `0.6.2`
- `packages/ai-sdk-provider/changelog/0.6.2/CHANGELOG.md` + `CHANGELOG_LLM.md`
- Root `packages/ai-sdk-provider/CHANGELOG.md` section for `[0.6.2]`

No code changes — the fix is already on `main` and in this branch's history via the release cut.

Shipping in 0.6.2:

- `uploadFile` handles the `{ type: 'stream' }` data variant
- An unrecognised data variant rejects with `UnsupportedFunctionalityError` instead of breaking the package build
- Per-call `abortSignal` is forwarded, so uploads can be cancelled
- Per-call `headers` are forwarded, matching the other adapters

## 🧪 How was it tested?

Ran the full SDK pod check set for this package on the release commit:

| check | result |
| --- | --- |
| `bun run format` | clean |
| `bun run lint` | clean |
| `bun run typecheck` | clean |
| `bun run build` | clean |
| `bun run test:unit` | 103 tests, 0 failures (2 pre-existing managed-integration skips) |

The code itself was tested in #4279, which merged green including `SDK Pod Checks`.
