### PR TITLE
QVAC-24464 feat[api]: build @qvac/fabric with the ggml vector-index API

### DIFF
--- a/packages/fabric/CHANGELOG.md
+++ b/packages/fabric/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.12.0] - 2026-09-08
+
+### Added
+
+- ggml vector-index API (`ggml_vec_index_*`) in the shared runtime, via the
+  `qvac-fabric[vector-index]` feature. `@qvac/embed-llamacpp` is the only
+  consumer of this API and was the last blocker to migrating it off its own
+  `qvac-fabric` vcpkg build: it requested the feature per-consumer, so a
+  fabric-based embed had nowhere to resolve `ggml_vec_index_*` from. The header
+  (`ggml-vector-index.h`) ships with the rest of the include tree, and the
+  existing `ggml_*` allow-list in `symbols.map` / `exports.txt` / the Windows
+  `.def` generator already covers the symbol names, so no export surface had to
+  be enumerated by hand.
+
+  The library is whole-archived into `qvac__fabric.bare` on ELF/Mach-O targets.
+  This is required rather than incidental: no llama or ggml code calls
+  `ggml_vec_index_*`, so a plain link pulls in none of those archive members and
+  the version script would filter an empty set. Windows needs no equivalent —
+  entries in the generated `.def` act as references that pull the members in.
+
+  Released as a **minor** for the same reason 0.9.0 was: this widens the
+  runtime's exported API surface. Consumers pinned to `^0.10.0` or `^0.11.0` do
+  not pick it up automatically and adopt it by widening their range.
+
 ## [0.11.0] - 2026-09-08
 
 ### Changed

--- a/packages/fabric/CMakeLists.txt
+++ b/packages/fabric/CMakeLists.txt
@@ -57,6 +57,28 @@ find_package(OpenSSL)
 find_package(llama CONFIG REQUIRED)
 find_package(ggml CONFIG REQUIRED)
 
+# --- ggml vector-index ---------------------------------------------------------
+# The qvac-fabric[vector-index] feature exports the ANN index API
+# (ggml_vec_index_*) as a library separate from the ggml core, under a target
+# name that has moved between port revisions. Resolve it here so the
+# whole-archive and Windows .def blocks below can both refer to one variable.
+# Requested unconditionally by our manifest, so a miss is a port contract
+# break, not a configuration the runtime can ship without: @qvac/embed-llamacpp
+# resolves ggml_vec_index_* from this runtime and would fail to link.
+set(QVAC_FABRIC_VECTOR_INDEX_TARGET "")
+foreach(_vec_index_candidate ggml::ggml-vector-index ggml::vector-index ggml-vector-index)
+  if(TARGET ${_vec_index_candidate})
+    set(QVAC_FABRIC_VECTOR_INDEX_TARGET ${_vec_index_candidate})
+    break()
+  endif()
+endforeach()
+if(NOT QVAC_FABRIC_VECTOR_INDEX_TARGET)
+  message(FATAL_ERROR
+    "qvac-fabric did not export a ggml vector-index target despite the "
+    "vector-index feature being requested in vcpkg.json")
+endif()
+message(STATUS "qvac-fabric: vector-index target '${QVAC_FABRIC_VECTOR_INDEX_TARGET}'")
+
 # --- ggml backends -----------------------------------------------------------
 # When ggml backends are built as separate shared libraries (e.g. Android, or a
 # GGML_BACKEND_DL build) they are loaded at runtime via
@@ -125,13 +147,17 @@ endif()
 # are separate MODULE .so targets (staged via BACKEND_DL_LIBS) and must not be
 # whole-archived here; the type guard also skips ggml core if a build exposes it
 # as a shared/interface target.
+#
+# The vector-index library is whole-archived for a stronger version of the same
+# reason: no llama or ggml code calls ggml_vec_index_*, so nothing references
+# those members and a plain link would pull in none of them at all.
 if(UNIX)
-  foreach(_ggml_core ggml::ggml ggml::ggml-base)
-    if(TARGET ${_ggml_core})
-      get_target_property(_ggml_core_type ${_ggml_core} TYPE)
-      if(_ggml_core_type STREQUAL "STATIC_LIBRARY")
+  foreach(_ggml_static ggml::ggml ggml::ggml-base ${QVAC_FABRIC_VECTOR_INDEX_TARGET})
+    if(TARGET ${_ggml_static})
+      get_target_property(_ggml_static_type ${_ggml_static} TYPE)
+      if(_ggml_static_type STREQUAL "STATIC_LIBRARY")
         target_link_libraries(${qvac-fabric}
-          PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${_ggml_core}>")
+          PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${_ggml_static}>")
       endif()
     endif()
   endforeach()
@@ -182,6 +208,14 @@ elseif(WIN32)
     "$<TARGET_FILE:llama::mtmd>"
     "$<TARGET_FILE:ggml::ggml>"
     "$<TARGET_FILE:ggml::ggml-base>")
