### PR TITLE
QVAC-24635 infra: stamp provenance into speech benchmark reports and raise findings retention

### DIFF
--- a/.github/workflows/benchmark-performance-asr-ggml.yml
+++ b/.github/workflows/benchmark-performance-asr-ggml.yml
@@ -152,7 +152,12 @@ jobs:
       - name: Generate consolidated benchmark report
         env:
           EXPECTED_DESKTOP_DEVICES: ${{ needs.desktop-benchmarks.outputs.rtf_expected_devices }}
+          # Repo@ref + run id, stamped into the report: a report generated from
+          # a feature branch must never pass for main in the channel
+          # (QVAC-24635).
+          REPORT_PROVENANCE: ${{ needs.context.outputs.repository }}@${{ needs.context.outputs.ref }} run ${{ github.run_id }}
         run: |
+          provenance="$REPORT_PROVENANCE, generated $(date -u '+%Y-%m-%d %H:%M UTC')"
           expect_args=()
           if [ -n "$EXPECTED_DESKTOP_DEVICES" ]; then
             expect_args=(--expect-devices "$EXPECTED_DESKTOP_DEVICES")
@@ -163,6 +168,7 @@ jobs:
             --output benchmark-artifacts/asr-ggml-performance-findings.md \
             --output-json benchmark-artifacts/asr-ggml-performance-findings.json \
             --output-html benchmark-artifacts/asr-ggml-performance-findings.html \
+            --provenance "$provenance" \
             "${expect_args[@]}"
 
       - name: Add summary
@@ -180,4 +186,7 @@ jobs:
             benchmark-artifacts/asr-ggml-performance-findings.md
             benchmark-artifacts/asr-ggml-performance-findings.json
             benchmark-artifacts/asr-ggml-performance-findings.html
-          retention-days: 30
+          # 90 is the GitHub maximum. The 2026-08-06 mobile sweep expired at 30
+          # days before anyone could re-read it (QVAC-24635); the consolidated
+          # findings are the durable record, keep them as long as GitHub allows.
+          retention-days: 90

--- a/.github/workflows/benchmark-performance-asr-ggml.yml
+++ b/.github/workflows/benchmark-performance-asr-ggml.yml
@@ -144,21 +144,35 @@ jobs:
           pattern: perf-report-asr-ggml-*
           path: benchmark-artifacts/mobile
 
+      # EXPECTED_DESKTOP_DEVICES is empty when the desktop leg was skipped
+      # (run_desktop=false) or died before producing the reusable workflow's
+      # output — the gate only arms when the desktop matrix actually ran. When
+      # armed, a device with zero rows fails this step AFTER the report files
+      # are written, so the steps below still publish the incomplete report.
       - name: Generate consolidated benchmark report
+        env:
+          EXPECTED_DESKTOP_DEVICES: ${{ needs.desktop-benchmarks.outputs.rtf_expected_devices }}
         run: |
+          expect_args=()
+          if [ -n "$EXPECTED_DESKTOP_DEVICES" ]; then
+            expect_args=(--expect-devices "$EXPECTED_DESKTOP_DEVICES")
+          fi
           node scripts/perf-report/aggregate-asr-ggml-rtf.js \
             --dir benchmark-artifacts \
             --manual-dir packages/asr-ggml/benchmarks/manual-results \
             --output benchmark-artifacts/asr-ggml-performance-findings.md \
             --output-json benchmark-artifacts/asr-ggml-performance-findings.json \
-            --output-html benchmark-artifacts/asr-ggml-performance-findings.html
+            --output-html benchmark-artifacts/asr-ggml-performance-findings.html \
+            "${expect_args[@]}"
 
       - name: Add summary
+        if: ${{ !cancelled() }}
         run: cat benchmark-artifacts/asr-ggml-performance-findings.md >> "$GITHUB_STEP_SUMMARY"
 
       # Replaces the retired whisper-performance-findings +
       # parakeet-performance-findings artifacts.
       - name: Upload consolidated benchmark report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:
           name: asr-ggml-performance-findings

--- a/.github/workflows/benchmark-performance-bci-whispercpp.yml
+++ b/.github/workflows/benchmark-performance-bci-whispercpp.yml
@@ -153,19 +153,34 @@ jobs:
           pattern: perf-report-bci-whispercpp-*
           path: benchmark-artifacts/mobile
 
+      # EXPECTED_DESKTOP_DEVICES is empty when the desktop leg was skipped
+      # (include_desktop=false) or died before producing the reusable
+      # workflow's output — the gate only arms when the desktop matrix
+      # actually ran. When armed, a device with zero rows fails this step
+      # AFTER the report files are written, so the steps below still publish
+      # the incomplete report.
       - name: Generate consolidated benchmark report
+        env:
+          EXPECTED_DESKTOP_DEVICES: ${{ needs.desktop-benchmarks.outputs.rtf_expected_devices }}
         run: |
+          expect_args=()
+          if [ -n "$EXPECTED_DESKTOP_DEVICES" ]; then
+            expect_args=(--expect-devices "$EXPECTED_DESKTOP_DEVICES")
+          fi
           node scripts/perf-report/aggregate-bci-rtf.js \
             --dir benchmark-artifacts \
             --manual-dir packages/bci-whispercpp/benchmarks/manual-results \
             --output benchmark-artifacts/bci-performance-findings.md \
             --output-json benchmark-artifacts/bci-performance-findings.json \
-            --output-html benchmark-artifacts/bci-performance-findings.html
+            --output-html benchmark-artifacts/bci-performance-findings.html \
+            "${expect_args[@]}"
 
       - name: Add summary
+        if: ${{ !cancelled() }}
         run: cat benchmark-artifacts/bci-performance-findings.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload consolidated benchmark report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:
           name: bci-performance-findings

--- a/.github/workflows/benchmark-performance-bci-whispercpp.yml
+++ b/.github/workflows/benchmark-performance-bci-whispercpp.yml
@@ -162,7 +162,12 @@ jobs:
       - name: Generate consolidated benchmark report
         env:
           EXPECTED_DESKTOP_DEVICES: ${{ needs.desktop-benchmarks.outputs.rtf_expected_devices }}
+          # Repo@ref + run id, stamped into the report: a report generated from
+          # a feature branch must never pass for main in the channel
+          # (QVAC-24635).
+          REPORT_PROVENANCE: ${{ needs.context.outputs.repository }}@${{ needs.context.outputs.ref }} run ${{ github.run_id }}
         run: |
+          provenance="$REPORT_PROVENANCE, generated $(date -u '+%Y-%m-%d %H:%M UTC')"
           expect_args=()
           if [ -n "$EXPECTED_DESKTOP_DEVICES" ]; then
             expect_args=(--expect-devices "$EXPECTED_DESKTOP_DEVICES")
@@ -173,6 +178,7 @@ jobs:
             --output benchmark-artifacts/bci-performance-findings.md \
             --output-json benchmark-artifacts/bci-performance-findings.json \
             --output-html benchmark-artifacts/bci-performance-findings.html \
+            --provenance "$provenance" \
             "${expect_args[@]}"
 
       - name: Add summary
@@ -188,4 +194,7 @@ jobs:
             benchmark-artifacts/bci-performance-findings.md
             benchmark-artifacts/bci-performance-findings.json
             benchmark-artifacts/bci-performance-findings.html
-          retention-days: 30
+          # 90 is the GitHub maximum. The 2026-08-06 mobile sweep expired at 30
+          # days before anyone could re-read it (QVAC-24635); the consolidated
+          # findings are the durable record, keep them as long as GitHub allows.
+          retention-days: 90

--- a/.github/workflows/benchmark-performance-tts-ggml.yml
+++ b/.github/workflows/benchmark-performance-tts-ggml.yml
@@ -151,16 +151,29 @@ jobs:
           pattern: perf-report-tts-ggml-*
           path: benchmark-artifacts/mobile
 
+      # EXPECTED_DESKTOP_DEVICES is empty when the desktop leg was skipped
+      # (run_desktop=false) or died before producing the reusable workflow's
+      # output — the gate only arms when the desktop matrix actually ran. When
+      # armed, a device with zero rows fails this step AFTER the report files
+      # are written, so the steps below still publish the incomplete report.
       - name: Generate consolidated benchmark report
+        env:
+          EXPECTED_DESKTOP_DEVICES: ${{ needs.desktop-benchmarks.outputs.rtf_expected_devices }}
         run: |
           mkdir -p benchmark-artifacts
