### PR TITLE
QVAC-24697 feat: balance registry ingestion by disk capacity

### DIFF
--- a/packages/registry-server/lib/metrics.js
+++ b/packages/registry-server/lib/metrics.js
@@ -10,6 +10,7 @@ const RPC_METHODS = Object.freeze([
   'put-license',
   'update-model-metadata',
   'delete-model',
+  'get-storage-capacity',
   'ping'
 ])
 

--- a/packages/registry-server/lib/registry-service.js
+++ b/packages/registry-server/lib/registry-service.js
@@ -113,6 +113,8 @@ class RegistryService extends ReadyResource {
     this.ackThreshold = opts.ackThreshold ?? 0
     this.autobaseBootstrap = opts.autobaseBootstrap || null
     this.blindPeerKeys = Array.isArray(opts.blindPeerKeys) ? opts.blindPeerKeys : []
+    this.storagePath = opts.storagePath || this.config.getRegistryStorage?.() || null
+    this._statfs = opts.statfs || fsPromises.statfs
     this.skipStorageCheck = opts.skipStorageCheck ?? false
     this.clearAfterReseed = opts.clearAfterReseed ?? false
     this.compactionIntervalMs = opts.compactionIntervalMs ?? 60 * 60 * 1000
@@ -755,6 +757,21 @@ class RegistryService extends ReadyResource {
       }
     })
 