+  # Scanning the vector-index archive is what exports ggml_vec_index_*: the
+  # generated EXPORTS entries double as references that pull those members in,
+  # so unlike the ELF/Mach-O builds this needs no whole-archive.
+  get_target_property(_fabric_vec_index_type ${QVAC_FABRIC_VECTOR_INDEX_TARGET} TYPE)
+  if(NOT _fabric_vec_index_type STREQUAL "OBJECT_LIBRARY"
+     AND NOT _fabric_vec_index_type STREQUAL "INTERFACE_LIBRARY")
+    list(APPEND _fabric_export_libs "$<TARGET_FILE:${QVAC_FABRIC_VECTOR_INDEX_TARGET}>")
+  endif()
   # llama-common-base (formerly build_info) carries the LLAMA_BUILD_NUMBER /
   # LLAMA_COMMIT data globals. Scan it only when it is a real archive; if the
   # vcpkg export ships it as an INTERFACE (or OBJECT) target with no TARGET_FILE,

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/fabric",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Shared bare addon hosting the qvac-fabric (forked llama.cpp + ggml) runtime for QVAC inference addons",
   "addon": true,
   "engines": {

--- a/packages/fabric/vcpkg.json
+++ b/packages/fabric/vcpkg.json
@@ -8,7 +8,8 @@
       "name": "qvac-fabric",
       "version>=": "10297.1.2",
       "features": [
-        "hip-backend"
+        "hip-backend",
+        "vector-index"
       ]
     },
     {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/embed-llamacpp` and `@qvac/llm-llamacpp` are the last two addons still building their own static `qvac-fabric` vcpkg copy instead of consuming the shared `@qvac/fabric` runtime.
- Embed specifically **cannot** migrate today. It is the only consumer of ggml's ANN index API (`ggml_vec_index_*`) and requests `qvac-fabric[vector-index]` per-consumer. The shared runtime is built without that feature, so it exports no `ggml_vec_index_*` and a fabric-based embed would have nowhere to resolve those symbols from.

This PR unblocks that migration. It is the base of a stacked pair; the embed migration itself (QVAC-24464) follows on top.

## 📝 How does it solve it?

- Adds `vector-index` to the `qvac-fabric` feature list in `packages/fabric/vcpkg.json`.
- Resolves the exported target once into `QVAC_FABRIC_VECTOR_INDEX_TARGET` (`ggml::ggml-vector-index`, with fallbacks for the names other port revisions have used) so the whole-archive and Windows `.def` blocks share one variable. A miss is a hard `FATAL_ERROR`: we request the feature unconditionally, so its absence is a port contract break, not a configuration the runtime can ship without.
- **ELF/Mach-O**: whole-archives the library into `qvac__fabric.bare`, joining `ggml::ggml` / `ggml::ggml-base` in the existing loop. This is required rather than incidental — no llama or ggml code calls `ggml_vec_index_*`, so a plain link pulls in none of those archive members and the version script would filter an empty set.
- **Windows**: no whole-archive equivalent is needed. Adding the archive to the `.def` scan *is* what exports the symbols, because the generated `EXPORTS` entries double as the references that pull the members in. Guarded on the target being a real archive, mirroring the existing `llama-common-base` handling.
- No export surface is enumerated by hand: the `ggml_*` allow-list in `symbols.map` / `exports.txt` / the `.def` generator already covers the names, and `ggml-vector-index.h` ships with the rest of the include tree.
- `0.11.0` → `0.12.0`. Minor for the same reason 0.9.0 (HIP backend) was: it widens the runtime's exported API surface. Consumers pinned to `^0.10.0` / `^0.11.0` do not pick it up automatically and adopt it by widening their range.

## 🧪 How was it tested?

Local `linux-x64` build, plus a downstream link check against the (not yet opened) embed migration branch.

**Runtime build**

- vcpkg built `qvac-fabric[core,gpu-backends,llama,vector-index]:x64-linux`. The port exports `ggml::ggml-vector-index` as a `STATIC IMPORTED` target — the first candidate in the probe, so both the whole-archive type guard and the `.def` type guard take the intended branch.
- `ggml-vector-index.h` ships in the include tree; `libggml-vector-index.a` defines 30 `ggml_vec_index_*` symbols, all type `T`, so they pass the `.def` generator's `[TtWw]` filter as well as the `ggml_` prefix allow-list.
- After linking, `nm -D --defined-only qvac__fabric@0.bare` exports all 30. Without the whole-archive it exports none — that half was confirmed by the pre-change build.

**Downstream consumption**

- The embed addon built against this runtime links with `DT_NEEDED qvac__fabric@0.bare`, leaves its 26 `ggml_vec_index_*` references undefined, and all 26 resolve against this runtime's exports (set difference is empty). The addon drops to 1.8 MB with no bundled runtime.
- Embed's full C++ suite passes — 166 tests, including cases that load a real GGUF and run inference, with the ggml backends loaded from the fabric prebuild.

**Not covered**

- **The local build predates the rebase onto `10297.1.2`.** It was verified against port `10297.1.1`, before `main` bumped the consumers in #4271. `.1.2` is an upstream mtmd patch that does not touch the vector-index feature, but the CI round on the current head is the sign-off.
- `x64-linux` only, and built **without** `hip-backend` locally (no ROCm SDK on the machine — the committed manifest keeps it). Windows `.def` generation, Apple, and Android triplets are CI-only here.

## 🔌 API Changes

Additive: 30 new exported C symbols from the shared runtime, no existing signature changes.

```c
#include <ggml-vector-index.h>

ggml_vec_index_t * idx = ggml_vec_index_create(dim, bit_width);
ggml_vec_index_add(idx, vectors, n, ids);
ggml_vec_index_search(idx, queries, n_q, k, out_scores, out_ids);
ggml_vec_index_free(idx);
```

---

<sub>Drafted by the Cursor agent via the `qv-addon-pr-create` skill.</sub>
