### PR TITLE
QVAC-24314 feat: opt-in CUDA on win32-x64 and linux-arm64 with runtime-loaded backends

### DIFF
--- a/.github/actions/setup-cuda/action.yml
+++ b/.github/actions/setup-cuda/action.yml
@@ -1,9 +1,10 @@
 name: "Setup CUDA toolkit for nvcc compile"
 description: >-
   Assembles a pinned CUDA toolkit from NVIDIA's redistributable component
-  archives on a linux runner, x64 or arm64, and exports
-  CUDA_PATH/CUDACXX/PATH(bin)/VCPKG_KEEP_ENV_VARS/LD_LIBRARY_PATH so a
-  consumer's speech-cpp cuda feature can compile the ggml CUDA backend.
+  archives on a linux (x64 or arm64) or windows x64 runner and exports
+  CUDA_PATH/CUDACXX/PATH(bin)/VCPKG_KEEP_ENV_VARS (plus LD_LIBRARY_PATH on
+  Linux) so a consumer's speech-cpp cuda feature can compile the ggml CUDA
+  backend.
   Component tarballs are used instead of the runfile installer because the
   installer hardcodes /tmp/cuda-installer.log and segfaults for every runner
   user on a shared host after the first user's install ("Log file not open.").
@@ -38,12 +39,15 @@ runs:
     # main's privileged runs then restore, and cpp-lint reaches here with no
     # label at all. r1 -> r2 because splitting only stops new writes; rotating
     # makes whatever the old lane already wrote unreachable.
+    # runner.os is part of the key too: a windows-x64 and a linux-x64 job
+    # share runner.arch == 'X64' and would otherwise restore each other's
+    # toolkit.
     - name: Restore CUDA toolkit
       id: cache-cuda
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ runner.temp }}/cuda
-        key: cuda-redist-${{ inputs.cuda-version }}-${{ runner.arch }}-r2
+        key: cuda-redist-${{ inputs.cuda-version }}-${{ runner.os }}-${{ runner.arch }}-r2
 
     - name: Download + verify + assemble CUDA toolkit
       if: steps.cache-cuda.outputs.cache-hit != 'true'
@@ -58,11 +62,17 @@ runs:
         #
         # QVAC-24442: NVIDIA calls the arm64 build "sbsa". It is a native
         # toolkit, not a cross-compiler, so it only runs on an arm64 runner.
-        case "$(uname -m)" in
-          x86_64)  REDIST_ARCH=linux-x86_64 ;;
-          aarch64) REDIST_ARCH=linux-sbsa ;;
-          *) echo "::error::setup-cuda: no CUDA redist for $(uname -m)"; exit 1 ;;
-        esac
+        # QVAC-24314: on Windows uname reports the MSYS environment, so the
+        # runner facts decide first.
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          REDIST_ARCH=windows-x86_64
+        else
+          case "$(uname -m)" in
+            x86_64)  REDIST_ARCH=linux-x86_64 ;;
+            aarch64) REDIST_ARCH=linux-sbsa ;;
+            *) echo "::error::setup-cuda: no CUDA redist for $(uname -m)"; exit 1 ;;
+          esac
+        fi
         echo "Assembling the $REDIST_ARCH toolkit"
 
         COMPONENTS_linux_x86_64="\
@@ -83,32 +93,67 @@ runs:
         cuda_culibos/linux-sbsa/cuda_culibos-linux-sbsa-13.2.51-archive.tar.xz 35244c4d90e5b1aa48fb98d655f6dfa3f9e4f7d0ac220266ebf85c0928a7524b
         libcublas/linux-sbsa/libcublas-linux-sbsa-13.3.0.5-archive.tar.xz edadce2ec8d997ffb08f5a1c4ee6b1d14a2c883f2aa11e1d3208b4f077d9225f"
 
