### PR TITLE
QVAC-21981 chore: bump diffusion-cpp to 0.21.1 on the release branch

### DIFF
--- a/packages/diffusion-cpp/CHANGELOG.md
+++ b/packages/diffusion-cpp/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [0.21.1] - 2026-09-07
+
+This release restores ABot-World generation quality. The `2026-08-11` engine
+line shipped in 0.21.0 had dropped the scene-creation prompt-padding zeroing,
+so walks collapsed into blur from the first generated block; the fix lands
+through a new registry revision of the engine, together with a ~1.9x faster
+walk and CI guards that would have caught the regression.
+
+### Fixed
+
+- **ABot-World blur regression.** Scene creation again zeroes every
+  prompt-embedding row past the last real token (the reference's
+  `u[v:] = 0`). The forward-ported engine had kept live pad-token embeddings
+  in all 512 context rows, and the walk DiT cross-attends the full context
+  every block, so generated frames washed out from block 0 while the first
+  decoded frame still looked fine. Delivered via
+  `stable-diffusion-cpp 2026-08-11#1` (qvac-ext-stable-diffusion.cpp#37 /
+  qvac-registry-vcpkg#357). Scene packs written by 0.21.0 carry the defect
+  and must be regenerated.
+- `ABOT_JPEG_QUALITY=85` no longer crashes `examples/world-walk-server.js`
+  at startup: the env value is coerced to a number before it reaches
+  `frameJpegQuality`'s `Number.isInteger` validation. The public API guard is
+  unchanged (`'85'` still throws) and is now pinned by a unit test.
+
+### Changed
+
+- ABot-World walk performance ~1.9x on the engine side: the compute
+  buffer/allocator is retained across the 5-6 graphs per block (also cuts
+  cold start 12 s -> 2.2 s), the masked attention softmax is one fused pass,
+  the per-block action planes are reused, and the taehv decoder uses direct
+  convolution — all byte-identical; the score matmul runs on the tensor-core
+  path (F16 accumulation, ~0.3/255 mean drift, quality unchanged). Measured
+  2.25 s -> 1.28 s/block (~5 -> ~9.4 fps) on an RTX 5090 (Vulkan, Q8, KV
+  cache).
+- `stable-diffusion-cpp` is pinned to `>= 2026-08-11#1` in `vcpkg.json`; the
+  registry baseline is unchanged. The engine logs
+  `scene pack: prompt rows N live / M` when a scene pack is loaded.
+- CI now gates ABot conditioning and frame quality: the world-generation
+  lane asserts the scene pack's live prompt rows form one leading block below
+  half the context and that a different prompt changes the embeddings, and
+  every walk lane asserts a luminance-stddev floor on generated frames (a
+  collapse measures 8-12, healthy 30+); a no-GPU unit lane exercises both
+  guards, including all five PNG row filters. The best-effort registry probe
+  for the unpublished `scene.safetensors` was removed — it only logged a
+  `MODEL_NOT_FOUND` false alarm on every run.
+- `docs/abot-world.md`: a Prompt-behaviour section, refreshed hardware/perf
+  numbers (Vulkan build: 1.28 s/block, 11.5/14.6 GB VRAM, a dedicated 16 GB
+  GPU as the practical minimum), and a Known-issues note on the engine
+  prompt-row log's last-index semantics.
+
+### Pull Requests
+
+- [#4232](https://github.com/tetherto/qvac/pull/4232) - QVAC-21981
+  fix[notask]: gate ABot conditioning regressions and fix ABOT_JPEG_QUALITY
+- [#4139](https://github.com/tetherto/qvac/pull/4139) - QVAC-21981 test:
+  drop the registry probe for the unpublished ABot scene pack
+
 ## [0.21.0] - 2026-08-28
 
 This release makes the diffusion addon load on Linux hosts with no graphics

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/diffusion-cpp` 0.21.1 must ship **only** the ABot-World quality fix ([#4232](https://github.com/tetherto/qvac/pull/4232)). On `main` that is no longer true: MiniMax-H3 ([#3923](https://github.com/tetherto/qvac/pull/3923)) merged between #4232 and the 0.21.1 bump ([#4308](https://github.com/tetherto/qvac/pull/4308)), so `main`'s "0.21.1" silently contains a new model family that the 0.21.1 changelog does not describe (`main` has since moved on to 0.22.0 in [#4309](https://github.com/tetherto/qvac/pull/4309)).
- Per the release discussion, `release-diffusion-cpp-0.21.1` was therefore cut from the #4232 merge commit (`f95825705`), which predates the bump: on the branch `package.json` still says `0.21.0` and the `## [0.21.1]` changelog entry is missing. The bump has to land on the release branch itself, as a reviewable PR.

## 📝 How does it solve it?

- One commit, `962d4363f`: `package.json` `0.21.0 → 0.21.1` and the `## [0.21.1] - 2026-09-07` CHANGELOG entry. **Byte-identical to the already-reviewed and merged #4308** (`git diff 37a2864a5 962d4363f -- packages/diffusion-cpp/package.json packages/diffusion-cpp/CHANGELOG.md` is empty).
- Patch bump, per the repo rule: engine regression fix via the `stable-diffusion-cpp >= 2026-08-11#1` pin, an env-coercion fix, test guards, docs; no new API, model or default.
- Touches exactly these two files; no code changes.

## 🧪 How was it tested?

- Changelog heading matches the release extractor regex (`^## \[0\.21\.1\]`); `package.json` version equals the branch version, as the Release Merge Guard requires; the diff against the branch base is exactly `package.json` + `CHANGELOG.md`.
- The released content carries its own proof: #4232 green on the overlay-free, registry-pinned build ([run 34117327958](https://github.com/tetherto/qvac/actions/runs/34117327958), both GPU lanes ran the full ABot suite against `2026-08-11#1`), and these exact release files built and reached the npm gate on all nine platforms in [run 34131153440](https://github.com/tetherto/qvac/actions/runs/34131153440) (with a temporary local `bare-headers` pin that has since been withdrawn in favour of the addon-wide fix).

## ⚠️ Build dependency

Since 2026-09-07 ~12:00 UTC every fresh native build fails on all platforms (`bare-headers` 1.32.0 changed `js_set_array_elements()`; the pinned `qvac-lib-inference-addon-cpp` 1.3.3 header no longer compiles). A fix covering all addons is being prepared separately. Release branches do not receive `main` changes automatically, so that fix also needs to reach `release-diffusion-cpp-0.21.1` (as its own PR against the branch, merged **before** this one so the Release Merge Guard's changelog rule stays satisfied), unless it lands outside the repo (e.g. a compatible `bare-headers` or addon-cpp release). Until then the on-merge run triggered by this PR would fail at the prebuild stage and nothing would publish.

On merge (with the build fix in place), the on-merge workflow rebuilds the prebuilds and stops at the human npm approval gate; the git tag `diffusion-cpp-v0.21.1` is created after a successful publish.

## Breaking changes

None.