+          expect_args=()
+          if [ -n "$EXPECTED_DESKTOP_DEVICES" ]; then
+            expect_args=(--expect-devices "$EXPECTED_DESKTOP_DEVICES")
+          fi
           node scripts/perf-report/aggregate-tts-ggml-rtf.js \
             --dir benchmark-artifacts \
             --manual-dir packages/tts-ggml/benchmarks/manual-results \
             --output benchmark-artifacts/tts-ggml-performance-findings.md \
-            --output-json benchmark-artifacts/tts-ggml-performance-findings.json
+            --output-json benchmark-artifacts/tts-ggml-performance-findings.json \
+            "${expect_args[@]}"
 
       - name: Add summary
+        if: ${{ !cancelled() }}
         run: |
           cat benchmark-artifacts/tts-ggml-performance-findings.md >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -177,6 +190,7 @@ jobs:
           echo "| opencl | Android Adreno (e.g. Samsung Galaxy S25, mobile) | AWS Device Farm; manual drops into packages/tts-ggml/benchmarks/manual-results/ |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload consolidated benchmark report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:
           name: tts-ggml-performance-findings

--- a/.github/workflows/benchmark-performance-tts-ggml.yml
+++ b/.github/workflows/benchmark-performance-tts-ggml.yml
@@ -159,8 +159,13 @@ jobs:
       - name: Generate consolidated benchmark report
         env:
           EXPECTED_DESKTOP_DEVICES: ${{ needs.desktop-benchmarks.outputs.rtf_expected_devices }}
+          # Repo@ref + run id, stamped into the report: a report generated from
+          # a feature branch must never pass for main in the channel
+          # (QVAC-24635).
+          REPORT_PROVENANCE: ${{ needs.context.outputs.repository }}@${{ needs.context.outputs.ref }} run ${{ github.run_id }}
         run: |
           mkdir -p benchmark-artifacts
+          provenance="$REPORT_PROVENANCE, generated $(date -u '+%Y-%m-%d %H:%M UTC')"
           expect_args=()
           if [ -n "$EXPECTED_DESKTOP_DEVICES" ]; then
             expect_args=(--expect-devices "$EXPECTED_DESKTOP_DEVICES")
@@ -170,6 +175,7 @@ jobs:
             --manual-dir packages/tts-ggml/benchmarks/manual-results \
             --output benchmark-artifacts/tts-ggml-performance-findings.md \
             --output-json benchmark-artifacts/tts-ggml-performance-findings.json \
+            --provenance "$provenance" \
             "${expect_args[@]}"
 
       - name: Add summary
@@ -197,4 +203,7 @@ jobs:
           path: |
             benchmark-artifacts/tts-ggml-performance-findings.md
             benchmark-artifacts/tts-ggml-performance-findings.json
-          retention-days: 30
+          # 90 is the GitHub maximum. The 2026-08-06 mobile sweep expired at 30
+          # days before anyone could re-read it (QVAC-24635); the consolidated
+          # findings are the durable record, keep them as long as GitHub allows.
+          retention-days: 90

--- a/.github/workflows/integration-test-asr-ggml.yml
+++ b/.github/workflows/integration-test-asr-ggml.yml
@@ -76,6 +76,17 @@ on:
         required: false
         default: "packages/asr-ggml"
         type: string
+    outputs:
+      # One entry per run-integration-tests matrix row, resolved through the
+      # same runner_names outputs the matrix rows use (matrix.runner ||
+      # matrix.os), so a runner-label rename cannot desynchronize the two.
+      # benchmark-performance-asr-ggml.yml feeds this to the aggregator's
+      # --expect-devices gate so a lane that loses its rtf-results artifact
+      # fails the summarize job instead of silently shrinking the report.
+      # Keep in step with the matrix `include` list below.
+      rtf_expected_devices:
+        description: "Comma-separated device labels every RTF benchmark matrix row reports as"
+        value: ${{ format('{0},{1},{2},{3},{4},{5},{6},{7}', jobs.runner_names.outputs.linux_ubuntu2204_x64, jobs.runner_names.outputs.linux_ubuntu2204_x64_gpu, jobs.runner_names.outputs.linux_ubuntu2404_x64_gpu, jobs.runner_names.outputs.ubuntu_2604, jobs.runner_names.outputs.ubuntu_2404_arm, jobs.runner_names.outputs.macos_arm64_gpu, jobs.runner_names.outputs.macos_15_large, jobs.runner_names.outputs.win_2025_x64_gpu) }}
 
 jobs:
   runner_names:
@@ -531,7 +542,15 @@ jobs:
       # Runner-qualified artifact name: two same-platform runners (e.g.
       # qvac-ubuntu2204-x64 cpu-only and qvac-ubuntu2204-x64-gpu) would
       # otherwise collide on one artifact name.
+      #
+      # Two attempts, and losing both fails the lane: a swallowed upload
+      # failure (run 34062003154, CreateArtifact ETIMEDOUT on the darwin-arm64
+      # runner) silently dropped all 48 of that lane's rows from the
+      # consolidated report. `if-no-files-found: error` instead of `warn` for
+      # the same reason — the verify step above already guarantees files exist
+      # on the happy path.
       - name: Upload RTF benchmark results
+        id: upload-rtf-results
         if: ${{ always() && !cancelled() && inputs.run_rtf_benchmarks }}
         continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
@@ -539,7 +558,17 @@ jobs:
           name: rtf-results-asr-ggml-${{ matrix.runner || matrix.os }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '-cpu' || '-gpu' }}
           path: packages/asr-ggml/benchmarks/results/rtf-benchmark-*.json
           retention-days: 30