-        # Same seven components and release either way, only the path and hash
+        # QVAC-24314: Windows ships the same release as zip archives; culibos
+        # does not exist as a Windows component (it is a Linux static lib) and
+        # is not needed there.
+        COMPONENTS_windows_x86_64="\
+        cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-13.2.51-archive.zip a6bacac79adb923e310eb39f2b86d4d9e756c896d035dfead50c69403eca4661
+        libnvvm/windows-x86_64/libnvvm-windows-x86_64-13.2.51-archive.zip ef2a24cf40f9394e2f13df5a8a7315c65325103006a53692cd12b8c48431e372
+        cuda_crt/windows-x86_64/cuda_crt-windows-x86_64-13.2.51-archive.zip 02892bd6bc7ec832c5fc6fc794491803166ee8455bd87d52976c4b195b76c8e7
+        cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-13.2.51-archive.zip 906b430b53e6396f7cbaa6874fbe7f9307a184e830b119a4ad3f58dc6e0165c6
+        cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-13.2.27-archive.zip fb61bbca384ea9e5722f3b77cfdd635c916f33593d187562510ce14831aa629a
+        libcublas/windows-x86_64/libcublas-windows-x86_64-13.3.0.5-archive.zip 438a88f07af3721eda15ed1f4d2b957ea810e29061b2a6292837f35520dbd212"
+
+        # Same components and release either way, only the path and hash
         # differ. An explicit case rather than an indirect expansion: it fails
         # closed if a new arch is added above without a matching list here,
         # instead of silently expanding to an empty COMPONENTS and assembling
         # nothing.
         case "$REDIST_ARCH" in
-          linux-x86_64) COMPONENTS="$COMPONENTS_linux_x86_64" ;;
-          linux-sbsa)   COMPONENTS="$COMPONENTS_linux_sbsa" ;;
+          linux-x86_64)    COMPONENTS="$COMPONENTS_linux_x86_64" ;;
+          linux-sbsa)      COMPONENTS="$COMPONENTS_linux_sbsa" ;;
+          windows-x86_64)  COMPONENTS="$COMPONENTS_windows_x86_64" ;;
           *) echo "::error::setup-cuda: no COMPONENTS list for $REDIST_ARCH"; exit 1 ;;
         esac
 
         prefix="$RUNNER_TEMP/cuda/toolkit"
+        # QVAC-24314: git-bash tools want POSIX paths — GNU tar parses the
+        # drive colon in C:\... as a remote-host spec ("Cannot connect to C").
+        # The exported CUDA_PATH/CUDACXX keep the Windows form CMake needs.
+        if command -v cygpath >/dev/null 2>&1; then
+          prefix="$(cygpath -u "$prefix")"
+          dl_dir="$(cygpath -u "$RUNNER_TEMP")"
+        else
+          dl_dir="$RUNNER_TEMP"
+        fi
         mkdir -p "$prefix"
+        # The Windows components are .zip, which GNU tar cannot read, and
+        # which of the two tars a Windows runner's bash resolves varies by
+        # machine. Use the system bsdtar explicitly there (zip-capable,
+        # native Windows paths); plain tar handles the Linux .tar.xz
+        # archives.
+        extract_archive() {
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            /c/Windows/System32/tar.exe -xf "$(cygpath -w "$1")" \
+              --strip-components=1 -C "$(cygpath -w "$prefix")"
+          else
+            tar -xJf "$1" --strip-components=1 -C "$prefix"
+          fi
+        }
         echo "$COMPONENTS" | while read -r rel sha; do
           [ -z "$rel" ] && continue
           url="https://developer.download.nvidia.com/compute/cuda/redist/$rel"
-          out="$RUNNER_TEMP/$(basename "$rel")"
+          out="$dl_dir/$(basename "$rel")"
           echo "Downloading $url"
           curl -fsSL --retry 3 "$url" -o "$out"
           echo "$sha  $out" | sha256sum -c -
-          tar -xJf "$out" --strip-components=1 -C "$prefix"
+          extract_archive "$out"
           rm -f "$out"
         done
-        # Redist archives ship lib/, not lib64/; some consumers look for
-        # lib64, so provide it as an alias.
-        if [ -d "$prefix/lib" ] && [ ! -e "$prefix/lib64" ]; then
+        # Redist archives ship lib/, not lib64/; some Linux consumers look
+        # for lib64, so provide it as an alias. Windows keeps NVIDIA's
+        # lib/x64 import-library layout, which FindCUDAToolkit knows.
+        if [ "$RUNNER_OS" != "Windows" ] && [ -d "$prefix/lib" ] && [ ! -e "$prefix/lib64" ]; then
           ln -s lib "$prefix/lib64"
         fi
 
