### PR TITLE
fix[notask]: pin bare-headers to 1.30.0 so the diffusion-cpp addon builds again

### DIFF
--- a/packages/diffusion-cpp/CMakeLists.txt
+++ b/packages/diffusion-cpp/CMakeLists.txt
@@ -112,6 +112,18 @@ if(GGML_BACKEND_DL AND (ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "Linux"))
   endforeach()
 endif()
 
+# TEMPORARY PIN - drop once qvac-lib-inference-addon-cpp ships a release that
+# compiles against bare-headers >= 1.32.0 and the vcpkg floor is raised.
+# bare-headers 1.32.0 (published 2026-09-07 11:58 UTC) changed the `elements`
+# parameter of js_set_array_elements() to `js_value_t *const []`, which the
+# pinned addon-cpp 1.3.3 header (JsUtils.hpp:531, `const js_value_t **`) can no
+# longer compile against - every fresh build after that time fails on all
+# platforms. add_bare_module() below fetches bare-headers@latest into _bare via
+# cmake-npm, whose install_node_module() keeps an already-present copy, so
+# installing the last compatible release first makes it stick. 1.30.0 is the
+# version every green build before 2026-09-07 used.
+download_bare_headers(_pinned_bare_headers VERSION 1.30.0)
+
 add_bare_module(inference-addon-sd EXPORTS ${BACKEND_DL_EXPORTS})
   set(ADDON_SOURCES
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Since 2026-09-07 ~12:00 UTC every **fresh** native build of `@qvac/diffusion-cpp` fails on all nine prebuild platforms, including the `main` on-merge runs for [#4232](https://github.com/tetherto/qvac/actions/runs/34127582746) and [#3923](https://github.com/tetherto/qvac/actions/runs/34129012017). PR runs that reuse prebuilt artifacts stay green, which is why it went unnoticed until the on-merge builds ran. Nothing can be released (0.21.1 or 0.22.0) until it builds again.

  ```
  node_modules/qvac-lib-inference-addon-cpp/JsUtils.hpp:531:8: error: no matching function for call to 'js_set_array_elements'
  build/_bare/node_modules/bare-headers/include/js.h:2879: candidate function not viable
  ```

- Root cause: `bare-headers@1.32.0` was published at 2026-09-07 11:58 UTC and changed the `elements` parameter of `js_set_array_elements()` to `js_value_t *const []`. The vcpkg-pinned `qvac-lib-inference-addon-cpp` 1.3.3 header passes `const js_value_t **` and no longer compiles. No addon-cpp release with a fix exists yet. cmake-bare's `add_bare_module()` fetches `bare-headers@latest` into `build/_bare` at configure time, **outside `package.json`**, so a devDependency pin cannot reach it.

## 📝 How does it solve it?

- One **TEMPORARY** CMake-level pin in `packages/diffusion-cpp/CMakeLists.txt`: `download_bare_headers(_pinned_bare_headers VERSION 1.30.0)` immediately before `add_bare_module()`, with a comment stating why and when to drop it. 1.30.0 is the version every green build before today used. cmake-npm's `install_node_module()` keeps an already-present copy, so the later `latest` fetch is a no-op and the pin sticks.
- Build-time only; nothing shipped changes. Twelve added lines, no other file touched.
- Drop it once `qvac-lib-inference-addon-cpp` ships a release compiling against `bare-headers >= 1.32.0` (`JsUtils.hpp:531` const fix) and the vcpkg floor is raised.

## 🧪 How was it tested?

- The identical commit was proven on the 0.21.1 release branch in [run 34131153440](https://github.com/tetherto/qvac/actions/runs/34131153440): **all nine prebuild jobs and the merge step green** against `bare-headers` 1.30.0, whereas every unpinned build after 11:58 UTC fails with the error above.
- `CMakeLists.txt` counts as a native change, so this PR's own checks rebuild the prebuilds rather than reusing artifacts.

## Breaking changes

None.
