### PR TITLE
infra[notask]: run workspace SDK source before registry install

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -373,6 +373,12 @@ jobs:
             # Run the checks once per declared SDK source. The optional
             # sdk-source:<source> script does that source's setup (e.g. link the
             # in-repo SDK); absent = plain install of the committed dependency.
+            #
+            # Workspace must rewrite the committed range to a sibling file:
+            # dep *before* install. Otherwise lockstep backmerge PRs into
+            # main fail at bun/npm install when @qvac/inference@^x.y.z is
+            # not on npm yet. Published/default keep install-first so they
+            # still resolve from the registry.
             src_idx=0
             for SRC in $SOURCES; do
               # Bracketed source shown after each check name, e.g. "build [workspace]".
@@ -390,14 +396,19 @@ jobs:
 
               # npm run --if-present reads package.json scripts and works regardless
               # of the installer (bun lacks --if-present).
+              if [ "$SRC" = "workspace" ]; then
+                run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+              fi
+
               if [ "$PKG" = "sdk" ]; then
                 run "install $src" bun install
               else
                 run "install $src" "$PM" install
               fi
 
-              # Per-source setup (no-op if the script is absent).
-              run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+              if [ "$SRC" != "workspace" ]; then
+                run "sdk-source $src" npm run --if-present "sdk-source:$SRC"
+              fi
 
               # Peer-resolution drift against this source's resolved @qvac/inference.
               if [ "$PKG" = "sdk" ]; then

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -170,18 +170,20 @@ jobs:
           "@tetherto" = { token = "${{ env.READ_NPM_TOKEN }}", url = "https://npm.pkg.github.com" }
           EOF
 
-      - name: Install dependencies
-        run: bun install
-        working-directory: ${{ env.WORKDIR }}
-
       # Compile the SDK against the in-repo @qvac/inference at this commit, not
       # the previously-published npm release (which lags behind engine API the
-      # SDK already consumes). This only affects the dist built here; the
-      # published dependency is set per channel below — GPR is pinned to the
-      # co-published @tetherto/inference-mono (see publish-gpr), npm keeps its
-      # committed range (resolved to the inference released in the same run).
+      # SDK already consumes). Link before bun install: lockstep cuts publish
+      # inference in this same workflow, so the committed range is not on npm
+      # yet. This only affects the dist built here; the published dependency
+      # is set per channel below — GPR is pinned to the co-published
+      # @tetherto/inference-mono (see publish-gpr), npm keeps its committed
+      # range (resolved to the inference released in the same run).
       - name: Build against workspace @qvac/inference
         run: bun run sdk-source:workspace
+        working-directory: ${{ env.WORKDIR }}
+
+      - name: Install dependencies
+        run: bun install
         working-directory: ${{ env.WORKDIR }}
 
       - name: Modify package name for branch-based builds

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.19.0
 
-QVAC SDK 0.19.0 is the first release after `@qvac/inference` became the in-process engine. You can assess whether a model will fit before downloading it, walk an ABot-World session, generate MiniMax music, and transcribe with Parakeet Unified. Delegated DHT inference is gone, `no_mmap` is `load_mode`, and batch translations return an array instead of a newline-joined string. `@qvac/bare-sdk` is no longer part of the lockstep pipeline.
+QVAC SDK 0.19.0 is the first release after `@qvac/inference` became the in-process engine. You can assess whether a model will fit before downloading it, walk an ABot-World session, generate MiniMax music, and transcribe with Parakeet Unified. Delegated DHT inference is gone; `no_mmap` is `load_mode`, and batch translations return an array instead of a newline-joined string. `@qvac/bare-sdk` is no longer part of the lockstep pipeline.
 
 ## Breaking Changes
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Cherry-pick of #4283 onto `release-sdk-0.19.0`. That cut's publish died at `bun install` because `@qvac/inference@^0.19.0` is not on npm yet ([run 34109626264](https://github.com/tetherto/qvac/actions/runs/34109626264/job/101702676147)).
- SDK Pod Checks on this release line have the same pre-link install order.

## 📝 How does it solve it?

- `publish-sdk.yml` `build`: run `sdk-source:workspace` before `bun install`.
- SDK Pod Checks `workspace` source: same swap; published/default stay install-first.
- Already on `main` via #4283. No backmerge.

## 🧪 How was it tested?

- Same as #4283. Cherry-pick of `a884a5d17` onto `ca7c1d71f` applied clean.

After merge, `publish-sdk.yml` will not auto-run: the path filter is `packages/{inference,sdk,sdk-python}/**`. Dispatch **Build and Publish QVAC SDK (sdk)** on `release-sdk-0.19.0` so the new YAML is what runs.