@@ -122,14 +167,17 @@ runs:
       uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ runner.temp }}/cuda
-        key: cuda-redist-${{ inputs.cuda-version }}-${{ runner.arch }}-r2
+        key: cuda-redist-${{ inputs.cuda-version }}-${{ runner.os }}-${{ runner.arch }}-r2
 
     - name: Export CUDA environment
       shell: bash
       run: |
-        nvcc="$RUNNER_TEMP/cuda/toolkit/bin/nvcc"
-        if [ ! -x "$nvcc" ]; then echo "::error::nvcc not found after assembly"; exit 1; fi
         cuda_prefix="$RUNNER_TEMP/cuda/toolkit"
+        nvcc="$cuda_prefix/bin/nvcc"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          nvcc="$nvcc.exe"
+        fi
+        if [ ! -x "$nvcc" ]; then echo "::error::nvcc not found after assembly"; exit 1; fi
         echo "CUDA prefix: $cuda_prefix"
         echo "CUDA_PATH=$cuda_prefix" >> "$GITHUB_ENV"
         echo "CUDACXX=$nvcc" >> "$GITHUB_ENV"
@@ -138,4 +186,6 @@ runs:
         # only sees the toolkit through an explicit keep-list. Append rather
         # than assign so a sibling setup action's keep-list survives.
         echo "VCPKG_KEEP_ENV_VARS=${VCPKG_KEEP_ENV_VARS:+$VCPKG_KEEP_ENV_VARS;}CUDA_PATH;CUDACXX" >> "$GITHUB_ENV"
-        echo "LD_LIBRARY_PATH=$cuda_prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+        if [ "$RUNNER_OS" != "Windows" ]; then
+          echo "LD_LIBRARY_PATH=$cuda_prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -108,6 +108,18 @@ on:
         type: boolean
         required: false
         default: false
+      include-cuda-win32:
+        description: >-
+          Extend `include-cuda` to the win32-x64 job, using NVIDIA's
+          windows-x86_64 redist components. Opt-in and off by default for the
+          same reason as `include-cuda-arm64`: widening `include-cuda` itself
+          would silently change builds of every addon already passing it.
+          Only provisions the toolkit; a caller also needs a matching
+          `win32-x64:` entry in platform-cmake-defines (e.g.
+          `-D ENABLE_CUDA=ON`) or win32 still ships without CUDA.
+        type: boolean
+        required: false
+        default: false
       extra-cmake-defines:
         description: >-
           Additional cmake defines appended verbatim to `bare-make generate` on every matrix entry. Space-separated. Example: "-D VK_PROFILING=ON" to enable Vulkan profiling on the llamacpp packages.
@@ -329,10 +341,10 @@ jobs:
       # compile-only and the CUDA backend is a runtime-loaded module that never
       # engages without a device.
       #
