### PR TITLE
chore[skiplog|notask]: backmerge release-openclaw-plugin-0.2.2 — version bump, changelog

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.2.2]
+
+Release Date: 2026-09-04
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.2
+
+OpenClaw moved its `latest` release to 2026.8.1, which changed three of the commands a QVAC install depends on and removed two type entry points the plugin imported. This patch brings the documented commands, the launcher's own error messages, and the plugin's type surface back in line with it. Nothing in your configuration changes, and no dependency floors move.
+
+## Setup Commands Changed in OpenClaw 2026.8.1
+
+Installing a plugin now asks for trust and for capability consent, and plugin-contributed auth choices are namespaced behind a `provider-plugin:` prefix. Every documented invocation moves:
+
+| Before                       | 2026.8.1 and later                                     |
+| ---------------------------- | ------------------------------------------------------ |
+| `plugins install <spec>`     | `plugins install <spec> --force --accept-capabilities` |
+| `plugins enable qvac`        | `plugins enable qvac --accept-capabilities`            |
+| `onboard --auth-choice qvac` | `onboard --auth-choice provider-plugin:qvac`           |
+
+Without the consent flags the install cancels. With the old auth choice, onboarding rejects `qvac` and lists only OpenClaw's built-in choices. The plugin still registers `choiceId: "qvac"` — OpenClaw namespaces plugin-contributed choices now, so it is the invocation that moves, not the plugin.
+
+The plugin supports `openclaw >=2026.6.0`, so the README documents both forms rather than replacing one with the other. On openclaw before 2026.8.1, drop the two consent flags and use the bare `--auth-choice qvac`.
+
+## Launcher Errors Name a Command That Works
+
+Two failures in the local service told you to recover by running `openclaw onboard --auth-choice qvac` — a command 2026.8.1 rejects, leaving you with an error whose remedy also failed:
+
+- A provider entry created before the managed serve required bearer authentication, whose persisted `localService.args` has no `--api-key-file` value.
+- A QVAC key file whose permissions have drifted so it is readable beyond its owner.
+
+Both now name the `provider-plugin:qvac` form first, with the pre-2026.8.1 form alongside it.
+
+## Builds Against OpenClaw 2026.8.1 Again
+
+2026.8.1 dropped `plugin-sdk/config-types` from its exports map and left `plugin-sdk/provider-model-shared` without type declarations, so `SecretProviderConfig` and `ModelProviderConfig` could no longer be imported by name and the plugin failed to typecheck and build against it.
+
+Both are now derived from `OpenClawConfig`, which is exported with types from `plugin-sdk/plugin-entry` — already the entry the plugin imports `definePluginEntry` from. These are type-only imports, so the emitted JavaScript is unchanged.
+
+## Requirements
+
+Unchanged from 0.2.1: `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog, `@qvac/cli@^0.12.0` for `qvac serve`, and `openclaw >=2026.6.0` as the optional host peer.
+
 ## [0.2.1]
 
 Release Date: 2026-08-21

--- a/plugins/openclaw/changelog/0.2.2/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.2.2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.2
+
+Release Date: 2026-09-04
+
+## 🐞 Fixes
+
+- Adapt the openclaw integration to 2026.8.1 (smoke, docs, plugin messages). (see PR [#4192](https://github.com/tetherto/qvac/pull/4192))

--- a/plugins/openclaw/changelog/0.2.2/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.2.2/CHANGELOG_LLM.md
@@ -1,0 +1,40 @@
+# QVAC OpenClaw Plugin v0.2.2 Release Notes
+
+Release Date: 2026-09-04
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.2
+
+OpenClaw moved its `latest` release to 2026.8.1, which changed three of the commands a QVAC install depends on and removed two type entry points the plugin imported. This patch brings the documented commands, the launcher's own error messages, and the plugin's type surface back in line with it. Nothing in your configuration changes, and no dependency floors move.
+
+## Setup Commands Changed in OpenClaw 2026.8.1
+
+Installing a plugin now asks for trust and for capability consent, and plugin-contributed auth choices are namespaced behind a `provider-plugin:` prefix. Every documented invocation moves:
+
+| Before                       | 2026.8.1 and later                                     |
+| ---------------------------- | ------------------------------------------------------ |
+| `plugins install <spec>`     | `plugins install <spec> --force --accept-capabilities` |
+| `plugins enable qvac`        | `plugins enable qvac --accept-capabilities`            |
+| `onboard --auth-choice qvac` | `onboard --auth-choice provider-plugin:qvac`           |
+
+Without the consent flags the install cancels. With the old auth choice, onboarding rejects `qvac` and lists only OpenClaw's built-in choices. The plugin still registers `choiceId: "qvac"` — OpenClaw namespaces plugin-contributed choices now, so it is the invocation that moves, not the plugin.
+
+The plugin supports `openclaw >=2026.6.0`, so the README documents both forms rather than replacing one with the other. On openclaw before 2026.8.1, drop the two consent flags and use the bare `--auth-choice qvac`.
+
+## Launcher Errors Name a Command That Works
+
+Two failures in the local service told you to recover by running `openclaw onboard --auth-choice qvac` — a command 2026.8.1 rejects, leaving you with an error whose remedy also failed:
+
+- A provider entry created before the managed serve required bearer authentication, whose persisted `localService.args` has no `--api-key-file` value.
+- A QVAC key file whose permissions have drifted so it is readable beyond its owner.
+
+Both now name the `provider-plugin:qvac` form first, with the pre-2026.8.1 form alongside it.
+
+## Builds Against OpenClaw 2026.8.1 Again
+
+2026.8.1 dropped `plugin-sdk/config-types` from its exports map and left `plugin-sdk/provider-model-shared` without type declarations, so `SecretProviderConfig` and `ModelProviderConfig` could no longer be imported by name and the plugin failed to typecheck and build against it.
+
+Both are now derived from `OpenClawConfig`, which is exported with types from `plugin-sdk/plugin-entry` — already the entry the plugin imports `definePluginEntry` from. These are type-only imports, so the emitted JavaScript is unchanged.
+
+## Requirements
+
+Unchanged from 0.2.1: `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog, `@qvac/cli@^0.12.0` for `qvac serve`, and `openclaw >=2026.6.0` as the optional host peer.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/openclaw-plugin@0.2.2` on `main`, per [gitflow.md](../docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- https://github.com/tetherto/qvac/pull/4284

## Files

- `plugins/openclaw/package.json` — version `0.2.1` → `0.2.2`
- `plugins/openclaw/changelog/0.2.2/` — generated `CHANGELOG.md` and hand-written `CHANGELOG_LLM.md`
- `plugins/openclaw/CHANGELOG.md` — aggregated changelog, rebuilt from all seven version folders

`plugins/openclaw/NOTICE` is not included: no dependency moved in this release, and the package sits outside both `qv-notice-generate` and the `notice-drift` glob (`packages/**`).
