### PR TITLE
infra[notask]: prefix translation-nmtcpp release tags with the package name

### DIFF
--- a/.github/workflows/on-merge-translation-nmtcpp.yml
+++ b/.github/workflows/on-merge-translation-nmtcpp.yml
@@ -210,7 +210,9 @@ jobs:
           workdir: ${{ env.PKG_DIR }}
 
   # Tag the published version (no GitHub Release; SDK-only releases policy).
-  # Preserves the historical bare "v<version>" tag scheme for this package.
+  # Earlier releases used a bare "v<version>" tag, which claims the repo-wide
+  # tag namespace; the prefixed scheme every other package uses is namespaced
+  # per package. Tags from before this change keep their old names.
   create-tag:
     needs: [publish-npm]
     if: |
@@ -221,8 +223,8 @@ jobs:
       contents: write
     uses: ./.github/workflows/create-release-tag.yml
     with:
+      repo_name: "translation-nmtcpp"
       published_version: ${{ needs.publish-npm.outputs.published_version }}
-      tag_name: v${{ needs.publish-npm.outputs.published_version }}
 
   post-build-gate:
     name: Post-Build Gate


### PR DESCRIPTION
## What problem does this PR solve?

`translation-nmtcpp` is the only package whose release run tags an unprefixed `v<version>` in the repo-wide tag namespace. Every other addon package tags `<prefix>-v<version>`.

The repo currently holds 22 bare version tags from this package (`v6.1.0` through `v10.0.0`) and zero `translation-nmtcpp-*` tags. The only prefixed ones are four older `nmtcpp-v*` tags from when the workflow still passed `repo_name`.

Besides being inconsistent, bare tags are a collision risk: `create-release-tag.yml` hard-fails when the tag already exists at a different SHA, so any other package or manual tag that ever claims the same `v<x.y.z>` breaks a release run after npm has already published.

## How does it solve it?

- `on-merge-translation-nmtcpp.yml` `create-tag` now passes `repo_name: "translation-nmtcpp"` instead of the `tag_name` override, so `create-release-tag.yml` builds `translation-nmtcpp-v<version>`.
- Updated the stale comment that described the bare scheme as intentional.

The next release (0.14.0) tags as `translation-nmtcpp-v0.14.0`.

Notes:

- Existing tags are untouched; `create-release-tag.yml` only creates the tag for the version being published.
- `tag_name` stays defined on `create-release-tag.yml` as an optional override, but no caller uses it after this change.
- No `packages/` files change, so this does not affect the published package contents.

## Breaking changes

None for consumers. Anything keying off the bare `v<version>` tag for this package would need to follow the prefixed name, but nothing in the repo does — the only other `nmtcpp-v` matches are unrelated vcpkg cache keys in `benchmark-translation-nmtcpp.yml`.