-      # arm64 is named rather than implied by "not x64", so a linux arch added
-      # later does not inherit the toolkit from include-cuda-arm64 without
-      # anyone asking for it.
-      - if: ${{ inputs.include-cuda && matrix.platform == 'linux' && (matrix.arch == 'x64' || (matrix.arch == 'arm64' && inputs.include-cuda-arm64)) }}
+      # arm64 and win32 are named rather than implied by "not x64", so a
+      # matrix entry added later does not inherit the toolkit from the
+      # platform-specific opt-ins without anyone asking for it.
+      - if: ${{ inputs.include-cuda && ((matrix.platform == 'linux' && (matrix.arch == 'x64' || (matrix.arch == 'arm64' && inputs.include-cuda-arm64))) || (matrix.platform == 'win32' && inputs.include-cuda-win32)) }}
         name: Setup CUDA toolkit for nvcc compile
         uses: ./.github/actions/setup-cuda
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in CUDA builds (`ENABLE_CUDA=ON`) now work on win32-x64 and linux-arm64
+  in addition to linux-x64. The CUDA backend ships as a runtime-loaded module
+  (`.dll` on Windows, `.so` on Linux) next to the addon, so a CUDA-enabled
+  build still loads on hosts without an NVIDIA stack and falls back to Vulkan
+  or CPU. linux-arm64 targets Jetson Orin (8.7), Grace-Hopper (9.0) and
+  GB10 / DGX Spark (12.1) natively, with 8.0 PTX for discrete Ampere+ cards.
+  Published prebuilds are unchanged (Vulkan on Linux/Windows).
+
+### Changed
+
+- Raise the `speech-cpp` floor to 2026-09-04#1 and the registry baseline to
+  ggml-speech 2026-09-04#2: fixes a Windows CUDA crash on engine unload and a
+  stale backend-capability cache that could abort GPU synthesis after backend
+  reloads, and brings in the fused speech ops and CUDA-graphs decode path.
+
 ## [0.8.1] - 2026-09-01
 
 ### Changed

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Raise the `speech-cpp` floor to 2026-09-04#1 and the registry baseline to
-  ggml-speech 2026-09-04#2: fixes a Windows CUDA crash on engine unload and a
-  stale backend-capability cache that could abort GPU synthesis after backend
+- Raise the `speech-cpp` floor to 2026-09-04#1 and floor `ggml-speech` at
+  2026-09-04#2: fixes a Windows CUDA crash on engine unload and a stale
+  backend-capability cache that could abort GPU synthesis after backend
   reloads, and brings in the fused speech ops and CUDA-graphs decode path.
 
 ## [0.8.1] - 2026-09-01

--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -109,22 +109,24 @@ endif()
 # Loose-file pickup for MODULE backends that aren't surfaced as
 # IMPORTED targets by find_package(ggml). On Android this is what
 # actually delivers Vulkan + OpenCL into the prebuilds folder, and on
-# hybrid Linux builds (arm64, x64 with ENABLE_CUDA) it delivers the
-# CPU-variant / Vulkan / CUDA modules. Glob runs at configure time -- the .so files come from
-# ggml-speech's `file(INSTALL ...)` step in its portfile, which has
-# already completed by the time vcpkg hands control back to us. Apple
-# / Windows static-only configs return an empty list and skip the
+# hybrid desktop builds (linux-arm64, linux-x64 / win32-x64 with
+# ENABLE_CUDA) it delivers the CPU-variant / Vulkan / CUDA modules.
+# Glob runs at configure time -- the module files come from ggml-speech's
+# portfile pickup into lib/ (.so on Linux/Android, .dll on Windows),
+# which has already completed by the time vcpkg hands control back to
+# us. Apple / static-only configs return an empty list and skip the
 # install rule below.
 set(BACKEND_DL_LOOSE_SOS "")
-if((ANDROID OR UNIX) AND NOT APPLE)
+if(((ANDROID OR UNIX) AND NOT APPLE) OR (WIN32 AND ENABLE_CUDA))
   if(NOT VCPKG_INSTALLED_PATH OR NOT EXISTS "${VCPKG_INSTALLED_PATH}/lib")
     message(WARNING "tts-ggml: VCPKG_INSTALLED_PATH "
       "('${VCPKG_INSTALLED_PATH}') has no lib/ dir; skipping loose "
-      "ggml backend .so pickup -- the runtime may fail to find "
+      "ggml backend module pickup -- the runtime may fail to find "
       "Vulkan / OpenCL / CUDA backends.")
   else()
     file(GLOB BACKEND_DL_LOOSE_SOS
-      "${VCPKG_INSTALLED_PATH}/lib/libqvac-speech-ggml-*.so")
+      "${VCPKG_INSTALLED_PATH}/lib/libqvac-speech-ggml-*.so"
+      "${VCPKG_INSTALLED_PATH}/lib/qvac-speech-ggml-*.dll")
     foreach(_lib IN LISTS BACKEND_DL_LOOSE_SOS)
       message(STATUS "tts-ggml: will stage ggml backend ${_lib}")
     endforeach()

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -556,7 +556,7 @@ host's policy:
 | Platform                | Default backend when `useGPU: true`          |
 |-------------------------|----------------------------------------------|
 | macOS / iOS             | Metal                                        |
