### PR TITLE
test[notask]: guard the batch newline case on /qvac/v1/translate

### DIFF
--- a/packages/cli/test/e2e/model/translate.test.ts
+++ b/packages/cli/test/e2e/model/translate.test.ts
@@ -69,6 +69,32 @@ describe('qvac translate: real NMT model', () => {
     assert.match(body.translations[1]!, /thank/i)
   })
 
+  it('keeps a newline inside one input from splitting it into two entries', async () => {
+    // The batch path used to return the translations joined by '\n', which made an
+    // input whose own translation contains a newline unrecoverable — the caller could
+    // not tell it apart from two separate inputs. These two requests produce the same
+    // text and must not produce the same shape.
+    const withNewline = await translate({
+      model: ALIAS,
+      text: ['Guten Morgen\nVielen Dank', 'Bis bald']
+    })
+    assert.equal(withNewline.statusCode, 200)
+
+    const joined = (withNewline.json() as TranslationResult).translations
+    assert.equal(joined.length, 2)
+    assert.ok(joined[0]!.includes('\n'), 'expected the newline to survive inside its own entry')
+    assert.match(joined[0]!, /morning/i)
+    assert.match(joined[0]!, /thank/i)
+    assert.match(joined[1]!, /soon/i)
+
+    const separate = await translate({
+      model: ALIAS,
+      text: ['Guten Morgen', 'Vielen Dank', 'Bis bald']
+    })
+    assert.equal(separate.statusCode, 200)
+    assert.equal((separate.json() as TranslationResult).translations.length, 3)
+  })
+
   it('streams a batch as one item per input', async () => {
     const res = await translate({
       model: ALIAS,


### PR DESCRIPTION
Offered on #3889 and invited by @victorchimakanu. It is much smaller than the harness I offered
there, and deliberately so — see below.

## The gap

`POST /qvac/v1/translate` returns a structured `translations[]`. The batch path it replaced
returned the translations joined by `'\n'`, which made an input whose own translation contains a
newline unrecoverable: the caller could not tell it apart from two separate inputs. That is the
defect #3889 was opened over, and #4165 fixed it.

Nothing currently covers it. Neither `test/e2e/model/translate.test.ts` nor
`test/e2e/default/translate.test.ts` sends a newline in any input, so a regression to
newline-joining would pass the suite.

## The test

One case added to the real-model suite. A two-input batch whose first translation contains a
newline must return **two** entries with the newline intact inside the first; the same text sent
as three separate inputs must return **three**.

```
['Guten Morgen\nVielen Dank', 'Bis bald']      -> ['Good morning\nThank you very much', 'See you soon']
['Guten Morgen', 'Vielen Dank', 'Bis bald']    -> ['Good morning', 'Thank you very much', 'See you soon']
```

The pair matters: the two requests produce the same text, and under a joined return they would
both yield three entries. Asserting either one alone would not distinguish the old behaviour.

Uses the existing `test-nmt` / `BERGAMOT_DE_EN` fixture and `useModelServer`, so it adds no new
configuration or dependency.

## Why only one test

I offered a 180-line harness on the thread. Having read what is already there, most of it would
have been duplication — the existing suites already cover ordering, stats presence, both SSE
shapes, the input cap, unknown model, unknown field, empty text and `invalid_model_type`, and
several of those more thoroughly than mine. The newline case is the one real gap I found, so it
is the only thing here. Happy to contribute more if something else would be useful.

The other two findings from that thread are not test material and are filed separately: a client
disconnect drops the result but does not stop the native batch (documented behaviour, though the
route description reads as though work is shed), and cumulative `stats` counters, now #4292.

## Verification

Run against a build of `main` — `packages/inference` → `packages/sdk` → `packages/cli` wired with
`file:` siblings, since main's CLI does not currently build against a published SDK (#3889):

- `npx tsx --test --test-concurrency=1 test/e2e/model/translate.test.ts` — **7/7 pass**, the six
  existing cases and the new one
- `npx prettier --check` — clean
- `npx lunte` — clean
