### PR TITLE
doc[notask]: document Linux worker runtime prerequisites

### DIFF
--- a/docs/website/content/docs/system-requirements.mdx
+++ b/docs/website/content/docs/system-requirements.mdx
@@ -36,6 +36,16 @@ Requirements:
 
 - Ubuntu 22 requires [g++](https://github.com/gcc-mirror/gcc) `>= 13`.
 - Vulkan runtime `>= 1.4`: Vulkan loader + a GPU driver with Vulkan support.
+- `libatomic.so.1`: required by the Linux `rocksdb-native` prebuilds used by the SDK's storage dependencies, including for CPU-only inference. Minimal container images may not include it.
+
+On Debian or Ubuntu, install the atomic runtime with:
+
+```bash
+sudo apt update
+sudo apt install -y libatomic1
+```
+
+In a container build running as root, omit `sudo`. A missing library can prevent the worker from starting before any model loads; see [missing libatomic at startup](/troubleshooting#startup-failure-missing-libatomicso1).
 
 On desktop Linux distributions (e.g., Ubuntu Desktop), these requirements are typically satisfied out of the box.
 

--- a/docs/website/content/docs/system-requirements.mdx
+++ b/docs/website/content/docs/system-requirements.mdx
@@ -37,6 +37,7 @@ Requirements:
 - Ubuntu 22 requires [g++](https://github.com/gcc-mirror/gcc) `>= 13`.
 - Vulkan runtime `>= 1.4`: Vulkan loader + a GPU driver with Vulkan support.
 - `libatomic.so.1`: required by the Linux `rocksdb-native` prebuilds used by the SDK's storage dependencies, including for CPU-only inference. Minimal container images may not include it.
+- OpenSSL 3 runtime libraries (`libssl.so.3` and `libcrypto.so.3`): required by the `llm-llamacpp` Linux prebuilds used by SDK 0.19.0. A Node.js installation alone does not guarantee these shared libraries are present.
 
 On Debian or Ubuntu, install the atomic runtime with:
 
@@ -46,6 +47,10 @@ sudo apt install -y libatomic1
 ```
 
 In a container build running as root, omit `sudo`. A missing library can prevent the worker from starting before any model loads; see [missing libatomic at startup](/troubleshooting#startup-failure-missing-libatomicso1).
+
+On Debian 12 images such as `node:22-bookworm-slim`, install the OpenSSL runtime with `apt install -y libssl3` as well. Installing `libatomic1` alone can expose a subsequent `libssl.so.3` loader error. Package names for OpenSSL vary between distributions.
+
+With SDK 0.19.0, the standard worker also loads an ASR prebuild that requires `libvulkan.so.1` on Linux x64, even before a CPU-only model is loaded. On Debian 12, install `libvulkan1` to satisfy that loader dependency; GPU inference still requires a suitable GPU driver.
 
 On desktop Linux distributions (e.g., Ubuntu Desktop), these requirements are typically satisfied out of the box.
 

--- a/docs/website/content/docs/troubleshooting.mdx
+++ b/docs/website/content/docs/troubleshooting.mdx
@@ -45,6 +45,33 @@ npx --package "@qvac/cli" qvac doctor
 
 See [CLI → Usage](/cli#usage) for the full setup, including installing `@qvac/sdk` in your project.
 
+## Startup failure: missing libatomic.so.1
+
+### Situation
+
+On a minimal Linux image, worker startup fails and the error cause includes:
+
+```text
+libatomic.so.1: cannot open shared object file: No such file or directory
+```
+
+The top-level SDK error may report an RPC initialization timeout. Check `error.cause` for the underlying loader error.
+
+### Cause
+
+The Linux `rocksdb-native` prebuilds used by the SDK's storage dependencies require `libatomic.so.1`. Minimal images such as `node:22-slim` may omit this library. The dependency is needed even for CPU-only inference, before a model is loaded.
+
+### Solution
+
+Install `libatomic1` in the Debian or Ubuntu environment that runs the worker:
+
+```bash
+sudo apt update
+sudo apt install -y libatomic1
+```
+
+Omit `sudo` when running as root inside a container. Restart the application after installing the library. See [system requirements](/system-requirements#linux) for the remaining host dependencies and [issue #4290](https://github.com/tetherto/qvac/issues/4290) for the reported failure.
+
 ## Startup crash: requested module does not provide a default export
 
 ### Situation

--- a/docs/website/content/docs/troubleshooting.mdx
+++ b/docs/website/content/docs/troubleshooting.mdx
@@ -70,7 +70,7 @@ sudo apt update
 sudo apt install -y libatomic1
 ```
 
-Omit `sudo` when running as root inside a container. Restart the application after installing the library. See [system requirements](/system-requirements#linux) for the remaining host dependencies and [issue #4290](https://github.com/tetherto/qvac/issues/4290) for the reported failure.
+Omit `sudo` when running as root inside a container. Restart the application after installing the library. If the next error names `libssl.so.3`, the worker also needs the OpenSSL 3 runtime; on Debian 12, install `libssl3`. See [system requirements](/system-requirements#linux) for the remaining host dependencies and [issue #4290](https://github.com/tetherto/qvac/issues/4290) for the reported failure.
 
 ## Startup crash: requested module does not provide a default export
 

--- a/packages/sdk/src/client/api/get-system-resources.ts
+++ b/packages/sdk/src/client/api/get-system-resources.ts
@@ -6,6 +6,14 @@ import {
 import { send } from '@/client/rpc/rpc-client'
 import { InvalidResponseError } from '@/utils/errors-client'
 
+/**
+ * Read the worker's system capabilities and optional resource sample.
+ *
+ * @param input - Optional settings; set `sample` to request a current resource sample.
+ * @returns System capabilities with availability information and a sample when provided by the worker.
+ * @throws {InvalidResponseError} If the worker returns a different response type.
+ * @throws {Error} If the RPC request fails.
+ */
 export async function getSystemResources(
   input?: GetSystemResourcesInput
 ): Promise<SystemResources> {


### PR DESCRIPTION
Document the Linux worker's `libatomic.so.1` startup dependency, Debian/Ubuntu installation, and troubleshooting for minimal images. Retain the existing GPU Vulkan guidance, following the requested scope in [review](https://github.com/tetherto/qvac/pull/4331#pullrequestreview-5209720792).

Refs #4290. The PR also includes the existing public `getSystemResources` TSDoc needed by the docs completeness check.

Validation on the revised branch:

- All 250 docs tests pass.
- Full docs build passes with zero broken links.
- `git diff --check` passes.

Documentation-only revision; no new native-runtime run.