-| Linux x64 — NVIDIA      | Vulkan (CUDA is opt-in at build via `ENABLE_CUDA`; CUDA then wins the cascade) |
+| Linux / Windows — NVIDIA | Vulkan (CUDA is opt-in at build via `ENABLE_CUDA` on linux-x64, linux-arm64 and win32-x64; CUDA then wins the cascade) |
 | Linux — other / Windows | Vulkan                                       |
 | Android — Adreno 700+   | OpenCL                                       |
 | Android — Mali / others | Vulkan                                       |
@@ -567,20 +567,23 @@ On hosts where more than one backend is usable, `TTS_CPP_GPU_BACKEND`
 and fails loudly when that backend cannot be resolved; unset (or empty)
 keeps the automatic preference above.
 
-When the addon is built with `ENABLE_CUDA`, the CUDA backend ships as a
-runtime-loaded module: engaging it requires the NVIDIA driver plus the CUDA
-13 runtime libraries (cudart and cuBLAS, from a CUDA toolkit install)
-resolvable at load time. On hosts without them — including CPU-only and
-non-NVIDIA machines — the module is skipped and the addon behaves exactly as
-before (Vulkan or CPU).
+When the addon is built with `ENABLE_CUDA` — supported on linux-x64,
+linux-arm64 and win32-x64 — the CUDA backend ships as a runtime-loaded module
+(`.so` on Linux, `.dll` on Windows): engaging it requires the NVIDIA driver
+plus the CUDA 13 runtime libraries (cudart and cuBLAS, from a CUDA toolkit
+install) resolvable at load time. On hosts without them — including CPU-only
+and non-NVIDIA machines — the module is skipped and the addon behaves exactly
+as before (Vulkan or CPU).
 
