### PR TITLE
chore[skiplog|notask]: backmerge openclaw-plugin 0.2.2 and 0.3.0 — releases, API key fix, changelogs

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,114 @@
 # Changelog
 
+## [0.3.0]
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.0
+
+The launcher moves onto the CLI 0.13 launch interface. `@qvac/cli` 0.13 mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand, so the plugin now starts `qvac serve --openai --no-default` and its dependency floors move with it.
+
+## Breaking Changes
+
+### Requires the @qvac/cli 0.13 line
+
+The bundled `local-service.js` launcher builds the serve command itself, and that command changes:
+
+**Before:**
+
+```bash
+qvac serve openai --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+**After:**
+
+```bash
+qvac serve --openai --no-default --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plugin, since a 0.x caret range does not cross a minor.
+
+`--no-default` is part of the pair rather than an extra flag. Bare `--openai` would also mount the QVAC surface on the port, while the deprecated subcommand exposed `/v1/*` alone — keeping both preserves the previous behaviour and keeps the extra surface off a port the plugin authenticates and owns.
+
+### @qvac/ai-sdk-provider moves to 0.7
+
+Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so the two floors have to move together: a plugin still asking for `@qvac/cli@^0.12.0` next to provider 0.7 would leave the install unresolvable. The plugin uses the provider for the shared model catalog only — it drives its own launcher rather than the provider's managed serve — so nothing else about that dependency changes here.
+
+Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2.
+
+## Onboarding No Longer Generates an Unusable Key
+
+The bearer key is generated as 32 random bytes encoded base64url. That alphabet includes `-`, and the plugin refuses a key beginning with `-` so a stored key can never be mistaken for a command-line flag. The generator did not exclude that case, so about 1.5% of freshly generated keys were rejected the moment the launcher read them back:
+
+```
+stored QVAC API key must be 32-128 base64url characters and cannot start with "-"
+```
+
+The result was a provider entry that onboarded cleanly and then refused to start. Key generation now draws again whenever a candidate starts with `-`. The same generator backs the recovery path for a stored key that no longer parses, so that path could previously replace an unusable key with another unusable one; it is fixed by the same change.
+
+## Upgrading
+
+No re-onboarding is needed. The argument list onboarding persists in `openclaw.json` holds only the plugin's own options — `--api-key-file`, `--model`, `--host`, `--port` and the rest — and the serve command is assembled at start time, so an existing provider entry keeps working. Configuration, the key file and your model choice are all untouched.
+
+The `openclaw` host peer is unchanged at `>=2026.6.0`.
+
+## Requirements
+
+- `@qvac/ai-sdk-provider@^0.7.0` for the shared model catalog
+- `@qvac/cli@^0.13.0` for `qvac serve --openai --no-default`
+- `openclaw >=2026.6.0` as the optional host peer
+
+## [0.2.2]
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.2
+
+OpenClaw moved its `latest` release to 2026.8.1, which changed three of the commands a QVAC install depends on and removed two type entry points the plugin imported. This patch brings the documented commands, the launcher's own error messages, and the plugin's type surface back in line with it. Nothing in your configuration changes, and no dependency floors move.
+
+## Setup Commands Changed in OpenClaw 2026.8.1
+
+Installing a plugin now asks for trust and for capability consent, and plugin-contributed auth choices are namespaced behind a `provider-plugin:` prefix. Every documented invocation moves:
+
+| Before                       | 2026.8.1 and later                                     |
+| ---------------------------- | ------------------------------------------------------ |
+| `plugins install <spec>`     | `plugins install <spec> --force --accept-capabilities` |
+| `plugins enable qvac`        | `plugins enable qvac --accept-capabilities`            |
+| `onboard --auth-choice qvac` | `onboard --auth-choice provider-plugin:qvac`           |
+
+Without the consent flags the install cancels. With the old auth choice, onboarding rejects `qvac` and lists only OpenClaw's built-in choices. The plugin still registers `choiceId: "qvac"` — OpenClaw namespaces plugin-contributed choices now, so it is the invocation that moves, not the plugin.
+
+The plugin supports `openclaw >=2026.6.0`, so the README documents both forms rather than replacing one with the other. On openclaw before 2026.8.1, drop the two consent flags and use the bare `--auth-choice qvac`.
+
+## Launcher Errors Name a Command That Works
+
+Two failures in the local service told you to recover by running `openclaw onboard --auth-choice qvac` — a command 2026.8.1 rejects, leaving you with an error whose remedy also failed:
+
+- A provider entry created before the managed serve required bearer authentication, whose persisted `localService.args` has no `--api-key-file` value.
+- A QVAC key file whose permissions have drifted so it is readable beyond its owner.
+
+Both now name the `provider-plugin:qvac` form first, with the pre-2026.8.1 form alongside it.
+
+## Builds Against OpenClaw 2026.8.1 Again
+
+2026.8.1 dropped `plugin-sdk/config-types` from its exports map and left `plugin-sdk/provider-model-shared` without type declarations, so `SecretProviderConfig` and `ModelProviderConfig` could no longer be imported by name and the plugin failed to typecheck and build against it.
+
+Both are now derived from `OpenClawConfig`, which is exported with types from `plugin-sdk/plugin-entry` — already the entry the plugin imports `definePluginEntry` from. These are type-only imports, so the emitted JavaScript is unchanged.
+
+## Onboarding No Longer Generates an Unusable Key
+
+The bearer key is generated as 32 random bytes encoded base64url. That alphabet includes `-`, and the plugin refuses a key beginning with `-` so a stored key can never be mistaken for a command-line flag. The generator did not exclude that case, so about 1.5% of freshly generated keys were rejected the moment the launcher read them back:
+
+```
+stored QVAC API key must be 32-128 base64url characters and cannot start with "-"
+```
+
+The result was a provider entry that onboarded cleanly and then refused to start. Key generation now draws again whenever a candidate starts with `-`. The same generator backs the recovery path for a stored key that no longer parses, so that path could previously replace an unusable key with another unusable one; it is fixed by the same change.
+
+## Requirements
+
+Unchanged from 0.2.1: `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog, `@qvac/cli@^0.12.0` for `qvac serve`, and `openclaw >=2026.6.0` as the optional host peer.
+
 ## [0.2.1]
 
 Release Date: 2026-08-21

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -3,7 +3,7 @@
 Run [OpenClaw](https://openclaw.ai) against a **local, on-device** QVAC model
 using OpenClaw's native `localService` lifecycle support. The plugin registers a
 `qvac` provider, exposes the shared QVAC model catalog, and asks OpenClaw to
-start `qvac serve openai` when the provider is used.
+start `qvac serve --openai --no-default` when the provider is used.
 
 ## Install
 
@@ -163,7 +163,7 @@ mode `0600`.
 
 OpenClaw's provider config uses a file SecretRef, and the local-service arguments
 contain only the key-file path. The launcher validates that file and points
-`qvac serve openai --api-key-file` at it. A missing, invalid, or unsafe key prevents the
+`qvac serve --openai --api-key-file` at it. A missing, invalid, or unsafe key prevents the
 server from starting. The generated QVAC serve config does not contain the key.
 The SecretRef provider id is namespaced as `qvac_key_file` so setup does not
 replace an unrelated `secrets.providers.qvac` entry.
@@ -287,10 +287,10 @@ If the local service fails with `--api-key-file requires a value`, see
 - Provider id: `qvac`
 - API adapter: `openai-completions`
 - Bearer authentication: the configured provider `apiKey` is required by the
-  managed `qvac serve openai` process through a file SecretRef
+  managed `qvac serve --openai` process through a file SecretRef
 - Base URL: `http://127.0.0.1:11434/v1` by default
 - Local service command: `node <plugin>/dist/local-service.js`, which writes a
