### PR TITLE
QVAC-21981 fix[notask]: raise the addon-cpp floor to 1.4.0 so the 0.21.1 release builds

### DIFF
--- a/packages/diffusion-cpp/CHANGELOG.md
+++ b/packages/diffusion-cpp/CHANGELOG.md
@@ -49,6 +49,9 @@ walk and CI guards that would have caught the regression.
   numbers (Vulkan build: 1.28 s/block, 11.5/14.6 GB VRAM, a dedicated 16 GB
   GPU as the practical minimum), and a Known-issues note on the engine
   prompt-row log's last-index semantics.
+- Build: `qvac-lib-inference-addon-cpp` floor raised to `>= 1.4.0`
+  (qvac-registry-vcpkg#359), which compiles against the `js_set_array_elements`
+  signature of `bare-headers` 1.32; build-time only, no runtime change.
 
 ### Pull Requests
 

--- a/packages/diffusion-cpp/vcpkg.json
+++ b/packages/diffusion-cpp/vcpkg.json
@@ -3,7 +3,7 @@
     "picojson",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.3.3"
+      "version>=": "1.4.0"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `release-diffusion-cpp-0.21.1` cannot build: since 2026-09-07 ~12:00 UTC every fresh native build fails on all platforms because `bare-headers` 1.32.0 changed the `elements` parameter of `js_set_array_elements()` and the `qvac-lib-inference-addon-cpp` 1.3.3 header no longer compiles against it. The release run triggered by the 0.21.1 bump ([run 34137102960](https://github.com/tetherto/qvac/actions/runs/34137102960)) passed the Release Merge Guard and then failed all nine prebuilds with exactly that error, so 0.21.1 is not published.
- The fix exists on `main` — addon-cpp **1.4.0** ([#4314](https://github.com/tetherto/qvac/pull/4314), published to the registry in [qvac-registry-vcpkg#359](https://github.com/tetherto/qvac-registry-vcpkg/pull/359)) with consumer adoption in [#4320](https://github.com/tetherto/qvac/pull/4320) — but release branches never receive `main` changes, so the release branch needs its own floor bump.

## 📝 How does it solve it?

- `packages/diffusion-cpp/vcpkg.json`: `qvac-lib-inference-addon-cpp` `version>= 1.3.3 → 1.4.0`. Same one-line change #4320 applies to diffusion-cpp on `main`. The registry `default-registry.baseline` is **not** moved (per the review rule on #4232); vcpkg resolves `1.4.0` from the registry's `main` versions database, the same mechanism that delivers the `stable-diffusion-cpp >= 2026-08-11#1` pin.
- `packages/diffusion-cpp/CHANGELOG.md`: one bullet under the existing `## [0.21.1]` → `### Changed` documenting the build-only floor raise. This also satisfies the Release Merge Guard's rule that every merge into a release branch touches the changelog, so the merge push runs the release workflow directly (no manual re-trigger).
- No code change: diffusion-cpp only *reads* `js::Array` (`getOptionalProperty<js::Array>`), it never calls `Array::set` / `Array::create`, which is the API 1.4.0 changed. Build-time only; nothing shipped changes.

## 🧪 How was it tested?

- diffusion-cpp compiled against addon-cpp 1.4.0 across the full prebuild matrix in #4314's validation ([run 34137936135](https://github.com/tetherto/qvac/actions/runs/34137936135), 10 platforms green); that ran on `main`'s diffusion-cpp, which differs from this branch only by MiniMax-H3 (#3923) and does not touch the JS array API either.
- Registry state verified: `versions/q-/qvac-lib-inference-addon-cpp.json` lists `1.4.0`, port `REF 453a482852cd03fabe5dffad340a2f7d6784142d` (= the #4314 merge commit).
- The PR's own checks run the light default set; the definitive proof is the release run on merge, which rebuilds all nine prebuilds before parking at the npm approval gate.

On merge, the on-merge workflow (guard → prebuilds → `publish-npm` waiting for approval) publishes `@qvac/diffusion-cpp@0.21.1` after the human gate and creates the `diffusion-cpp-v0.21.1` tag.

## Breaking changes

None.
