### PR TITLE
QVAC-24716 feat: surface whisper encode/decode per-call timings in the asr-ggml RTF report

### DIFF
--- a/scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js
@@ -48,6 +48,8 @@ function whisperDesktopReport (useGPU) {
     summary: {
       rtf: { mean: 0.1, stddev: 0.01, p50: 0.1, p95: 0.12 },
       wallMs: { mean: 500 },
+      whisperEncodeMs: { mean: 390.75 },
+      whisperDecodeMs: { mean: 9.614 },
       memory: {
         avgRssMb: 320.5,
         peakRssMb: 410.25,
@@ -126,6 +128,24 @@ test('whisper desktop record leaves the parakeet-only columns empty', () => {
   const record = normalizeDesktopRecord(whisperDesktopReport(true), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-gpu.json')
   assert.equal(record.gpuModel, null)
   assert.equal(record.version, '')
+})
+
+test('whisper desktop record surfaces the per-call encode and decode phase timings', () => {
+  const record = normalizeDesktopRecord(whisperDesktopReport(false), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-cpu.json')
+  assert.equal(record.encodeMs, 390.75)
+  assert.equal(record.decodeMsPerCall, 9.614)
+})
+
+test('phase timings are NaN when the report does not carry the whisper timers', () => {
+  const report = whisperDesktopReport(false)
+  delete report.summary.whisperEncodeMs
+  delete report.summary.whisperDecodeMs
+  const record = normalizeDesktopRecord(report, 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-cpu.json')
+  assert.ok(Number.isNaN(record.encodeMs))
+  assert.ok(Number.isNaN(record.decodeMsPerCall))
+  const parakeet = normalizeDesktopRecord(parakeetDesktopReport(false), 'rtf-benchmark-win32-x64-tdt-q8_0-cpu.json')
+  assert.ok(Number.isNaN(parakeet.encodeMs))
+  assert.ok(Number.isNaN(parakeet.decodeMsPerCall))
 })
 
 // --- parakeet desktop --------------------------------------------------------
@@ -652,6 +672,17 @@ test('markdown table carries the Engine column, memory columns and per-engine co
   assert.ok(markdown.includes('- parakeet: 1 row(s)'))
 })
 
+test('markdown table carries the whisper phase columns and n/a for parakeet rows', () => {
+  const records = [
+    normalizeDesktopRecord(whisperDesktopReport(true), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-gpu.json'),
+    normalizeDesktopRecord(parakeetDesktopReport(true), 'rtf-benchmark-win32-x64-tdt-q8_0-gpu.json')
+  ]
+  const markdown = renderMarkdown(records)
+  assert.ok(markdown.includes('| Enc (ms/call) | Dec (ms/call) |'))
+  assert.ok(markdown.includes('| 390.8 | 9.61 |'), 'whisper row should carry the formatted phase timings')
+  assert.ok(markdown.includes('| n/a | n/a |'), 'parakeet row should render n/a for the whisper-only timers')
+})
+
 test('html table includes the Engine header, memory columns and rounded values', () => {
   const record = normalizeDesktopRecord(parakeetDesktopReport(true), 'rtf-benchmark-win32-x64-tdt-q8_0-gpu.json')
   const html = renderHtml([record])
@@ -709,4 +740,32 @@ test('a fully reporting device list renders without the missing-devices warning'
   const markdown = renderMarkdown(records, ['qvac-ubuntu2404-x64-gpu'])
   assert.ok(markdown.includes('- Expected desktop devices reporting: 1/1'))
   assert.ok(!markdown.includes('MISSING desktop devices'))
+})
+
+test('html table carries the whisper phase columns with formatted values', () => {
+  const html = renderHtml([
+    normalizeDesktopRecord(whisperDesktopReport(false), 'rtf-benchmark-linux-x64-ggml-tiny-q5_1-cpu.json')
+  ])
+  assert.ok(html.includes('<th>Enc (ms/call)</th>'))
+  assert.ok(html.includes('<th>Dec (ms/call)</th>'))
+  assert.ok(html.includes('<td>390.8</td>'))
+  assert.ok(html.includes('<td>9.61</td>'))
+})
+
+test('flattened manual rows keep their phase timings', () => {
+  const record = normalizeManualRecord({
+    engine: 'whisper',
+    device: 'Apple M1 Pro (macOS 15.1.1)',
+    platform: 'darwin-arm64',
+    model: 'ggml-base-q5_1',
+    quant: 'q5_1',
+    gpu: 'cpu',
+    backend: 'cpu',
+    meanRtf: 0.02,
+    stddevRtf: 0.001,
+    encodeMs: 210.4,
+    decodeMsPerCall: 2.31
+  }, 'manual-results/whisper/row.json')
+  assert.equal(record.encodeMs, 210.4)
+  assert.equal(record.decodeMsPerCall, 2.31)
 })

--- a/scripts/perf-report/aggregate-asr-ggml-rtf.js
+++ b/scripts/perf-report/aggregate-asr-ggml-rtf.js
@@ -289,6 +289,13 @@ function normalizeReport (report, sourceFile, source) {
   const summary = report.summary || {}
   const rtf = summary.rtf || {}
   const wallMs = summary.wallMs || {}
+  // whisper-only per-call phase timers from whisper's internal timings; the
+  // parakeet reports have no equivalent, so those rows render n/a. Kept in the
+  // table because an engine regression can hide inside a flat-looking RTF: the
+  // QVAC-24716 Windows regression only localized once decode ms/call was read
+  // out of the raw artifacts (encode flat, decode 3.5 -> 9.6 ms/call).
+  const encodeMs = summary.whisperEncodeMs || {}
+  const decodeMs = summary.whisperDecodeMs || {}
   const memory = summary.memory || {}
   const platformName = report.platformName || report.platform || ''
   const useGPU = Boolean(
@@ -322,6 +329,8 @@ function normalizeReport (report, sourceFile, source) {
     p50: Number(rtf.p50),
     p95: Number(rtf.p95),
     wallMs: Number(wallMs.mean),
+    encodeMs: Number(encodeMs.mean),
+    decodeMsPerCall: Number(decodeMs.mean),
     avgRssMb: numberOrNaN(memory.avgRssMb),
     peakRssMb: numberOrNaN(memory.peakRssMb),
     reclaimedMb: numberOrNaN(memory.reclaimedMb),
@@ -364,6 +373,8 @@ function normalizeManualRecord (record, sourceFile) {
     p50: Number(record.p50),
     p95: Number(record.p95),
     wallMs: Number(record.wallMs),
+    encodeMs: Number(record.encodeMs),
+    decodeMsPerCall: Number(record.decodeMsPerCall),
     avgRssMb: numberOrNaN(record.avgRssMb),
     peakRssMb: numberOrNaN(record.peakRssMb),
     reclaimedMb: numberOrNaN(record.reclaimedMb),
@@ -706,12 +717,12 @@ function renderMarkdown (records, expectedDevices = []) {
 
   lines.push('## ASR GGML Performance Findings')
   lines.push('')
-  lines.push('| Source | Engine | Device | Platform | Model | Quant | GPU | Backend | GPU Model | Version | Mean RTF | ± Stddev | P50 | P95 | Mean Wall (ms) | Avg RSS (MB) | Peak RSS (MB) | Reclaimed (MB) | Notes |')
-  lines.push('|--------|--------|--------|----------|-------|-------|-----|---------|-----------|---------|----------|----------|-----|-----|----------------|--------------|---------------|----------------|-------|')
+  lines.push('| Source | Engine | Device | Platform | Model | Quant | GPU | Backend | GPU Model | Version | Mean RTF | ± Stddev | P50 | P95 | Mean Wall (ms) | Enc (ms/call) | Dec (ms/call) | Avg RSS (MB) | Peak RSS (MB) | Reclaimed (MB) | Notes |')
+  lines.push('|--------|--------|--------|----------|-------|-------|-----|---------|-----------|---------|----------|----------|-----|-----|----------------|---------------|---------------|--------------|---------------|----------------|-------|')
 
   for (const record of records) {
     lines.push(
-      `| ${record.source} | ${record.engine} | ${record.device} | ${record.platform} | ${record.model} | ${record.quant || '-'} | ${record.gpu} | ${record.backend} | ${record.gpuModel || '-'} | ${record.version || '-'} | ${formatNumber(record.meanRtf)} | ${formatNumber(record.stddevRtf)} | ${formatNumber(record.p50)} | ${formatNumber(record.p95)} | ${formatMaybeInteger(record.wallMs)} | ${formatMaybeInteger(record.avgRssMb)} | ${formatMaybeInteger(record.peakRssMb)} | ${formatMaybeInteger(record.reclaimedMb)} | ${record.notes || ''} |`
+      `| ${record.source} | ${record.engine} | ${record.device} | ${record.platform} | ${record.model} | ${record.quant || '-'} | ${record.gpu} | ${record.backend} | ${record.gpuModel || '-'} | ${record.version || '-'} | ${formatNumber(record.meanRtf)} | ${formatNumber(record.stddevRtf)} | ${formatNumber(record.p50)} | ${formatNumber(record.p95)} | ${formatMaybeInteger(record.wallMs)} | ${formatNumber(record.encodeMs, 1)} | ${formatNumber(record.decodeMsPerCall, 2)} | ${formatMaybeInteger(record.avgRssMb)} | ${formatMaybeInteger(record.peakRssMb)} | ${formatMaybeInteger(record.reclaimedMb)} | ${record.notes || ''} |`
     )
   }
 
@@ -769,6 +780,8 @@ function renderHtml (records, expectedDevices = []) {
       formatNumber(record.p50),
       formatNumber(record.p95),
       formatMaybeInteger(record.wallMs),
+      formatNumber(record.encodeMs, 1),
+      formatNumber(record.decodeMsPerCall, 2),
       formatMaybeInteger(record.avgRssMb),
       formatMaybeInteger(record.peakRssMb),
       formatMaybeInteger(record.reclaimedMb),
@@ -842,6 +855,8 @@ function renderHtml (records, expectedDevices = []) {
     '        <th>P50</th>',
     '        <th>P95</th>',
     '        <th>Mean Wall (ms)</th>',
+    '        <th>Enc (ms/call)</th>',
+    '        <th>Dec (ms/call)</th>',
     '        <th>Avg RSS (MB)</th>',
     '        <th>Peak RSS (MB)</th>',
     '        <th>Reclaimed (MB)</th>',

--- a/scripts/perf-report/aggregate-asr-ggml-rtf.js
+++ b/scripts/perf-report/aggregate-asr-ggml-rtf.js
@@ -279,6 +279,15 @@ function reportQuant (report, sourceFile) {
     ''
 }
 
+// whisper stamps its internal per-call encode/decode timers into the summary;
+// parakeet reports have no equivalent, so their rows render n/a.
+function whisperPhaseTimings (summary) {
+  return {
+    encodeMs: Number((summary.whisperEncodeMs || {}).mean),
+    decodeMsPerCall: Number((summary.whisperDecodeMs || {}).mean)
+  }
+}
+
 /**
  * One normalizer for both engines' desktop-shaped reports (`summary.rtf` etc.).
  * whisper reports do not carry `addonVersion` or a probed GPU name yet, so those
@@ -289,13 +298,6 @@ function normalizeReport (report, sourceFile, source) {
   const summary = report.summary || {}
   const rtf = summary.rtf || {}
   const wallMs = summary.wallMs || {}
-  // whisper-only per-call phase timers from whisper's internal timings; the
-  // parakeet reports have no equivalent, so those rows render n/a. Kept in the
-  // table because an engine regression can hide inside a flat-looking RTF: the
-  // QVAC-24716 Windows regression only localized once decode ms/call was read
-  // out of the raw artifacts (encode flat, decode 3.5 -> 9.6 ms/call).
-  const encodeMs = summary.whisperEncodeMs || {}
-  const decodeMs = summary.whisperDecodeMs || {}
   const memory = summary.memory || {}
   const platformName = report.platformName || report.platform || ''
   const useGPU = Boolean(
@@ -329,8 +331,7 @@ function normalizeReport (report, sourceFile, source) {
     p50: Number(rtf.p50),
     p95: Number(rtf.p95),
     wallMs: Number(wallMs.mean),
-    encodeMs: Number(encodeMs.mean),
-    decodeMsPerCall: Number(decodeMs.mean),
+    ...whisperPhaseTimings(summary),
     avgRssMb: numberOrNaN(memory.avgRssMb),
     peakRssMb: numberOrNaN(memory.peakRssMb),
     reclaimedMb: numberOrNaN(memory.reclaimedMb),


### PR DESCRIPTION
## What problem does this PR solve?

QVAC-24716 asked to confirm and bisect the Windows whisper base-quant CPU regression seen in Benchmark Results between asr-ggml 0.3.0 (run [31603189415](https://github.com/tetherto/qvac/actions/runs/31603189415), 2026-08-12) and 0.4.2 (runs [34053466802](https://github.com/tetherto/qvac/actions/runs/34053466802) / [34062003154](https://github.com/tetherto/qvac/actions/runs/34062003154), 2026-09-06).

**Confirmed.** Three runs, tight stddevs, `qvac-win25-x64-gpu`, CPU lanes (RTF, mean):

| Model | Aug 12 (0.3.0) | Sep 6 19:00 (0.4.2) | Sep 6 21:45 (0.4.2) |
|---|---|---|---|
| base-q5_1 | 0.0358 | 0.0661 (+85%) | 0.0603 (+68%) |
| base-q8_0 | 0.0374 | 0.0643 (+72%) | 0.0559 (+49%) |
| base f32 | 0.0553 | 0.0665 (+20%) | 0.0624 (+13%) |
| small (all quants) | — | +1..8% | -1..+7% |

**Localized.** The regression is not in the RTF the report shows — it is in the decoder, visible only in the raw artifacts' phase timers. Encoder per-call time is flat (q5_1: 388 -> 391 ms); decode per-call rose to a ~9.4–9.9 ms floor for every base variant (q5_1 3.52 -> 9.61, q8_0 4.72 -> 9.40, f32 8.16 -> 9.92), while small (12.1–15.9 ms/call, already above the floor) is untouched and token counts are identical. Windows Vulkan decode is fine (1.1–2.6 ms/call), and every parakeet CPU lane on the same box is stable within 1%, so the machine, the shared ggml kernels, and the GPU path are all exonerated.

**Bisected (static).** Between the two runs whisper moved from the standalone `whisper-cpp` port (qvac-ext-lib-whisper.cpp@928369c9, ggml-speech 2026-07-29 @ f102f946) to the `speech-cpp` umbrella (fabric@5b51971e, ggml-speech 2026-09-04#0 @ c393f11b). Every code-level candidate in that window checks out clean:

- ggml diff f102f946 -> c393f11b: additive only (LSTM_CELL / TDT_STEP ops, SIGLU); no threadpool, mul_mat scheduling, or quant-kernel changes.
- whisper subtree diff 928369c9 -> 5b51971e: two VAD-only changes (QVAC-24420); decode path untouched.
- Windows port flags identical on both sides (`GGML_NATIVE=OFF`, `GGML_OPENMP=OFF`, static, no `GGML_CPU_ALL_VARIANTS` — the DL/ALL_VARIANTS blocks cover Android, linux-arm64, and linux-x64+cuda only).
- Addon thread mapping unchanged (`threads: 0` -> `hardware_concurrency / 2` on both SHAs); benchmark config byte-identical in the artifacts.

What remains is a per-graph-launch cost on the Windows CPU backend (~62 sequential small decode graphs per run pay it; the single big encode graph and parakeet's unrolled decode graphs do not), which static analysis cannot attribute further.

**Verdict — runner environment, not code.** Two A/B dispatches on today's runner, same main harness, only the engine package differing ([0.3.0](https://github.com/tetherto/qvac/actions/runs/34330232236) vs [0.4.2](https://github.com/tetherto/qvac/actions/runs/34330248311)):

| Model (CPU) | 0.3.0 pkg, Aug 12 | 0.3.0 pkg, today | 0.4.2 pkg, today |
|---|---|---|---|
| base-q5_1 RTF | 0.0358 | 0.0607 | 0.0628 |
| base-q5_1 dec (ms/call) | 3.52 | 9.84 | 10.34 |
| base-q8_0 RTF | 0.0374 | 0.0614 | 0.0610 |
| small-q8_0 RTF | 0.1168 | 0.1231 | 0.1208 |

The 0.3.0 package reproduces the slow numbers on today's box: the ~10 ms/call decode floor is environmental on `qvac-win25-x64-gpu`, appearing between Aug 12 and Sep 6 (the win Vulkan lanes improving ~27% in the same window points at a driver/OS maintenance event; a power-plan/core-parking change would produce exactly this tiny-graph launch tax). The engines, addon, and ports are exonerated — no speech-side code fix applies. Follow-up is fleet-side: audit the box's Windows/driver updates and power plan from that window. An engine-side mitigation exists independently: Windows prebuilds still ship the static baseline CPU backend, while linux-x64 gained hybrid `GGML_BACKEND_DL` + `GGML_CPU_ALL_VARIANTS` builds (which is what improved the Linux CPU lanes 33–54% in the same reports).

## How does it solve it?

The report change that makes this class of regression visible without hand-reading raw artifacts: `aggregate-asr-ggml-rtf.js` now surfaces the whisper phase timers the artifacts already carry — `summary.whisperEncodeMs.mean` and `summary.whisperDecodeMs.mean` — as `Enc (ms/call)` and `Dec (ms/call)` columns in the markdown and HTML tables and as `encodeMs` / `decodeMsPerCall` fields in the JSON records (desktop and flattened manual rows). Parakeet reports have no whisper timers, so those rows render `n/a`, consistent with the existing missing-value style.

With these columns the regression reads directly off the findings table: base CPU rows show Dec 9.40–9.92 ms/call against 1.08–1.33 on the same box's Vulkan lanes.

## How was it tested?

- `node --test scripts/perf-report/__tests__/aggregate-asr-ggml-rtf.test.js` — 34/34 pass (5 new: phase-timing extraction, NaN fallback for reports without the timers, markdown and HTML columns with formatted values and `n/a` parakeet cells, flattened manual-row passthrough).
- `npx standard` clean on both changed files.
- Smoke run against the real `rtf-results-asr-ggml-qvac-win25-x64-gpu-x64-gpu` artifact from run 34062003154: 48 rows render, whisper rows carry `390.8 | 9.61`-style values, parakeet rows `n/a`, coverage section unchanged.

No addon or workflow change; report tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218245854379338