### PR TITLE
QVAC-24566 feat: map minimax-h3 video duration in the cli

### DIFF
--- a/packages/cli/src/serve/extensions/openai/routes/videos.ts
+++ b/packages/cli/src/serve/extensions/openai/routes/videos.ts
@@ -509,7 +509,12 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
       }
       let params: VideoClientParams
       try {
-        params = extractVideoCreateParams(req.body, initImage, sdkModelId)
+        params = extractVideoCreateParams(
+          req.body,
+          initImage,
+          sdkModelId,
+          req.qvacModel!.entry.config
+        )
       } catch (err) {
         if (err instanceof InvalidVideoStrengthError) {
           throw new HttpError(400, 'invalid_strength', err.message)

--- a/packages/cli/src/serve/extensions/openai/schemas/videos.ts
+++ b/packages/cli/src/serve/extensions/openai/schemas/videos.ts
@@ -36,7 +36,7 @@ export const videosCreateBody = z
       )
       .optional()
       .describe(
-        'Target duration in seconds, as a string. Mapped to `video_frames = nearest_4k+1(seconds * fps)`.'
+        'Target duration in seconds. Rounded to supported frame counts: 4*k+1 for Wan, 17*k+5 at 24 FPS for an explicitly configured MiniMax-H3 model.'
       ),
     size: z
       .string()
@@ -74,7 +74,9 @@ export const videosCreateBody = z
       .positive()
       .max(120)
       .optional()
-      .describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
+      .describe(
+        'QVAC extension. 0 < fps ≤ 120; duration mapping defaults to 16 for Wan and 24 for MiniMax-H3.'
+      ),
     steps: z.coerce
       .number()
       .int()
@@ -224,7 +226,20 @@ function parseSizeFields(size: string): { width: number; height: number } {
   return { width: Number(match[1]), height: Number(match[2]) }
 }
 
-function videoFramesFor(seconds: string, fps: number | undefined): number {
+function videoFramesFor(seconds: string, fps: number | undefined, config: Record<string, unknown>) {
+  const isH3 =
+    config['mode'] === 'video' &&
+    config['llmModelSrc'] &&
+    config['vaeModelSrc'] &&
+    config['audioVaeModelSrc'] &&
+    !config['embeddingsConnectorsModelSrc'] &&
+    !config['t5XxlModelSrc'] &&
+    !config['highNoiseDiffusionModelSrc'] &&
+    !config['clipVisionModelSrc']
+  if (isH3) {
+    const frames = Number(seconds) * 24
+    return Number.isFinite(frames) ? 17 * Math.max(0, Math.round((frames - 5) / 17)) + 5 : 5
+  }
   return nearestVideoFrameCount(Number(seconds) * (fps ?? DEFAULT_FPS))
 }
 
@@ -256,7 +271,8 @@ function coerceStrength(raw: string | number | undefined): number | undefined {
 export function extractVideoCreateParams(
   body: VideosCreateBody,
   initImage: Uint8Array | undefined,
-  modelId: string
+  modelId: string,
+  config: Record<string, unknown> = {}
 ): VideoClientParams {
   const direct: Record<string, unknown> = {}
   for (const key of DIRECT_PARAM_KEYS) {
@@ -267,7 +283,9 @@ export function extractVideoCreateParams(
     prompt: body.prompt,
     ...direct,
     ...(body.size !== undefined ? parseSizeFields(body.size) : {}),
-    ...(body.seconds !== undefined ? { video_frames: videoFramesFor(body.seconds, body.fps) } : {})
+    ...(body.seconds !== undefined
+      ? { video_frames: videoFramesFor(body.seconds, body.fps, config) }
+      : {})
   }
   if (initImage !== undefined) {
     const strength = coerceStrength(body.strength as string | number | undefined)

--- a/packages/cli/test/e2e/openai/videos-h3.test.ts
+++ b/packages/cli/test/e2e/openai/videos-h3.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type CreateServerOptions } from '../helpers/server.js'
+import { openaiState } from '@/serve/extensions/openai/state'
+import type { VideoClientParams } from '@qvac/sdk'
+
+describe('serve: H3 video', () => {
+  it('loads the four-file layout and serves the result of a five-second request', async (t) => {
+    const config = {
+      mode: 'video',
+      llmModelSrc: '/models/encoder.gguf',
+      vaeModelSrc: '/models/video.safetensors',
+      audioVaeModelSrc: '/models/audio.safetensors',
+      backend: 'cuda',
+      max_vram: 'cuda0=6',
+      stream_layers: false
+    }
+    const loads: Parameters<NonNullable<CreateServerOptions['loadModelOverride']>>[0][] = []
+    const requests: VideoClientParams[] = []
+    const app = await createServer(t, {
+      config: {
+        serve: {
+          models: {
+            'neutral-alias': {
+              type: 'sdcpp-video',
+              src: '/models/denoiser.gguf',
+              config,
+              preload: false
+            }
+          }
+        }
+      },
+      loadModelOverride: (params) => {
+        loads.push(params)
+        return Promise.resolve('loaded-h3')
+      }
+    })
+    await app.ready()
+    const bytes = Buffer.from('native AVI bytes')
+    openaiState(app.qvac).videoOverride = (params) => {
+      requests.push(params)
+      return {
+        requestId: 'h3-request',
+        progressStream: (async function* () {
+          yield await Promise.resolve({ step: 1, totalSteps: 1, elapsedMs: 1 })
+        })(),
+        outputs: Promise.resolve([bytes]),
+        stats: Promise.resolve(undefined)
+      }
+    }
+    const created = await app.inject({
+      method: 'POST',
+      url: '/v1/videos',
+      payload: { model: 'neutral-alias', prompt: 'Steam rises from coffee.', seconds: '5' }
+    })
+    assert.equal(created.statusCode, 200, created.body)
+    assert.equal(loads.length, 1)
+    assert.equal(loads[0]?.modelType, 'sdcpp-generation')
+    assert.deepEqual(loads[0]?.modelConfig, config)
+    assert.equal(requests[0]?.modelId, 'loaded-h3')
+    assert.equal(requests[0]?.video_frames, 124)
+    assert.equal(requests[0]?.fps, undefined)
+
+    const { id } = created.json<{ id: string }>()
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const response = await app.inject({ method: 'GET', url: `/v1/videos/${id}` })
+      const job = response.json<{ status: string }>()
+      if (job.status === 'completed') break
+      assert.notEqual(job.status, 'failed', response.body)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    const content = await app.inject({
+      method: 'GET',
+      url: `/v1/videos/${id}/content?format=avi`
+    })
+    assert.equal(content.statusCode, 200, content.body)
+    assert.deepEqual(content.rawPayload, bytes)
+  })
+})

--- a/packages/cli/test/unit/commands/param-schemas.test.ts
+++ b/packages/cli/test/unit/commands/param-schemas.test.ts
@@ -10,6 +10,24 @@ import {
 import { TTS_ENGINES, buildEntry } from '@/configure/presets'
 
 describe('configure: param-schemas', () => {
+  it('exposes and validates H3 backend and memory controls from the SDK', () => {
+    const schema = configSchemaForAddon('diffusion')
+    assert.ok(schema)
+    const fields = paramFields(schema)
+    for (const name of ['backend', 'params_backend', 'max_vram', 'stream_layers']) {
+      const field = fields.find((field) => field.name === name)
+      assert.ok(field, `${name} is editable`)
+      assert.ok(field.description, `${name} is described`)
+    }
+    const maxVram = fields.find((field) => field.name === 'max_vram')!
+    const streamLayers = fields.find((field) => field.name === 'stream_layers')!
+    assert.equal(validateParam(maxVram, '0'), true)
+    assert.equal(validateParam(maxVram, 'cuda0=6,vulkan0=2'), true)
+    assert.equal(validateParam(streamLayers, 'false'), true)
+    assert.equal(coerceParam('false'), false)
+    assert.notEqual(validateParam(streamLayers, 'yes'), true)
+  })
+
   it('resolves a config schema for every built-in addon', () => {
     // Addon strings are model-type aliases; the SDK resolves each to its schema,
     // so a new addon is documented without wiring anything here.

--- a/packages/cli/test/unit/extensions/openai/videos.test.ts
+++ b/packages/cli/test/unit/extensions/openai/videos.test.ts
@@ -141,6 +141,62 @@ describe('nearestVideoFrameCount', () => {
 })
 
 describe('extractVideoCreateParams', () => {
+  const h3Config = {
+    mode: 'video',
+    llmModelSrc: '/models/encoder.gguf',
+    vaeModelSrc: '/models/video.safetensors',
+    audioVaeModelSrc: '/models/audio.safetensors'
+  }
+
+  it('maps H3 duration to 17*k+5 frames at 24 FPS from the configured layout', () => {
+    const params = extractVideoCreateParams(
+      { prompt: 'Coffee at sunrise', seconds: '5' },
+      undefined,
+      'neutral-alias',
+      h3Config
+    )
+    assert.equal(params.video_frames, 124)
+    assert.equal(params.fps, undefined)
+    assert.equal(
+      extractVideoCreateParams({ prompt: 'Coffee', seconds: '1' }, undefined, 'm', h3Config)
+        .video_frames,
+      22
+    )
+  })
+
+  it('preserves omitted H3 defaults and invalid explicit FPS for SDK validation', () => {
+    const minimal = extractVideoCreateParams({ prompt: 'Coffee' }, undefined, 'm', h3Config)
+    assert.equal(minimal.video_frames, undefined)
+    assert.equal(minimal.fps, undefined)
+    const invalid = extractVideoCreateParams(
+      { prompt: 'Coffee', seconds: '5', fps: 16 },
+      undefined,
+      'm',
+      h3Config
+    )
+    assert.equal(invalid.fps, 16)
+    assert.equal(invalid.video_frames, 124)
+  })
+
+  it('does not infer H3 from the alias, incomplete configuration or another layout', () => {
+    for (const config of [
+      {},
+      { ...h3Config, audioVaeModelSrc: undefined },
+      { ...h3Config, embeddingsConnectorsModelSrc: '/models/connectors' },
+      { ...h3Config, t5XxlModelSrc: '/models/t5' }
+    ]) {
+      assert.equal(
+        extractVideoCreateParams(
+          { prompt: 'Coffee', seconds: '5' },
+          undefined,
+          'minimax-h3',
+          config
+        ).video_frames,
+        81
+      )
+    }
+  })
+
   it('returns mode=txt2vid when no initImage', () => {
     const params = extractVideoCreateParams({ prompt: 'a cat surfing' }, undefined, 'sdk-vid-1')
     assert.equal(params.modelId, 'sdk-vid-1')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

A five-second video request currently becomes a Wan frame count that MiniMax-H3 rejects. H3 needs 124 frames at 24 FPS.

## 📝 How does it solve it?

- Recognize an explicitly configured H3 companion layout and round duration to the nearest supported `17*k+5` frame count at 24 FPS.
- Preserve omitted native defaults and explicit values for SDK validation; retain the existing Wan mapping.
- Verify configure discovers the new fields from the SDK and the existing POST/poll/AVI-content route passes the correct request.
- Depends on #4351 (combined inference, SDK and Python integration). Retarget to main after the dependencies land; adoption of the published H3 SDK version belongs to the coordinated release.

## 🧪 How was it tested?

- Build, typecheck, lint and formatting passed.
- 573 unit tests and 95 benchmark tests passed.
- Full e2e command: 154 general and 77 real-model tests passed. Four encoded-TTS tests initially skipped for missing ffmpeg/ffprobe; after supplying those tools, the entire TTS file passed 8/8 with zero skips.
- New H3 HTTP test uses the existing generation override. **Pending before merge:** real H3 generation and confirmation that AVI-to-MP4 conversion preserves its audio.

```json
{ "model": "minimax-h3", "prompt": "Steam rises from coffee.", "seconds": "5" }
```

Configure the alias with `type: "sdcpp-video"`, its primary `src`, and `mode: "video"`, `llmModelSrc`, `vaeModelSrc`, and `audioVaeModelSrc` in `config`.

