### PR TITLE
chore[notask]: release @qvac/opencode-plugin 0.3.1

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.3.1]
+
+Release Date: 2026-09-07
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.3.1
+
+This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.7 and `@qvac/cli` 0.13, so managed installs resolve a provider and CLI that agree on how a serve is launched.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.7.0` for managed mode, which launches `qvac serve --openai --no-default` and narrows its own optional CLI peer to `^0.13.0`
+- `@qvac/cli@^0.13.0` for that serve, which mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand
+
+The two floors have to move together. Provider 0.7 refuses a CLI on the 0.10–0.12 lines, so a plugin that asked for `@qvac/cli@^0.12.0` alongside it would leave the install unresolvable. Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plugin, since a 0.x caret range does not cross a minor.
+
+Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2, so upgrading from a 0.6.1-era install picks those up here.
+
+Plugin behavior is unchanged: the host still starts a managed QVAC serve, injects the OpenAI-compatible `qvac` provider, and keeps the existing compatibility shim. No plugin source changed in this release — the serve launch command lives in the provider.
+
 ## [0.3.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.3.0

--- a/plugins/opencode/changelog/0.3.1/CHANGELOG.md
+++ b/plugins/opencode/changelog/0.3.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.3.1
+
+Release Date: 2026-09-07
+
+## Compatibility
+
+- Depends on `@qvac/ai-sdk-provider@^0.7.0` and `@qvac/cli@^0.13.0` so managed OpenCode installs resolve the provider that launches `qvac serve --openai --no-default` and the CLI that accepts it.

--- a/plugins/opencode/changelog/0.3.1/CHANGELOG_LLM.md
+++ b/plugins/opencode/changelog/0.3.1/CHANGELOG_LLM.md
@@ -1,0 +1,20 @@
+# QVAC OpenCode Plugin v0.3.1 Release Notes
+
+Release Date: 2026-09-07
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/opencode-plugin/v/0.3.1
+
+This patch moves the OpenCode plugin onto `@qvac/ai-sdk-provider` 0.7 and `@qvac/cli` 0.13, so managed installs resolve a provider and CLI that agree on how a serve is launched.
+
+## Dependency Alignment
+
+Installs now resolve:
+
+- `@qvac/ai-sdk-provider@^0.7.0` for managed mode, which launches `qvac serve --openai --no-default` and narrows its own optional CLI peer to `^0.13.0`
+- `@qvac/cli@^0.13.0` for that serve, which mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand
+
+The two floors have to move together. Provider 0.7 refuses a CLI on the 0.10–0.12 lines, so a plugin that asked for `@qvac/cli@^0.12.0` alongside it would leave the install unresolvable. Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plugin, since a 0.x caret range does not cross a minor.
+
+Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2, so upgrading from a 0.6.1-era install picks those up here.
+
+Plugin behavior is unchanged: the host still starts a managed QVAC serve, injects the OpenAI-compatible `qvac` provider, and keeps the existing compatibility shim. No plugin source changed in this release — the serve launch command lives in the provider.

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/opencode-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenCode plugin that runs a local, managed QVAC serve so `opencode` works against on-device models with no second terminal",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.0",
-    "@qvac/ai-sdk-provider": "^0.6.0",
-    "@qvac/cli": "^0.12.0",
+    "@qvac/ai-sdk-provider": "^0.7.0",
+    "@qvac/cli": "^0.13.0",
     "ai": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/ai-sdk-provider@0.7.0` peers `@qvac/cli@^0.13.0`. This plugin asks for provider `^0.6.0` and cli `^0.12.0`, so resolving provider 0.7 next to it is unresolvable.

## 📝 How does it solve it?

- `0.3.0` → `0.3.1`; `@qvac/ai-sdk-provider` `^0.6.0` → `^0.7.0`, `@qvac/cli` `^0.12.0` → `^0.13.0`.
- Adds `changelog/0.3.1/` and rebuilds `CHANGELOG.md`.
- No source change: OpenCode goes through the provider's `startManagedServe`, so the cli 0.13 launch form lives in the provider. Diff against `opencode-plugin-v0.3.0` is empty.
- Changelog hand-written — no PR landed against `plugins/opencode` since 0.3.0, so the generator writes nothing. Follows `changelog/0.1.2`, the previous dependency-only release.
- `main` still has `packages/ai-sdk-provider` at 0.6.1 with the old peer range until #4288 lands. Doesn't affect this PR (resolves from npm).

## 🧪 How was it tested?

- Against published `@qvac/cli@0.13.0` / `@qvac/ai-sdk-provider@0.7.0`: install, format, lint, typecheck, build clean; 62 pass / 1 skip.
