### PR TITLE
chore: DO NOT MERGE, overlay-validate the 3 fabric consumers against qvac-fabric 10549.0.0

### DIFF
--- a/packages/embed-llamacpp/vcpkg-configuration.json
+++ b/packages/embed-llamacpp/vcpkg-configuration.json
@@ -1,4 +1,5 @@
 {
+  "overlay-ports": ["../../vcpkg-overlays/ports"],
   "default-registry": {
     "kind": "git",
     "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",

--- a/packages/fabric/vcpkg-configuration.json
+++ b/packages/fabric/vcpkg-configuration.json
@@ -1,4 +1,5 @@
 {
+  "overlay-ports": ["../../vcpkg-overlays/ports"],
   "default-registry": {
     "kind": "git",
     "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",

--- a/packages/llm-llamacpp/vcpkg-configuration.json
+++ b/packages/llm-llamacpp/vcpkg-configuration.json
@@ -1,4 +1,5 @@
 {
+  "overlay-ports": ["../../vcpkg-overlays/ports"],
   "default-registry": {
     "kind": "git",
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",

--- a/packages/model-fit/addon/src/fit/FitParams.cpp
+++ b/packages/model-fit/addon/src/fit/FitParams.cpp
@@ -382,6 +382,9 @@ FitResult runFit(const FitRequest& req) {
       buftOverrides.data(),
       margins.data(),
       nCtxMin,
+      // prefetch_weights_auto — see the note at the invoker call in
+      // LlamaLoadConfig.cpp. False preserves the pre-10549.0.0 projection.
+      false,
       GGML_LOG_LEVEL_INFO);
 
   out.status = static_cast<int>(status);

--- a/packages/model-fit/addon/src/fit/LlamaLoadConfig.cpp
+++ b/packages/model-fit/addon/src/fit/LlamaLoadConfig.cpp
@@ -811,6 +811,12 @@ LlamaFitExecution invokeLlamaFit(
       execution.buftOverrides.data(),
       margins.data(),
       nCtxMin,
+      // prefetch_weights_auto. False keeps the projection identical to what
+      // this addon reported before qvac-fabric 10549.0.0: fabric gates its
+      // automatic weight prefetch on this flag, so false leaves an explicit
+      // cparams.prefetch_weights the only way to turn prefetch on. Opting in
+      // is a behaviour change for the fit projection, not a build fix.
+      false,
       GGML_LOG_LEVEL_INFO);
   return execution;
 }

--- a/packages/model-fit/addon/src/fit/LlamaLoadConfig.hpp
+++ b/packages/model-fit/addon/src/fit/LlamaLoadConfig.hpp
@@ -61,9 +61,12 @@ struct LlamaLoadFitRequest {
   uint32_t nCtxMin = 0;
 };
 
+// The `bool` is fabric's `prefetch_weights_auto`, added in common/fit.h by
+// qvac-fabric 10549.0.0. It is the last parameter before the log level.
 using LlamaFitInvoker = std::function<common_params_fit_status(
     const char*, llama_model_params*, llama_context_params*, float*,
-    llama_model_tensor_buft_override*, size_t*, uint32_t, ggml_log_level)>;
+    llama_model_tensor_buft_override*, size_t*, uint32_t, bool,
+    ggml_log_level)>;
 using SupportedLlamaLoadHandler = std::function<void(common_params&)>;
 
 struct LlamaFitExecution {

--- a/packages/model-fit/test/unit/LlamaLoadConfig.test.cpp
+++ b/packages/model-fit/test/unit/LlamaLoadConfig.test.cpp
@@ -740,6 +740,7 @@ int main() {
                                      llama_model_tensor_buft_override*,
                                      size_t*,
                                      uint32_t,
+                                     bool,
                                      ggml_log_level) {
                                    ++completionFitCalls;
                                    return COMMON_PARAMS_FIT_STATUS_SUCCESS;
@@ -779,6 +780,7 @@ int main() {
                                     llama_model_tensor_buft_override*,
                                     size_t*,
                                     uint32_t,
+                                    bool,
                                     ggml_log_level) {
                                   ++embeddingFitCalls;
                                   return COMMON_PARAMS_FIT_STATUS_SUCCESS;
@@ -811,6 +813,7 @@ int main() {
                   llama_model_tensor_buft_override*,
                   size_t*,
                   uint32_t,
+                  bool,
                   ggml_log_level) {
                 ++unsupportedFitCalls;
                 return COMMON_PARAMS_FIT_STATUS_SUCCESS;

--- a/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
+++ b/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,234 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-fabric-llm.cpp
+  REF ba2ca88a11ae7ca9dade1120b9d9d86c1c55f9ec
+  SHA512 c538c8564faee546ebfb616e85ff57592b7007b7a8ab120fb64819467b2eb6321503fba97dfa37272e3b44085d52678fba6b1c5feeb445e56bbbe2f5166919e4
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+    vector-index GGML_VECTOR_INDEX
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+    hip-backend BUILD_HIP_BACKEND
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # The Android NDK ships only the C Vulkan headers; the ggml Vulkan backend
+  # additionally needs the C++ bindings (vulkan.hpp) and SPIRV-Headers, which as
+  # of b9840 ggml fetches itself via FetchContent (ggml/src/ggml-vulkan/CMakeLists.txt,
+  # `if (ANDROID)` block). The registry vcpkg-cmake sets FETCHCONTENT_FULLY_DISCONNECTED=ON
+  # globally, so allow the fetch here (same as the kleidiai path below).
+  list(APPEND PLATFORM_OPTIONS -DFETCHCONTENT_FULLY_DISCONNECTED=OFF)
+endif()
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID OR (VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS))
+  # Desktop Linux also needs GGML_BACKEND_DL=ON so that multiple GPU backends
+  # (Vulkan + HIP/ROCm) can coexist as separately-loaded modules, the same way
+  # Android dispatches CPU variants at runtime. Without DL the Linux build links
+  # a single static GPU backend and a second one (HIP) cannot be stacked.
+  # GGML_NATIVE is incompatible with DL, so CPU variants are dispatched via
+  # GGML_CPU_ALL_VARIANTS instead. Consumers must ship the core ggml/llama libs
+  # alongside their backend modules so the dynamically-linked .bare can resolve
+  # them at load time.
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# HIP/ROCm backend — opt-in via the 'hip-backend' feature (Linux + AMD only).
+# Only @qvac/vla-ggml requests it, so every other consumer builds with no HIP
+# and gains no ROCm dependency. Builds libqvac-ggml-hip.so as a standalone DL
+# module alongside Vulkan (GGML_BACKEND_DL is already ON above), so the addon
+# dlopen's whichever GPU backend BackendSelection picks at runtime. The `hip`
+# feature-dependency port forwards the system ROCm's find_package() configs.
+#
+# FAIL-SAFE: enable GGML_HIP only when a ROCm SDK is actually present. On a build
+# host without ROCm we skip HIP and build Vulkan/CPU only — the build never
+# hard-fails, and at runtime a missing HIP module just isn't loaded (the DL
+# loader skips it) so BackendSelection falls back to Vulkan/CPU. Targets gfx1151
+# (Strix Halo / Radeon 8060S); the HIP compiler + ROCM_PATH come from the build env.
+# linux-x64 only: AMD GPU hosts (Strix Halo / gfx1151) are x86_64, and the ROCm
+# dist is x64. On other arches (e.g. linux-arm64) HIP is skipped even if the
+# feature is requested — no ROCm requirement, no build break.
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND BUILD_GPU_BACKENDS AND BUILD_HIP_BACKEND)
+  # DETERMINISTIC: requesting hip-backend REQUIRES a ROCm SDK at build time. We
+  # must NOT silently skip when ROCm is absent — a host-dependent skip yields a
+  # no-HIP package with the SAME vcpkg ABI as a real HIP build, which the binary
+  # cache then conflates (cache poisoning: a no-ROCm build caches a no-HIP
+  # package that ROCm-equipped builds then restore). So ROCm present => HIP;
+  # ROCm absent => hard error (don't request hip-backend on a host without ROCm).
+  # The RUNTIME fail-safe is unchanged: an absent HIP module / non-AMD target is
+  # simply not loaded and BackendSelection falls back to Vulkan/CPU.
+  if(NOT (DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/cmake/hip/hip-config.cmake"))
+    message(FATAL_ERROR "qvac-fabric: hip-backend feature requires a ROCm SDK — set ROCM_PATH to a ROCm/TheRock install containing lib/cmake/hip/hip-config.cmake. Do not request hip-backend on a host without ROCm.")
+  endif()
+  message(STATUS "qvac-fabric: hip-backend ON — building GGML_HIP (gfx1151)")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_HIP=ON
+    -DAMDGPU_TARGETS=gfx1151
+    -DCMAKE_HIP_ARCHITECTURES=gfx1151)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+# Under GGML_BACKEND_DL the per-microarch backends ship as standalone
+# libqvac-ggml-*.so modules that the consumer dlopen's at runtime. Built with
+# -stdlib=libc++ they otherwise carry a runtime NEEDED dependency on the system
+# libc++.so.1 / libc++abi.so.1, so they silently fail to dlopen on any target
+# without libc++ installed (e.g. stock ubuntu-24.04 — no CPU backend registers,
+# inference aborts). Statically link the C++ runtime into the modules so they
+# are self-contained, matching how the addons link themselves. The module<->addon
+# boundary is the C ggml-backend ABI, so per-module libc++ copies never exchange
+# C++ objects. Linux only: Apple/iOS use Metal frameworks, Android ships
+# libc++_shared via the NDK STL, Windows uses the MSVC runtime.
+if(VCPKG_TARGET_IS_LINUX AND DL_BACKENDS)
+  string(APPEND VCPKG_LINKER_FLAGS " -static-libstdc++")
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_BUILD_APP=OFF
+    -DMTMD_VIDEO=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
+++ b/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,61 @@
+{
+  "name": "qvac-fabric",
+  "version": "10549.0.0",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "hip-backend": {
+      "description": "Build the ROCm/HIP GPU backend (libqvac-ggml-hip.so) for AMD GPUs on Linux as a DL module alongside Vulkan. Opt-in (only @qvac/vla-ggml requests it). Fail-safe: if no ROCm SDK is present at build time the HIP backend is skipped (Vulkan/CPU only). Targets gfx1151 (Strix Halo). The 'hip' dependency forwards the system ROCm find_package configs.",
+      "dependencies": [
+        {
+          "name": "hip",
+          "platform": "linux & x64"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    },
+    "vector-index": {
+      "description": "Build and install the ggml vector index library."
+    }
+  }
+}


### PR DESCRIPTION
## DO NOT MERGE

This branch is Rollout Phase A scaffolding for **qvac-fabric 10549.0.0**. It exists only so the fabric
consumers compile against the new fabric commit *before* the `v10549.0.0` tag is cut and before anything is
published to `qvac-registry-vcpkg`. `/rollout-phase-b` closes it once the registry PR merges; the consumer
`version>=` bumps ride Phase B's own bundled PR, not this one.

Precedent: qvac#3954 and qvac#3814, both opened and later closed, never merged.

## 🎯 Problem

`temp-10549` is the next fabric release line and nothing in `tetherto/qvac` has ever built against it. The
three remaining fabric consumers still resolve `qvac-fabric` from the registry at `10297.1.2`, so a break
introduced by the new line would only surface after the tag exists and the registry PR has merged — the
point at which backing it out is most expensive.

## 📝 How

Adds `vcpkg-overlays/ports/qvac-fabric/` and points the three consumers at it via `overlay-ports`. An
overlay port bypasses vcpkg's version resolution entirely, so the consumers build the pinned commit
regardless of what the registry publishes.

**What is being validated**

| | |
|---|---|
| ref | `temp-10549` |
| pinned commit | [`ba2ca88a1`](https://github.com/tetherto/qvac-fabric-llm.cpp/commit/ba2ca88a11ae7ca9dade1120b9d9d86c1c55f9ec) — "ggml: return success after scheduler split", 2026-09-08 |
| tag `v10549.0.0` | does not exist yet — Phase B creates it |

The top six commits on `temp-10549`, all landed 2026-09-08, are the scheduler-error-propagation work:

- `ggml: report scheduler assignment failures`
- `ggml: fix scheduler error log formatting`
- `ggml: return scheduler reservation failures`
- `llama: propagate scheduler errors from graph reservation`
- `common: report failed fit context creation as a fit failure`
- `ggml: return success after scheduler split`

Together these convert `ggml_backend_sched_split_graph` / `ggml_backend_sched_reserve_size` from `void` to
`bool`, carry a `has_error` flag on the scheduler, and replace two hard aborts (the pre-allocated-tensor
`GGML_ABORT` and the `*cur_backend_id != -1` assert) with logged errors that propagate. `common/fit.cpp` then
reports a failed `llama_context` creation as a `common_params_fit_exception` rather than a `std::runtime_error`
that nothing catches. That is the same change upstream [ggml-org/llama.cpp#26292](https://github.com/ggml-org/llama.cpp/pull/26292)
makes — still open upstream — forward-ported onto this line. It reached `temp-10297` via fabric#236 but was
absent here until today, so this validation is the first time any consumer compiles it on the 10549 line.

**REF is the commit sha, not the branch name.** A later push to `temp-10549` would otherwise invalidate the
recorded SHA512 and leave the overlay building something the hash no longer describes.

**Consumers — three, not seven.** `git grep -l qvac-fabric origin/main -- "packages/*/vcpkg.json"` returns
only:

- `embed-llamacpp`
- `fabric`
- `llm-llamacpp`

`model-fit`, `ocr-ggml`, `vla-ggml` and `translation-nmtcpp` have dropped the `qvac-fabric` dependency and
now carry only `qvac-lib-inference-addon-cpp` + `qvac-lint-cpp`, neither of which pulls `qvac-fabric`
transitively — so the overlay cannot reach them and they need no bump in Phase B either. `classification-ggml`
is excluded for the older reason: it consumes the published npm `@qvac/fabric`.

**Untouched, deliberately:**

- Consumer `version>=` pins stay at `10297.1.2` in all three. The overlay bypasses version resolution, so
  only the overlay port's own version matters here. Bumping the pins is Phase B.
- `default-registry.baseline` is unchanged in all three — and all three differ from each other
  (`f04e2447…`, `803c0d11…`, `c57eec31…`), which is normal and not something this PR should flatten.

## 🧪 Tested

- `git diff --stat` is exactly **5 files, +298**: the 3 `packages/<consumer>/vcpkg-configuration.json`
  one-liners plus `vcpkg-overlays/ports/qvac-fabric/{portfile.cmake,vcpkg.json}`. Nothing else swept in.
- The overlay port is byte-identical to `qvac-registry-vcpkg/ports/qvac-fabric` at registry HEAD except two
  hunks, confirmed by `diff -u`: `REF`/`SHA512` in `portfile.cmake`, and `"version"` in `vcpkg.json`. No
  `HEAD_REF` was added — the registry port carries none, and fabric's default branch is `master`.
- SHA512 computed over the `/archive/<sha>.tar.gz` tarball vcpkg actually fetches (37,819,656 bytes), not
  `gh api …/tarball/`, whose differently-named top-level directory yields a different hash:
  `c538c8564faee546ebfb616e85ff57592b7007b7a8ab120fb64819467b2eb6321503fba97dfa37272e3b44085d52678fba6b1c5feeb445e56bbbe2f5166919e4`
- Consumer CI is driven by this PR. Labels `run-cpp-addon-tests`, `run-desktop-addon-tests` and
  `run-coload-tests` are what make it a real validation — `run_verified_checks` alone gates only
  `sanity-checks` and `cpp-lint`, not `prebuild`, so an unlabelled PR would go green having compiled nothing.

## ⚠️ Notes for reviewers

- **A green consumer has not necessarily compiled fabric.** vcpkg restores `qvac-fabric` from the binary
  cache on an ABI-hash match and then `portfile.cmake` never runs. Check the install log for
  `Building qvac-fabric`; a real build is 30+ minutes.
- **`classification-ggml` will fire** and its result means nothing here — its workflow path-matches the PR's
  cumulative diff, but it consumes the npm package, so the overlay never reaches it.
- **`Merge Guard` / `validate-pr` are rollups**, not independent signals: a consumer red makes them red.
- If the overlay is ever re-pinned, every earlier green is void — greens against a superseded ref say nothing
  about the new one.
- There is **no fabric-side PR** for this ref: the six commits were pushed directly to `temp-10549` and
  `GET /commits/ba2ca88a/pulls` returns nothing. Phase A Step 8 would normally write the validation run links
  into the fabric PR description; with no such PR, they will be posted in this PR instead.
