### PR TITLE
QVAC-24725 chore: adopt qvac-lib-inference-addon-cpp 1.4.0 across addon consumers

### DIFF
--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.8.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.8.2] - 2026-09-01
 
 ### Changed

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.23.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.23.0] - 2026-09-01
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {

--- a/packages/classification-ggml/vcpkg.json
+++ b/packages/classification-ggml/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/diffusion-cpp/CHANGELOG.md
+++ b/packages/diffusion-cpp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.23.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.22.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.22.0] - 2026-09-07
 
 This release adds production MiniMax-H3 text-to-audio-video generation. The

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {

--- a/packages/diffusion-cpp/vcpkg.json
+++ b/packages/diffusion-cpp/vcpkg.json
@@ -3,7 +3,7 @@
     "picojson",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.38.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.37.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.37.0] - 2026-08-29
 
 ### Changed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/embed-llamacpp/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.50.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.49.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.49.1] - 2026-09-02
 
 ### Fixed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/llm-llamacpp/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/model-fit/CHANGELOG.md
+++ b/packages/model-fit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.8.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.8.0] - 2026-08-29
 
 ### Fixed

--- a/packages/model-fit/package.json
+++ b/packages/model-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/model-fit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Memory-fit preflight addon for QVAC — wraps llama.cpp's common_fit_params to project whether a GGUF model fits available device memory before loading it",
   "addon": true,
   "scripts": {

--- a/packages/model-fit/vcpkg.json
+++ b/packages/model-fit/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -6,6 +6,10 @@ project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Route OCR JS array construction through `js::Array::set` so the addon compiles against libjs 1.32's `js_set_array_elements` const placement. Requires `qvac-lib-inference-addon-cpp` 1.4.0 and libjs 1.32 headers (`bare-headers` >= 1.32).
+
 ## [0.21.0] - 2026-08-29
 
 ### Changed

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -6,6 +6,8 @@ project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-09-07
+
 ### Fixed
 
 - Route OCR JS array construction through `js::Array::set` so the addon compiles against libjs 1.32's `js_set_array_elements` const placement. Requires `qvac-lib-inference-addon-cpp` 1.4.0 and libjs 1.32 headers (`bare-headers` >= 1.32).

--- a/packages/ocr-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/ocr-ggml/addon/src/addon/AddonJs.hpp
@@ -46,15 +46,10 @@ namespace {
 
 js_value_t*
 createArrayFromElements(js_env_t* env, std::span<js_value_t*> elements) {
-  js_value_t* jsArray = nullptr;
-  js_create_array_with_length(env, elements.size(), &jsArray);
-  js_set_array_elements(
-      env,
-      jsArray,
-      const_cast<const js_value_t**>(elements.data()),
-      elements.size(),
-      0);
-  return jsArray;
+  auto array =
+      qvac_lib_inference_addon_cpp::js::Array::create(env, elements.size());
+  array.set(env, std::span<js_value_t* const>{elements});
+  return array;
 }
 
 // Mirrors @qvac/ocr-onnx's `getJsArrayFromOutput`. Output schema for each

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR and DocTR pipelines on GGUF weights)",
   "addon": true,
   "engines": {

--- a/packages/ocr-ggml/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.13.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.13.0] - 2026-08-29
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.25.0] - 2026-09-07
+
+### Changed
+
+- `qvac-lib-inference-addon-cpp` dependency floor raised `1.3.3` -> `1.4.0`, which requires libjs 1.32 headers (`bare-headers` >= 1.32). Compile-time only; no API or runtime behaviour change for this package. Released as a minor bump so dependents on `^0.24.x` adopt the new build floor deliberately rather than automatically.
+
 ## [0.24.0] - 2026-09-01
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/vcpkg.json
+++ b/packages/vla-ggml/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked — do not merge yet.** This PR requires `qvac-lib-inference-addon-cpp` 1.4.0 to be resolvable from `qvac-registry-vcpkg`. Order of operations:
> 1. Merge #4314 (the 1.4.0 library change).
> 2. Point the `qvac-lib-inference-addon-cpp` portfile in `qvac-registry-vcpkg` at that merge commit and publish 1.4.0.
> 3. Then this PR's vcpkg resolution — and its CI — can pass.
>
> Until step 2 lands, every addon build here fails at dependency resolution because the registry only offers 1.3.3.

## 🎯 What problem does this PR solve?

`qvac-lib-inference-addon-cpp` 1.4.0 matches libjs 1.32's `js_set_array_elements` const placement (`js_value_t *const []`). Consumers still declare `version>= 1.3.3`, so nothing in the monorepo would pick the new library up, and ocr-ggml still builds its JS arrays with raw `js_*` calls that encode the libjs 1.30 signature.

## 📝 How does it solve it?

- Raises the `qvac-lib-inference-addon-cpp` floor to **1.4.0** in all 12 consumer manifests: asr-ggml, audiogen-ggml, bci-whispercpp, classification-ggml, diffusion-cpp, embed-llamacpp, llm-llamacpp, model-fit, ocr-ggml, translation-nmtcpp, tts-ggml, vla-ggml.
- ocr-ggml `createArrayFromElements` drops its `const_cast<const js_value_t**>` and goes through `js::Array::create` / `set`, so the const spelling lives in one place in addon-cpp.
- The 11 other consumers need no code changes — the signature change is source-compatible for callers holding `js_value_t*[]` or `std::vector<js_value_t*>`.

The ocr-ggml behavior change is worth noting for review: failed libjs calls now throw `StatusError` and surface through the existing `JSCATCH` handlers as `js_throw_error`, where the old code ignored the return status and could return a null or half-built array.

## 🧪 How was it tested?

- The ocr-ggml change was validated in #4314 with an overlay port supplying in-tree 1.4.0, which is how the consumer build was exercised against the new header before the registry has it.
- CI here is the real check for the remaining 11 consumers, and only becomes meaningful once 1.4.0 is published to the registry.
