### PR TITLE
test[notask]: header-only fit check on a real device

### DIFF
--- a/packages/sdk/e2e/README.md
+++ b/packages/sdk/e2e/README.md
@@ -134,6 +134,14 @@ the same way a real app would add a third-party or in-repo custom plugin. `Plugi
 own client wrapper (`custom-echo-plugin/client`) for the happy-path tests, mirroring how a real consumer would
 use a custom plugin rather than calling `invokePlugin` directly.
 
+[`fixtures/fit-stub-plugin/`](./fixtures/fit-stub-plugin) is a second custom plugin, this one with a native
+dependency (`@qvac/model-fit`). The `fit-stub-check` test loads a small catalogue GGUF through it (the plugin only
+records the cache path), then inside the worker writes a header-only copy truncated to the full length, checks the
+filesystem made it sparse, and runs the fitter on both files. It passes when the stub is sparse and the two plans are
+identical; the whole JSON report is the test output. Run it alone with `--filter fit-stub`. On Android pass
+`backendsDir` in the test params if the fitter reports `nDevices: 0` (the ggml backends ship as shared libraries
+there). Electron skips it because the plugin is not in `qvac.config.electron.json`.
+
 Both `qvac.config.*` files list built-in plugins explicitly, not just `custom-echo-plugin/plugin`: an empty
 or missing `plugins` array bundles all built-ins by default, but as soon as it's non-empty only the listed
 plugins are included (see `resolvePluginSpecifiers` in `@qvac/sdk/commands/bundle`). Omitting the built-ins here

--- a/packages/sdk/e2e/fixtures/fit-stub-plugin/check.mjs
+++ b/packages/sdk/e2e/fixtures/fit-stub-plugin/check.mjs
@@ -8,16 +8,29 @@
 //   4. runs @qvac/model-fit on the full file and on the stub, compares the plans
 //   5. deletes the stub
 //
+// Metro also parses this file for the React Native side of the e2e app, so it
+// must stay Hermes-safe: no top-level await, no import.meta, and the Bare-only
+// modules are loaded lazily so importing this file has no side effects.
+//
 // CLI: bare check.mjs /abs/path/model.gguf [nCtx] [backendsDir]
-
-import fs from 'bare-fs'
-import path from 'bare-path'
-import modelFit from '@qvac/model-fit'
 
 const GGUF_MAGIC = 0x46554747 // "GGUF" little-endian
 const SIZES = { 0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8 }
 
-export function readHeaderOffsets(fd) {
+function unwrap(mod) {
+  return mod && mod.default && typeof mod.default === 'object' ? mod.default : mod
+}
+
+async function loadDeps() {
+  const [fsMod, pathMod, fitMod] = await Promise.all([
+    import('bare-fs'),
+    import('bare-path'),
+    import('@qvac/model-fit')
+  ])
+  return { fs: unwrap(fsMod), path: unwrap(pathMod), modelFit: unwrap(fitMod) }
+}
+
+export function readHeaderOffsets(fs, fd) {
   let buf = Buffer.alloc(0)
   let filePos = 0
   let pos = 0
@@ -102,7 +115,7 @@ export function readHeaderOffsets(fd) {
   }
 }
 
-function copyPrefix(srcFd, dstPath, length) {
+function copyPrefix(fs, srcFd, dstPath, length) {
   const out = fs.openSync(dstPath, 'w')
   try {
     const chunk = Buffer.alloc(1 << 20)
@@ -148,28 +161,14 @@ function planFields(r) {
   }
 }
 
-function resolveBackendsDir(explicit) {
-  if (explicit) return explicit
-  // Statically linked prebuilds (iOS, macOS, Windows) need no directory. Where
-  // backends ship as shared libraries (Android, Linux) the addon must be told
-  // where they are; on a packed phone build neither package tree is resolvable,
-  // so the test lets the caller pass `backendsDir` and reports what was used.
-  for (const spec of ['@qvac/fabric/package', '@qvac/model-fit/package']) {
-    try {
-      const url = import.meta.resolve(spec)
-      const file = url.startsWith('file://') ? decodeURIComponent(url.slice('file://'.length)) : url
-      const dir = path.join(path.dirname(file), 'prebuilds')
-      if (fs.statSync(dir).isDirectory()) return dir
-    } catch {}
-  }
-  return undefined
-}
-
 function platformTag() {
   if (typeof Bare !== 'undefined') return `${Bare.platform}-${Bare.arch}`
   return `${process.platform}-${process.arch}`
 }
 
+// Statically linked prebuilds (iOS, macOS, Windows) need no backends directory.
+// Where backends ship as shared libraries (Android, Linux) the caller passes it
+// explicitly; the report echoes what was used.
 export async function runFitStubCheck({
   modelPath,
   nCtx = 4096,
@@ -188,11 +187,6 @@ export async function runFitStubCheck({
     errors: {}
   }
   const t0 = Date.now()
-  const srcFd = fs.openSync(modelPath, 'r')
-  const fullSize = fs.fstatSync(srcFd).size
-  const dir = stubDir || path.dirname(modelPath)
-  const stubPath = path.join(dir, `${path.basename(modelPath)}.fitstub-${Date.now()}.gguf`)
-  let stubFd = null
   const finish = () => {
     report.totalMs = Date.now() - t0
     report.verdict = {
@@ -208,10 +202,28 @@ export async function runFitStubCheck({
     }
     return report
   }
-  try {
-    report.header = Object.assign(readHeaderOffsets(srcFd), { fullSize })
 
-    stubFd = copyPrefix(srcFd, stubPath, report.header.dataOffset)
+  let deps
+  try {
+    deps = await loadDeps()
+  } catch (e) {
+    report.errors.loadDeps = String((e && e.stack) || e)
+    return finish()
+  }
+  const { fs, path, modelFit } = deps
+
+  let srcFd = null
+  let stubFd = null
+  let stubPath = null
+  try {
+    srcFd = fs.openSync(modelPath, 'r')
+    const fullSize = fs.fstatSync(srcFd).size
+    const dir = stubDir || path.dirname(modelPath)
+    stubPath = path.join(dir, `${path.basename(modelPath)}.fitstub-${Date.now()}.gguf`)
+
+    report.header = Object.assign(readHeaderOffsets(fs, srcFd), { fullSize })
+
+    stubFd = copyPrefix(fs, srcFd, stubPath, report.header.dataOffset)
     fs.ftruncateSync(stubFd, fullSize)
     fs.closeSync(stubFd)
     stubFd = null
@@ -234,13 +246,12 @@ export async function runFitStubCheck({
       report.errors.requireModelFit = 'fitParams not exported by @qvac/model-fit'
       return finish()
     }
-    const resolvedBackends = resolveBackendsDir(backendsDir)
     const opts = Object.assign(
       { nCtx, nCtxMin: nCtx, marginMiB },
-      resolvedBackends ? { backendsDir: resolvedBackends } : {}
+      backendsDir ? { backendsDir } : {}
     )
     report.fit = {
-      backendsDir: resolvedBackends || null,
+      backendsDir: backendsDir || null,
       full: null,
       stub: null,
       identical: null,
@@ -273,12 +284,16 @@ export async function runFitStubCheck({
         fs.closeSync(stubFd)
       } catch {}
     }
-    try {
-      fs.unlinkSync(stubPath)
-    } catch {}
-    try {
-      fs.closeSync(srcFd)
-    } catch {}
+    if (stubPath) {
+      try {
+        fs.unlinkSync(stubPath)
+      } catch {}
+    }
+    if (srcFd !== null) {
+      try {
+        fs.closeSync(srcFd)
+      } catch {}
+    }
   }
 }
 
@@ -293,12 +308,11 @@ if (
     console.error('usage: bare check.mjs <model.gguf> [nCtx] [backendsDir]')
     Bare.exitCode = 2
   } else {
-    const report = await runFitStubCheck({
-      modelPath,
-      nCtx: nCtxArg ? Number(nCtxArg) : 4096,
-      backendsDir
-    })
-    console.log(JSON.stringify(report, null, 2))
-    Bare.exitCode = report.verdict.pass ? 0 : 1
+    runFitStubCheck({ modelPath, nCtx: nCtxArg ? Number(nCtxArg) : 4096, backendsDir }).then(
+      (report) => {
+        console.log(JSON.stringify(report, null, 2))
+        Bare.exitCode = report.verdict.pass ? 0 : 1
+      }
+    )
   }
 }

--- a/packages/sdk/e2e/fixtures/fit-stub-plugin/check.mjs
+++ b/packages/sdk/e2e/fixtures/fit-stub-plugin/check.mjs
@@ -1,0 +1,304 @@
+// Header-only fit check. Runs under Bare: as a desktop CLI, or imported by the
+// custom-fit-stub-plugin handler inside the SDK worker on a phone.
+//
+// Given a full GGUF on disk it:
+//   1. finds the data offset by walking the header (KV pairs + tensor infos)
+//   2. writes a stub: the header bytes, then ftruncate to the full length
+//   3. reports whether the filesystem made the stub sparse (allocated bytes)
+//   4. runs @qvac/model-fit on the full file and on the stub, compares the plans
+//   5. deletes the stub
+//
+// CLI: bare check.mjs /abs/path/model.gguf [nCtx] [backendsDir]
+
+import fs from 'bare-fs'
+import path from 'bare-path'
+import modelFit from '@qvac/model-fit'
+
+const GGUF_MAGIC = 0x46554747 // "GGUF" little-endian
+const SIZES = { 0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8 }
+
+export function readHeaderOffsets(fd) {
+  let buf = Buffer.alloc(0)
+  let filePos = 0
+  let pos = 0
+  const ensure = (n) => {
+    while (pos + n > buf.length) {
+      const chunk = Buffer.alloc(1 << 20)
+      const read = fs.readSync(fd, chunk, 0, chunk.length, filePos)
+      if (read === 0) throw new Error('unexpected EOF while reading GGUF header')
+      filePos += read
+      buf = Buffer.concat([buf, chunk.subarray(0, read)])
+    }
+  }
+  const u32 = () => {
+    ensure(4)
+    const v = buf.readUInt32LE(pos)
+    pos += 4
+    return v
+  }
+  const u64 = () => {
+    ensure(8)
+    const v = Number(buf.readBigUInt64LE(pos))
+    pos += 8
+    return v
+  }
+  const str = () => {
+    const n = u64()
+    ensure(n)
+    const s = buf.toString('utf8', pos, pos + n)
+    pos += n
+    return s
+  }
+  const skipValue = (t) => {
+    if (t === 8) {
+      str()
+      return
+    }
+    if (t === 9) {
+      const et = u32()
+      const n = u64()
+      for (let i = 0; i < n; i++) skipValue(et)
+      return
+    }
+    const s = SIZES[t]
+    if (s === undefined) throw new Error(`unknown GGUF value type ${t}`)
+    ensure(s)
+    pos += s
+  }
+
+  if (u32() !== GGUF_MAGIC) throw new Error('not a GGUF file')
+  const version = u32()
+  const nTensors = u64()
+  const nKv = u64()
+  let alignment = 32
+  let tokenizerKv = 0
+  for (let i = 0; i < nKv; i++) {
+    const key = str()
+    const type = u32()
+    if (key === 'general.alignment') {
+      ensure(4)
+      alignment = buf.readUInt32LE(pos)
+    }
+    if (key.startsWith('tokenizer.')) tokenizerKv++
+    skipValue(type)
+  }
+  const tensorInfoStart = pos
+  for (let i = 0; i < nTensors; i++) {
+    str()
+    const nd = u32()
+    ensure(8 * nd + 4 + 8)
+    pos += 8 * nd + 4 + 8
+  }
+  const headerEnd = pos
+  const dataOffset = Math.ceil(headerEnd / alignment) * alignment
+  return {
+    version,
+    nTensors,
+    nKv,
+    tokenizerKv,
+    tensorInfoBytes: headerEnd - tensorInfoStart,
+    headerEnd,
+    dataOffset
+  }
+}
+
+function copyPrefix(srcFd, dstPath, length) {
+  const out = fs.openSync(dstPath, 'w')
+  try {
+    const chunk = Buffer.alloc(1 << 20)
+    let copied = 0
+    while (copied < length) {
+      const want = Math.min(chunk.length, length - copied)
+      const read = fs.readSync(srcFd, chunk, 0, want, copied)
+      if (read === 0) throw new Error('short read while copying header')
+      fs.writeSync(out, chunk, 0, read)
+      copied += read
+    }
+    return out
+  } catch (e) {
+    fs.closeSync(out)
+    throw e
+  }
+}
+
+function allocatedBytes(st) {
+  // st_blocks is in 512-byte units on every POSIX libuv target.
+  return typeof st.blocks === 'number' && st.blocks > 0 ? st.blocks * 512 : null
+}
+
+function planFields(r) {
+  if (!r) return null
+  return {
+    status: r.status,
+    fits: r.fits,
+    reason: r.reason,
+    nGpuLayers: r.nGpuLayers,
+    nCtx: r.nCtx,
+    nBatch: r.nBatch,
+    nUbatch: r.nUbatch,
+    splitMode: r.splitMode,
+    mainGpu: r.mainGpu,
+    typeK: r.typeK,
+    typeV: r.typeV,
+    flashAttnType: r.flashAttnType,
+    tensorSplit: r.tensorSplit,
+    buftOverrides: Array.isArray(r.buftOverrides) ? r.buftOverrides.length : r.buftOverrides,
+    nDevices: r.nDevices,
+    nGpuDevices: r.nGpuDevices
+  }
+}
+
+function resolveBackendsDir(explicit) {
+  if (explicit) return explicit
+  // Statically linked prebuilds (iOS, macOS, Windows) need no directory. Where
+  // backends ship as shared libraries (Android, Linux) the addon must be told
+  // where they are; on a packed phone build neither package tree is resolvable,
+  // so the test lets the caller pass `backendsDir` and reports what was used.
+  for (const spec of ['@qvac/fabric/package', '@qvac/model-fit/package']) {
+    try {
+      const url = import.meta.resolve(spec)
+      const file = url.startsWith('file://') ? decodeURIComponent(url.slice('file://'.length)) : url
+      const dir = path.join(path.dirname(file), 'prebuilds')
+      if (fs.statSync(dir).isDirectory()) return dir
+    } catch {}
+  }
+  return undefined
+}
+
+function platformTag() {
+  if (typeof Bare !== 'undefined') return `${Bare.platform}-${Bare.arch}`
+  return `${process.platform}-${process.arch}`
+}
+
+export async function runFitStubCheck({
+  modelPath,
+  nCtx = 4096,
+  marginMiB = 1024,
+  backendsDir,
+  stubDir
+} = {}) {
+  const report = {
+    platform: platformTag(),
+    modelPath,
+    nCtx,
+    marginMiB,
+    header: null,
+    stub: null,
+    fit: null,
+    errors: {}
+  }
+  const t0 = Date.now()
+  const srcFd = fs.openSync(modelPath, 'r')
+  const fullSize = fs.fstatSync(srcFd).size
+  const dir = stubDir || path.dirname(modelPath)
+  const stubPath = path.join(dir, `${path.basename(modelPath)}.fitstub-${Date.now()}.gguf`)
+  let stubFd = null
+  const finish = () => {
+    report.totalMs = Date.now() - t0
+    report.verdict = {
+      sparseOk: !!report.stub && report.stub.sparse === true,
+      stubLoads: !!(report.fit && report.fit.stub) && !report.errors.fitStub,
+      planIdentical: !!(report.fit && report.fit.identical === true),
+      pass: !!(
+        report.stub &&
+        report.stub.sparse === true &&
+        report.fit &&
+        report.fit.identical === true
+      )
+    }
+    return report
+  }
+  try {
+    report.header = Object.assign(readHeaderOffsets(srcFd), { fullSize })
+
+    stubFd = copyPrefix(srcFd, stubPath, report.header.dataOffset)
+    fs.ftruncateSync(stubFd, fullSize)
+    fs.closeSync(stubFd)
+    stubFd = null
+    const st = fs.statSync(stubPath)
+    const alloc = allocatedBytes(st)
+    report.stub = {
+      path: stubPath,
+      apparentSize: st.size,
+      allocatedBytes: alloc,
+      // sparse if the filesystem allocated little more than the header we actually wrote
+      sparse:
+        alloc === null
+          ? 'unknown (no st_blocks)'
+          : alloc < report.header.dataOffset * 2 + (1 << 20),
+      apparentMatchesFull: st.size === fullSize
+    }
+
+    const fitParams = modelFit && modelFit.fitParams
+    if (typeof fitParams !== 'function') {
+      report.errors.requireModelFit = 'fitParams not exported by @qvac/model-fit'
+      return finish()
+    }
+    const resolvedBackends = resolveBackendsDir(backendsDir)
+    const opts = Object.assign(
+      { nCtx, nCtxMin: nCtx, marginMiB },
+      resolvedBackends ? { backendsDir: resolvedBackends } : {}
+    )
+    report.fit = {
+      backendsDir: resolvedBackends || null,
+      full: null,
+      stub: null,
+      identical: null,
+      ms: {}
+    }
+    try {
+      const a = Date.now()
+      report.fit.full = planFields(fitParams(Object.assign({ modelPath }, opts)))
+      report.fit.ms.full = Date.now() - a
+    } catch (e) {
+      report.errors.fitFull = String((e && e.stack) || e)
+    }
+    try {
+      const a = Date.now()
+      report.fit.stub = planFields(fitParams(Object.assign({ modelPath: stubPath }, opts)))
+      report.fit.ms.stub = Date.now() - a
+    } catch (e) {
+      report.errors.fitStub = String((e && e.stack) || e)
+    }
+    if (report.fit.full && report.fit.stub) {
+      report.fit.identical = JSON.stringify(report.fit.full) === JSON.stringify(report.fit.stub)
+    }
+    return finish()
+  } catch (e) {
+    report.errors.fatal = String((e && e.stack) || e)
+    return finish()
+  } finally {
+    if (stubFd !== null) {
+      try {
+        fs.closeSync(stubFd)
+      } catch {}
+    }
+    try {
+      fs.unlinkSync(stubPath)
+    } catch {}
+    try {
+      fs.closeSync(srcFd)
+    } catch {}
+  }
+}
+
+// CLI entry: bare check.mjs <model.gguf> [nCtx] [backendsDir]
+if (
+  typeof Bare !== 'undefined' &&
+  Array.isArray(Bare.argv) &&
+  /check\.mjs$/.test(Bare.argv[1] || '')
+) {
+  const [, , modelPath, nCtxArg, backendsDir] = Bare.argv
+  if (!modelPath) {
+    console.error('usage: bare check.mjs <model.gguf> [nCtx] [backendsDir]')
+    Bare.exitCode = 2
+  } else {
+    const report = await runFitStubCheck({
+      modelPath,
+      nCtx: nCtxArg ? Number(nCtxArg) : 4096,
+      backendsDir
+    })
+    console.log(JSON.stringify(report, null, 2))
+    Bare.exitCode = report.verdict.pass ? 0 : 1
+  }
+}

--- a/packages/sdk/e2e/fixtures/fit-stub-plugin/client.d.ts
+++ b/packages/sdk/e2e/fixtures/fit-stub-plugin/client.d.ts
@@ -1,0 +1,63 @@
+export interface FitStubCheckParams {
+  nCtx?: number
+  marginMiB?: number
+  backendsDir?: string
+}
+
+export interface FitStubPlan {
+  status: number
+  fits: boolean
+  reason: string
+  nGpuLayers: number
+  nCtx: number
+  nBatch: number
+  nUbatch: number
+  splitMode: number
+  mainGpu: number
+  typeK: number
+  typeV: number
+  flashAttnType: number
+  tensorSplit: number[]
+  buftOverrides: number
+  nDevices: number
+  nGpuDevices: number
+}
+
+export interface FitStubCheckReport {
+  platform: string
+  modelPath: string
+  nCtx: number
+  marginMiB: number
+  header: {
+    version: number
+    nTensors: number
+    nKv: number
+    tokenizerKv: number
+    tensorInfoBytes: number
+    headerEnd: number
+    dataOffset: number
+    fullSize: number
+  } | null
+  stub: {
+    path: string
+    apparentSize: number
+    allocatedBytes: number | null
+    sparse: boolean | string
+    apparentMatchesFull: boolean
+  } | null
+  fit: {
+    backendsDir: string | null
+    full: FitStubPlan | null
+    stub: FitStubPlan | null
+    identical: boolean | null
+    ms: { full?: number; stub?: number }
+  } | null
+  errors: Record<string, string>
+  totalMs: number
+  verdict: { sparseOk: boolean; stubLoads: boolean; planIdentical: boolean; pass: boolean }
+}
+
+export function fitStubCheck(
+  modelId: string,
+  params?: FitStubCheckParams
+): Promise<FitStubCheckReport>

--- a/packages/sdk/e2e/fixtures/fit-stub-plugin/client.js
+++ b/packages/sdk/e2e/fixtures/fit-stub-plugin/client.js
@@ -1,0 +1,10 @@
+import { invokePlugin } from '@qvac/sdk'
+
+// Plugin handlers only see the params object, so the model id rides inside it.
+export async function fitStubCheck(modelId, params = {}) {
+  return invokePlugin({
+    modelId,
+    handler: 'check',
+    params: { modelId, ...params }
+  })
+}

--- a/packages/sdk/e2e/fixtures/fit-stub-plugin/package.json
+++ b/packages/sdk/e2e/fixtures/fit-stub-plugin/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "custom-fit-stub-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "e2e fixture: runs @qvac/model-fit on a header-only sparse stub of a downloaded GGUF and compares with the full file",
+  "exports": {
+    "./plugin": "./plugin.js",
+    "./check": "./check.mjs",
+    "./client": {
+      "types": "./client.d.ts",
+      "default": "./client.js"
+    }
+  },
+  "dependencies": {
+    "@qvac/model-fit": "^0.8.0"
+  },
+  "peerDependencies": {
+    "@qvac/sdk": "*",
+    "zod": "*"
+  }
+}

--- a/packages/sdk/e2e/fixtures/fit-stub-plugin/plugin.js
+++ b/packages/sdk/e2e/fixtures/fit-stub-plugin/plugin.js
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+import { definePlugin, defineHandler } from '@qvac/sdk'
+import { runFitStubCheck } from './check.mjs'
+
+// The SDK resolves (and downloads) the catalogue GGUF and hands its cache path
+// to createModel. Nothing is loaded into an engine: createModel only records
+// the path so the `check` handler can build a header-only stub next to it.
+// Handlers receive the caller's params verbatim, so the client wrapper passes
+// the modelId along and the handler looks the path up here.
+const modelPaths = new Map()
+
+const checkRequestSchema = z.object({
+  modelId: z.string(),
+  nCtx: z.number().int().positive().default(4096),
+  marginMiB: z.number().int().nonnegative().default(1024),
+  backendsDir: z.string().optional()
+})
+
+const checkResponseSchema = z.object({}).passthrough()
+
+const fitStubPlugin = definePlugin({
+  modelType: 'fit-stub-check',
+  displayName: 'Fit stub check (e2e)',
+  addonPackage: 'custom-fit-stub-plugin',
+  loadConfigSchema: z.object({}).passthrough(),
+
+  createModel({ modelId, modelPath }) {
+    modelPaths.set(modelId, modelPath)
+    return {
+      model: {
+        async load() {},
+        unload() {
+          modelPaths.delete(modelId)
+        }
+      }
+    }
+  },
+
+  handlers: {
+    check: defineHandler({
+      requestSchema: checkRequestSchema,
+      responseSchema: checkResponseSchema,
+      streaming: false,
+      async handler(request) {
+        const { modelId, ...options } = request
+        const modelPath = modelPaths.get(modelId)
+        if (typeof modelPath !== 'string') {
+          return {
+            errors: { fatal: `no model path recorded for ${modelId}` },
+            verdict: { sparseOk: false, stubLoads: false, planIdentical: false, pass: false }
+          }
+        }
+        return runFitStubCheck({ modelPath, ...options })
+      }
+    })
+  }
+})
+
+export default fitStubPlugin

--- a/packages/sdk/e2e/fixtures/qvac.config.e2e.json
+++ b/packages/sdk/e2e/fixtures/qvac.config.e2e.json
@@ -12,7 +12,8 @@
     "@qvac/sdk/audiogen-ggml/plugin",
     "@qvac/sdk/ggml-vla/plugin",
     "@qvac/sdk/ggml-classification/plugin",
-    "custom-echo-plugin/plugin"
+    "custom-echo-plugin/plugin",
+    "custom-fit-stub-plugin/plugin"
   ],
   "registryDownloadMaxRetries": 10,
   "registryStreamTimeoutMs": 600000

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -24,6 +24,7 @@
     "@qvac/sdk": "file:..",
     "@qvac/test-suite": "^0.11.0",
     "custom-echo-plugin": "file:./fixtures/echo-plugin",
+    "custom-fit-stub-plugin": "file:./fixtures/fit-stub-plugin",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
     "react-native-bare-kit": "^0.14.0"

--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -8,6 +8,7 @@ import {
   WHISPER_TINY,
   VAD_SILERO_5_1_2,
   QWEN3_1_7B_INST_Q4,
+  QWEN3_600M_INST_Q4,
   OCR_CRAFT,
   OCR_LATIN,
   OCR_DOCTR,
@@ -102,6 +103,7 @@ import { NoLingeringBareExecutor } from '../shared/executors/node/no-lingering-b
 import { MultiGpuExecutor } from '../shared/executors/multi-gpu-executor.js'
 import { NodeCancellationExecutor } from '../shared/executors/node/cancellation-executor.js'
 import { PluginExecutor } from '../shared/executors/plugin-executor.js'
+import { FitStubExecutor } from '../shared/executors/fit-stub-executor.js'
 
 const resources = new ResourceManager({
   downloadTarget: 'desktop'
@@ -250,6 +252,13 @@ resources.define('echo', {
   type: 'echo',
   modelSrc: '',
   skipPreDownload: true
+})
+
+// Small catalogue GGUF loaded through the fit-stub fixture: the SDK downloads
+// it and hands the cache path to the plugin, which never loads it into an engine.
+resources.define('fit-stub', {
+  constant: QWEN3_600M_INST_Q4,
+  type: 'fit-stub-check'
 })
 
 resources.define('sharded-embeddings', {
@@ -737,6 +746,7 @@ export const executor = createExecutor({
     new NoLingeringBareExecutor(),
     new MultiGpuExecutor(resources),
     new NodeCancellationExecutor(resources),
+    new FitStubExecutor(resources),
     new PluginExecutor(resources)
   ],
   profiling: {

--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -256,8 +256,15 @@ resources.define('echo', {
 
 // Small catalogue GGUF loaded through the fit-stub fixture: the SDK downloads
 // it and hands the cache path to the plugin, which never loads it into an engine.
+// The catalogue entry declares `engine: 'llamacpp-completion'` and loadModel now
+// rejects an explicit modelType that disagrees, so the engine hints are dropped;
+// pre-download only reads `src`.
+const fitStubSrc: Record<string, unknown> = { ...QWEN3_600M_INST_Q4 }
+delete fitStubSrc['engine']
+delete fitStubSrc['addon']
+
 resources.define('fit-stub', {
-  constant: QWEN3_600M_INST_Q4,
+  constant: fitStubSrc as unknown as typeof QWEN3_600M_INST_Q4,
   type: 'fit-stub-check'
 })
 

--- a/packages/sdk/e2e/tests/electron/consumer.ts
+++ b/packages/sdk/e2e/tests/electron/consumer.ts
@@ -551,6 +551,10 @@ export const executor = createExecutor({
       'Electron skips diffusion tests because image generation takes too long for the stable Electron pass'
     ),
     new SkipExecutor(
+      /^fit-stub-/,
+      'custom-fit-stub-plugin is not bundled in the Electron config; the check targets desktop and mobile'
+    ),
+    new SkipExecutor(
       /^world-/,
       'Electron skips ABot-World: a walk session needs a dedicated GPU and the 13.3 GB model set is far beyond the stable Electron pass'
     ),

--- a/packages/sdk/e2e/tests/fit-stub-tests.ts
+++ b/packages/sdk/e2e/tests/fit-stub-tests.ts
@@ -1,0 +1,22 @@
+import type { TestDefinition } from '@qvac/test-suite'
+
+// Runs @qvac/model-fit on a header-only, sparse-truncated copy of a downloaded
+// GGUF and on the full file, inside the SDK worker on the device under test.
+// Passes when the stub is sparse on this filesystem and both plans are equal.
+// The full JSON report is the test output either way, so a failure still says
+// which of the three steps (sparse, stub load, plan equality) broke.
+export const fitStubCheck = {
+  testId: 'fit-stub-check',
+  params: { nCtx: 4096, marginMiB: 1024 },
+  expectation: {
+    validation: 'contains-all',
+    contains: ['"pass":true']
+  },
+  metadata: {
+    category: 'fit-stub',
+    dependency: 'fit-stub',
+    estimatedDurationMs: 120_000
+  }
+} as const satisfies TestDefinition
+
+export const fitStubTests = [fitStubCheck]

--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -185,8 +185,15 @@ resources.define('echo', {
 
 // Small catalogue GGUF loaded through the fit-stub fixture: the SDK downloads
 // it and hands the cache path to the plugin, which never loads it into an engine.
+// The catalogue entry declares `engine: 'llamacpp-completion'` and loadModel now
+// rejects an explicit modelType that disagrees, so the engine hints are dropped;
+// pre-download only reads `src`.
+const fitStubSrc: Record<string, unknown> = { ...QWEN3_600M_INST_Q4 }
+delete fitStubSrc['engine']
+delete fitStubSrc['addon']
+
 resources.define('fit-stub', {
-  constant: QWEN3_600M_INST_Q4,
+  constant: fitStubSrc as unknown as typeof QWEN3_600M_INST_Q4,
   type: 'fit-stub-check'
 })
 

--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -10,6 +10,7 @@ import {
   WHISPER_TINY,
   VAD_SILERO_5_1_2,
   QWEN3_1_7B_INST_Q4,
+  QWEN3_600M_INST_Q4,
   OCR_CRAFT,
   OCR_LATIN,
   BERGAMOT_EN_FR,
@@ -73,6 +74,7 @@ import { SystemResourcesExecutor } from '../shared/executors/system-resources-ex
 import { ConfigExecutor } from '../shared/executors/config-executor.js'
 import { MobileCancellationExecutor } from './executors/cancellation-executor.js'
 import { PluginExecutor } from '../shared/executors/plugin-executor.js'
+import { FitStubExecutor } from '../shared/executors/fit-stub-executor.js'
 
 const resources = new ResourceManager({
   downloadTarget: 'mobile',
@@ -179,6 +181,13 @@ resources.define('echo', {
   type: 'echo',
   modelSrc: '',
   skipPreDownload: true
+})
+
+// Small catalogue GGUF loaded through the fit-stub fixture: the SDK downloads
+// it and hands the cache path to the plugin, which never loads it into an engine.
+resources.define('fit-stub', {
+  constant: QWEN3_600M_INST_Q4,
+  type: 'fit-stub-check'
 })
 
 resources.define('sharded-embeddings', {
@@ -699,6 +708,7 @@ export const executor = createExecutor({
     new SystemResourcesExecutor(),
     new ConfigExecutor(),
     new MobileCancellationExecutor(resources),
+    new FitStubExecutor(resources),
     new PluginExecutor(resources)
   ],
   profiling: {

--- a/packages/sdk/e2e/tests/shared/executors/fit-stub-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/fit-stub-executor.ts
@@ -26,6 +26,9 @@ export class FitStubExecutor extends AbstractModelExecutor<typeof fitStubTests> 
     try {
       const modelId = await this.resources.ensureLoaded('fit-stub')
       const report = await fitStubCheck(modelId, params)
+      // The harness only publishes `output` for a failing test, and the numbers
+      // are the point of this check, so log the report on every run.
+      console.log(`fit-stub-check report: ${JSON.stringify(report)}`)
       return ValidationHelpers.validate(JSON.stringify(report), expectation)
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)

--- a/packages/sdk/e2e/tests/shared/executors/fit-stub-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/fit-stub-executor.ts
@@ -27,8 +27,12 @@ export class FitStubExecutor extends AbstractModelExecutor<typeof fitStubTests> 
       const modelId = await this.resources.ensureLoaded('fit-stub')
       const report = await fitStubCheck(modelId, params)
       // The harness only publishes `output` for a failing test, and the numbers
-      // are the point of this check, so log the report on every run.
-      console.log(`fit-stub-check report: ${JSON.stringify(report)}`)
+      // are the point of this check, so log the report on every run. The iOS
+      // syslog truncates long lines, hence the chunks.
+      const json = JSON.stringify(report)
+      for (let i = 0; i < json.length; i += 600) {
+        console.log(`fit-stub-check report[${i / 600}]: ${json.slice(i, i + 600)}`)
+      }
       return ValidationHelpers.validate(JSON.stringify(report), expectation)
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)

--- a/packages/sdk/e2e/tests/shared/executors/fit-stub-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/fit-stub-executor.ts
@@ -1,0 +1,35 @@
+import { ValidationHelpers, type TestResult, type Expectation } from '@qvac/test-suite'
+import { fitStubCheck } from 'custom-fit-stub-plugin/client'
+import { AbstractModelExecutor } from './abstract-model-executor.js'
+import { fitStubTests, fitStubCheck as fitStubCheckTest } from '../../fit-stub-tests.js'
+
+interface FitStubParams {
+  nCtx?: number
+  marginMiB?: number
+  backendsDir?: string
+}
+
+/**
+ * Loads a small catalogue GGUF through the `custom-fit-stub-plugin` fixture
+ * (which only records the cache path) and asks the plugin to run the
+ * header-only fit check in the worker. The whole report is returned as the
+ * test output so a failing run is still diagnosable from the results file.
+ */
+export class FitStubExecutor extends AbstractModelExecutor<typeof fitStubTests> {
+  pattern = /^fit-stub-/
+
+  protected handlers = {
+    [fitStubCheckTest.testId]: this.check.bind(this)
+  }
+
+  async check(params: FitStubParams, expectation: Expectation): Promise<TestResult> {
+    try {
+      const modelId = await this.resources.ensureLoaded('fit-stub')
+      const report = await fitStubCheck(modelId, params)
+      return ValidationHelpers.validate(JSON.stringify(report), expectation)
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      return { passed: false, output: `fit-stub-check failed before producing a report: ${msg}` }
+    }
+  }
+}

--- a/packages/sdk/e2e/tests/test-definitions.ts
+++ b/packages/sdk/e2e/tests/test-definitions.ts
@@ -40,6 +40,7 @@ import { multiGpuTests } from './multi-gpu-tests.js'
 import { cancellationTests } from './cancellation-tests.js'
 import { vlaTests } from './vla-tests.js'
 import { pluginTests } from './plugin-tests.js'
+import { fitStubTests } from './fit-stub-tests.js'
 import { snapStorageTests } from './snap-storage-tests.js'
 import { systemResourcesTests } from './system-resources-tests.js'
 
@@ -366,6 +367,9 @@ export const tests = [
 
   // Custom plugin system tests (custom-echo-plugin, error paths)
   ...pluginTests,
+
+  // Header-only sparse stub vs full-file fit parity (custom-fit-stub-plugin)
+  ...fitStubTests,
 
   // Strict Snap storage-path conformance
   ...snapStorageTests,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Pre-download fit estimates need the engine fitter to run on a GGUF header, not a full download. Nothing verified that on real hardware.
- Open: does a header-only copy truncated to the original length stay sparse on a device, and does its plan match the full file?

## 📝 How does it solve it?

- Adds e2e test `fit-stub-check` (category `fit-stub`) and fixture plugin `custom-fit-stub-plugin`, which records the downloaded GGUF path and runs the check in the SDK worker. Nothing is loaded into an engine.
- `check.mjs` doubles as a standalone Bare CLI: `bare check.mjs <model.gguf> [nCtx] [backendsDir]`.
- Drops the catalogue entry's `engine`/`addon` hints for this load — `loadModel` rejects an explicit `modelType` that disagrees with the `modelSrc` engine, which currently blocks any custom plugin from loading a catalogue model.
- Logs the report in chunks: the harness publishes `output` only on failure, and the iOS syslog and `adb logcat` both truncate long lines.

## 🧪 How was it tested?

Qwen3-0.6B Q4_0 @ 4096, apparent size 382,156,480 B. `pass`, `sparse` and `identical` all true on three platforms:

| | Allocated | Full fit | `fit.ms` full / stub |
|---|---|---|---|
| iOS 26.6.1 | 5,955,584 B | nDevices 2, nGpuDevices 1 | 194 / 143 |
| Android | 5,959,680 B | nDevices 2, nGpuDevices 1 | 596 / 325 |
| macOS M4 Pro | 5,955,584 B | nDevices 3, nGpuDevices 1 | 151 / 122 |

- Both phones reported `backendsDir: null` and still registered a GPU backend, so no explicit backends directory was needed.
- Linux not run yet.