-The module targets **compute capability 7.5 and newer**: native code for
-Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6), Ada (8.9), Hopper
-(9.0) and Blackwell (12.0, 12.1), and a JIT compile from the bundled 8.0 PTX
-for anything newer that the driver caches after first use. Volta and Pascal
-fall outside CUDA 13's support entirely, so they have no code path here: the
-backend skips such devices at registration and the addon falls back to Vulkan
-or CPU.
+On x64 the module targets **compute capability 7.5 and newer**: native code
+for Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6), Ada (8.9),
+Hopper (9.0) and Blackwell (12.0, 12.1), and a JIT compile from the bundled
+8.0 PTX for anything newer that the driver caches after first use. On
+linux-arm64 the native set is Jetson Orin (8.7), Grace-Hopper (9.0) and
+GB10 / DGX Spark (12.1), with discrete Ampere+ cards and newer parts covered
+through the bundled 8.0 PTX. Volta and Pascal fall outside CUDA 13's support
+entirely, so they have no code path here: the backend skips such devices at
+registration and the addon falls back to Vulkan or CPU.
 
 > Both Chatterbox and Supertonic run on ARM Mali via Vulkan: `tts-cpp` sets
 > `allow_arm_mali=true` for both graphs. (Earlier `tts-cpp` builds declined

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "29e6c8772cd0a13f6c6d82d12d57c8dd88ba257a",
+    "baseline": "b9ca3b07a85cd88fdd30730c662b4c138ede1ca3",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b9ca3b07a85cd88fdd30730c662b4c138ede1ca3",
+    "baseline": "29e6c8772cd0a13f6c6d82d12d57c8dd88ba257a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -9,6 +9,11 @@
       "version>=": "1.4.4#3"
     },
     {
+      "name": "ggml-speech",
+      "version>=": "2026-09-04#2",
+      "default-features": false
+    },
+    {
       "name": "speech-cpp",
       "version>=": "2026-09-04#1",
       "default-features": false,

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-04#1",
       "default-features": false,
       "features": [
         "tts",
@@ -20,7 +20,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-04#1",
       "default-features": false,
       "features": [
         "tts",
@@ -31,7 +31,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-01#2",
+      "version>=": "2026-09-04#1",
       "default-features": false,
       "features": [
         "tts",
@@ -46,7 +46,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-01#2",
+          "version>=": "2026-09-04#1",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-01#2",
+          "version>=": "2026-09-04#1",
           "default-features": false,
           "features": [
             "vulkan"


### PR DESCRIPTION
## What problem does this PR solve?

QVAC-24314: CUDA support existed only on linux-x64. The registry side landed in qvac-registry-vcpkg #348 (ggml-speech 2026-09-04#2), whose hybrid recipe builds the CUDA backend as a runtime-loaded module on win32-x64 and linux-arm64; this PR is the monorepo half that makes it consumable, aligned with the CUDA-free published-prebuilds policy from #4215.

## How does it solve it?

- **Floors: ggml-speech -> 2026-09-04#2** (the hybrid recipe from qvac-registry-vcpkg #348; direct floor with `default-features: false` because the speech-cpp umbrella floors it one port-version short) and **speech-cpp -> 2026-09-04#1**. The default-registry baseline is untouched per review. Besides the recipe, the floor ships the two engine fixes this work surfaced and fixed (qvac-fabric-speech.cpp #206: a deterministic Windows CUDA crash on engine unload under the loader lock, and a stale backend-capability cache that could intermittently abort GPU synthesis after backend reloads) plus the fused speech ops / CUDA-graphs decode path from the 2026-09-04 engines.
- **setup-cuda gains the windows-x86_64 redist components** (zip archives, same sha256 pinning, no culibos — Linux-only component), selected by runner facts; extraction uses the system bsdtar on Windows because git-bash GNU tar parses the drive colon as a remote-host spec and cannot read zip. Cache key gains `runner.os` so windows-x64 and linux-x64 stop sharing an entry.
- **reusable-prebuilds gains `include-cuda-win32`**, mirroring QVAC-24442's `include-cuda-arm64` opt-in. No consumer turns it on — published prebuilds stay CUDA-free.
- **tts-ggml stages the Windows `.dll` module layout** in the loose backend pickup, so an `ENABLE_CUDA` win32 build puts the CUDA, Vulkan and per-arch CPU-variant DLLs next to the `.bare` addon (active only with `ENABLE_CUDA`; the default win32 build is unchanged).
- README documents the three `ENABLE_CUDA` platforms and the arm64 architecture set (Orin 8.7, Grace-Hopper 9.0, GB10 12.1, 8.0 PTX for the rest); CHANGELOG entry under `[Unreleased]`.

## How was it tested?

The full capability was preflighted end to end on this repo's CI before the registry recipe merged, via a temporary fork-registry baseline on branch `QVAC-24314/win32-cuda-preflight`:

- Prebuilds with `ENABLE_CUDA` on win32-x64 and linux-arm64: run 33794237204 — win32 stages nine CPU-variant DLLs + vulkan.dll + cuda.dll, arm64 the NEON CPU tiers + vulkan.so + cuda.so; `dumpbin`/`readelf` verified the `.bare` addons carry no CUDA imports (KERNEL32+ADVAPI32 / libc only), so CUDA-enabled builds still load anywhere.
- Integration run 33804005920: all lanes green — win32 cuda-pinned (`backendId=2` through the full suite, including the kv-cache cases that crashed before the engine fixes), win32 vulkan-pinned, linux-x64 cuda + vulkan, and the no-GPU CPU-fallback lanes on win32/arm64/x64 with the CUDA module present and skipped cleanly.
- A further prebuild sweep at the exact merged recipe (2026-09-04#2) and the 2026-09-04 engines: run 34111698415, all 10 lanes green.
- This PR itself ships no CUDA in prebuilds, so its own CI proves the default (Vulkan) path is unchanged at the raised floors.

## Notes

- Everything between the previously resolved and the newly floored port versions is accounted for in the floor bump above; the resolved speech-cpp is 2026-09-04#1 and ggml-speech 2026-09-04#2.
- Follow-up candidates, deliberately out of scope: a scheduled/opt-in CUDA CI lane (needs an `ENABLE_CUDA` build per run since prebuild artifacts are CUDA-free), and the `prebuild_run_id` dispatch input plus same-runner lane serialization used by the preflight branch.


