### PR TITLE
fix[notask]: explain missing libatomic during worker startup

### DIFF
--- a/packages/sdk/src/client/rpc/worker-startup-error.ts
+++ b/packages/sdk/src/client/rpc/worker-startup-error.ts
@@ -15,17 +15,22 @@ export function createRPCInitTimeoutCause(
   workerExit: WorkerExit | null
 ): WorkerStartupError {
   const stderr = stderrTail.trimEnd()
+  const dependencyHint = stderr.includes(
+    'libatomic.so.1: cannot open shared object file: No such file or directory'
+  )
+    ? '. Missing Linux runtime library libatomic.so.1. On Debian or Ubuntu, install libatomic1 in the environment running the worker'
+    : ''
 
   if (workerExit) {
     return new WorkerStartupError(
-      `Worker process exited with code ${workerExit.code}, signal ${workerExit.signal} before IPC connection was established`,
+      `Worker process exited with code ${workerExit.code}, signal ${workerExit.signal} before IPC connection was established${dependencyHint}`,
       { code: workerExit.code, signal: workerExit.signal as NodeJS.Signals | null },
       stderr
     )
   }
 
   return new WorkerStartupError(
-    'Worker did not establish IPC before the RPC initialization timeout',
+    `Worker did not establish IPC before the RPC initialization timeout${dependencyHint}`,
     null,
     stderr
   )

--- a/packages/sdk/test/worker-startup-error-cause.test.ts
+++ b/packages/sdk/test/worker-startup-error-cause.test.ts
@@ -56,3 +56,33 @@ test('startup cause carries the registered error identity', (t) => {
   t.is(cause.name, 'WORKER_STARTUP_FAILED')
   t.is(cause.code, SDK_CLIENT_ERROR_CODES.WORKER_STARTUP_FAILED)
 })
+
+test('missing libatomic gives an actionable hint without changing startup metadata', (t) => {
+  const stderr =
+    'Error: libatomic.so.1: cannot open shared object file: No such file or directory\n' +
+    'at rocksdb-native/prebuilds/linux-arm64/rocksdb-native.bare\n'
+
+  for (const workerExit of [null, { code: 134, signal: null }]) {
+    const cause = createRPCInitTimeoutCause(stderr, workerExit)
+
+    t.ok(cause.message.includes('Missing Linux runtime library libatomic.so.1'))
+    t.ok(cause.message.includes('On Debian or Ubuntu, install libatomic1'))
+    t.is(cause.stderrTail, stderr.trimEnd())
+    t.is(cause.workerExited, workerExit !== null)
+    t.is(cause.exitCode, workerExit?.code ?? null)
+    t.is(cause.code, SDK_CLIENT_ERROR_CODES.WORKER_STARTUP_FAILED)
+  }
+})
+
+test('other loader failures and library mentions do not suggest libatomic1', (t) => {
+  for (const stderr of [
+    'Cannot find addon rocksdb-native',
+    'libvulkan.so.1: cannot open shared object file: No such file or directory',
+    'libatomic.so.1: version ATOMIC_9.0 not found',
+    'Loaded libatomic.so.1 successfully'
+  ]) {
+    const cause = createRPCInitTimeoutCause(stderr, { code: 1, signal: null })
+    t.absent(cause.message.includes('install libatomic1'))
+    t.is(cause.stderrTail, stderr)
+  }
+})


### PR DESCRIPTION
When a worker fails to start because Linux cannot load `libatomic.so.1`, include a short hint to install `libatomic1` on Debian/Ubuntu in the environment running the worker. Preserve the existing startup error identity, exit metadata and raw stderr.

The hint matches the missing-library loader message specifically. Other missing libraries, an incompatible libatomic version and ordinary mentions of libatomic keep their existing diagnostics.

Refs #4290; complements the runtime setup/troubleshooting docs in #4331. The broader dependency audit is scoped in #4337.

Validation:

- Full SDK unit suite: 488 tests across 48 files pass. SDK build, typecheck, lint, formatting and `git diff --check` pass. The regression fails on unchanged main.
- [Real Linux x64 and arm64 container checks](https://github.com/localhost41/qvac/actions/runs/34211240397) pass using SDK/inference 0.19.0 on `node:22-bookworm-slim`. The released SDK reproduces the actual rocksdb-native loader failure. Applying this PR’s exact `5ae0616cd` source adds the hint while retaining the typed `WorkerStartupError`, error code, exit fields and byte-identical stderr tail.
- Worker startup and heartbeat pass after installing the runtime prerequisites. The clean images also exposed OpenSSL 3 on both architectures and the ASR prebuild’s Vulkan loader on x64; installing libatomic alone is not sufficient for that standard-worker setup. Those requirements are documented in #4331. The artifacts preserve source hashes, lockfiles and baseline/patched/recovery results.

The container checks exercise startup and heartbeat; they do not claim GPU model inference coverage.
