### PR TITLE
infra[notask]: run workspace SDK source before registry install

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -373,6 +373,12 @@ jobs:
             # Run the checks once per declared SDK source. The optional
             # sdk-source:<source> script does that source's setup (e.g. link the
             # in-repo SDK); absent = plain install of the committed dependency.
+            #
+            # Workspace must rewrite the committed range to a sibling file:
+            # dep *before* install. Otherwise lockstep backmerge PRs into
+            # main fail at bun/npm install when @qvac/inference@^x.y.z is
+            # not on npm yet. Published/default keep install-first so they
+            # still resolve from the registry.
             src_idx=0
             for SRC in $SOURCES; do
               # Bracketed source shown after each check name, e.g. "build [workspace]".
@@ -390,14 +396,19 @@ jobs:
 
               # npm run --if-present reads package.json scripts and works regardless
               # of the installer (bun lacks --if-present).
+              if [ "$SRC" = "workspace" ]; then
+                run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+              fi
+
               if [ "$PKG" = "sdk" ]; then
                 run "install $src" bun install
               else
                 run "install $src" "$PM" install
               fi
 
-              # Per-source setup (no-op if the script is absent).
-              run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+              if [ "$SRC" != "workspace" ]; then
+                run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+              fi
 
               # Peer-resolution drift against this source's resolved @qvac/inference.
               if [ "$PKG" = "sdk" ]; then

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -170,18 +170,20 @@ jobs:
           "@tetherto" = { token = "${{ env.READ_NPM_TOKEN }}", url = "https://npm.pkg.github.com" }
           EOF
 
-      - name: Install dependencies
-        run: bun install
-        working-directory: ${{ env.WORKDIR }}
-
       # Compile the SDK against the in-repo @qvac/inference at this commit, not
       # the previously-published npm release (which lags behind engine API the
-      # SDK already consumes). This only affects the dist built here; the
-      # published dependency is set per channel below — GPR is pinned to the
-      # co-published @tetherto/inference-mono (see publish-gpr), npm keeps its
-      # committed range (resolved to the inference released in the same run).
+      # SDK already consumes). Link before bun install: lockstep cuts publish
+      # inference in this same workflow, so the committed range is not on npm
+      # yet. This only affects the dist built here; the published dependency
+      # is set per channel below — GPR is pinned to the co-published
+      # @tetherto/inference-mono (see publish-gpr), npm keeps its committed
+      # range (resolved to the inference released in the same run).
       - name: Build against workspace @qvac/inference
         run: bun run sdk-source:workspace
+        working-directory: ${{ env.WORKDIR }}
+
+      - name: Install dependencies
+        run: bun install
         working-directory: ${{ env.WORKDIR }}
 
       - name: Modify package name for branch-based builds


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK Pod Checks on `main` run a workspace install against the committed `@qvac/inference` range before `sdk-source:workspace` rewrites it to `file:../inference`.
- `publish-sdk.yml` has the same order: `bun install` then workspace link. Lockstep cuts die at install when the new inference version is not on npm yet (see [run 34109626264](https://github.com/tetherto/qvac/actions/runs/34109626264/job/101702676147) on `release-sdk-0.19.0`).
- The workspace compile / checks themselves would pass; they never run because the pre-link registry install fails.

## 📝 How does it solve it?

- For SDK Pod Checks `workspace` source only, run `sdk-source:workspace` first, then the existing install. Published/default stay install-first.
- Do not skip the workspace install: CLI still needs a full package install after linking the sibling SDK.
- In `publish-sdk.yml` `build`, run `sdk-source:workspace` before `bun install`. Publish jobs check out a fresh tree and rewrite the published dep separately, so the `file:` rewrite is compile-only.

## 🧪 How was it tested?

- Inspected `packages/sdk` `sdk-source:workspace` (`link-workspace-inference.ts`) and `packages/cli` `sdk-source:workspace` (`preinstall-build-local-sdk.cjs` + `npm install ../sdk`) to confirm the post-link install still has work to do for CLI and is a cheap re-resolve for SDK.
- `bun run sdk-source:workspace` does not need a prior install: the linker is local TS using node builtins.
- `actionlint` is not installed locally; CI `security-baseline` / workflow lint will scan the edited files.

Merging this PR to `main` does not retry the failed 0.19.0 publish. That workflow loads from `release-sdk-0.19.0`; cherry-pick this commit onto that branch after merge (non-`release-*` head).