-  temporary QVAC serve config and starts `qvac serve openai`
+  temporary QVAC serve config and starts `qvac serve --openai --no-default`
 - Model catalog: the shared `@qvac/ai-sdk-provider` catalog ids, including
   `qwen3.5-0.8b`, `qwen3.5-2b`, `qwen3.5-4b`, `qwen3.5-9b`,
   `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b`

--- a/plugins/openclaw/changelog/0.2.2/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.2.2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.2.2
+
+Release Date: 2026-09-08
+
+## 🐞 Fixes
+
+- Adapt the openclaw integration to 2026.8.1 (smoke, docs, plugin messages). (see PR [#4192](https://github.com/tetherto/qvac/pull/4192))
+- Stop generating QVAC API keys that the plugin's own validator rejects. A base64url draw beginning with `-` was refused by `normalizeApiKey`, so roughly one onboarding in 64 produced a key file the launcher would not accept.

--- a/plugins/openclaw/changelog/0.2.2/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.2.2/CHANGELOG_LLM.md
@@ -1,0 +1,50 @@
+# QVAC OpenClaw Plugin v0.2.2 Release Notes
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.2.2
+
+OpenClaw moved its `latest` release to 2026.8.1, which changed three of the commands a QVAC install depends on and removed two type entry points the plugin imported. This patch brings the documented commands, the launcher's own error messages, and the plugin's type surface back in line with it. Nothing in your configuration changes, and no dependency floors move.
+
+## Setup Commands Changed in OpenClaw 2026.8.1
+
+Installing a plugin now asks for trust and for capability consent, and plugin-contributed auth choices are namespaced behind a `provider-plugin:` prefix. Every documented invocation moves:
+
+| Before                       | 2026.8.1 and later                                     |
+| ---------------------------- | ------------------------------------------------------ |
+| `plugins install <spec>`     | `plugins install <spec> --force --accept-capabilities` |
+| `plugins enable qvac`        | `plugins enable qvac --accept-capabilities`            |
+| `onboard --auth-choice qvac` | `onboard --auth-choice provider-plugin:qvac`           |
+
+Without the consent flags the install cancels. With the old auth choice, onboarding rejects `qvac` and lists only OpenClaw's built-in choices. The plugin still registers `choiceId: "qvac"` — OpenClaw namespaces plugin-contributed choices now, so it is the invocation that moves, not the plugin.
+
+The plugin supports `openclaw >=2026.6.0`, so the README documents both forms rather than replacing one with the other. On openclaw before 2026.8.1, drop the two consent flags and use the bare `--auth-choice qvac`.
+
+## Launcher Errors Name a Command That Works
+
+Two failures in the local service told you to recover by running `openclaw onboard --auth-choice qvac` — a command 2026.8.1 rejects, leaving you with an error whose remedy also failed:
+
+- A provider entry created before the managed serve required bearer authentication, whose persisted `localService.args` has no `--api-key-file` value.
+- A QVAC key file whose permissions have drifted so it is readable beyond its owner.
+
+Both now name the `provider-plugin:qvac` form first, with the pre-2026.8.1 form alongside it.
+
+## Builds Against OpenClaw 2026.8.1 Again
+
+2026.8.1 dropped `plugin-sdk/config-types` from its exports map and left `plugin-sdk/provider-model-shared` without type declarations, so `SecretProviderConfig` and `ModelProviderConfig` could no longer be imported by name and the plugin failed to typecheck and build against it.
+
+Both are now derived from `OpenClawConfig`, which is exported with types from `plugin-sdk/plugin-entry` — already the entry the plugin imports `definePluginEntry` from. These are type-only imports, so the emitted JavaScript is unchanged.
+
+## Onboarding No Longer Generates an Unusable Key
+
+The bearer key is generated as 32 random bytes encoded base64url. That alphabet includes `-`, and the plugin refuses a key beginning with `-` so a stored key can never be mistaken for a command-line flag. The generator did not exclude that case, so about 1.5% of freshly generated keys were rejected the moment the launcher read them back:
+
+```
+stored QVAC API key must be 32-128 base64url characters and cannot start with "-"
+```
+
+The result was a provider entry that onboarded cleanly and then refused to start. Key generation now draws again whenever a candidate starts with `-`. The same generator backs the recovery path for a stored key that no longer parses, so that path could previously replace an unusable key with another unusable one; it is fixed by the same change.
+
+## Requirements
+
+Unchanged from 0.2.1: `@qvac/ai-sdk-provider@^0.6.0` for the shared model catalog, `@qvac/cli@^0.12.0` for `qvac serve`, and `openclaw >=2026.6.0` as the optional host peer.

--- a/plugins/openclaw/changelog/0.3.0/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.3.0/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog v0.3.0
+
+Release Date: 2026-09-08
+
+## Breaking Changes
+
+- Require the `@qvac/cli` 0.13 line and `@qvac/ai-sdk-provider` 0.7, and start the managed serve with `qvac serve --openai --no-default`. - See [breaking changes](./breaking.md)
+
+## Fixes
+
+- Stop generating QVAC API keys that the plugin's own validator rejects. A base64url draw beginning with `-` was refused by `normalizeApiKey`, so roughly one onboarding in 64 produced a key file the launcher would not accept.
+
+## Compatibility
+
+- Depends on `@qvac/ai-sdk-provider@^0.7.0` and `@qvac/cli@^0.13.0` so installs resolve a provider and CLI that agree on how a serve is launched.

--- a/plugins/openclaw/changelog/0.3.0/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.3.0/CHANGELOG_LLM.md
@@ -1,0 +1,57 @@
+# QVAC OpenClaw Plugin v0.3.0 Release Notes
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.0
+
+The launcher moves onto the CLI 0.13 launch interface. `@qvac/cli` 0.13 mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand, so the plugin now starts `qvac serve --openai --no-default` and its dependency floors move with it.
+
+## Breaking Changes
+
+### Requires the @qvac/cli 0.13 line
+
+The bundled `local-service.js` launcher builds the serve command itself, and that command changes:
+
+**Before:**
+
+```bash
+qvac serve openai --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+**After:**
+
+```bash
+qvac serve --openai --no-default --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plugin, since a 0.x caret range does not cross a minor.
+
+`--no-default` is part of the pair rather than an extra flag. Bare `--openai` would also mount the QVAC surface on the port, while the deprecated subcommand exposed `/v1/*` alone — keeping both preserves the previous behaviour and keeps the extra surface off a port the plugin authenticates and owns.
+
+### @qvac/ai-sdk-provider moves to 0.7
+
+Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so the two floors have to move together: a plugin still asking for `@qvac/cli@^0.12.0` next to provider 0.7 would leave the install unresolvable. The plugin uses the provider for the shared model catalog only — it drives its own launcher rather than the provider's managed serve — so nothing else about that dependency changes here.
+
+Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2.
+
+## Onboarding No Longer Generates an Unusable Key
+
+The bearer key is generated as 32 random bytes encoded base64url. That alphabet includes `-`, and the plugin refuses a key beginning with `-` so a stored key can never be mistaken for a command-line flag. The generator did not exclude that case, so about 1.5% of freshly generated keys were rejected the moment the launcher read them back:
+
+```
+stored QVAC API key must be 32-128 base64url characters and cannot start with "-"
+```
+
+The result was a provider entry that onboarded cleanly and then refused to start. Key generation now draws again whenever a candidate starts with `-`. The same generator backs the recovery path for a stored key that no longer parses, so that path could previously replace an unusable key with another unusable one; it is fixed by the same change.
+
+## Upgrading
+
+No re-onboarding is needed. The argument list onboarding persists in `openclaw.json` holds only the plugin's own options — `--api-key-file`, `--model`, `--host`, `--port` and the rest — and the serve command is assembled at start time, so an existing provider entry keeps working. Configuration, the key file and your model choice are all untouched.
+
+The `openclaw` host peer is unchanged at `>=2026.6.0`.
+
+## Requirements
+
+- `@qvac/ai-sdk-provider@^0.7.0` for the shared model catalog
+- `@qvac/cli@^0.13.0` for `qvac serve --openai --no-default`
+- `openclaw >=2026.6.0` as the optional host peer

--- a/plugins/openclaw/changelog/0.3.0/breaking.md
+++ b/plugins/openclaw/changelog/0.3.0/breaking.md
@@ -1,0 +1,25 @@
+# 💥 Breaking Changes v0.3.0
+
+## Requires the @qvac/cli 0.13 line
+
+`@qvac/cli` 0.13 mounts the serve surfaces as extensions and deprecates the `qvac serve openai` subcommand. The launcher moves to the flag form, and the dependency floors move with it.
+
+**BEFORE:**
+
+```bash
+qvac serve openai --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+**AFTER:**
+
+```bash
+qvac serve --openai --no-default --config <path> --host 127.0.0.1 --port 11434 --model <id> --api-key-file <path>
+```
+
+- Installs that pin `@qvac/cli` to `0.12.x` must move to `0.13.x` alongside the plugin, since a 0.x caret range does not cross a minor.
+- `@qvac/ai-sdk-provider` moves to `^0.7.0` in the same step. Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so a plugin still asking for `@qvac/cli@^0.12.0` next to it would leave the install unresolvable.
+- `--no-default` is part of the pair rather than an extra flag: bare `--openai` also mounts the QVAC surface on the port, while the retired subcommand exposed `/v1/*` alone. Keeping both preserves the previous behaviour on a port the plugin authenticates and owns.
+
+No re-onboarding is needed. The serve command is built by the launcher at start time; the argument list onboarding persists in `openclaw.json` holds only the plugin's own options (`--api-key-file`, `--model`, `--host`, `--port`, …) and is unaffected.
+
+---

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -60,8 +60,8 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@qvac/ai-sdk-provider": "^0.6.0",
-    "@qvac/cli": "^0.12.0"
+    "@qvac/ai-sdk-provider": "^0.7.0",
+    "@qvac/cli": "^0.13.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",

--- a/plugins/openclaw/src/local-service.ts
+++ b/plugins/openclaw/src/local-service.ts
@@ -258,6 +258,10 @@ export interface QvacLaunch {
   readonly args: string[]
 }
 
+// `--no-default` is part of the pair, not an extra: bare `--openai` also mounts
+// the QVAC surface on the port, while the `serve openai` subcommand this
+// replaces exposed `/v1/*` alone. Keeping both preserves that and keeps the
+// extra surface off a port the plugin authenticates and owns.
 function qvacLaunch(options: LocalServiceOptions, configPath: string, apiKey: string): QvacLaunch {
   const cli = resolveQvacCli(options.qvacCommand)
   return {
@@ -265,7 +269,8 @@ function qvacLaunch(options: LocalServiceOptions, configPath: string, apiKey: st
     args: [
       ...cli.baseArgs,
       'serve',
-      'openai',
+      '--openai',
+      '--no-default',
       '--config',
       configPath,
       '--host',

--- a/plugins/openclaw/src/provider-config.ts
+++ b/plugins/openclaw/src/provider-config.ts
@@ -333,6 +333,17 @@ export function normalizeApiKey(value: unknown, option: string): string {
   return normalized
 }
 
+// base64url includes `-`, and `normalizeApiKey` rejects a leading one so a
+// stored key can never be mistaken for a CLI flag. A raw draw therefore fails
+// its own validator about once in 64. Redrawing keeps every position uniform;
+// rewriting the first character would bias it and shrink the keyspace.
+export function generateApiKey(): string {
+  for (;;) {
+    const candidate = randomBytes(32).toString('base64url')
+    if (!candidate.startsWith('-')) return candidate
+  }
+}
+
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error
 }
@@ -390,14 +401,14 @@ export function ensureApiKeyFile(keyFile: string, configuredApiKey?: string): st
     // place (over the already-validated regular-file path) instead of leaving the
     // user to delete the file by hand. Read failures (EACCES, …) still propagate.
     if (error instanceof TypeError) {
-      const replacement = randomBytes(32).toString('base64url')
+      const replacement = generateApiKey()
       writePrivateKeyFile(keyFile, replacement, false)
       return replacement
     }
     if (!isNodeError(error) || error.code !== 'ENOENT') throw error
   }
 
-  const generated = randomBytes(32).toString('base64url')
+  const generated = generateApiKey()
   try {
     writePrivateKeyFile(keyFile, generated, true)
     return generated

--- a/plugins/openclaw/test/local-service.test.ts
+++ b/plugins/openclaw/test/local-service.test.ts
@@ -81,7 +81,8 @@ test('local service launcher creates QVAC serve config and command args from Ope
 
   assert.deepEqual(buildQvacLaunch(options, '/tmp/qvac-openclaw/qvac.config.json').args, [
     'serve',
-    'openai',
+    '--openai',
+    '--no-default',
     '--config',
     '/tmp/qvac-openclaw/qvac.config.json',
     '--host',
@@ -232,7 +233,13 @@ test('spawn errors are formatted without args or secret-bearing properties', () 
   const error = Object.assign(new Error('spawn qvac ENOENT'), {
     code: 'ENOENT',
     syscall: 'spawn qvac',
-    spawnargs: ['serve', 'openai', '--api-key', 'abcdefghijklmnopqrstuvwxyzABCDE_']
+    spawnargs: [
+      'serve',
+      '--openai',
+      '--no-default',
+      '--api-key',
+      'abcdefghijklmnopqrstuvwxyzABCDE_'
+    ]
   })
 
   const formatted = formatSpawnError(error, '/usr/local/bin/qvac')

--- a/plugins/openclaw/test/provider-config.test.ts
+++ b/plugins/openclaw/test/provider-config.test.ts
@@ -23,6 +23,7 @@ import {
   createQvacServeModels,
   createQvacSetupResult,
   ensureApiKeyFile,
+  generateApiKey,
   normalizeApiKey,
   openClawModels,
   registerQvacProvider,
@@ -188,12 +189,24 @@ test('API keys are normalized to a conservative base64url form', () => {
   }
 })
 
+test('generated API keys always satisfy the key validator', () => {
+  // base64url includes `-` and normalizeApiKey rejects a leading one, so an
+  // unguarded draw fails its own validator about once in 64. Enough draws that
+  // a regression here is a certainty rather than a coin flip: an unguarded
+  // generator surviving 4096 of them has probability (63/64)^4096, about 1e-28.
+  for (let index = 0; index < 4096; index += 1) {
+    const key = generateApiKey()
+    assert.equal(key.startsWith('-'), false)
+    assert.equal(normalizeApiKey(key, 'generated QVAC API key'), key)
+  }
+})
+
 test('API key file is generated once, reused, and permission-hardened', () => {
   const stateDir = mkdtempSync(join(tmpdir(), 'qvac-openclaw-state-test-'))
   const keyFile = join(stateDir, 'plugins', 'qvac', 'api-key')
 
   const first = ensureApiKeyFile(keyFile)
-  assert.match(first, /^[A-Za-z0-9_-]{43}$/)
+  assert.match(first, /^[A-Za-z0-9_][A-Za-z0-9_-]{42}$/)
   assert.equal(ensureApiKeyFile(keyFile), first)
   assert.equal(statSync(join(stateDir, 'plugins', 'qvac')).mode & 0o777, 0o700)
   assert.equal(statSync(keyFile).mode & 0o777, 0o600)
@@ -226,7 +239,7 @@ test('re-onboarding regenerates a corrupt key file in place', () => {
   ]) {
     writeFileSync(keyFile, corrupt)
     const regenerated = ensureApiKeyFile(keyFile)
-    assert.match(regenerated, /^[A-Za-z0-9_-]{43}$/)
+    assert.match(regenerated, /^[A-Za-z0-9_][A-Za-z0-9_-]{42}$/)
     assert.equal(readFileSync(keyFile, 'utf8'), regenerated)
     assert.equal(statSync(keyFile).mode & 0o777, 0o600)
     // Stable once healthy again.


### PR DESCRIPTION
## What this PR does

Single backmerge carrying both openclaw-plugin releases onto `main`, per [gitflow.md](../docs/gitflow.md) "Keep main aligned". Tagged `[skiplog]`. Replaces the three earlier backmerge PRs (#4285, #4299 as first opened, #4318).

Rebuilt from current `main`, taking the plugin tree from `release-openclaw-plugin-0.3.0` plus `changelog/0.2.2/` from `release-openclaw-plugin-0.2.2` — the 0.3.0 branch carries a pre-fix copy of that folder, since it was cut before #4336 landed.

## Companion release PRs

- #4284 + #4336 — 0.2.2
- #4298 + #4339 — 0.3.0

## Files

- `plugins/openclaw/package.json` — `0.2.1` → `0.3.0`, `@qvac/ai-sdk-provider` `^0.6.0` → `^0.7.0`, `@qvac/cli` `^0.12.0` → `^0.13.0`
- `plugins/openclaw/src/local-service.ts` — launcher builds `serve --openai --no-default`
- `plugins/openclaw/src/provider-config.ts` — `generateApiKey()` redraws while a candidate starts with `-`
- `plugins/openclaw/test/*` — launcher argv assertions, 4096-draw key property test, two key regexes tightened
- `plugins/openclaw/README.md` — four references to the old serve command
- `plugins/openclaw/changelog/0.2.2/`, `plugins/openclaw/changelog/0.3.0/` — as published
- `plugins/openclaw/CHANGELOG.md` — rebuilt aggregate, 8 versions

No `changelog/0.3.1/` — 0.3.1 was dropped once the fix went into both release branches.

## How was it tested?

- On this branch: format, lint, typecheck, build clean; 36/36 unit tests.