+    rpc.respond('get-storage-capacity', async () => {
+      if (this.metrics) this.metrics.recordRpcRequest('get-storage-capacity')
+      try {
+        ensureWriterAccess()
+
+        if (!this.opened) await this.ready()
+        await this._ensureIndexer()
+
+        return await this._getStorageCapacity()
+      } catch (err) {
+        if (this.metrics) this.metrics.recordRpcError('get-storage-capacity')
+        throw err
+      }
+    })
+
     // lunte-disable-next-line require-await
     rpc.respond('ping', async () => {
       if (this.metrics) this.metrics.recordRpcRequest('ping')
@@ -776,6 +793,23 @@ class RegistryService extends ReadyResource {
     if (!remoteKeyHex) return false
     const keys = this.config.getAllowedWriterKeys()
     return keys.has(remoteKeyHex)
+  }
+
+  async _getStorageCapacity() {
+    try {
+      if (!this.storagePath) throw new Error('Registry storage path is unavailable')
+
+      const stats = await this._statfs(this.storagePath, { bigint: true })
+      const availableBytes = BigInt(stats.bavail) * BigInt(stats.bsize)
+
+      return { availableBytes: availableBytes.toString() }
+    } catch (err) {
+      this.logger.error({ error: err.message }, 'Failed to read registry storage capacity')
+
+      const capacityError = new Error('Registry storage capacity is unavailable')
+      capacityError.code = 'ERR_STORAGE_CAPACITY_UNAVAILABLE'
+      throw capacityError
+    }
   }
 
   _validateAddModelRequest(entry) {

--- a/packages/registry-server/scripts/bin.js
+++ b/packages/registry-server/scripts/bin.js
@@ -106,6 +106,7 @@ const runCmd = command(
       ackThreshold: toInt(flags.ackThreshold),
       autobaseBootstrap,
       blindPeerKeys,
+      storagePath,
       clearAfterReseed: flags.clearAfterReseed,
       compactionIntervalMs,
       skipStorageCheck: flags.skipStorageCheck

--- a/packages/registry-server/scripts/sync-models.js
+++ b/packages/registry-server/scripts/sync-models.js
@@ -5,7 +5,7 @@ const fs = require('fs').promises
 
 const RegistryConfig = require('../lib/config')
 const logger = require('../lib/logger')
-const { connectToRegistry } = require('./utils/rpc-client')
+const { connectToRegistry, connectToRegistryByCapacity } = require('./utils/rpc-client')
 const { parseCanonicalSource } = require('../lib/source-helpers')
 const QVACRegistryClient = require('../client/lib/client')
 
@@ -35,7 +35,8 @@ async function syncModels() {
   const client = new QVACRegistryClient({ registryCoreKey, logger })
   await client.ready()
 
-  let connection = await connectToRegistry({ config, logger })
+  let connection = null
+  let selectedPeerKey = null
 
   try {
     const configModels = JSON.parse(await fs.readFile(path.resolve(filePath), 'utf8'))
@@ -54,6 +55,11 @@ async function syncModels() {
     }
 
     logger.info(`Found ${dbModels.length} model(s) in database`)
+
+    if (!dryRun) {
+      connection = await connectToRegistryByCapacity({ config, logger })
+      selectedPeerKey = connection.peerKey
+    }
 
     const report = { added: [], updated: [], skipped: [], autoDeprecated: [], errors: [] }
     const configKeys = new Set()
@@ -122,7 +128,13 @@ async function syncModels() {
                 sourceInfo,
                 logger,
                 connection,
-                reconnect: () => connectToRegistry({ config, logger })
+                reconnect: () =>
+                  connectToRegistry({
+                    config,
+                    logger,
+                    targetPeer: selectedPeerKey,
+                    indexerKeys: [selectedPeerKey]
+                  })
               })
               connection = recovery.connection
 
@@ -214,7 +226,7 @@ async function syncModels() {
     return report
   } finally {
     await client.close()
-    await connection.cleanup()
+    if (connection) await connection.cleanup()
   }
 }
 

--- a/packages/registry-server/scripts/utils/rpc-client.js
+++ b/packages/registry-server/scripts/utils/rpc-client.js
@@ -8,6 +8,9 @@ const IdEnc = require('hypercore-id-encoding')
 const cenc = require('compact-encoding')
 const { ENV_KEYS } = require('../../shared/constants')
 
+const CAPACITY_CONNECTION_TIMEOUT_MS = 10000
+const CAPACITY_RPC_TIMEOUT_MS = 5000
+
 /**
  * Derive a dedicated RPC discovery key from the autobase key.
  * Must match the derivation in registry-service.js.
@@ -172,6 +175,115 @@ async function connectToRegistry({
   })
 }
 
+async function connectToRegistryByCapacity({
+  config,
+  logger = console,
+  storage = './temp-client-storage',
+  timeout = 30000,
+  primaryKey = null,
+  indexerKeys = null,
+  connectionTimeout = CAPACITY_CONNECTION_TIMEOUT_MS,
+  capacityTimeout = CAPACITY_RPC_TIMEOUT_MS,
+  connect = connectToRegistry
+}) {
+  const resolvedIndexerKeys = indexerKeys || config.getIndexerKeys()
+  const peerKeys = [
+    ...new Set(resolvedIndexerKeys.map((key) => IdEnc.normalize(IdEnc.decode(key))))
+  ]
+
+  if (peerKeys.length === 0) {
+    logger.warn('RPC Client: No indexer keys configured; using legacy peer selection')
+    return connect({ config, logger, storage, timeout, primaryKey, indexerKeys })
+  }
+
+  const candidates = []
+
+  for (const peerKey of peerKeys) {
+    let probe = null
+    try {
+      probe = await connect({
+        config,
+        logger,
+        storage,
+        timeout: connectionTimeout,
+        primaryKey,
+        targetPeer: peerKey,
+        indexerKeys: [peerKey]
+      })
+
+      const response = await probe.rpc.request(
+        'get-storage-capacity',
+        {},
+        {
+          timeout: capacityTimeout
+        }
+      )
+      const availableBytes = parseAvailableBytes(response?.availableBytes)
+      if (availableBytes === null) throw new Error('Invalid storage capacity response')
+
+      candidates.push({ peerKey, availableBytes })
+    } catch (err) {
+      if (getErrorCode(err) === 'ERR_WRITER_UNAUTHORIZED') throw err
+
+      logger.warn(
+        { peer: peerKey, error: err.message, code: getErrorCode(err) },
+        'RPC Client: Capacity probe failed'
+      )
+    } finally {
+      if (probe) await probe.cleanup()
+    }
+  }
+
+  const winner = selectPeerByCapacity(candidates)
+  if (!winner) {
+    logger.warn('RPC Client: Capacity selection unavailable; using legacy peer selection')
+    return connect({ config, logger, storage, timeout, primaryKey, indexerKeys })
+  }
+
+  logger.info(
+    { peer: winner.peerKey, availableBytes: winner.availableBytes.toString() },
+    'RPC Client: Selected indexer with most available storage'
+  )
+
+  return connect({
+    config,
+    logger,
+    storage,
+    timeout,
+    primaryKey,
+    targetPeer: winner.peerKey,
+    indexerKeys: [winner.peerKey]
+  })
+}
+
+function parseAvailableBytes(value) {
+  if (typeof value === 'bigint' && value >= 0n) return value
+  if (typeof value === 'string' && /^\d+$/.test(value)) return BigInt(value)
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) return BigInt(value)
+  return null
+}
+
+function selectPeerByCapacity(candidates) {
+  const valid = candidates
+    .map((candidate) => ({
+      ...candidate,
+      availableBytes: parseAvailableBytes(candidate.availableBytes)
+    }))
+    .filter((candidate) => candidate.availableBytes !== null)
+
+  valid.sort((a, b) => {
+    if (a.availableBytes > b.availableBytes) return -1
+    if (a.availableBytes < b.availableBytes) return 1
+    return a.peerKey.localeCompare(b.peerKey)
+  })
+
+  return valid[0] || null
+}
+
+function getErrorCode(err) {
+  return err?.cause?.code || err?.code || null
+}
+
 function getKeyPairFromEnv() {
   const publicKeyHex = process.env[ENV_KEYS.QVAC_WRITER_PUBLIC_KEY]
   const secretKeyHex = process.env[ENV_KEYS.QVAC_WRITER_SECRET_KEY]
@@ -233,6 +345,11 @@ async function updateModelMetadata({
 }
 
 module.exports = {
+  CAPACITY_CONNECTION_TIMEOUT_MS,
+  CAPACITY_RPC_TIMEOUT_MS,
   connectToRegistry,
+  connectToRegistryByCapacity,
+  parseAvailableBytes,
+  selectPeerByCapacity,
   updateModelMetadata
 }

--- a/packages/registry-server/tests/integration/capacity-rpc.integration.test.js
+++ b/packages/registry-server/tests/integration/capacity-rpc.integration.test.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const test = require('brittle')
+const Corestore = require('corestore')
+const Hyperswarm = require('hyperswarm')
+const DHT = require('hyperdht')
+const ProtomuxRPC = require('protomux-rpc')
+const cenc = require('compact-encoding')
+const createTestnet = require('hyperdht/testnet')
+const crypto = require('crypto')
+
+const RegistryService = require('../../lib/registry-service')
+const RegistryConfig = require('../../lib/config')
+const { AUTOBASE_NAMESPACE } = require('../../shared/constants')
+const { createTempStorage } = require('../helpers/test-utils')
+
+const noopLogger = {
+  info() {},
+  debug() {},
+  error() {},
+  warn() {}
+}
+
+test('capacity RPC returns only available bytes to an authorized writer', async (t) => {
+  t.timeout(60000)
+  const writerKeyPair = DHT.keyPair()
+  const ctx = await createCapacityService(t, writerKeyPair.publicKey)
+  const client = await connectRpcClient(ctx.bootstrap, writerKeyPair, ctx.service.base.key)
+
+  try {
+    const result = await client.rpc.request('get-storage-capacity', {}, { timeout: 10000 })
+
+    t.alike(Object.keys(result), ['availableBytes'])
+    t.ok(/^\d+$/.test(result.availableBytes), 'available bytes is an exact decimal string')
+  } finally {
+    await client.cleanup()
+    await ctx.cleanup()
+  }
+})
+
+test('capacity RPC rejects a writer outside the allowlist', async (t) => {
+  t.timeout(60000)
+  const allowedWriter = DHT.keyPair()
+  const unauthorizedWriter = DHT.keyPair()
+  const ctx = await createCapacityService(t, allowedWriter.publicKey)
+  const client = await connectRpcClient(ctx.bootstrap, unauthorizedWriter, ctx.service.base.key)
+
+  try {
+    await client.rpc.request('get-storage-capacity', {}, { timeout: 10000 })
+    t.fail('Expected unauthorized capacity request to fail')
+  } catch (err) {
+    t.is(err.cause?.code, 'ERR_WRITER_UNAUTHORIZED')
+  } finally {
+    await client.cleanup()
+    await ctx.cleanup()
+  }
+})
+
+async function createCapacityService(t, allowedWriterKey) {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const storagePath = await createTempStorage(t)
+  const store = new Corestore(storagePath)
+  await store.ready()
+
+  const swarm = new Hyperswarm({ bootstrap })
+  const config = new RegistryConfig({ logger: noopLogger })
+  config.getAllowedWriterKeys = () => new Set([allowedWriterKey.toString('hex')])
+
+  const service = new RegistryService(store.namespace(AUTOBASE_NAMESPACE), swarm, config, {
+    logger: noopLogger,
+    storagePath,
+    ackInterval: 5,
+    skipStorageCheck: true
+  })
+  await service.ready()
+  await swarm.flush()
+
+  return {
+    bootstrap,
+    store,
+    swarm,
+    service,
+    async cleanup() {
+      if (service.opened) await service.close().catch(() => {})
+      await swarm.destroy().catch(() => {})
+      await store.close().catch(() => {})
+    }
+  }
+}
+
+async function connectRpcClient(bootstrap, keyPair, autobaseKey) {
+  const swarm = new Hyperswarm({ bootstrap, keyPair })
+
+  const connection = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('RPC connection timed out')), 10000)
+
+    swarm.on('connection', (conn) => {
+      clearTimeout(timer)
+      conn.on('error', () => {})
+      resolve(conn)
+    })
+  })
+
+  const rpcDiscoveryKey = crypto
+    .createHash('sha256')
+    .update(autobaseKey)
+    .update('qvac-registry-rpc')
+    .digest()
+  swarm.join(rpcDiscoveryKey, { client: true, server: false })
+  await swarm.flush()
+
+  const conn = await connection
+  const rpc = new ProtomuxRPC(conn, {
+    protocol: 'qvac-registry-rpc',
+    valueEncoding: cenc.json
+  })
+
+  return {
+    rpc,
+    async cleanup() {
+      conn.destroy()
+      await swarm.destroy().catch(() => {})
+    }
+  }
+}

--- a/packages/registry-server/tests/integration/metrics.integration.test.js
+++ b/packages/registry-server/tests/integration/metrics.integration.test.js
@@ -158,6 +158,14 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     t.ok(rpcPingRequests, 'rpc_requests_total{method="ping"} series is pre-initialised')
     t.ok(rpcPingRequests.endsWith(' 0'), 'rpc_requests_total{method="ping"} starts at 0')
 
+    const capacityRequests = body
+      .split('\n')
+      .find((line) =>
+        line.startsWith('qvac_registry_rpc_requests_total{method="get-storage-capacity"}')
+      )
+    t.ok(capacityRequests, 'capacity request series is pre-initialised')
+    t.ok(capacityRequests.endsWith(' 0'), 'capacity request series starts at 0')
+
     const rpcPingErrors = body
       .split('\n')
       .find((line) => line.startsWith('qvac_registry_rpc_errors_total{method="add-model"}'))

--- a/packages/registry-server/tests/unit/registry-service.test.js
+++ b/packages/registry-server/tests/unit/registry-service.test.js
@@ -55,6 +55,40 @@ test('RegistryService.getModelByKey validates input', async (t) => {
   await assertThrows({ path: '' })
 })
 
+test('RegistryService reports bytes available to the registry filesystem', async (t) => {
+  const calls = []
+  const service = createServiceWithRpc()
+  service.storagePath = '/registry-storage'
+  // lunte-disable-next-line require-await
+  service._statfs = async (...args) => {
+    calls.push(args)
+    return { bavail: 1234n, bsize: 4096n, bfree: 9999n }
+  }
+
+  const result = await service._getStorageCapacity()
+
+  t.alike(result, { availableBytes: String(1234n * 4096n) })
+  t.alike(calls, [['/registry-storage', { bigint: true }]])
+})
+
+test('RegistryService hides filesystem details when capacity cannot be read', async (t) => {
+  const service = createServiceWithRpc()
+  service.storagePath = '/private/registry-storage'
+  // lunte-disable-next-line require-await
+  service._statfs = async () => {
+    throw new Error('ENOENT: /private/registry-storage')
+  }
+
+  try {
+    await service._getStorageCapacity()
+    t.fail('Expected storage capacity lookup to fail')
+  } catch (err) {
+    t.is(err.code, 'ERR_STORAGE_CAPACITY_UNAVAILABLE')
+    t.is(err.message, 'Registry storage capacity is unavailable')
+    t.absent(err.message.includes('/private/registry-storage'))
+  }
+})
+
 test('isTransientHfDownloadError retries on undici socket errors', (t) => {
   for (const code of [
     'ECONNRESET',
@@ -108,6 +142,6 @@ test('isTransientHfDownloadError fast-fails on unknown / unstructured errors', (
 
 function createServiceWithRpc() {
   const service = Object.create(RegistryService.prototype)
-  service.logger = { warn() {} }
+  service.logger = { error() {}, warn() {} }
   return service
 }

--- a/packages/registry-server/tests/unit/rpc-client.test.js
+++ b/packages/registry-server/tests/unit/rpc-client.test.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const test = require('brittle')
+const crypto = require('crypto')
+const IdEnc = require('hypercore-id-encoding')
+const {
+  connectToRegistryByCapacity,
+  parseAvailableBytes,
+  selectPeerByCapacity
+} = require('../../scripts/utils/rpc-client')
+
+const noopLogger = {
+  info() {},
+  warn() {}
+}
+
+test('connectToRegistryByCapacity probes each peer once and connects to the winner', async (t) => {
+  const peerKeys = [randomPeerKey(), randomPeerKey(), randomPeerKey()]
+  const capacities = new Map([
+    [peerKeys[0], '100'],
+    [peerKeys[1], '300'],
+    [peerKeys[2], '200']
+  ])
+  const calls = []
+  const cleaned = []
+  const selectedConnection = { peerKey: peerKeys[1] }
+
+  const result = await connectToRegistryByCapacity({
+    config: { getIndexerKeys: () => peerKeys },
+    logger: noopLogger,
+    connect: (opts) => {
+      calls.push(opts)
+      if (calls.length > peerKeys.length) return Promise.resolve(selectedConnection)
+
+      return Promise.resolve({
+        rpc: {
+          request: () => Promise.resolve({ availableBytes: capacities.get(opts.targetPeer) })
+        },
+        cleanup: () => {
+          cleaned.push(opts.targetPeer)
+          return Promise.resolve()
+        }
+      })
+    }
+  })
+
+  t.is(result, selectedConnection)
+  t.alike(
+    calls.slice(0, 3).map((call) => call.targetPeer),
+    peerKeys
+  )
+  t.is(calls[3].targetPeer, peerKeys[1])
+  t.alike(cleaned, peerKeys)
+})
+
+test('connectToRegistryByCapacity does not hide writer authorization failures', async (t) => {
+  const peerKey = randomPeerKey()
+  let cleaned = false
+
+  try {
+    await connectToRegistryByCapacity({
+      config: { getIndexerKeys: () => [peerKey] },
+      logger: noopLogger,
+      connect: () =>
+        Promise.resolve({
+          rpc: {
+            request: () => {
+              const cause = new Error('Unauthorized writer RPC request')
+              cause.code = 'ERR_WRITER_UNAUTHORIZED'
+              const err = new Error('Request failed', { cause })
+              err.code = 'REQUEST_ERROR'
+              return Promise.reject(err)
+            }
+          },
+          cleanup: () => {
+            cleaned = true
+            return Promise.resolve()
+          }
+        })
+    })
+    t.fail('Expected writer authorization failure')
+  } catch (err) {
+    t.is(err.cause.code, 'ERR_WRITER_UNAUTHORIZED')
+    t.ok(cleaned)
+  }
+})
+
+test('selectPeerByCapacity chooses the peer with the most available bytes', (t) => {
+  const selected = selectPeerByCapacity([
+    { peerKey: 'peer-a', availableBytes: '100' },
+    { peerKey: 'peer-b', availableBytes: '300' },
+    { peerKey: 'peer-c', availableBytes: '200' }
+  ])
+
+  t.is(selected.peerKey, 'peer-b')
+  t.is(selected.availableBytes, 300n)
+})
+
+test('selectPeerByCapacity breaks equal-capacity ties by peer key', (t) => {
+  const selected = selectPeerByCapacity([
+    { peerKey: 'peer-c', availableBytes: '300' },
+    { peerKey: 'peer-a', availableBytes: '300' },
+    { peerKey: 'peer-b', availableBytes: '300' }
+  ])
+
+  t.is(selected.peerKey, 'peer-a')
+})
+
+test('selectPeerByCapacity ignores malformed capacity values', (t) => {
+  const selected = selectPeerByCapacity([
+    { peerKey: 'negative', availableBytes: '-1' },
+    { peerKey: 'fractional', availableBytes: 1.5 },
+    { peerKey: 'missing' },
+    { peerKey: 'valid', availableBytes: '42' }
+  ])
+
+  t.is(selected.peerKey, 'valid')
+  t.is(selectPeerByCapacity([{ peerKey: 'invalid', availableBytes: 'many' }]), null)
+})
+
+test('parseAvailableBytes preserves integers larger than Number.MAX_SAFE_INTEGER', (t) => {
+  t.is(parseAvailableBytes('18446744073709551615'), 18446744073709551615n)
+  t.is(parseAvailableBytes(Number.MAX_SAFE_INTEGER + 1), null)
+})
+
+function randomPeerKey() {
+  return IdEnc.normalize(crypto.randomBytes(32))
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Registry model sync selects an indexer randomly, allowing repeated syncs to increase disk usage imbalance.
- CI cannot consider node capacity without relying on private hostnames or network addresses.

## 📝 How does it solve it?

- Adds a writer-authorized capacity RPC over the existing Noise-authenticated peer connection.
- Probes each configured indexer once, selects the peer with the most usable space, and keeps that peer selected for the entire sync.
- Uses deterministic tie-breaking and preserves random selection as a compatibility fallback when capacity reporting is unavailable.
- Returns only available bytes without exposing paths, hostnames, or IP addresses.

## 🧪 How was it tested?

- Added unit coverage for capacity calculation, response validation, peer selection, deterministic ties, cleanup, and authorization failures.
- Added integration coverage for authorized and unauthorized capacity requests and RPC metrics.
- Passed 55 unit tests and 31 integration tests.
- Passed lint, formatting, syntax, and diff checks.
