### PR TITLE
chore[skiplog|notask]: backmerge release-openclaw-plugin-0.3.1 — version bump, changelog

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1]
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.1
+
+Republish of 0.3.0 to restore the `latest` dist-tag, which had landed on 0.2.2. No code changes — see the 0.3.0 notes.
+
 ## [0.3.0]
 
 Release Date: 2026-09-08

--- a/plugins/openclaw/changelog/0.3.1/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.3.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.3.1
+
+Release Date: 2026-09-08
+
+## Chores
+
+- Republish 0.3.0's contents to restore the `latest` dist-tag. No code changes.

--- a/plugins/openclaw/changelog/0.3.1/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.3.1/CHANGELOG_LLM.md
@@ -1,0 +1,7 @@
+# QVAC OpenClaw Plugin v0.3.1 Release Notes
+
+Release Date: 2026-09-08
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.3.1
+
+Republish of 0.3.0 to restore the `latest` dist-tag, which had landed on 0.2.2. No code changes — see the 0.3.0 notes.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What this PR does

Lands `@qvac/openclaw-plugin@0.3.1` on `main`. Tagged `[skiplog]`. No functional change.

## Companion release PR

- #4343

## Files

- `plugins/openclaw/package.json` — version `0.3.0` → `0.3.1`
- `plugins/openclaw/changelog/0.3.1/` — hand-written `CHANGELOG.md` and `CHANGELOG_LLM.md`
- `plugins/openclaw/CHANGELOG.md` — rebuilt aggregate
