### PR TITLE
chore[notask]: release @qvac/rag v0.8.1

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.8.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.1
+
+This patch makes TurboVec-backed RAG usable on Windows. In 0.8.0 every attempt to open a TurboVec workspace failed there, and the package could not be built on Windows at all.
+
+## Fixed
+
+### TurboVec workspaces open and checkpoint on Windows
+
+`TurboVecAdapter` forces its writer lock and its checkpoint files to disk before installing them, and Windows refuses that unless the file was opened for writing. Opening a workspace therefore always ended in `Failed to acquire the TurboVec writer lock`. Workspaces now open, checkpoints complete, and the journal records a checkpoint covers are pruned, so a Windows workspace no longer retains every mutation record. When the lock genuinely cannot be taken, the error names the underlying reason rather than only a generic code.
+
+### `@qvac/rag` builds on Windows
+
+Installing the package on Windows failed while running its build, because the build scripts derived their own directory from a file URL and produced a doubled drive letter (`C:\C:\...`). The integration test and the quickstart example resolved their fixture paths the same way.
+
 ## [0.8.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.0

--- a/packages/rag/changelog/0.8.1/CHANGELOG.md
+++ b/packages/rag/changelog/0.8.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.8.1
+
+Release Date: 2026-09-09
+
+## 🐞 Fixes
+
+- Make TurboVec RAG work on Windows. Opening a workspace, taking a checkpoint and pruning the journal a checkpoint covers all succeed there, and the package builds on Windows. (see PR [#4272](https://github.com/tetherto/qvac/pull/4272))

--- a/packages/rag/changelog/0.8.1/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.8.1/CHANGELOG_LLM.md
@@ -1,0 +1,15 @@
+# QVAC RAG v0.8.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.1
+
+This patch makes TurboVec-backed RAG usable on Windows. In 0.8.0 every attempt to open a TurboVec workspace failed there, and the package could not be built on Windows at all.
+
+## Fixed
+
+### TurboVec workspaces open and checkpoint on Windows
+
+`TurboVecAdapter` forces its writer lock and its checkpoint files to disk before installing them, and Windows refuses that unless the file was opened for writing. Opening a workspace therefore always ended in `Failed to acquire the TurboVec writer lock`. Workspaces now open, checkpoints complete, and the journal records a checkpoint covers are pruned, so a Windows workspace no longer retains every mutation record. When the lock genuinely cannot be taken, the error names the underlying reason rather than only a generic code.
+
+### `@qvac/rag` builds on Windows
+
+Installing the package on Windows failed while running its build, because the build scripts derived their own directory from a file URL and produced a doubled drive letter (`C:\C:\...`). The integration test and the quickstart example resolved their fixture paths the same way.

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rag/src/errors.ts
+++ b/packages/rag/src/errors.ts
@@ -98,4 +98,4 @@ const definitions: ErrorCodesMap = {
   }
 }
 
-addCodes(definitions, { name: '@qvac/rag', version: '0.8.0' })
+addCodes(definitions, { name: '@qvac/rag', version: '0.8.1' })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Publish `@qvac/rag` `0.8.1` from `release-rag-0.8.1`.
- `main` already has the Windows fix ([#4272](https://github.com/tetherto/qvac/pull/4272)). It is not on npm; latest published is `0.8.0`.
- Against the published `0.8.0`, Windows cannot open a TurboVec workspace and the package cannot be built at all, so the SDK e2e `rag-turbovec-ingest-search` still fails on Windows.

## 📝 How does it solve it?

- Bump `packages/rag/package.json` `0.8.0 → 0.8.1`.
- Bump the error metadata version in `packages/rag/src/errors.ts` `0.8.0 → 0.8.1`, which `test/unit/error-version.test.ts` asserts against `package.json`.
- Add `changelog/0.8.1/` (raw + human-readable notes).
- Rebuild `packages/rag/CHANGELOG.md` with `scripts/sdk/generate-changelog-sdk-pod.cjs --package=rag --update-root-changelog`.
- Fragments written by hand: the generator's base resolution fail-stops because `rag-v0.8.0` points at `a9a51241a` on `release-rag-0.8.0` and is not an ancestor of `main`, and the range holds a single includable PR.
- `NOTICE` unchanged — the fix adds `bare-url` to `devDependencies` only, and NOTICE covers production dependencies.

## 🧪 How was it tested?

- Changelog range `rag-v0.8.0..main -- packages/rag`: three commits, one included ([#4272](https://github.com/tetherto/qvac/pull/4272)); the devDependency bump ([#4207](https://github.com/tetherto/qvac/pull/4207)) and the 0.8.0 release metadata ([#4095](https://github.com/tetherto/qvac/pull/4095)) excluded as having no informational value.
- `packages/rag/CHANGELOG.md` carries a literal `## [0.8.1]` heading, which `create-github-release.yml` extracts with `^## \[<version>\]`.
- `bun run format` and `bun run test:unit` pass in `packages/rag` (160/160 tests, 848/848 assertions).
- The shipped fix was verified on macOS and Windows before merge: `test:unit` 159/159, `test:integration` 12/12 with the real embedder and native index.
