### PR TITLE
chore[notask]: release @qvac/openclaw-plugin 0.2.2

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.2.2]
+
+Release Date: 2026-09-04
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.2
+
+OpenClaw moved its `latest` release to 2026.8.1, which changed three of the commands a QVAC install depends on and removed two type entry points the plugin imported. This patch brings the documented commands, the launcher's own error messages, and the plugin's type surface back in line with it. Nothing in your configuration changes, and no dependency floors move.
+
+## Setup Commands Changed in OpenClaw 2026.8.1
+
+Installing a plugin now asks for trust and for capability consent, and plugin-contributed auth choices are namespaced behind a `provider-plugin:` prefix. Every documented invocation moves:
+
+| Before                       | 2026.8.1 and later                                     |
+| ---------------------------- | ------------------------------------------------------ |
+| `plugins install <spec>`     | `plugins install <spec> --force --accept-capabilities` |
+| `plugins enable qvac`        | `plugins enable qvac --accept-capabilities`            |
+| `onboard --auth-choice qvac` | `onboard --auth-choice provider-plugin:qvac`           |
+
+Without the consent flags the install cancels. With the old auth choice, onboarding rejects `qvac` and lists only OpenClaw's built-in choices. The plugin still registers `choiceId: "qvac"` — OpenClaw namespaces plugin-contributed choices now, so it is the invocation that moves, not the plugin.
+
+The plugin supports `openclaw >=2026.6.0`, so the README documents both forms rather than replacing one with the other. On openclaw before 2026.8.1, drop the two consent flags and use the bare `--auth-choice qvac`.
+
+## Launcher Errors Name a Command That Works
+
+Two failures in the local service told you to recover by running `openclaw onboard --auth-choice qvac` — a command 2026.8.1 rejects, leaving you with an error whose remedy also failed:
+
+- A provider entry created before the managed serve required bearer authentication, whose persisted `localService.args` has no `--api-key-file` value.
+- A QVAC key file whose permissions have drifted so it is readable beyond its owner.
+
+Both now name the `provider-plugin:qvac` form first, with the pre-2026.8.1 form alongside it.
+
+## Builds Against OpenClaw 2026.8.1 Again
+
+2026.8.1 dropped `plugin-sdk/config-types` from its exports map and left `plugin-sdk/provider-model-shared` without type declarations, so `SecretProviderConfig` and `ModelProviderConfig` could no longer be imported by name and the plugin failed to typecheck and build against it.
+
+Both are now derived from `OpenClawConfig`, which is exported with types from `plugin-sdk/plugin-entry` — already the entry the plugin imports `definePluginEntry` from. These are type-only imports, so the emitted JavaScript is unchanged.
+
+## Requirements
+
+Unchanged from 0.2.1: `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog, `@qvac/cli@^0.12.0` for `qvac serve`, and `openclaw >=2026.6.0` as the optional host peer.
+
 ## [0.2.1]
 
 Release Date: 2026-08-21

--- a/plugins/openclaw/changelog/0.2.2/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.2.2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.2
+
+Release Date: 2026-09-04
+
+## 🐞 Fixes
+
+- Adapt the openclaw integration to 2026.8.1 (smoke, docs, plugin messages). (see PR [#4192](https://github.com/tetherto/qvac/pull/4192))

--- a/plugins/openclaw/changelog/0.2.2/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.2.2/CHANGELOG_LLM.md
@@ -1,0 +1,40 @@
+# QVAC OpenClaw Plugin v0.2.2 Release Notes
+
+Release Date: 2026-09-04
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.2
+
+OpenClaw moved its `latest` release to 2026.8.1, which changed three of the commands a QVAC install depends on and removed two type entry points the plugin imported. This patch brings the documented commands, the launcher's own error messages, and the plugin's type surface back in line with it. Nothing in your configuration changes, and no dependency floors move.
+
+## Setup Commands Changed in OpenClaw 2026.8.1
+
+Installing a plugin now asks for trust and for capability consent, and plugin-contributed auth choices are namespaced behind a `provider-plugin:` prefix. Every documented invocation moves:
+
+| Before                       | 2026.8.1 and later                                     |
+| ---------------------------- | ------------------------------------------------------ |
+| `plugins install <spec>`     | `plugins install <spec> --force --accept-capabilities` |
+| `plugins enable qvac`        | `plugins enable qvac --accept-capabilities`            |
+| `onboard --auth-choice qvac` | `onboard --auth-choice provider-plugin:qvac`           |
+
+Without the consent flags the install cancels. With the old auth choice, onboarding rejects `qvac` and lists only OpenClaw's built-in choices. The plugin still registers `choiceId: "qvac"` — OpenClaw namespaces plugin-contributed choices now, so it is the invocation that moves, not the plugin.
+
+The plugin supports `openclaw >=2026.6.0`, so the README documents both forms rather than replacing one with the other. On openclaw before 2026.8.1, drop the two consent flags and use the bare `--auth-choice qvac`.
+
+## Launcher Errors Name a Command That Works
+
+Two failures in the local service told you to recover by running `openclaw onboard --auth-choice qvac` — a command 2026.8.1 rejects, leaving you with an error whose remedy also failed:
+
+- A provider entry created before the managed serve required bearer authentication, whose persisted `localService.args` has no `--api-key-file` value.
+- A QVAC key file whose permissions have drifted so it is readable beyond its owner.
+
+Both now name the `provider-plugin:qvac` form first, with the pre-2026.8.1 form alongside it.
+
+## Builds Against OpenClaw 2026.8.1 Again
+
+2026.8.1 dropped `plugin-sdk/config-types` from its exports map and left `plugin-sdk/provider-model-shared` without type declarations, so `SecretProviderConfig` and `ModelProviderConfig` could no longer be imported by name and the plugin failed to typecheck and build against it.
+
+Both are now derived from `OpenClawConfig`, which is exported with types from `plugin-sdk/plugin-entry` — already the entry the plugin imports `definePluginEntry` from. These are type-only imports, so the emitted JavaScript is unchanged.
+
+## Requirements
+
+Unchanged from 0.2.1: `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog, `@qvac/cli@^0.12.0` for `qvac serve`, and `openclaw >=2026.6.0` as the optional host peer.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/openclaw-plugin@0.2.1` is the published version, and the 2026.8.1 adaptation in #4192 has been sitting unreleased on `main` since 2026-09-03.
- Until it ships, every install follows README commands that OpenClaw 2026.8.1 rejects, and the two launcher errors point at an `openclaw onboard --auth-choice qvac` remedy that also fails.

## 📝 How does it solve it?

- Bumps `plugins/openclaw` to `0.2.2`.
- Adds `changelog/0.2.2/` — generated `CHANGELOG.md` plus a hand-written `CHANGELOG_LLM.md`.
- Rebuilds `plugins/openclaw/CHANGELOG.md` from all seven version folders.

Scope is #4192 only. `@qvac/ai-sdk-provider@^0.6.0`, `@qvac/cli@^0.12.0` and the `openclaw >=2026.6.0` peer are all unchanged, so nothing here waits on another package.

Changelog base is `cf5fd1214` (the commit `release-openclaw-plugin-0.2.1` was cut from) passed as `--base-commit`, because `openclaw-plugin-v0.2.1` lives only on its own release branch and is not an ancestor of `main`. The range yields #4192 and the 0.2.1 backmerge, and the generator drops the latter on its `[skiplog]` tag.

`plugins/openclaw/NOTICE` is unchanged and was not regenerated: `qv-notice-generate` has no `plugins/*` entry, and `notice-drift` only globs `packages/**`. No dependency moved in this release either way.

## 🧪 How was it tested?

Run in `plugins/openclaw` on the release commit:

- `npm run format` — clean (the generated `changelog/0.2.2/CHANGELOG.md` needed one prettier pass first)
- `npm run lint` — `lunte`, no issues
- `npm run typecheck` — clean
- `npm run test:unit` — 35/35 pass
- `npm run build` — clean
