### PR TITLE
fix[bc|notask]: launch qvac serve via --openai and require CLI 0.13

### DIFF
--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -2,13 +2,13 @@
 
 [Vercel AI SDK](https://ai-sdk.dev) provider for the [QVAC](https://qvac.tether.io) local AI runtime.
 
-QVAC is an open-source, cross-platform ecosystem for **local-first, peer-to-peer AI** — LLMs, embeddings, transcription, translation, speech, OCR, and image generation, all running on the user's own hardware. This package implements the native provider contracts for language, embedding, image, file-reference, transcription, and speech operations against a local `qvac serve openai` runtime. It also re-exports QVAC's model metadata so callers can introspect typed model constants without an HTTP round-trip.
+QVAC is an open-source, cross-platform ecosystem for **local-first, peer-to-peer AI** — LLMs, embeddings, transcription, translation, speech, OCR, and image generation, all running on the user's own hardware. This package implements the native provider contracts for language, embedding, image, file-reference, transcription, and speech operations against a local `qvac serve --openai` runtime. It also re-exports QVAC's model metadata so callers can introspect typed model constants without an HTTP round-trip.
 
 The provider is OpenAI-compatible by construction: the OpenAI-compatible transport is its fallback provider, while the SDK's native custom-provider composition adds QVAC-specific files, transcription, and speech capabilities. Existing OpenAI-shaped chat, completion, embedding, and image requests keep the same wire protocol.
 
 > **Runtime modes:**
 >
-> - **External** (default): the package wraps a `qvac serve openai` HTTP endpoint that you run yourself.
+> - **External** (default): the package wraps a `qvac serve --openai` HTTP endpoint that you run yourself.
 > - **Managed** (`mode: 'managed'`): the provider synthesizes an ephemeral config from a model list, then spawns (or reuses) a shared `qvac serve` on a free port and keeps it alive for as long as anything is using it, reaping it automatically once everyone is done. See [Managed mode](#managed-mode) below. Requires the optional [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) peer dependency.
 >
 > See the [QVAC-19194 epic](https://app.asana.com/1/45238840754660/task/1214968611313049).
@@ -35,7 +35,7 @@ Runtime requirements:
 
 ## Quickstart
 
-### 1. Run `qvac serve openai`
+### 1. Run `qvac serve --openai`
 
 You need [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) installed and a minimal config that preloads at least one chat model:
 
@@ -53,7 +53,7 @@ cat > qvac.config.json <<'EOF'
 EOF
 
 export QVAC_API_KEY='replace-with-a-random-secret'
-qvac serve openai --api-key "$QVAC_API_KEY"
+qvac serve --openai --no-default --api-key "$QVAC_API_KEY"
 ```
 
 By default, `qvac serve` listens on `http://127.0.0.1:11434/v1` (the port may change in a future CLI release — see the **Default base URL** note below).
@@ -150,7 +150,7 @@ Per-request transcription `prompt` is supported. Language is selected when the Q
 
 ## Managed mode
 
-External mode (above) assumes you've already authored a `qvac.config.json` and have `qvac serve openai` running in another terminal. **Managed mode removes both steps**: pass `mode: 'managed'` and a list of model constants, and the provider will synthesize an ephemeral config, spawn `qvac serve` on a free port, wait until it's healthy, and reap it automatically once nothing is using it.
+External mode (above) assumes you've already authored a `qvac.config.json` and have `qvac serve --openai` running in another terminal. **Managed mode removes both steps**: pass `mode: 'managed'` and a list of model constants, and the provider will synthesize an ephemeral config, spawn `qvac serve` on a free port, wait until it's healthy, and reap it automatically once nothing is using it.
 
 The serve is **shared and self-cleaning**: a second session (or a separate tool) asking for the same models attaches to the already-warm serve instead of paying another cold start, and the serve is torn down by a detached supervisor a few minutes after the last user goes away. You never have to babysit a process — see [Shared serves & lifecycle](#shared-serves--lifecycle).
 
@@ -160,7 +160,7 @@ Custom `fetch` wrappers receive requests after managed authorization has been ap
 
 ```bash
 # Managed mode needs the QVAC CLI available (optional peer dependency):
-npm install @qvac/ai-sdk-provider ai @ai-sdk/openai-compatible @qvac/cli
+npm install @qvac/ai-sdk-provider ai @ai-sdk/openai-compatible @qvac/cli@^0.13.0
 ```
 
 ```ts
@@ -233,7 +233,7 @@ const res = await fetch(`${qvac.baseURL}/models`, {
 
 Treat it as secret material. The property is non-enumerable, so `{ ...provider }`, `Object.keys(provider)`, and object dumps never carry it; never log it or hand it to an untrusted process.
 
-Neither the detached runner nor the `qvac serve` it starts receives the key through argv: both read it from a one-shot `0600` file, so it cannot be recovered from `ps` or `/proc/<pid>/cmdline`. Passing the key on the serve command line requires a CLI too old for `--api-key-file`, which the provider detects and falls back to; the same is true of a `serveBinPath` override, whose version cannot be determined. Install `@qvac/cli` 0.11.0 or newer to keep the key out of the process list.
+Neither the detached runner nor the `qvac serve` it starts receives the key through argv: both read it from a one-shot `0600` file, so it cannot be recovered from `ps` or `/proc/<pid>/cmdline`. Every CLI in the supported `^0.13.0` peer range takes `--api-key-file`, so the argv fallback is reached only behind a `serveBinPath` override, whose version cannot be determined.
 
 ### Per-model configuration
 

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^3.0",
-    "@qvac/cli": "^0.10.0 || ^0.11.0 || ^0.12.0",
+    "@qvac/cli": "^0.13.0",
     "ai": "^7.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ai-sdk-provider/src/managed/serve-process.ts
+++ b/packages/ai-sdk-provider/src/managed/serve-process.ts
@@ -19,7 +19,7 @@ import {
   ServeStartTimeoutError
 } from './errors.js'
 
-// Low-level lifecycle of a single `qvac serve openai` child: resolve the
+// Low-level lifecycle of a single `qvac serve --openai` child: resolve the
 // command, pick a port, spawn, wait until healthy, and stop. Deliberately
 // free of any registry/process-handler coupling — the detached runner owns
 // those concerns and uses these primitives.
@@ -248,7 +248,7 @@ export interface SpawnedServe {
   readonly baseURL: string
 }
 
-// Spawn `qvac serve openai` on the given port and resolve once it answers a
+// Spawn `qvac serve --openai` on the given port and resolve once it answers a
 // health check. On any failure the child is killed and a structured error is
 // thrown, so the caller never leaks a half-started process.
 export async function spawnServe(options: SpawnServeOptions): Promise<SpawnedServe> {
@@ -265,7 +265,11 @@ export async function spawnServe(options: SpawnServeOptions): Promise<SpawnedSer
   const args = [
     ...baseArgs,
     'serve',
-    'openai',
+    // `--no-default` keeps the QVAC surface off the port: this provider only
+    // speaks /v1/*, and the pair is what the retired `serve openai` subcommand
+    // expanded to.
+    '--openai',
+    '--no-default',
     '--config',
     options.configPath,
     '--port',

--- a/packages/ai-sdk-provider/src/managed/serve-process.ts
+++ b/packages/ai-sdk-provider/src/managed/serve-process.ts
@@ -266,8 +266,7 @@ export async function spawnServe(options: SpawnServeOptions): Promise<SpawnedSer
     ...baseArgs,
     'serve',
     // `--no-default` keeps the QVAC surface off the port: this provider only
-    // speaks /v1/*, and the pair is what the retired `serve openai` subcommand
-    // expanded to.
+    // speaks /v1/*.
     '--openai',
     '--no-default',
     '--config',

--- a/packages/ai-sdk-provider/src/provider.ts
+++ b/packages/ai-sdk-provider/src/provider.ts
@@ -18,7 +18,7 @@ import type {
 // External mode synchronously composes the OpenAI-compatible language-model
 // surface with QVAC's native files, transcription, and speech capabilities.
 // Language models also resolve QVAC file references through the caller-managed
-// `qvac serve openai` endpoint.
+// `qvac serve --openai` endpoint.
 export function createExternalQvac(options: QvacExternalOptions = {}): QvacProvider {
   const apiKey = options.apiKey ?? DEFAULT_API_KEY
   const headers = mergeHeaders(DEFAULT_HEADERS, options.headers)

--- a/packages/ai-sdk-provider/src/types.ts
+++ b/packages/ai-sdk-provider/src/types.ts
@@ -10,7 +10,7 @@ interface QvacCommonOptions {
 }
 
 // External mode (default): the provider is a thin wrapper around a
-// `qvac serve openai` HTTP endpoint that the caller runs and supervises
+// `qvac serve --openai` HTTP endpoint that the caller runs and supervises
 // themselves. This is the v1 (0.1.0) surface, unchanged.
 export interface QvacExternalOptions extends QvacCommonOptions {
   readonly mode?: 'external'
@@ -41,7 +41,7 @@ export interface QvacManagedModel {
 }
 
 // Managed mode: the provider synthesizes an ephemeral `qvac.config.json` from
-// the requested model list, spawns `qvac serve openai` on a free port,
+// the requested model list, spawns `qvac serve --openai` on a free port,
 // health-checks it, and tears the process down on host exit. `createQvac`
 // returns a `Promise<ManagedQvacProvider>` in this mode. Managed mode generates
 // and owns the serve API key; caller headers and custom fetch wrappers receive

--- a/packages/ai-sdk-provider/test/helpers/fake-serve.ts
+++ b/packages/ai-sdk-provider/test/helpers/fake-serve.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { isProcessAlive, readAllRecords, removeRecord } from '../../src/managed/registry.js'
 
-// A stand-in for `qvac serve openai`: parses its managed launch options, then behaves
+// A stand-in for `qvac serve --openai`: parses its managed launch options, then behaves
 // per FAKE_SERVE_BEHAVIOR. Lets the managed-mode tests drive every supervisor
 // path (healthy, timeout, crash, SIGKILL escalation) without @qvac/cli or real
 // models. Spawned verbatim through `serveBinPath`, so it relies on a POSIX
@@ -17,6 +17,10 @@ const port = Number(arg('--port'))
 const host = arg('--host') || '127.0.0.1'
 const apiKey = arg('--api-key')
 const behavior = process.env.FAKE_SERVE_BEHAVIOR || 'healthy'
+
+if (process.env.FAKE_SERVE_ARGV_FILE) {
+  require('node:fs').writeFileSync(process.env.FAKE_SERVE_ARGV_FILE, JSON.stringify(args))
+}
 
 if (behavior === 'exit-immediately') { console.error('fake serve boom'); process.exit(3) }
 
@@ -87,6 +91,12 @@ const BEHAVIOR_KEY = 'FAKE_SERVE_BEHAVIOR'
 export function setBehavior(value: string | undefined): void {
   if (value === undefined) delete process.env[BEHAVIOR_KEY]
   else process.env[BEHAVIOR_KEY] = value
+}
+
+const ARGV_FILE_KEY = 'FAKE_SERVE_ARGV_FILE'
+export function setArgvFile(path: string | undefined): void {
+  if (path === undefined) delete process.env[ARGV_FILE_KEY]
+  else process.env[ARGV_FILE_KEY] = path
 }
 
 // Managed mode now spawns a *detached* runner that owns the serve and only

--- a/packages/ai-sdk-provider/test/managed-serve-process.test.ts
+++ b/packages/ai-sdk-provider/test/managed-serve-process.test.ts
@@ -13,7 +13,12 @@ import {
   stopServe,
   writeApiKeyFile
 } from '../src/managed/serve-process.js'
-import { fakeServeSkip as skip, makeFakeServe, setBehavior } from './helpers/fake-serve.js'
+import {
+  fakeServeSkip as skip,
+  makeFakeServe,
+  setArgvFile,
+  setBehavior
+} from './helpers/fake-serve.js'
 
 const API_KEY = 'managed-test-key'
 
@@ -52,6 +57,44 @@ test(
     } finally {
       setBehavior(undefined)
       await fake.cleanup()
+    }
+  }
+)
+
+test(
+  'spawnServe launches the serve with --openai --no-default, not the retired subcommand',
+  { skip },
+  async () => {
+    const fake = await makeFakeServe()
+    const dir = await mkdtemp(join(tmpdir(), 'qvac-argv-'))
+    const argvFile = join(dir, 'argv.json')
+    setBehavior('healthy')
+    setArgvFile(argvFile)
+    try {
+      const port = await allocateFreePort('127.0.0.1')
+      const serve = await spawnServe({
+        apiKey: API_KEY,
+        configPath: 'unused.json',
+        port,
+        serveBinPath: fake.binPath,
+        startTimeoutMs: 10_000
+      })
+
+      const argv = JSON.parse(await readFile(argvFile, 'utf8')) as string[]
+
+      // `serve openai` is deprecated as of @qvac/cli 0.13 and warns on start.
+      // The flag pair is what it expanded to: the OpenAI surface only.
+      assert.equal(argv[0], 'serve')
+      assert.equal(argv[1], '--openai')
+      assert.equal(argv[2], '--no-default')
+      assert.equal(argv.includes('openai'), false)
+
+      await stopServe(serve.child)
+    } finally {
+      setArgvFile(undefined)
+      setBehavior(undefined)
+      await fake.cleanup()
+      await rm(dir, { recursive: true, force: true })
     }
   }
 )

--- a/packages/ai-sdk-provider/test/managed-serve-process.test.ts
+++ b/packages/ai-sdk-provider/test/managed-serve-process.test.ts
@@ -61,43 +61,39 @@ test(
   }
 )
 
-test(
-  'spawnServe launches the serve with --openai --no-default, not the retired subcommand',
-  { skip },
-  async () => {
-    const fake = await makeFakeServe()
-    const dir = await mkdtemp(join(tmpdir(), 'qvac-argv-'))
-    const argvFile = join(dir, 'argv.json')
-    setBehavior('healthy')
-    setArgvFile(argvFile)
-    try {
-      const port = await allocateFreePort('127.0.0.1')
-      const serve = await spawnServe({
-        apiKey: API_KEY,
-        configPath: 'unused.json',
-        port,
-        serveBinPath: fake.binPath,
-        startTimeoutMs: 10_000
-      })
+test('spawnServe launches the serve with --openai --no-default', { skip }, async () => {
+  const fake = await makeFakeServe()
+  const dir = await mkdtemp(join(tmpdir(), 'qvac-argv-'))
+  const argvFile = join(dir, 'argv.json')
+  setBehavior('healthy')
+  setArgvFile(argvFile)
+  try {
+    const port = await allocateFreePort('127.0.0.1')
+    const serve = await spawnServe({
+      apiKey: API_KEY,
+      configPath: 'unused.json',
+      port,
+      serveBinPath: fake.binPath,
+      startTimeoutMs: 10_000
+    })
 
-      const argv = JSON.parse(await readFile(argvFile, 'utf8')) as string[]
+    const argv = JSON.parse(await readFile(argvFile, 'utf8')) as string[]
 
-      // `serve openai` is deprecated as of @qvac/cli 0.13 and warns on start.
-      // The flag pair is what it expanded to: the OpenAI surface only.
-      assert.equal(argv[0], 'serve')
-      assert.equal(argv[1], '--openai')
-      assert.equal(argv[2], '--no-default')
-      assert.equal(argv.includes('openai'), false)
+    // Bare `--openai` would also mount the QVAC surface; this provider only
+    // speaks /v1/*, so the pair has to stay together.
+    assert.equal(argv[0], 'serve')
+    assert.equal(argv[1], '--openai')
+    assert.equal(argv[2], '--no-default')
+    assert.equal(argv.includes('openai'), false)
 
-      await stopServe(serve.child)
-    } finally {
-      setArgvFile(undefined)
-      setBehavior(undefined)
-      await fake.cleanup()
-      await rm(dir, { recursive: true, force: true })
-    }
+    await stopServe(serve.child)
+  } finally {
+    setArgvFile(undefined)
+    setBehavior(undefined)
+    await fake.cleanup()
+    await rm(dir, { recursive: true, force: true })
   }
-)
+})
 
 test(
   'spawnServe throws ServeStartTimeoutError when the serve never gets healthy',


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/cli` 0.13 mounts the serve surfaces as extensions ([#4164](https://github.com/tetherto/qvac/pull/4164)) and retires the `qvac serve openai` subcommand. The provider still spawns that subcommand in managed mode, so against CLI 0.13 every managed serve now starts with a deprecation warning on its stderr:

```
`qvac serve openai` is deprecated. Use `qvac serve --openai --no-default`.
```

It still works today, but it's on a deprecation path the provider shouldn't be sitting on, and the provider's own captured output tail is where that warning lands.

## 📝 How does it solve it?

- `spawnServe` now passes `serve --openai --no-default`.
- The optional `@qvac/cli` peer narrows to `^0.13.0`.

**Why `--no-default` and not bare `--openai`:** the two are not equivalent. `--openai` mounts the QVAC surface *and* `/v1/*`; `--openai --no-default` mounts `/v1/*` only. The retired subcommand expanded to the latter — `packages/cli/src/serve/command.ts:51` sets `{ openai: true, [DEFAULT_EXTENSION]: false }` — so the flag pair is what preserves current behaviour and keeps the extra surface off a port this provider authenticates and owns.

The `serve.models` config the provider synthesizes is unchanged in 0.13, so `config-synthesizer.ts` needed no changes. The OpenAI config keys that moved under `serve.openai` in 0.13 are ones the provider never writes.

## 💥 Breaking Changes

The optional managed-mode `@qvac/cli` peer no longer accepts the `0.10`–`0.12` lines. Those CLIs have no `--openai` flag, so they cannot run the launch command this version emits.

**BEFORE:**

```json
{ "peerDependencies": { "@qvac/cli": "^0.10.0 || ^0.11.0 || ^0.12.0" } }
```

**AFTER:**

```json
{ "peerDependencies": { "@qvac/cli": "^0.13.0" } }
```

External mode is unaffected — it never spawns a CLI. Managed-mode users must move to CLI 0.13.

⚠️ **Sequencing:** `@qvac/cli` 0.13.0 is not on npm yet — its release PRs are [#4277](https://github.com/tetherto/qvac/pull/4277) / [#4278](https://github.com/tetherto/qvac/pull/4278). A provider release carrying this change should be promoted after CLI 0.13.0 publishes, as was done for 0.5.0 and CLI 0.10.0.

## 🧪 How was it tested?

Full SDK pod check set for this package, on a clean `bun install`:

| check | result |
| --- | --- |
| `bun run format` | clean |
| `bun run lint` | clean |
| `bun run typecheck` | clean |
| `bun run build` | clean |
| `bun run test:unit` | 104 tests, 0 failures (2 pre-existing managed-integration skips) |

The clean install was re-run after the peer narrowing to confirm the unpublished `^0.13.0` doesn't break resolution — it doesn't, since `@qvac/cli` is an optional peer and not a devDependency.

New test, `spawnServe launches the serve with --openai --no-default, not the retired subcommand`: nothing pinned the launch argv before, so a silent regression to the deprecated form would only have shown up as a warning on a real CLI. The fake serve now records its argv when `FAKE_SERVE_ARGV_FILE` is set, and the test asserts the flag pair is present and the bare `openai` subcommand is absent.
