### PR TITLE
chore[notask]: re-release @qvac/openclaw-plugin 0.3.0 — API key generation fix

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.3.0]
 
-Release Date: 2026-09-07
+Release Date: 2026-09-08
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.0
 
@@ -35,6 +35,16 @@ Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plug
 Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so the two floors have to move together: a plugin still asking for `@qvac/cli@^0.12.0` next to provider 0.7 would leave the install unresolvable. The plugin uses the provider for the shared model catalog only — it drives its own launcher rather than the provider's managed serve — so nothing else about that dependency changes here.
 
 Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2.
+
+## Onboarding No Longer Generates an Unusable Key
+
+The bearer key is generated as 32 random bytes encoded base64url. That alphabet includes `-`, and the plugin refuses a key beginning with `-` so a stored key can never be mistaken for a command-line flag. The generator did not exclude that case, so about 1.5% of freshly generated keys were rejected the moment the launcher read them back:
+
+```
+stored QVAC API key must be 32-128 base64url characters and cannot start with "-"
+```
+
+The result was a provider entry that onboarded cleanly and then refused to start. Key generation now draws again whenever a candidate starts with `-`. The same generator backs the recovery path for a stored key that no longer parses, so that path could previously replace an unusable key with another unusable one; it is fixed by the same change.
 
 ## Upgrading
 

--- a/plugins/openclaw/changelog/0.3.0/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.3.0/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog v0.3.0
 
-Release Date: 2026-09-07
+Release Date: 2026-09-08
 
 ## Breaking Changes
 
 - Require the `@qvac/cli` 0.13 line and `@qvac/ai-sdk-provider` 0.7, and start the managed serve with `qvac serve --openai --no-default`. - See [breaking changes](./breaking.md)
+
+## Fixes
+
+- Stop generating QVAC API keys that the plugin's own validator rejects. A base64url draw beginning with `-` was refused by `normalizeApiKey`, so roughly one onboarding in 64 produced a key file the launcher would not accept.
 
 ## Compatibility
 

--- a/plugins/openclaw/changelog/0.3.0/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.3.0/CHANGELOG_LLM.md
@@ -1,6 +1,6 @@
 # QVAC OpenClaw Plugin v0.3.0 Release Notes
 
-Release Date: 2026-09-07
+Release Date: 2026-09-08
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.0
 
@@ -33,6 +33,16 @@ Installs that pin `@qvac/cli` to `0.12.x` need to move to `0.13.x` with the plug
 Provider 0.7 narrows its own optional `@qvac/cli` peer to `^0.13.0`, so the two floors have to move together: a plugin still asking for `@qvac/cli@^0.12.0` next to provider 0.7 would leave the install unresolvable. The plugin uses the provider for the shared model catalog only — it drives its own launcher rather than the provider's managed serve — so nothing else about that dependency changes here.
 
 Provider 0.7 also carries the streamed file-upload fixes released in 0.6.2.
+
+## Onboarding No Longer Generates an Unusable Key
+
+The bearer key is generated as 32 random bytes encoded base64url. That alphabet includes `-`, and the plugin refuses a key beginning with `-` so a stored key can never be mistaken for a command-line flag. The generator did not exclude that case, so about 1.5% of freshly generated keys were rejected the moment the launcher read them back:
+
+```
+stored QVAC API key must be 32-128 base64url characters and cannot start with "-"
+```
+
+The result was a provider entry that onboarded cleanly and then refused to start. Key generation now draws again whenever a candidate starts with `-`. The same generator backs the recovery path for a stored key that no longer parses, so that path could previously replace an unusable key with another unusable one; it is fixed by the same change.
 
 ## Upgrading
 

--- a/plugins/openclaw/src/provider-config.ts
+++ b/plugins/openclaw/src/provider-config.ts
@@ -333,6 +333,17 @@ export function normalizeApiKey(value: unknown, option: string): string {
   return normalized
 }
 
+// base64url includes `-`, and `normalizeApiKey` rejects a leading one so a
+// stored key can never be mistaken for a CLI flag. A raw draw therefore fails
+// its own validator about once in 64. Redrawing keeps every position uniform;
+// rewriting the first character would bias it and shrink the keyspace.
+export function generateApiKey(): string {
+  for (;;) {
+    const candidate = randomBytes(32).toString('base64url')
+    if (!candidate.startsWith('-')) return candidate
+  }
+}
+
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error
 }
