### PR TITLE
QVAC-24635 infra: schedule the speech benchmarks and fix the weekly report's dead reference

### DIFF
--- a/.github/workflows/benchmark-performance-asr-ggml.yml
+++ b/.github/workflows/benchmark-performance-asr-ggml.yml
@@ -5,6 +5,13 @@ name: Benchmark Performance (ASR GGML)
 # benchmark lanes for BOTH engines, then aggregate one consolidated report.
 
 on:
+  # Weekly full sweep (desktop + mobile) on main, so the channel numbers stop
+  # going stale between manual dispatches. Staggered against the TTS (04:00)
+  # and BCI (07:00) sweeps because the desktop legs share the self-hosted
+  # qvac-* runner fleet. On a scheduled run every dispatch input is empty, so
+  # the desktop/mobile gates below treat `schedule` as "run everything".
+  schedule:
+    - cron: "0 1 * * 1" # Every Monday 1am UTC
   workflow_dispatch:
     inputs:
       repository:
@@ -87,7 +94,7 @@ jobs:
       run_integration_tests: false
       run_rtf_benchmarks: true
 
-    if: ${{ !cancelled() && inputs.run_desktop && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
+    if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.run_desktop) && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
   mobile-benchmarks:
     needs:
       - context
@@ -105,7 +112,7 @@ jobs:
       prebuild_package: ${{ inputs.prebuild_package }}
       run_rtf_benchmarks: true
 
-    if: ${{ !cancelled() && inputs.run_mobile && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
+    if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.run_mobile) && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
   summarize:
     needs:
       - context

--- a/.github/workflows/benchmark-performance-bci-whispercpp.yml
+++ b/.github/workflows/benchmark-performance-bci-whispercpp.yml
@@ -7,6 +7,13 @@ name: Benchmark Performance (BCI Whispercpp)
 # registry model, so the sweep is platform × CPU/GPU backend (no quant axis).
 
 on:
+  # Weekly full sweep (desktop + mobile) on main, so the channel numbers stop
+  # going stale between manual dispatches. Staggered against the ASR (01:00)
+  # and TTS (04:00) sweeps because the desktop legs share the self-hosted
+  # qvac-* runner fleet. The desktop/mobile gates below already read the
+  # dispatch toggles as `!= 'false'`, so empty scheduled inputs run everything.
+  schedule:
+    - cron: "0 7 * * 1" # Every Monday 7am UTC
   workflow_dispatch:
     inputs:
       repository:

--- a/.github/workflows/benchmark-performance-tts-ggml.yml
+++ b/.github/workflows/benchmark-performance-tts-ggml.yml
@@ -1,6 +1,13 @@
 name: Benchmark Performance (TTS GGML)
 
 on:
+  # Weekly full sweep (desktop + mobile) on main, so the channel numbers stop
+  # going stale between manual dispatches. Staggered against the ASR (01:00)
+  # and BCI (07:00) sweeps because the desktop legs share the self-hosted
+  # qvac-* runner fleet. On a scheduled run every dispatch input is empty, so
+  # the desktop/mobile gates below treat `schedule` as "run everything".
+  schedule:
+    - cron: "0 4 * * 1" # Every Monday 4am UTC
   workflow_dispatch:
     inputs:
       repository:
@@ -95,7 +102,7 @@ jobs:
       run_integration_tests: false
       run_rtf_benchmarks: true
       benchmark_matrix_json: ${{ needs.context.outputs.benchmark_matrix_json }}
-    if: ${{ !cancelled() && inputs.run_desktop && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
+    if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.run_desktop) && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
 
   mobile-benchmarks:
     needs:
@@ -112,8 +119,8 @@ jobs:
       repository: ${{ needs.context.outputs.repository }}
       ref: ${{ needs.context.outputs.ref }}
       prebuild_package: ${{ inputs.prebuild_package }}
-      run_rtf_benchmarks: ${{ inputs.mobile_run_rtf_benchmarks }}
-    if: ${{ !cancelled() && inputs.run_mobile && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
+      run_rtf_benchmarks: ${{ github.event_name == 'schedule' || inputs.mobile_run_rtf_benchmarks }}
+    if: ${{ !cancelled() && (github.event_name == 'schedule' || inputs.run_mobile) && (needs.prebuild.result == 'success' || (needs.prebuild.result == 'skipped' && inputs.prebuild_package != '')) }}
 
   summarize:
     needs:

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -13,7 +13,7 @@ on:
           - nmtcpp
           - llamacpp-llm
           - vlm
-          - parakeet
+          - asr-ggml
           - diffusion-cpp
           - audiogen-ggml
       workflow_name:
@@ -24,7 +24,7 @@ on:
           - "Integration Tests (NMTCPP)"
           - "Integration Tests (LLM)"
           - "Mobile Integration Tests (LLM)"
-          - "Mobile Integration Tests (Parakeet)"
+          - "Mobile Integration Tests (ASR GGML)"
           - "Integration Tests (Stable Diffusion)"
           - "Mobile Integration Tests (Diffusion CPP)"
           - "Benchmark Performance (AudioGen GGML)"
@@ -150,14 +150,17 @@ jobs:
             --output-json reports/vlm-mobile-performance.json \
             --output-html reports/vlm-mobile-performance.html || true
 
-          echo "=== Parakeet (Mobile) ==="
+          # QVAC-24635: "Mobile Integration Tests (Parakeet)" was retired when
+          # parakeet folded into the unified asr-ggml addon; querying the old
+          # name aggregated nothing (swallowed by `|| true`) every week.
+          echo "=== ASR GGML (Mobile) ==="
           node scripts/perf-report/aggregate.js \
-            --addon parakeet \
-            --workflow "Mobile Integration Tests (Parakeet)" \
+            --addon asr-ggml \
+            --workflow "Mobile Integration Tests (ASR GGML)" \
             --runs 6 \
-            --output reports/parakeet-mobile-performance.md \
-            --output-json reports/parakeet-mobile-performance.json \
-            --output-html reports/parakeet-mobile-performance.html || true
+            --output reports/asr-ggml-mobile-performance.md \
+            --output-json reports/asr-ggml-mobile-performance.json \
+            --output-html reports/asr-ggml-mobile-performance.html || true
 
           echo "=== Diffusion (Desktop) ==="
           node scripts/perf-report/aggregate.js \


### PR DESCRIPTION
## What problem does this PR solve?

Two staleness bugs found in the QVAC-24635 benchmark gap analysis:

1. The weekly `perf-report.yml` (scheduled Mondays) still aggregates `--workflow "Mobile Integration Tests (Parakeet)"`. That workflow was retired when parakeet folded into the unified asr-ggml addon (the live workflow is "Mobile Integration Tests (ASR GGML)"), so the weekly speech mobile section has aggregated nothing for months, with the failure swallowed by `|| true`.
2. The three speech benchmark workflows (`benchmark-performance-asr-ggml.yml`, `benchmark-performance-tts-ggml.yml`, `benchmark-performance-bci-whispercpp.yml`) are dispatch-only. The channel shows whatever someone last dispatched, from whatever branch: at analysis time the TTS and BCI numbers were 26 days old, mobile ASR was 32 days old (and its artifacts already expired), and the freshest desktop ASR numbers came from a feature branch.

## How does it solve it?

**perf-report.yml** - the mobile speech section now queries "Mobile Integration Tests (ASR GGML)" with `--addon asr-ggml` and `asr-ggml-mobile-performance.*` outputs; the manual-dispatch `addon` / `workflow_name` choice lists are updated to match. (`--addon` only selects the `perf-report-*` artifact download pattern and the output label, so the workflow name was the actual breakage.)

**Weekly schedule** - each benchmark-performance workflow gets a Monday cron on main, staggered because the desktop legs share the self-hosted `qvac-*` runner fleet: ASR 01:00, TTS 04:00, BCI 07:00 UTC.

**Schedule-safe gating** - on a `schedule` event every `workflow_dispatch` input is empty:

- ASR and TTS gate their desktop/mobile legs on `inputs.run_desktop` / `inputs.run_mobile` as truthy booleans, which would skip both legs on a scheduled run. The conditions now accept `github.event_name == 'schedule'` as run-everything.
- TTS additionally passed `run_rtf_benchmarks: ${{ inputs.mobile_run_rtf_benchmarks }}` to the mobile leg, which on schedule would silently flip it from the benchmark matrix to the functional matrix; the scheduled run now pins benchmark mode.
- BCI already routes its toggles through `context` outputs compared as `!= 'false'`, so empty inputs run everything; it needed only the trigger.
- `prebuild` runs when `inputs.prebuild_package` is empty, and `context` falls back to `github.repository` / `github.ref_name` - both correct for a scheduled run on main with no changes.

Dispatch behavior is unchanged: all inputs and gates behave exactly as before on `workflow_dispatch`.

## How was it tested?

- All four edited workflow files re-parse as valid YAML with `schedule` + `workflow_dispatch` triggers.
- Gating table walked through for both event types: on `schedule`, ASR/TTS/BCI run prebuild, desktop, mobile and summarize; on `workflow_dispatch` every condition reduces to its previous form.
- `aggregate.js` reviewed to confirm `--addon` affects only the artifact pattern (`perf-report-*`) and labeling - the workflow-name fix is what restores data flow; mobile ASR runs upload `perf-report-asr-ggml-*` artifacts on normal runs too, so the weekly aggregation has data to find.

CI workflow changes only - no addon or package change, no version bump or CHANGELOG entry.

Note: this touches different hunks of the same `benchmark-performance-*` files as the QVAC-24713 PR (summarize hardening); the two merge independently without conflicts.

Prepared with Claude Code.
