### PR TITLE
chore[skiplog|notask]: backmerge release-rag-0.8.1 — version bump, changelog

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.8.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.1
+
+This patch makes TurboVec-backed RAG usable on Windows. In 0.8.0 every attempt to open a TurboVec workspace failed there, and the package could not be built on Windows at all.
+
+## Fixed
+
+### TurboVec workspaces open and checkpoint on Windows
+
+`TurboVecAdapter` forces its writer lock and its checkpoint files to disk before installing them, and Windows refuses that unless the file was opened for writing. Opening a workspace therefore always ended in `Failed to acquire the TurboVec writer lock`. Workspaces now open, checkpoints complete, and the journal records a checkpoint covers are pruned, so a Windows workspace no longer retains every mutation record. When the lock genuinely cannot be taken, the error names the underlying reason rather than only a generic code.
+
+### `@qvac/rag` builds on Windows
+
+Installing the package on Windows failed while running its build, because the build scripts derived their own directory from a file URL and produced a doubled drive letter (`C:\C:\...`). The integration test and the quickstart example resolved their fixture paths the same way.
+
 ## [0.8.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.0

--- a/packages/rag/changelog/0.8.1/CHANGELOG.md
+++ b/packages/rag/changelog/0.8.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.8.1
+
+Release Date: 2026-09-09
+
+## 🐞 Fixes
+
+- Make TurboVec RAG work on Windows. Opening a workspace, taking a checkpoint and pruning the journal a checkpoint covers all succeed there, and the package builds on Windows. (see PR [#4272](https://github.com/tetherto/qvac/pull/4272))

--- a/packages/rag/changelog/0.8.1/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.8.1/CHANGELOG_LLM.md
@@ -1,0 +1,15 @@
+# QVAC RAG v0.8.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.8.1
+
+This patch makes TurboVec-backed RAG usable on Windows. In 0.8.0 every attempt to open a TurboVec workspace failed there, and the package could not be built on Windows at all.
+
+## Fixed
+
+### TurboVec workspaces open and checkpoint on Windows
+
+`TurboVecAdapter` forces its writer lock and its checkpoint files to disk before installing them, and Windows refuses that unless the file was opened for writing. Opening a workspace therefore always ended in `Failed to acquire the TurboVec writer lock`. Workspaces now open, checkpoints complete, and the journal records a checkpoint covers are pruned, so a Windows workspace no longer retains every mutation record. When the lock genuinely cannot be taken, the error names the underlying reason rather than only a generic code.
+
+### `@qvac/rag` builds on Windows
+
+Installing the package on Windows failed while running its build, because the build scripts derived their own directory from a file URL and produced a doubled drive letter (`C:\C:\...`). The integration test and the quickstart example resolved their fixture paths the same way.

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rag/src/errors.ts
+++ b/packages/rag/src/errors.ts
@@ -98,4 +98,4 @@ const definitions: ErrorCodesMap = {
   }
 }
 
-addCodes(definitions, { name: '@qvac/rag', version: '0.8.0' })
+addCodes(definitions, { name: '@qvac/rag', version: '0.8.1' })


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/rag@0.8.1` on `main`, per [gitflow.md](../docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- https://github.com/tetherto/qvac/pull/4363

## Files

- `packages/rag/package.json` — version `0.8.0` → `0.8.1`
- `packages/rag/src/errors.ts` — error metadata version `0.8.0` → `0.8.1`
- `packages/rag/changelog/0.8.1/` — generated changelog files
- `packages/rag/CHANGELOG.md` — aggregated changelog
