### PR TITLE
chore[notask]: release @qvac/openclaw-plugin 0.3.0

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [0.3.0]
+
+Release Date: 2026-09-07
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.0
+
+The launcher moves onto the CLI 0.13 launch interface. `@qvac/cli` 0.13 mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand, so the plugin now starts `qvac serve --openai --no-default` and its dependency floors move with it.
+
+## Breaking Changes
+
+### Requires the @qvac/cli 0.13 line
+
+The bundled `local-service.js` launcher builds the serve command itself, and that command changes:
+
+**Before:**
+
+```bash
+qvac serve openai --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+**After:**
+
+```bash
+qvac serve --openai --no-default --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plugin, since a 0.x caret range does not cross a minor.
+
+`--no-default` is part of the pair rather than an extra flag. Bare `--openai` would also mount the QVAC surface on the port, while the deprecated subcommand exposed `/v1/*` alone — keeping both preserves the previous behaviour and keeps the extra surface off a port the plugin authenticates and owns.
+
+### @qvac/ai-sdk-provider moves to 0.7
+
+Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so the two floors have to move together: a plugin still asking for `@qvac/cli@^0.12.0` next to provider 0.7 would leave the install unresolvable. The plugin uses the provider for the shared model catalog only — it drives its own launcher rather than the provider's managed serve — so nothing else about that dependency changes here.
+
+Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2.
+
+## Upgrading
+
+No re-onboarding is needed. The argument list onboarding persists in `openclaw.json` holds only the plugin's own options — `--api-key-file`, `--model`, `--host`, `--port` and the rest — and the serve command is assembled at start time, so an existing provider entry keeps working. Configuration, the key file and your model choice are all untouched.
+
+The `openclaw` host peer is unchanged at `>=2026.6.0`.
+
+## Requirements
+
+- `@qvac/ai-sdk-provider@^0.7.0` for the shared model catalog
+- `@qvac/cli@^0.13.0` for `qvac serve --openai --no-default`
+- `openclaw >=2026.6.0` as the optional host peer
+
 ## [0.2.2]
 
 Release Date: 2026-09-04

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -3,7 +3,7 @@
 Run [OpenClaw](https://openclaw.ai) against a **local, on-device** QVAC model
 using OpenClaw's native `localService` lifecycle support. The plugin registers a
 `qvac` provider, exposes the shared QVAC model catalog, and asks OpenClaw to
-start `qvac serve openai` when the provider is used.
+start `qvac serve --openai --no-default` when the provider is used.
 
 ## Install
 
@@ -163,7 +163,7 @@ mode `0600`.
 
 OpenClaw's provider config uses a file SecretRef, and the local-service arguments
 contain only the key-file path. The launcher validates that file and points
-`qvac serve openai --api-key-file` at it. A missing, invalid, or unsafe key prevents the
+`qvac serve --openai --api-key-file` at it. A missing, invalid, or unsafe key prevents the
 server from starting. The generated QVAC serve config does not contain the key.
 The SecretRef provider id is namespaced as `qvac_key_file` so setup does not
 replace an unrelated `secrets.providers.qvac` entry.
@@ -287,10 +287,10 @@ If the local service fails with `--api-key-file requires a value`, see
 - Provider id: `qvac`
 - API adapter: `openai-completions`
 - Bearer authentication: the configured provider `apiKey` is required by the
-  managed `qvac serve openai` process through a file SecretRef
+  managed `qvac serve --openai` process through a file SecretRef
 - Base URL: `http://127.0.0.1:11434/v1` by default
 - Local service command: `node <plugin>/dist/local-service.js`, which writes a
-  temporary QVAC serve config and starts `qvac serve openai`
+  temporary QVAC serve config and starts `qvac serve --openai --no-default`
 - Model catalog: the shared `@qvac/ai-sdk-provider` catalog ids, including
   `qwen3.5-0.8b`, `qwen3.5-2b`, `qwen3.5-4b`, `qwen3.5-9b`,
   `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b`

--- a/plugins/openclaw/changelog/0.3.0/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.3.0/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog v0.3.0
+
+Release Date: 2026-09-07
+
+## Breaking Changes
+
+- Require the `@qvac/cli` 0.13 line and `@qvac/ai-sdk-provider` 0.7, and start the managed serve with `qvac serve --openai --no-default`. - See [breaking changes](./breaking.md)
+
+## Compatibility
+
+- Depends on `@qvac/ai-sdk-provider@^0.7.0` and `@qvac/cli@^0.13.0` so installs resolve a provider and CLI that agree on how a serve is launched.

--- a/plugins/openclaw/changelog/0.3.0/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.3.0/CHANGELOG_LLM.md
@@ -1,0 +1,47 @@
+# QVAC OpenClaw Plugin v0.3.0 Release Notes
+
+Release Date: 2026-09-07
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.0
+
+The launcher moves onto the CLI 0.13 launch interface. `@qvac/cli` 0.13 mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand, so the plugin now starts `qvac serve --openai --no-default` and its dependency floors move with it.
+
+## Breaking Changes
+
+### Requires the @qvac/cli 0.13 line
+
+The bundled `local-service.js` launcher builds the serve command itself, and that command changes:
+
+**Before:**
+
+```bash
+qvac serve openai --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+**After:**
+
+```bash
+qvac serve --openai --no-default --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plugin, since a 0.x caret range does not cross a minor.
+
+`--no-default` is part of the pair rather than an extra flag. Bare `--openai` would also mount the QVAC surface on the port, while the deprecated subcommand exposed `/v1/*` alone — keeping both preserves the previous behaviour and keeps the extra surface off a port the plugin authenticates and owns.
+
+### @qvac/ai-sdk-provider moves to 0.7
+
+Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so the two floors have to move together: a plugin still asking for `@qvac/cli@^0.12.0` next to provider 0.7 would leave the install unresolvable. The plugin uses the provider for the shared model catalog only — it drives its own launcher rather than the provider's managed serve — so nothing else about that dependency changes here.
+
+Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2.
+
+## Upgrading
+
+No re-onboarding is needed. The argument list onboarding persists in `openclaw.json` holds only the plugin's own options — `--api-key-file`, `--model`, `--host`, `--port` and the rest — and the serve command is assembled at start time, so an existing provider entry keeps working. Configuration, the key file and your model choice are all untouched.
+
+The `openclaw` host peer is unchanged at `>=2026.6.0`.
+
+## Requirements
+
+- `@qvac/ai-sdk-provider@^0.7.0` for the shared model catalog
+- `@qvac/cli@^0.13.0` for `qvac serve --openai --no-default`
+- `openclaw >=2026.6.0` as the optional host peer

--- a/plugins/openclaw/changelog/0.3.0/breaking.md
+++ b/plugins/openclaw/changelog/0.3.0/breaking.md
@@ -1,0 +1,25 @@
+# 💥 Breaking Changes v0.3.0
+
+## Requires the @qvac/cli 0.13 line
+
+`@qvac/cli` 0.13 mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand. The launcher moves to the flag form, and the dependency floors move with it.
+
+**BEFORE:**
+
+```bash
+qvac serve openai --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+**AFTER:**
+
+```bash
+qvac serve --openai --no-default --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+- Installs that pin `@qvac/cli` to `0.12.x` must move to `0.13.x` alongside the plugin, since a 0.x caret range does not cross a minor.
+- `@qvac/ai-sdk-provider` moves to `^0.7.0` in the same step. Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so a plugin still asking for `@qvac/cli@^0.12.0` next to it would leave the install unresolvable.
+- `--no-default` is part of the pair rather than an extra flag: bare `--openai` also mounts the QVAC surface on the port, while the retired subcommand exposed `/v1/*` alone. Keeping both preserves the previous behaviour on a port the plugin authenticates and owns.
+
+No re-onboarding is needed. The serve command is built by the launcher at start time; the argument list onboarding persists in `openclaw.json` holds only the plugin's own options (`--api-key-file`, `--model`, `--host`, `--port`, …) and is unaffected.
+
+---

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -60,8 +60,8 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@qvac/ai-sdk-provider": "^0.6.0",
-    "@qvac/cli": "^0.12.0"
+    "@qvac/ai-sdk-provider": "^0.7.0",
+    "@qvac/cli": "^0.13.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",

--- a/plugins/openclaw/src/local-service.ts
+++ b/plugins/openclaw/src/local-service.ts
@@ -258,6 +258,10 @@ export interface QvacLaunch {
   readonly args: string[]
 }
 
+// `--no-default` is part of the pair, not an extra: bare `--openai` also mounts
+// the QVAC surface on the port, while the `serve openai` subcommand this
+// replaces exposed `/v1/*` alone. Keeping both preserves that and keeps the
+// extra surface off a port the plugin authenticates and owns.
 function qvacLaunch(options: LocalServiceOptions, configPath: string, apiKey: string): QvacLaunch {
   const cli = resolveQvacCli(options.qvacCommand)
   return {
@@ -265,7 +269,8 @@ function qvacLaunch(options: LocalServiceOptions, configPath: string, apiKey: st
     args: [
       ...cli.baseArgs,
       'serve',
-      'openai',
+      '--openai',
+      '--no-default',
       '--config',
       configPath,
       '--host',

--- a/plugins/openclaw/test/local-service.test.ts
+++ b/plugins/openclaw/test/local-service.test.ts
@@ -81,7 +81,8 @@ test('local service launcher creates QVAC serve config and command args from Ope
 
   assert.deepEqual(buildQvacLaunch(options, '/tmp/qvac-openclaw/qvac.config.json').args, [
     'serve',
-    'openai',
+    '--openai',
+    '--no-default',
     '--config',
     '/tmp/qvac-openclaw/qvac.config.json',
     '--host',
@@ -232,7 +233,13 @@ test('spawn errors are formatted without args or secret-bearing properties', () 
   const error = Object.assign(new Error('spawn qvac ENOENT'), {
     code: 'ENOENT',
     syscall: 'spawn qvac',
-    spawnargs: ['serve', 'openai', '--api-key', 'abcdefghijklmnopqrstuvwxyzABCDE_']
+    spawnargs: [
+      'serve',
+      '--openai',
+      '--no-default',
+      '--api-key',
+      'abcdefghijklmnopqrstuvwxyzABCDE_'
+    ]
   })
 
   const formatted = formatSpawnError(error, '/usr/local/bin/qvac')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `local-service.ts:267` spawns `qvac serve openai`, deprecated by `@qvac/cli` 0.13. OpenClaw drives its own launcher rather than the provider's managed serve, so this command lives in the plugin.
- `@qvac/ai-sdk-provider@0.7.0` peers `@qvac/cli@^0.13.0`, so the dependency floors have to move with it.

## 📝 How does it solve it?

- `0.2.2` → `0.3.0` — minor, because the required CLI line moves.
- Launcher builds `serve --openai --no-default`; `docs/website/content/docs/cli/http-server/index.mdx:33` documents the two as equivalent.
- `@qvac/ai-sdk-provider` `^0.6.0` → `^0.7.0`, `@qvac/cli` `^0.12.0` → `^0.13.0`.
- Updates the launcher argv assertions and four README references to the old form.
- Adds `changelog/0.3.0/` (with `breaking.md`) and rebuilds `CHANGELOG.md`.
- No re-onboarding needed: the serve command is assembled at start time, and the args onboarding persists in `openclaw.json` hold only the plugin's own options.
- Base is cut from the 0.2.2 backmerge tip, so this diff is 0.3.0 only. Merge after #4284/#4285.

## 🧪 How was it tested?

- Against published `@qvac/cli@0.13.0` / `@qvac/ai-sdk-provider@0.7.0`: install, format, lint, typecheck, build clean; 35/35 unit tests, including the launcher asserting `['serve', '--openai', '--no-default', …]`.