-          if-no-files-found: warn
+          if-no-files-found: error
+
+      - name: Upload RTF benchmark results (retry)
+        if: ${{ always() && !cancelled() && inputs.run_rtf_benchmarks && steps.upload-rtf-results.outcome == 'failure' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: rtf-results-asr-ggml-${{ matrix.runner || matrix.os }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '-cpu' || '-gpu' }}
+          path: packages/asr-ggml/benchmarks/results/rtf-benchmark-*.json
+          retention-days: 30
+          if-no-files-found: error
+          overwrite: true
 
       - name: Print run state (Unix)
         if: ${{ matrix.platform != 'win32' }}

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -56,6 +56,17 @@ on:
         required: false
         default: "packages/bci-whispercpp"
         type: string
+    outputs:
+      # One entry per run-integration-tests matrix row, resolved through the
+      # same runner_names outputs the matrix rows use (matrix.runner ||
+      # matrix.os), so a runner-label rename cannot desynchronize the two.
+      # benchmark-performance-bci-whispercpp.yml feeds this to the aggregator's
+      # --expect-devices gate so a lane that loses its rtf-results artifact
+      # fails the summarize job instead of silently shrinking the report.
+      # Keep in step with the matrix `include` list below.
+      rtf_expected_devices:
+        description: "Comma-separated device labels every RTF benchmark matrix row reports as"
+        value: ${{ format('{0},{1},{2},{3},{4},{5},{6}', jobs.runner_names.outputs.linux_ubuntu2204_x64_gpu, jobs.runner_names.outputs.linux_ubuntu2404_x64_gpu, jobs.runner_names.outputs.ubuntu_2604, jobs.runner_names.outputs.ubuntu_2404_arm, jobs.runner_names.outputs.macos_arm64_gpu, jobs.runner_names.outputs.macos_15_large, jobs.runner_names.outputs.win_2025_x64_gpu) }}
 
 jobs:
   runner_names:
@@ -354,7 +365,15 @@ jobs:
           QVAC_BCI_BENCHMARK_RUNNER: ${{ matrix.runner || matrix.os }}
           QVAC_BCI_BENCHMARK_MATRIX_JSON: ${{ inputs.benchmark_matrix_json || matrix.benchmark_matrix_json }}
 
+      # Two attempts, and losing both fails the lane: the job runs with
+      # continue-on-error, so a swallowed upload failure (the asr-ggml matrix
+      # lost all 48 darwin-arm64 rows of run 34062003154 to a CreateArtifact
+      # ETIMEDOUT) would silently drop this device from the consolidated
+      # report. `if-no-files-found: error` instead of `ignore`: the benchmark
+      # steps above tolerate per-entry failures, so zero files means the whole
+      # lane produced nothing and must be loud, not absent.
       - name: Upload RTF benchmark results
+        id: upload-rtf-results
         if: ${{ always() && !cancelled() && inputs.run_rtf_benchmarks }}
         continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
@@ -362,7 +381,17 @@ jobs:
           name: rtf-results-${{ matrix.runner || matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}
           path: ${{ inputs.workdir }}/benchmarks/results/rtf-benchmark-*.json
           retention-days: 30
-          if-no-files-found: ignore
+          if-no-files-found: error
+
+      - name: Upload RTF benchmark results (retry)
+        if: ${{ always() && !cancelled() && inputs.run_rtf_benchmarks && steps.upload-rtf-results.outcome == 'failure' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: rtf-results-${{ matrix.runner || matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ inputs.workdir }}/benchmarks/results/rtf-benchmark-*.json
+          retention-days: 30
+          if-no-files-found: error
+          overwrite: true
 
       - name: Print run state (Unix)
         if: ${{ matrix.platform != 'win32' }}

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -53,6 +53,17 @@ on:
         type: string
         required: false
         default: ""
+    outputs:
+      # One entry per run-integration-tests matrix row, resolved through the
+      # same runner_names outputs the matrix rows use (matrix.runner ||
+      # matrix.os), so a runner-label rename cannot desynchronize the two.
+      # benchmark-performance-tts-ggml.yml feeds this to the aggregator's
+      # --expect-devices gate so a lane that loses its rtf-results artifact
+      # fails the summarize job instead of silently shrinking the report.
+      # Keep in step with the matrix `include` list below.
+      rtf_expected_devices:
+        description: "Comma-separated device labels every RTF benchmark matrix row reports as"
+        value: ${{ format('{0},{1},{2},{3},{4},{5},{6}', jobs.runner_names.outputs.linux_ubuntu2204_x64_gpu, jobs.runner_names.outputs.linux_ubuntu2404_x64_gpu, jobs.runner_names.outputs.ubuntu_2604, jobs.runner_names.outputs.ubuntu_2404_arm, jobs.runner_names.outputs.macos_arm64_gpu, jobs.runner_names.outputs.macos_15_large, jobs.runner_names.outputs.win_2025_x64_gpu) }}
 
 # Least-privilege default scoped to the whole file (CodeQL
 # actions/missing-workflow-permissions).  Individual jobs widen this as
@@ -325,14 +336,35 @@ jobs:
             exit 1
           fi
 
+      # Two attempts, and losing both fails the lane: the job runs with
+      # continue-on-error, so a swallowed upload failure (the asr-ggml matrix
+      # lost all 48 darwin-arm64 rows of run 34062003154 to a CreateArtifact
+      # ETIMEDOUT) would silently drop this device from the consolidated
+      # report. `if-no-files-found: error` instead of `warn` for the same
+      # reason — the verify step above already guarantees files exist on the
+      # happy path.
       - name: Upload RTF benchmark results
+        id: upload-rtf-results
         if: ${{ always() && !cancelled() && inputs.run_rtf_benchmarks }}
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:
           name: rtf-results-tts-ggml-${{ matrix.runner || matrix.os }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '-cpu' || '-gpu' }}
           path: |
             packages/tts-ggml/benchmarks/results/rtf-benchmark-*.json
             packages/tts-ggml/benchmarks/results/streaming-benchmark-*.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 30
+
+      - name: Upload RTF benchmark results (retry)
+        if: ${{ always() && !cancelled() && inputs.run_rtf_benchmarks && steps.upload-rtf-results.outcome == 'failure' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: rtf-results-tts-ggml-${{ matrix.runner || matrix.os }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '-cpu' || '-gpu' }}
+          path: |
+            packages/tts-ggml/benchmarks/results/rtf-benchmark-*.json
+            packages/tts-ggml/benchmarks/results/streaming-benchmark-*.json
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
 

--- a/scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js
@@ -33,7 +33,8 @@ const {
   dedupeRecords,
   renderMarkdown,
   renderHtml,
-  buildCoverage
+  buildCoverage,
+  missingExpectedDevices
 } = require('../aggregate-asr-ggml-rtf')
 
 function whisperDesktopReport (useGPU) {
@@ -618,4 +619,50 @@ test('html table includes the Engine header, memory columns and rounded values',
   assert.ok(html.includes('<td>906</td>'), 'peak RSS should be rounded to 906 in a table cell')
   assert.ok(html.includes('<td>812</td>'), 'avg RSS should be rounded to 812 in a table cell')
   assert.ok(html.includes('<td>parakeet</td>'))
+})
+
+// ---------------------------------------------------------------------------
+// Expected-device gate (--expect-devices)
+
+test('missing expected devices are detected from desktop rows only', () => {
+  const records = [
+    normalizeDesktopRecord(whisperDesktopReport(true), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-gpu.json'),
+    { source: 'mobile-ci', device: 'qvac-macos26-arm64-gpu' },
+    { source: 'manual', device: 'macos-15-large' }
+  ]
+  assert.deepEqual(missingExpectedDevices(records, []), [])
+  assert.deepEqual(missingExpectedDevices(records, ['qvac-ubuntu2404-x64-gpu']), [])
+  // Mobile and manual rows never stand in for a desktop lane: only the
+  // whisper desktop record's device satisfies the expectation.
+  assert.deepEqual(
+    missingExpectedDevices(records, ['qvac-ubuntu2404-x64-gpu', 'qvac-macos26-arm64-gpu', 'macos-15-large']),
+    ['qvac-macos26-arm64-gpu', 'macos-15-large']
+  )
+})
+
+test('coverage, markdown and html surface missing expected devices', () => {
+  const records = [normalizeDesktopRecord(whisperDesktopReport(true), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-gpu.json')]
+  const expected = ['qvac-ubuntu2404-x64-gpu', 'qvac-macos26-arm64-gpu']
+
+  const coverage = buildCoverage(records, expected)
+  assert.deepEqual(coverage.expectedDesktopDevices, expected)
+  assert.deepEqual(coverage.missingDesktopDevices, ['qvac-macos26-arm64-gpu'])
+  assert.equal(buildCoverage(records).expectedDesktopDevices, undefined)
+
+  const markdown = renderMarkdown(records, expected)
+  assert.ok(markdown.includes('- Expected desktop devices reporting: 1/2'))
+  assert.ok(markdown.includes('MISSING desktop devices'))
+  assert.ok(markdown.includes('qvac-macos26-arm64-gpu'))
+  assert.ok(!renderMarkdown(records).includes('Expected desktop devices'))
+
+  const html = renderHtml(records, expected)
+  assert.ok(html.includes('MISSING desktop devices'))
+  assert.ok(html.includes('qvac-macos26-arm64-gpu'))
+})
+
+test('a fully reporting device list renders without the missing-devices warning', () => {
+  const records = [normalizeDesktopRecord(whisperDesktopReport(true), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-gpu.json')]
+  const markdown = renderMarkdown(records, ['qvac-ubuntu2404-x64-gpu'])
+  assert.ok(markdown.includes('- Expected desktop devices reporting: 1/1'))
+  assert.ok(!markdown.includes('MISSING desktop devices'))
 })

--- a/scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js
@@ -666,3 +666,12 @@ test('a fully reporting device list renders without the missing-devices warning'
   assert.ok(markdown.includes('- Expected desktop devices reporting: 1/1'))
   assert.ok(!markdown.includes('MISSING desktop devices'))
 })
+
+test('provenance is stamped into markdown and html, and absent without it', () => {
+  const records = [normalizeDesktopRecord(whisperDesktopReport(true), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-gpu.json')]
+  const stamp = 'tetherto/qvac@main run 123, generated 2026-09-07 10:00 UTC'
+  assert.ok(renderMarkdown(records, [], stamp).includes(`Source: ${stamp}`))
+  assert.ok(renderHtml(records, [], stamp).includes('tetherto/qvac@main run 123'))
+  assert.ok(!renderMarkdown(records).includes('Source:'))
+  assert.ok(!renderHtml(records).includes('Source:'))
+})

--- a/scripts/perf-report/__tests__/aggregate-bci-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-bci-rtf.test.js
@@ -27,7 +27,9 @@ const {
   normalizeReport,
   normalizeMobileRecords,
   renderMarkdown,
-  renderHtml
+  renderHtml,
+  buildCoverage,
+  missingExpectedDevices
 } = require('../aggregate-bci-rtf')
 
 function desktopReport (useGPU) {
@@ -186,4 +188,49 @@ test('html table includes the memory columns and rounded values', () => {
   // Guards against the header/cell lists silently desyncing on future edits.
   assert.ok(html.includes('<td>403</td>'), 'peak RSS should be rounded to 403 in a table cell')
   assert.ok(html.includes('<td>318</td>'), 'avg RSS should be rounded to 318 in a table cell')
+})
+
+// ---------------------------------------------------------------------------
+// Expected-device gate (--expect-devices)
+
+test('missing expected devices are detected from desktop rows only', () => {
+  const records = [
+    normalizeReport(desktopReport(true), 'rtf-benchmark-linux-x64-ggml-bci-windowed-gpu.json', 'desktop-ci'),
+    { source: 'mobile-ci', device: 'qvac-macos26-arm64-gpu' },
+    { source: 'manual', device: 'macos-15-large' }
+  ]
+  assert.deepEqual(missingExpectedDevices(records, []), [])
+  assert.deepEqual(missingExpectedDevices(records, ['qvac-ubuntu2404-x64-gpu']), [])
+  // Mobile and manual rows never stand in for a desktop lane.
+  assert.deepEqual(
+    missingExpectedDevices(records, ['qvac-ubuntu2404-x64-gpu', 'qvac-macos26-arm64-gpu', 'macos-15-large']),
+    ['qvac-macos26-arm64-gpu', 'macos-15-large']
+  )
+})
+
+test('coverage, markdown and html surface missing expected devices', () => {
+  const records = [normalizeReport(desktopReport(true), 'rtf-benchmark-linux-x64-ggml-bci-windowed-gpu.json', 'desktop-ci')]
+  const expected = ['qvac-ubuntu2404-x64-gpu', 'qvac-macos26-arm64-gpu']
+
+  const coverage = buildCoverage(records, expected)
+  assert.deepEqual(coverage.expectedDesktopDevices, expected)
+  assert.deepEqual(coverage.missingDesktopDevices, ['qvac-macos26-arm64-gpu'])
+  assert.equal(buildCoverage(records).expectedDesktopDevices, undefined)
+
+  const markdown = renderMarkdown(records, expected)
+  assert.ok(markdown.includes('- Expected desktop devices reporting: 1/2'))
+  assert.ok(markdown.includes('MISSING desktop devices'))
+  assert.ok(markdown.includes('qvac-macos26-arm64-gpu'))
+  assert.ok(!renderMarkdown(records).includes('Expected desktop devices'))
+
+  const html = renderHtml(records, expected)
+  assert.ok(html.includes('MISSING desktop devices'))
+  assert.ok(html.includes('qvac-macos26-arm64-gpu'))
+})
+
+test('a fully reporting device list renders without the missing-devices warning', () => {
+  const records = [normalizeReport(desktopReport(true), 'rtf-benchmark-linux-x64-ggml-bci-windowed-gpu.json', 'desktop-ci')]
+  const markdown = renderMarkdown(records, ['qvac-ubuntu2404-x64-gpu'])
+  assert.ok(markdown.includes('- Expected desktop devices reporting: 1/1'))
+  assert.ok(!markdown.includes('MISSING desktop devices'))
 })

--- a/scripts/perf-report/__tests__/aggregate-bci-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-bci-rtf.test.js
@@ -234,3 +234,12 @@ test('a fully reporting device list renders without the missing-devices warning'
   assert.ok(markdown.includes('- Expected desktop devices reporting: 1/1'))
   assert.ok(!markdown.includes('MISSING desktop devices'))
 })
+
+test('provenance is stamped into markdown and html, and absent without it', () => {
+  const records = [normalizeReport(desktopReport(true), 'rtf-benchmark-linux-x64-ggml-bci-windowed-gpu.json', 'desktop-ci')]
+  const stamp = 'tetherto/qvac@main run 123, generated 2026-09-07 10:00 UTC'
+  assert.ok(renderMarkdown(records, [], stamp).includes(`Source: ${stamp}`))
+  assert.ok(renderHtml(records, [], stamp).includes('tetherto/qvac@main run 123'))
+  assert.ok(!renderMarkdown(records).includes('Source:'))
+  assert.ok(!renderHtml(records).includes('Source:'))
+})

--- a/scripts/perf-report/__tests__/aggregate-tts-ggml-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-tts-ggml-rtf.test.js
@@ -31,7 +31,8 @@ const {
   normalizeStreamingRecord,
   expandCanonicalReport,
   dedupeRecords,
-  renderMarkdown
+  renderMarkdown,
+  missingExpectedDevices
 } = require('../aggregate-tts-ggml-rtf')
 
 const MB = 1024 * 1024
@@ -616,4 +617,38 @@ test('dedupeRecords keeps rows evaluated by different Whisper models separate', 
   )
 
   assert.equal(dedupeRecords([small, tiny]).length, 2)
+})
+
+// ---------------------------------------------------------------------------
+// Expected-device gate (--expect-devices)
+
+test('missing expected devices are detected from desktop rows only', () => {
+  const records = [
+    normalizeDesktopRecord(desktopReport(true), 'rtf-benchmark-linux-x64-chatterbox-q4-gpu.json'),
+    { source: 'mobile-ci', device: 'qvac-macos26-arm64-gpu' },
+    { source: 'manual', device: 'macos-15-large' }
+  ]
+  assert.deepEqual(missingExpectedDevices(records, []), [])
+  assert.deepEqual(missingExpectedDevices(records, ['rtx-4090-box']), [])
+  // Mobile and manual rows never stand in for a desktop lane.
+  assert.deepEqual(
+    missingExpectedDevices(records, ['rtx-4090-box', 'qvac-macos26-arm64-gpu', 'macos-15-large']),
+    ['qvac-macos26-arm64-gpu', 'macos-15-large']
+  )
+})
+
+test('markdown surfaces missing expected devices and stays silent without the flag', () => {
+  const records = [normalizeDesktopRecord(desktopReport(true), 'rtf-benchmark-linux-x64-chatterbox-q4-gpu.json')]
+  const expected = ['rtx-4090-box', 'qvac-macos26-arm64-gpu']
+
+  const markdown = renderMarkdown(records, [], expected)
+  assert.ok(markdown.includes('- Expected desktop devices reporting: 1/2'))
+  assert.ok(markdown.includes('MISSING desktop devices'))
+  assert.ok(markdown.includes('qvac-macos26-arm64-gpu'))
+
+  assert.ok(!renderMarkdown(records, []).includes('Expected desktop devices'))
+
+  const complete = renderMarkdown(records, [], ['rtx-4090-box'])
+  assert.ok(complete.includes('- Expected desktop devices reporting: 1/1'))
+  assert.ok(!complete.includes('MISSING desktop devices'))
 })

--- a/scripts/perf-report/__tests__/aggregate-tts-ggml-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-tts-ggml-rtf.test.js
@@ -652,3 +652,10 @@ test('markdown surfaces missing expected devices and stays silent without the fl
   assert.ok(complete.includes('- Expected desktop devices reporting: 1/1'))
   assert.ok(!complete.includes('MISSING desktop devices'))
 })
+
+test('provenance is stamped into markdown, and absent without it', () => {
+  const records = [normalizeDesktopRecord(desktopReport(true), 'rtf-benchmark-linux-x64-chatterbox-q4-gpu.json')]
+  const stamp = 'tetherto/qvac@main run 123, generated 2026-09-07 10:00 UTC'
+  assert.ok(renderMarkdown(records, [], [], stamp).includes(`Source: ${stamp}`))
+  assert.ok(!renderMarkdown(records, []).includes('Source:'))
+})

--- a/scripts/perf-report/aggregate-asr-ggml-rtf.js
+++ b/scripts/perf-report/aggregate-asr-ggml-rtf.js
@@ -49,7 +49,8 @@ function parseArgs (argv) {
     output: '',
     jsonOutput: '',
     htmlOutput: '',
-    manualDir: path.resolve('packages/asr-ggml/benchmarks/manual-results')
+    manualDir: path.resolve('packages/asr-ggml/benchmarks/manual-results'),
+    expectDevices: []
   }
 
   for (let i = 0; i < argv.length; i++) {
@@ -69,6 +70,9 @@ function parseArgs (argv) {
       i++
     } else if (arg === '--manual-dir' && next) {
       args.manualDir = next
+      i++
+    } else if (arg === '--expect-devices' && next) {
+      args.expectDevices = next.split(',').map(device => device.trim()).filter(Boolean)
       i++
     }
   }
@@ -617,7 +621,24 @@ function coverageFor (records) {
   }
 }
 
-function buildCoverage (records) {
+// The benchmark matrix jobs run with job-level continue-on-error, so a lane
+// can lose its rtf-results artifact (upload timeout, dead runner, renamed
+// runner label) without failing the run — run 34062003154 shipped a report
+// with all 48 darwin-arm64 rows silently absent. The summarize workflow passes
+// the matrix's device list via --expect-devices; an expected device with zero
+// desktop rows must surface as an incomplete report, not as a smaller one.
+// Mobile and manual rows never satisfy the expectation — it describes the
+// desktop matrix only.
+function missingExpectedDevices (records, expectedDevices) {
+  const reporting = new Set(
+    records
+      .filter(record => record.source === 'desktop-ci')
+      .map(record => record.device)
+  )
+  return expectedDevices.filter(device => !reporting.has(device))
+}
+
+function buildCoverage (records, expectedDevices = []) {
   const versions = Array.from(new Set(
     records.map(record => record.version).filter(Boolean)
   )).sort()
@@ -630,10 +651,17 @@ function buildCoverage (records) {
     byEngine[engine] = coverageFor(records.filter(record => record.engine === engine))
   }
 
-  return Object.assign(coverageFor(records), {
+  const coverage = Object.assign(coverageFor(records), {
     addonVersions: versions,
     byEngine
   })
+
+  if (expectedDevices.length > 0) {
+    coverage.expectedDesktopDevices = expectedDevices
+    coverage.missingDesktopDevices = missingExpectedDevices(records, expectedDevices)
+  }
+
+  return coverage
 }
 
 // Fastest config per device (lowest mean RTF). Mirrors the LLM suite's
@@ -654,9 +682,9 @@ function buildBestPerDevice (records) {
   })
 }
 
-function renderMarkdown (records) {
+function renderMarkdown (records, expectedDevices = []) {
   const lines = []
-  const coverage = buildCoverage(records)
+  const coverage = buildCoverage(records, expectedDevices)
 
   lines.push('## ASR GGML Performance Findings')
   lines.push('')
@@ -686,6 +714,13 @@ function renderMarkdown (records) {
   lines.push('### Coverage')
   lines.push('')
   lines.push(`- Rows aggregated: ${coverage.rowCount}`)
+  if (coverage.expectedDesktopDevices) {
+    const reporting = coverage.expectedDesktopDevices.length - coverage.missingDesktopDevices.length
+    lines.push(`- Expected desktop devices reporting: ${reporting}/${coverage.expectedDesktopDevices.length}`)
+    if (coverage.missingDesktopDevices.length > 0) {
+      lines.push(`- MISSING desktop devices (lane ran without an rtf-results artifact, or never ran): ${coverage.missingDesktopDevices.join(', ')} — this report is INCOMPLETE`)
+    }
+  }
   lines.push(`- Addon version(s): ${coverage.addonVersions.join(', ') || 'unknown'}`)
   lines.push(`- GPU backends covered: ${coverage.gpuBackendsCovered.join(', ') || 'none'}`)
   lines.push(`- GPU backends still missing: ${coverage.missingBackends.join(', ') || 'none'}`)
@@ -697,8 +732,8 @@ function renderMarkdown (records) {
   return lines.join('\n') + '\n'
 }
 
-function renderHtml (records) {
-  const coverage = buildCoverage(records)
+function renderHtml (records, expectedDevices = []) {
+  const coverage = buildCoverage(records, expectedDevices)
   const rows = records.map(record => {
     return [
       record.source,
@@ -741,6 +776,15 @@ function renderHtml (records) {
     const engineCoverage = coverage.byEngine[engine]
     return `    <li>${escapeHtml(engine)}: <code>${escapeHtml(String(engineCoverage.rowCount))}</code> row(s), covered: <code>${escapeHtml(engineCoverage.gpuBackendsCovered.join(', ') || 'none')}</code>, still missing: <code>${escapeHtml(engineCoverage.missingBackends.join(', ') || 'none')}</code></li>`
   }).join('\n')
+
+  const expectedDeviceItems = []
+  if (coverage.expectedDesktopDevices) {
+    const reporting = coverage.expectedDesktopDevices.length - coverage.missingDesktopDevices.length
+    expectedDeviceItems.push(`    <li>Expected desktop devices reporting: <code>${escapeHtml(`${reporting}/${coverage.expectedDesktopDevices.length}`)}</code></li>`)
+    if (coverage.missingDesktopDevices.length > 0) {
+      expectedDeviceItems.push(`    <li><strong>MISSING desktop devices (lane ran without an rtf-results artifact, or never ran): <code>${escapeHtml(coverage.missingDesktopDevices.join(', '))}</code> — this report is INCOMPLETE</strong></li>`)
+    }
+  }
 
   return [
     '<!doctype html>',
@@ -813,6 +857,7 @@ function renderHtml (records) {
     '  <h2>Coverage</h2>',
     '  <ul>',
     `    <li>Rows aggregated: <code>${escapeHtml(String(coverage.rowCount))}</code></li>`,
+    ...expectedDeviceItems,
     `    <li>Addon version(s): <code>${escapeHtml(coverage.addonVersions.join(', ') || 'unknown')}</code></li>`,
     `    <li>GPU backends covered: <code>${escapeHtml(coverage.gpuBackendsCovered.join(', ') || 'none')}</code></li>`,
     `    <li>GPU backends still missing: <code>${escapeHtml(coverage.missingBackends.join(', ') || 'none')}</code></li>`,
@@ -833,8 +878,8 @@ function main () {
   const mobileRecords = loadMobilePerformanceRecords(inputDir)
   const manualRecords = loadManualRecords(manualDir)
   const records = sortRecords(dedupeRecords(desktopRecords.concat(mobileRecords, manualRecords)))
-  const markdown = renderMarkdown(records)
-  const html = renderHtml(records)
+  const markdown = renderMarkdown(records, args.expectDevices)
+  const html = renderHtml(records, args.expectDevices)
 
   if (args.output) {
     const outputPath = path.resolve(args.output)
@@ -845,7 +890,7 @@ function main () {
   if (args.jsonOutput) {
     const jsonOutputPath = path.resolve(args.jsonOutput)
     ensureParentDir(jsonOutputPath)
-    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, coverage: buildCoverage(records) }, null, 2) + '\n', 'utf8')
+    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, coverage: buildCoverage(records, args.expectDevices) }, null, 2) + '\n', 'utf8')
   }
 
   if (args.htmlOutput) {
@@ -855,6 +900,14 @@ function main () {
   }
 
   process.stdout.write(markdown)
+
+  // Fail only after every output is written: the incomplete report must stay
+  // inspectable (later workflow steps upload it with `if: !cancelled()`).
+  const missing = missingExpectedDevices(records, args.expectDevices)
+  if (missing.length > 0) {
+    console.error(`::error title=RTF report is missing benchmark device(s)::No desktop rows from: ${missing.join(', ')}. The lane lost its rtf-results artifact, its runner label changed, or it never ran — the consolidated report is incomplete.`)
+    process.exitCode = 1
+  }
 }
 
 if (require.main === module) {
@@ -870,5 +923,6 @@ module.exports = {
   dedupeRecords,
   renderMarkdown,
   renderHtml,
-  buildCoverage
+  buildCoverage,
+  missingExpectedDevices
 }

--- a/scripts/perf-report/aggregate-asr-ggml-rtf.js
+++ b/scripts/perf-report/aggregate-asr-ggml-rtf.js
@@ -50,7 +50,8 @@ function parseArgs (argv) {
     jsonOutput: '',
     htmlOutput: '',
     manualDir: path.resolve('packages/asr-ggml/benchmarks/manual-results'),
-    expectDevices: []
+    expectDevices: [],
+    provenance: ''
   }
 
   for (let i = 0; i < argv.length; i++) {
@@ -73,6 +74,9 @@ function parseArgs (argv) {
       i++
     } else if (arg === '--expect-devices' && next) {
       args.expectDevices = next.split(',').map(device => device.trim()).filter(Boolean)
+      i++
+    } else if (arg === '--provenance' && next) {
+      args.provenance = next
       i++
     }
   }
@@ -682,12 +686,19 @@ function buildBestPerDevice (records) {
   })
 }
 
-function renderMarkdown (records, expectedDevices = []) {
+function renderMarkdown (records, expectedDevices = [], provenance = '') {
   const lines = []
   const coverage = buildCoverage(records, expectedDevices)
 
   lines.push('## ASR GGML Performance Findings')
   lines.push('')
+  // Channel numbers have been published from feature branches that were
+  // indistinguishable from main in the report (QVAC-24635), so the summarize
+  // workflow stamps repo@ref, run id and date here.
+  if (provenance) {
+    lines.push(`Source: ${provenance}`)
+    lines.push('')
+  }
   lines.push('| Source | Engine | Device | Platform | Model | Quant | GPU | Backend | GPU Model | Version | Mean RTF | ± Stddev | P50 | P95 | Mean Wall (ms) | Avg RSS (MB) | Peak RSS (MB) | Reclaimed (MB) | Notes |')
   lines.push('|--------|--------|--------|----------|-------|-------|-----|---------|-----------|---------|----------|----------|-----|-----|----------------|--------------|---------------|----------------|-------|')
 
@@ -732,7 +743,7 @@ function renderMarkdown (records, expectedDevices = []) {
   return lines.join('\n') + '\n'
 }
 
-function renderHtml (records, expectedDevices = []) {
+function renderHtml (records, expectedDevices = [], provenance = '') {
   const coverage = buildCoverage(records, expectedDevices)
   const rows = records.map(record => {
     return [
@@ -806,6 +817,7 @@ function renderHtml (records, expectedDevices = []) {
     '</head>',
     '<body>',
     '  <h1>ASR GGML Performance Findings</h1>',
+    ...(provenance ? [`  <p>Source: <code>${escapeHtml(provenance)}</code></p>`] : []),
     '  <table>',
     '    <thead>',
     '      <tr>',
@@ -878,8 +890,8 @@ function main () {
   const mobileRecords = loadMobilePerformanceRecords(inputDir)
   const manualRecords = loadManualRecords(manualDir)
   const records = sortRecords(dedupeRecords(desktopRecords.concat(mobileRecords, manualRecords)))
-  const markdown = renderMarkdown(records, args.expectDevices)
-  const html = renderHtml(records, args.expectDevices)
+  const markdown = renderMarkdown(records, args.expectDevices, args.provenance)
+  const html = renderHtml(records, args.expectDevices, args.provenance)
 
   if (args.output) {
     const outputPath = path.resolve(args.output)
@@ -890,7 +902,7 @@ function main () {
   if (args.jsonOutput) {
     const jsonOutputPath = path.resolve(args.jsonOutput)
     ensureParentDir(jsonOutputPath)
-    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, coverage: buildCoverage(records, args.expectDevices) }, null, 2) + '\n', 'utf8')
+    fs.writeFileSync(jsonOutputPath, JSON.stringify({ provenance: args.provenance || undefined, records, coverage: buildCoverage(records, args.expectDevices) }, null, 2) + '\n', 'utf8')
   }
 
   if (args.htmlOutput) {

--- a/scripts/perf-report/aggregate-bci-rtf.js
+++ b/scripts/perf-report/aggregate-bci-rtf.js
@@ -27,13 +27,14 @@ function parseArgs (argv) {
     jsonOutput: '',
     htmlOutput: '',
     manualDir: path.resolve('packages/bci-whispercpp/benchmarks/manual-results'),
-    expectDevices: []
+    expectDevices: [],
+    provenance: ''
   }
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     const next = argv[i + 1]
-    if ((arg === '--input' || arg === '--dir') && next) { args.input = next; i++ } else if (arg === '--output' && next) { args.output = next; i++ } else if ((arg === '--json-output' || arg === '--output-json') && next) { args.jsonOutput = next; i++ } else if (arg === '--output-html' && next) { args.htmlOutput = next; i++ } else if (arg === '--manual-dir' && next) { args.manualDir = next; i++ } else if (arg === '--expect-devices' && next) { args.expectDevices = next.split(',').map((device) => device.trim()).filter(Boolean); i++ }
+    if ((arg === '--input' || arg === '--dir') && next) { args.input = next; i++ } else if (arg === '--output' && next) { args.output = next; i++ } else if ((arg === '--json-output' || arg === '--output-json') && next) { args.jsonOutput = next; i++ } else if (arg === '--output-html' && next) { args.htmlOutput = next; i++ } else if (arg === '--manual-dir' && next) { args.manualDir = next; i++ } else if (arg === '--expect-devices' && next) { args.expectDevices = next.split(',').map((device) => device.trim()).filter(Boolean); i++ } else if (arg === '--provenance' && next) { args.provenance = next; i++ }
   }
 
   if (!args.input) throw new Error('Missing required --input argument')
@@ -372,11 +373,15 @@ function buildCoverage (records, expectedDevices = []) {
   return coverage
 }
 
-function renderMarkdown (records, expectedDevices = []) {
+function renderMarkdown (records, expectedDevices = [], provenance = '') {
   const coverage = buildCoverage(records, expectedDevices)
   const lines = [
     '## BCI Performance Findings',
     '',
+    // Channel numbers have been published from feature branches that were
+    // indistinguishable from main in the report (QVAC-24635), so the summarize
+    // workflow stamps repo@ref, run id and date here.
+    ...(provenance ? [`Source: ${provenance}`, ''] : []),
     '| Source | Device | Platform | Model | GPU | Backend | Mean tok/s | Stddev tok/s | P50 tok/s | Mean Wall (ms) | RTF | Avg RSS (MB) | Peak RSS (MB) | Reclaimed (MB) | Notes |',
     '|--------|--------|----------|-------|-----|---------|------------|--------------|-----------|----------------|-----|--------------|---------------|----------------|-------|'
   ]
@@ -401,7 +406,7 @@ function renderMarkdown (records, expectedDevices = []) {
   return lines.join('\n') + '\n'
 }
 
-function renderHtml (records, expectedDevices = []) {
+function renderHtml (records, expectedDevices = [], provenance = '') {
   const coverage = buildCoverage(records, expectedDevices)
   const expectedDeviceItems = []
   if (coverage.expectedDesktopDevices) {
@@ -441,6 +446,7 @@ function renderHtml (records, expectedDevices = []) {
     '</head>',
     '<body>',
     '  <h1>BCI Performance Findings</h1>',
+    ...(provenance ? [`  <p>Source: <code>${escapeHtml(provenance)}</code></p>`] : []),
     '  <table>',
     '    <thead>',
     '      <tr>',
@@ -490,8 +496,8 @@ function main () {
         .concat(loadManualRecords(manualDir))
     )
   )
-  const markdown = renderMarkdown(records, args.expectDevices)
-  const html = renderHtml(records, args.expectDevices)
+  const markdown = renderMarkdown(records, args.expectDevices, args.provenance)
+  const html = renderHtml(records, args.expectDevices, args.provenance)
 
   if (args.output) {
     const outputPath = path.resolve(args.output)
@@ -501,7 +507,7 @@ function main () {
   if (args.jsonOutput) {
     const jsonOutputPath = path.resolve(args.jsonOutput)
     ensureParentDir(jsonOutputPath)
-    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, coverage: buildCoverage(records, args.expectDevices) }, null, 2) + '\n', 'utf8')
+    fs.writeFileSync(jsonOutputPath, JSON.stringify({ provenance: args.provenance || undefined, records, coverage: buildCoverage(records, args.expectDevices) }, null, 2) + '\n', 'utf8')
   }
   if (args.htmlOutput) {
     const htmlOutputPath = path.resolve(args.htmlOutput)

--- a/scripts/perf-report/aggregate-bci-rtf.js
+++ b/scripts/perf-report/aggregate-bci-rtf.js
@@ -26,13 +26,14 @@ function parseArgs (argv) {
     output: '',
     jsonOutput: '',
     htmlOutput: '',
-    manualDir: path.resolve('packages/bci-whispercpp/benchmarks/manual-results')
+    manualDir: path.resolve('packages/bci-whispercpp/benchmarks/manual-results'),
+    expectDevices: []
   }
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     const next = argv[i + 1]
-    if ((arg === '--input' || arg === '--dir') && next) { args.input = next; i++ } else if (arg === '--output' && next) { args.output = next; i++ } else if ((arg === '--json-output' || arg === '--output-json') && next) { args.jsonOutput = next; i++ } else if (arg === '--output-html' && next) { args.htmlOutput = next; i++ } else if (arg === '--manual-dir' && next) { args.manualDir = next; i++ }
+    if ((arg === '--input' || arg === '--dir') && next) { args.input = next; i++ } else if (arg === '--output' && next) { args.output = next; i++ } else if ((arg === '--json-output' || arg === '--output-json') && next) { args.jsonOutput = next; i++ } else if (arg === '--output-html' && next) { args.htmlOutput = next; i++ } else if (arg === '--manual-dir' && next) { args.manualDir = next; i++ } else if (arg === '--expect-devices' && next) { args.expectDevices = next.split(',').map((device) => device.trim()).filter(Boolean); i++ }
   }
 
   if (!args.input) throw new Error('Missing required --input argument')
@@ -343,19 +344,36 @@ function dedupeRecords (records) {
   return [...byKey.values()]
 }
 
-function buildCoverage (records) {
+// Same silent-loss guard as aggregate-asr-ggml-rtf.js: the desktop matrix jobs
+// tolerate step failures, so a lane can lose its rtf-results artifact without
+// failing the run. The summarize workflow passes the matrix's device list via
+// --expect-devices; a device with zero desktop rows makes the report loudly
+// incomplete. Mobile and manual rows never satisfy the expectation.
+function missingExpectedDevices (records, expectedDevices) {
+  const reporting = new Set(
+    records.filter((record) => record.source === 'desktop-ci').map((record) => record.device)
+  )
+  return expectedDevices.filter((device) => !reporting.has(device))
+}
+
+function buildCoverage (records, expectedDevices = []) {
   const gpuCoverage = new Set(
     records.filter((record) => record.gpu === 'gpu').map((record) => record.backend).filter(Boolean)
   )
-  return {
+  const coverage = {
     rowCount: records.length,
     gpuBackendsCovered: Array.from(gpuCoverage).sort(),
     missingBackends: SUPPORTED_GPU_BACKENDS.filter((backend) => !gpuCoverage.has(backend))
   }
+  if (expectedDevices.length > 0) {
+    coverage.expectedDesktopDevices = expectedDevices
+    coverage.missingDesktopDevices = missingExpectedDevices(records, expectedDevices)
+  }
+  return coverage
 }
 
-function renderMarkdown (records) {
-  const coverage = buildCoverage(records)
+function renderMarkdown (records, expectedDevices = []) {
+  const coverage = buildCoverage(records, expectedDevices)
   const lines = [
     '## BCI Performance Findings',
     '',
@@ -371,13 +389,28 @@ function renderMarkdown (records) {
   lines.push('### Coverage')
   lines.push('')
   lines.push(`- Rows aggregated: ${coverage.rowCount}`)
+  if (coverage.expectedDesktopDevices) {
+    const reporting = coverage.expectedDesktopDevices.length - coverage.missingDesktopDevices.length
+    lines.push(`- Expected desktop devices reporting: ${reporting}/${coverage.expectedDesktopDevices.length}`)
+    if (coverage.missingDesktopDevices.length > 0) {
+      lines.push(`- MISSING desktop devices (lane ran without an rtf-results artifact, or never ran): ${coverage.missingDesktopDevices.join(', ')} — this report is INCOMPLETE`)
+    }
+  }
   lines.push(`- GPU backends covered: ${coverage.gpuBackendsCovered.join(', ') || 'none'}`)
   lines.push(`- GPU backends still missing: ${coverage.missingBackends.join(', ') || 'none'}`)
   return lines.join('\n') + '\n'
 }
 
-function renderHtml (records) {
-  const coverage = buildCoverage(records)
+function renderHtml (records, expectedDevices = []) {
+  const coverage = buildCoverage(records, expectedDevices)
+  const expectedDeviceItems = []
+  if (coverage.expectedDesktopDevices) {
+    const reporting = coverage.expectedDesktopDevices.length - coverage.missingDesktopDevices.length
+    expectedDeviceItems.push(`    <li>Expected desktop devices reporting: <code>${escapeHtml(`${reporting}/${coverage.expectedDesktopDevices.length}`)}</code></li>`)
+    if (coverage.missingDesktopDevices.length > 0) {
+      expectedDeviceItems.push(`    <li><strong>MISSING desktop devices (lane ran without an rtf-results artifact, or never ran): <code>${escapeHtml(coverage.missingDesktopDevices.join(', '))}</code> — this report is INCOMPLETE</strong></li>`)
+    }
+  }
   const rows = records.map((record) => {
     return [
       record.source, record.device, record.platform, record.model, record.gpu, record.backend,
@@ -435,6 +468,7 @@ function renderHtml (records) {
     '  <h2>Coverage</h2>',
     '  <ul>',
     `    <li>Rows aggregated: <code>${escapeHtml(String(coverage.rowCount))}</code></li>`,
+    ...expectedDeviceItems,
     `    <li>GPU backends covered: <code>${escapeHtml(coverage.gpuBackendsCovered.join(', ') || 'none')}</code></li>`,
     `    <li>GPU backends still missing: <code>${escapeHtml(coverage.missingBackends.join(', ') || 'none')}</code></li>`,
     '  </ul>',
@@ -456,8 +490,8 @@ function main () {
         .concat(loadManualRecords(manualDir))
     )
   )
-  const markdown = renderMarkdown(records)
-  const html = renderHtml(records)
+  const markdown = renderMarkdown(records, args.expectDevices)
+  const html = renderHtml(records, args.expectDevices)
 
   if (args.output) {
     const outputPath = path.resolve(args.output)
@@ -467,7 +501,7 @@ function main () {
   if (args.jsonOutput) {
     const jsonOutputPath = path.resolve(args.jsonOutput)
     ensureParentDir(jsonOutputPath)
-    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, coverage: buildCoverage(records) }, null, 2) + '\n', 'utf8')
+    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, coverage: buildCoverage(records, args.expectDevices) }, null, 2) + '\n', 'utf8')
   }
   if (args.htmlOutput) {
     const htmlOutputPath = path.resolve(args.htmlOutput)
@@ -476,6 +510,14 @@ function main () {
   }
 
   process.stdout.write(markdown)
+
+  // Fail only after every output is written: the incomplete report must stay
+  // inspectable (later workflow steps upload it with `if: !cancelled()`).
+  const missing = missingExpectedDevices(records, args.expectDevices)
+  if (missing.length > 0) {
+    console.error(`::error title=BCI report is missing benchmark device(s)::No desktop rows from: ${missing.join(', ')}. The lane lost its rtf-results artifact, its runner label changed, or it never ran — the consolidated report is incomplete.`)
+    process.exitCode = 1
+  }
 }
 
 if (require.main === module) {
@@ -487,5 +529,6 @@ module.exports = {
   normalizeMobileRecords,
   renderMarkdown,
   renderHtml,
-  buildCoverage
+  buildCoverage,
+  missingExpectedDevices
 }

--- a/scripts/perf-report/aggregate-tts-ggml-rtf.js
+++ b/scripts/perf-report/aggregate-tts-ggml-rtf.js
@@ -35,7 +35,8 @@ function parseArgs (argv) {
     input: '',
     output: '',
     jsonOutput: '',
-    manualDir: path.resolve('packages/tts-ggml/benchmarks/manual-results')
+    manualDir: path.resolve('packages/tts-ggml/benchmarks/manual-results'),
+    expectDevices: []
   }
 
   for (let i = 0; i < argv.length; i++) {
@@ -52,6 +53,9 @@ function parseArgs (argv) {
       i++
     } else if (arg === '--manual-dir' && next) {
       args.manualDir = next
+      i++
+    } else if (arg === '--expect-devices' && next) {
+      args.expectDevices = next.split(',').map(device => device.trim()).filter(Boolean)
       i++
     }
   }
@@ -709,13 +713,26 @@ function formatEnhancerCell (enhancer, enhancerVariant) {
   return `${name}/${variant}`
 }
 
-function renderMarkdown (records, streamingRecords) {
+// Same silent-loss guard as aggregate-asr-ggml-rtf.js: the desktop matrix jobs
+// tolerate step failures, so a lane can lose its rtf-results artifact without
+// failing the run. The summarize workflow passes the matrix's device list via
+// --expect-devices; a device with zero desktop rows makes the report loudly
+// incomplete. Mobile and manual rows never satisfy the expectation.
+function missingExpectedDevices (records, expectedDevices) {
+  const reporting = new Set(
+    records.filter(r => r.source === 'desktop-ci').map(r => r.device)
+  )
+  return expectedDevices.filter(device => !reporting.has(device))
+}
+
+function renderMarkdown (records, streamingRecords, expectedDevices = []) {
   const lines = []
   const gpuCoverage = new Set(
     records.filter(r => r.gpu === 'gpu').map(r => r.backend).filter(Boolean)
   )
   const missingBackends = SUPPORTED_GPU_BACKENDS.filter(b => !gpuCoverage.has(b))
   const noisyCount = records.filter(r => r.noisy === true).length
+  const missingDevices = missingExpectedDevices(records, expectedDevices)
 
   lines.push('## GGML TTS Performance Findings')
   lines.push('')
@@ -800,6 +817,12 @@ function renderMarkdown (records, streamingRecords) {
   lines.push('### Coverage')
   lines.push('')
   lines.push(`- Rows aggregated: ${records.length}` + (streamingRecords && streamingRecords.length > 0 ? ` (+ ${streamingRecords.length} streaming row(s))` : ''))
+  if (expectedDevices.length > 0) {
+    lines.push(`- Expected desktop devices reporting: ${expectedDevices.length - missingDevices.length}/${expectedDevices.length}`)
+    if (missingDevices.length > 0) {
+      lines.push(`- MISSING desktop devices (lane ran without an rtf-results artifact, or never ran): ${missingDevices.join(', ')} — this report is INCOMPLETE`)
+    }
+  }
   lines.push(`- GPU backends covered: ${Array.from(gpuCoverage).sort().join(', ') || 'none'}`)
   lines.push(`- GPU backends still missing: ${missingBackends.join(', ') || 'none'}`)
   if (noisyCount > 0) {
@@ -826,7 +849,7 @@ function main () {
 
   const records = sortRecords(dedupeRecords(fromArtifacts.records.concat(fromManual.records)))
   const streaming = sortRecords(dedupeRecords(fromArtifacts.streaming.concat(fromManual.streaming)))
-  const markdown = renderMarkdown(records, streaming)
+  const markdown = renderMarkdown(records, streaming, args.expectDevices)
 
   if (args.output) {
     const outputPath = path.resolve(args.output)
@@ -841,6 +864,14 @@ function main () {
   }
 
   process.stdout.write(markdown)
+
+  // Fail only after every output is written: the incomplete report must stay
+  // inspectable (later workflow steps upload it with `if: !cancelled()`).
+  const missing = missingExpectedDevices(records, args.expectDevices)
+  if (missing.length > 0) {
+    console.error(`::error title=TTS report is missing benchmark device(s)::No desktop rows from: ${missing.join(', ')}. The lane lost its rtf-results artifact, its runner label changed, or it never ran — the consolidated report is incomplete.`)
+    process.exitCode = 1
+  }
 }
 
 if (require.main === module) {
@@ -856,5 +887,6 @@ module.exports = {
   expandCanonicalReport,
   memoryFromSummary,
   dedupeRecords,
-  renderMarkdown
+  renderMarkdown,
+  missingExpectedDevices
 }

--- a/scripts/perf-report/aggregate-tts-ggml-rtf.js
+++ b/scripts/perf-report/aggregate-tts-ggml-rtf.js
@@ -36,7 +36,8 @@ function parseArgs (argv) {
     output: '',
     jsonOutput: '',
     manualDir: path.resolve('packages/tts-ggml/benchmarks/manual-results'),
-    expectDevices: []
+    expectDevices: [],
+    provenance: ''
   }
 
   for (let i = 0; i < argv.length; i++) {
@@ -56,6 +57,9 @@ function parseArgs (argv) {
       i++
     } else if (arg === '--expect-devices' && next) {
       args.expectDevices = next.split(',').map(device => device.trim()).filter(Boolean)
+      i++
+    } else if (arg === '--provenance' && next) {
+      args.provenance = next
       i++
     }
   }
@@ -725,7 +729,7 @@ function missingExpectedDevices (records, expectedDevices) {
   return expectedDevices.filter(device => !reporting.has(device))
 }
 
-function renderMarkdown (records, streamingRecords, expectedDevices = []) {
+function renderMarkdown (records, streamingRecords, expectedDevices = [], provenance = '') {
   const lines = []
   const gpuCoverage = new Set(
     records.filter(r => r.gpu === 'gpu').map(r => r.backend).filter(Boolean)
@@ -736,6 +740,13 @@ function renderMarkdown (records, streamingRecords, expectedDevices = []) {
 
   lines.push('## GGML TTS Performance Findings')
   lines.push('')
+  // Channel numbers have been published from feature branches that were
+  // indistinguishable from main in the report (QVAC-24635), so the summarize
+  // workflow stamps repo@ref, run id and date here.
+  if (provenance) {
+    lines.push(`Source: ${provenance}`)
+    lines.push('')
+  }
   lines.push('RTF = generation_time / audio_duration. Lower is faster. RTF < 1 is faster than real-time.')
   lines.push('')
   lines.push('WER and CER are optional Whisper round-trip quality metrics. Lower is better.')
@@ -849,7 +860,7 @@ function main () {
 
   const records = sortRecords(dedupeRecords(fromArtifacts.records.concat(fromManual.records)))
   const streaming = sortRecords(dedupeRecords(fromArtifacts.streaming.concat(fromManual.streaming)))
-  const markdown = renderMarkdown(records, streaming, args.expectDevices)
+  const markdown = renderMarkdown(records, streaming, args.expectDevices, args.provenance)
 
   if (args.output) {
     const outputPath = path.resolve(args.output)
@@ -860,7 +871,7 @@ function main () {
   if (args.jsonOutput) {
     const jsonOutputPath = path.resolve(args.jsonOutput)
     ensureParentDir(jsonOutputPath)
-    fs.writeFileSync(jsonOutputPath, JSON.stringify({ records, streaming }, null, 2) + '\n', 'utf8')
+    fs.writeFileSync(jsonOutputPath, JSON.stringify({ provenance: args.provenance || undefined, records, streaming }, null, 2) + '\n', 'utf8')
   }
 
   process.stdout.write(markdown)


### PR DESCRIPTION
## What problem does this PR solve?

Two data-lifetime findings from the QVAC-24635 benchmark gap analysis:

1. **No provenance.** The consolidated speech performance reports never say what they were generated from. The most recent ASR channel numbers came from a feature branch (`feat/QVAC-23141-...`, addon 0.4.2) and nothing in the report distinguishes them from a main run - anyone reading the channel takes branch numbers as canonical.
2. **30-day retention loses history.** The findings artifacts are the only machine-readable record of past sweeps. The 2026-08-06 mobile sweep - the only recent source of OpenCL/Android rows - expired before the gap analysis could re-read it.

## How does it solve it?

**Provenance stamping** - the three speech aggregators (`aggregate-asr-ggml-rtf.js`, `aggregate-tts-ggml-rtf.js`, `aggregate-bci-rtf.js`) accept a new `--provenance <string>` flag:

- markdown and HTML render it as a `Source: ...` line directly under the report title, so every channel paste carries it;
- the findings JSON gains a top-level `provenance` key (omitted when the flag is absent, keeping the no-flag output byte-identical).

The three `benchmark-performance-*` summarize jobs compose the stamp from what they actually checked out - `<repository>@<ref> run <run_id>, generated <UTC date>` - via the `context` job outputs, so a dispatch against a fork or branch is stamped as exactly that.

**Retention** - the consolidated findings artifacts move from `retention-days: 30` to `90` (the GitHub maximum) in all three workflows. Raw per-runner `rtf-results-*` artifacts stay at 30 days; only the aggregate is the durable record. A real archive (S3 or committed history, plus the CPU-model stamping half of the original task) is a separate follow-up - this PR is the incremental piece that needs no infrastructure decision.

## Stacking

Built on top of `fix/QVAC-24713-rtf-artifact-loss-guard` (the artifact-loss guard PR): both PRs modify the same "Generate consolidated benchmark report" steps and aggregator entry points. Merge QVAC-24713 first; this diff then reads as provenance + retention only.

## How was it tested?

- `node --test scripts/perf-report/__tests__/aggregate-{asr-ggml,bci,tts-ggml}-rtf.test.js` - 84 pass (81 from the base branch, 3 new: provenance rendered in markdown/HTML, absent without the flag).
- CLI smoke: the ASR aggregator with `--provenance "tetherto/qvac@main run 999, generated 2026-09-07 12:00 UTC"` renders the Source line under the title and writes the JSON key; without the flag output is unchanged.
- `node --check` clean on all three aggregators; all three edited workflow files re-parse as valid YAML.

CI workflow and report tooling only - no addon or package change, no version bump or CHANGELOG entry.

Prepared with Claude Code.
