### PR TITLE
chore[notask]: release @qvac/openclaw-plugin 0.3.1 — restore latest dist-tag

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1]
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.1
+
+Republish of 0.3.0 to restore the `latest` dist-tag, which had landed on 0.2.2. No code changes — see the 0.3.0 notes.
+
 ## [0.3.0]
 
 Release Date: 2026-09-08

--- a/plugins/openclaw/changelog/0.3.1/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.3.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.3.1
+
+Release Date: 2026-09-08
+
+## Chores
+
+- Republish 0.3.0's contents to restore the `latest` dist-tag. No code changes.

--- a/plugins/openclaw/changelog/0.3.1/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.3.1/CHANGELOG_LLM.md
@@ -1,0 +1,7 @@
+# QVAC OpenClaw Plugin v0.3.1 Release Notes
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.1
+
+Republish of 0.3.0 to restore the `latest` dist-tag, which had landed on 0.2.2. No code changes — see the 0.3.0 notes.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `latest` on npm points at `0.2.2`, so `npm install @qvac/openclaw-plugin` resolves below the 0.3.x line.
- `npm dist-tag add` is not an option: npm access is CI-only and no workflow performs it.

## 📝 How does it solve it?

- Bumps `plugins/openclaw` to `0.3.1`; contents identical to 0.3.0.
- Being higher than 0.2.2, the existing auto-decide in `publish-library-to-npm` puts `latest` back on the 0.3.x line.
- Adds hand-written `changelog/0.3.1/` and rebuilds `CHANGELOG.md`.
- Cut from the current `release-openclaw-plugin-0.3.0` tip (`7b67d6809`), so it includes #4339. The `release-openclaw-plugin-0.3.1` branch was recreated at that tip.
- Does not fix the underlying publish race — separate ticket.

## 🧪 How was it tested?

- format, lint, typecheck, build clean; 36/36 unit tests.