@@ -390,14 +401,14 @@ export function ensureApiKeyFile(keyFile: string, configuredApiKey?: string): st
     // place (over the already-validated regular-file path) instead of leaving the
     // user to delete the file by hand. Read failures (EACCES, …) still propagate.
     if (error instanceof TypeError) {
-      const replacement = randomBytes(32).toString('base64url')
+      const replacement = generateApiKey()
       writePrivateKeyFile(keyFile, replacement, false)
       return replacement
     }
     if (!isNodeError(error) || error.code !== 'ENOENT') throw error
   }
 
-  const generated = randomBytes(32).toString('base64url')
+  const generated = generateApiKey()
   try {
     writePrivateKeyFile(keyFile, generated, true)
     return generated

--- a/plugins/openclaw/test/provider-config.test.ts
+++ b/plugins/openclaw/test/provider-config.test.ts
@@ -23,6 +23,7 @@ import {
   createQvacServeModels,
   createQvacSetupResult,
   ensureApiKeyFile,
+  generateApiKey,
   normalizeApiKey,
   openClawModels,
   registerQvacProvider,
@@ -188,12 +189,24 @@ test('API keys are normalized to a conservative base64url form', () => {
   }
 })
 
+test('generated API keys always satisfy the key validator', () => {
+  // base64url includes `-` and normalizeApiKey rejects a leading one, so an
+  // unguarded draw fails its own validator about once in 64. Enough draws that
+  // a regression here is a certainty rather than a coin flip: an unguarded
+  // generator surviving 4096 of them has probability (63/64)^4096, about 1e-28.
+  for (let index = 0; index < 4096; index += 1) {
+    const key = generateApiKey()
+    assert.equal(key.startsWith('-'), false)
+    assert.equal(normalizeApiKey(key, 'generated QVAC API key'), key)
+  }
+})
+
 test('API key file is generated once, reused, and permission-hardened', () => {
   const stateDir = mkdtempSync(join(tmpdir(), 'qvac-openclaw-state-test-'))
   const keyFile = join(stateDir, 'plugins', 'qvac', 'api-key')
 
   const first = ensureApiKeyFile(keyFile)
-  assert.match(first, /^[A-Za-z0-9_-]{43}$/)
+  assert.match(first, /^[A-Za-z0-9_][A-Za-z0-9_-]{42}$/)
   assert.equal(ensureApiKeyFile(keyFile), first)
   assert.equal(statSync(join(stateDir, 'plugins', 'qvac')).mode & 0o777, 0o700)
   assert.equal(statSync(keyFile).mode & 0o777, 0o600)
@@ -226,7 +239,7 @@ test('re-onboarding regenerates a corrupt key file in place', () => {
   ]) {
     writeFileSync(keyFile, corrupt)
     const regenerated = ensureApiKeyFile(keyFile)
-    assert.match(regenerated, /^[A-Za-z0-9_-]{43}$/)
+    assert.match(regenerated, /^[A-Za-z0-9_][A-Za-z0-9_-]{42}$/)
     assert.equal(readFileSync(keyFile, 'utf8'), regenerated)
     assert.equal(statSync(keyFile).mode & 0o777, 0o600)
     // Stable once healthy again.


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Keys were generated as `randomBytes(32).toString('base64url')`, which can start with `-`. `normalizeApiKey` rejects a leading `-`, so onboarding could write a key file the launcher then refused with `stored QVAC API key must be 32-128 base64url characters and cannot start with "-"`.
- Measured 971/64000 draws = 1.52% (1 in 64). This is what failed `Run tests` on the 0.3.0 publish build (run 34134394854), which left no dist artifact and blocked the publish.

## 📝 How does it solve it?

- `generateApiKey()` redraws while a candidate starts with `-`, used by both generation sites — including the corrupt-key recovery path, which previously replaced one invalid key with another.
- Test asserting 4096 generated keys satisfy `normalizeApiKey`.
- Tightened two key regexes from `/^[A-Za-z0-9_-]{43}$/` to `/^[A-Za-z0-9_][A-Za-z0-9_-]{42}$/`; the old form allowed a leading `-`.
- Adds the fix to `changelog/0.3.0/` and rebuilds `CHANGELOG.md`. Version stays `0.3.0` — Release Merge Guard requires `package.json` to match the branch version and requires the changelog to be touched in the push.
- Release Date moved to 2026-09-08, the actual publish date.

Same change as #4336 on the 0.2.2 line; `provider-config.ts` and its test are identical across both release branches.

## 🧪 How was it tested?

- On the release branch content, against published `@qvac/cli@0.13.0` / `@qvac/ai-sdk-provider@0.7.0`: install, format, lint, typecheck, build clean; 36/36 unit tests.
