### PR TITLE
QVAC-24729 feat: add CUDA support for audiogen on linux-arm64 and win32-x64

### DIFF
--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Extend opt-in CUDA builds (`ENABLE_CUDA=ON`) from linux-x64 to linux-arm64
+  and win32-x64. CUDA, Vulkan, and CPU variants ship as runtime-loaded modules
+  beside the addon, allowing hosts without an NVIDIA stack to fall back to
+  Vulkan or CPU. Published prebuilds remain CUDA-free.
 - `generateLrc` generation control: karaoke-style synchronized lyric
   timestamps in `stats.lrc` (standard LRC text) with an alignment confidence
   in `stats.lyricsScore`. Requires lyrics — explicit or Simple-Mode written —
@@ -31,9 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Require `speech-cpp` port revision `2026-09-03#1`, which adds the engine's
+- Require `speech-cpp` port revision `2026-09-04#1`, which adds the engine's
   ACE-Step LRC generation, audio understanding (reverse pipeline) and Query
-  Rewriting (FORMAT pass) on top of the teacher-forced LM quality scoring.
+  Rewriting (FORMAT pass) on top of the teacher-forced LM quality scoring,
+  fixes Windows CUDA engine unloading, and refreshes backend capabilities after
+  module reloads. Floor `ggml-speech` at 2026-09-09 for hybrid CUDA modules on
+  linux-arm64 and win32-x64 and correct module-local timing initialization.
 
 ## [0.3.3] - 2026-09-01
 

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -38,9 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require `speech-cpp` port revision `2026-09-04#1`, which adds the engine's
   ACE-Step LRC generation, audio understanding (reverse pipeline) and Query
   Rewriting (FORMAT pass) on top of the teacher-forced LM quality scoring,
-  fixes Windows CUDA engine unloading, and refreshes backend capabilities after
-  module reloads. Floor `ggml-speech` at 2026-09-09 for hybrid CUDA modules on
-  linux-arm64 and win32-x64 and correct module-local timing initialization.
+  and rejects `[Instrumental]` lyrics under Query Rewriting. Floor
+  `ggml-speech` at 2026-09-09 for hybrid CUDA modules on linux-arm64 and
+  win32-x64 and correct module-local timing initialization.
 
 ## [0.3.3] - 2026-09-01
 

--- a/packages/audiogen-ggml/CMakeLists.txt
+++ b/packages/audiogen-ggml/CMakeLists.txt
@@ -64,10 +64,19 @@ if((ANDROID OR UNIX) AND NOT APPLE)
 endif()
 
 set(BACKEND_DL_LOOSE_SOS "")
-if((ANDROID OR UNIX) AND NOT APPLE)
-  if(VCPKG_INSTALLED_PATH AND EXISTS "${VCPKG_INSTALLED_PATH}/lib")
+if(((ANDROID OR UNIX) AND NOT APPLE) OR (WIN32 AND ENABLE_CUDA))
+  if(NOT VCPKG_INSTALLED_PATH OR NOT EXISTS "${VCPKG_INSTALLED_PATH}/lib")
+    message(WARNING "audiogen-ggml: VCPKG_INSTALLED_PATH "
+      "('${VCPKG_INSTALLED_PATH}') has no lib/ dir; skipping loose "
+      "ggml backend module pickup -- the runtime may fail to find "
+      "Vulkan / OpenCL / CUDA backends.")
+  else()
     file(GLOB BACKEND_DL_LOOSE_SOS
-      "${VCPKG_INSTALLED_PATH}/lib/libqvac-speech-ggml-*.so")
+      "${VCPKG_INSTALLED_PATH}/lib/libqvac-speech-ggml-*.so"
+      "${VCPKG_INSTALLED_PATH}/lib/qvac-speech-ggml-*.dll")
+    foreach(_lib IN LISTS BACKEND_DL_LOOSE_SOS)
+      message(STATUS "audiogen-ggml: will stage ggml backend ${_lib}")
+    endforeach()
   endif()
 endif()
 

--- a/packages/audiogen-ggml/README.md
+++ b/packages/audiogen-ggml/README.md
@@ -40,23 +40,26 @@ Android arm64, and iOS arm64. You also need the model GGUFs on disk (see
 [Models](#models)); point the addon at the folder that holds them.
 MiniMax-Music3 is available only in the Linux, macOS, and Windows prebuilds.
 
-The published linux-x64 prebuild ships Vulkan. CUDA is opt-in at build time
-via `bare-make generate -D ENABLE_CUDA=ON` (needs `nvcc` on the build host).
-When CUDA is compiled in, ggml runs in hybrid dynamically-loaded backend
-mode: the CPU-variant, Vulkan, and CUDA backends ship as `.so` modules beside
-the addon, and only the CUDA module depends on the CUDA runtime. Engaging
-CUDA needs the NVIDIA driver plus the CUDA 13 runtime libraries (cudart and
-cuBLAS) resolvable at load time; hosts that cannot resolve them skip the
-module and fall back to Vulkan or CPU. The engine prefers CUDA when both GPU
-backends are usable.
+The published Linux and Windows prebuilds ship Vulkan. CUDA is opt-in at build
+time on linux-x64, linux-arm64, and win32-x64 via
+`bare-make generate -D ENABLE_CUDA=ON` (needs `nvcc` on the build host). When
+CUDA is compiled in, ggml runs in hybrid dynamically-loaded backend mode: the
+CPU-variant, Vulkan, and CUDA backends ship as runtime-loaded modules (`.so` on
+Linux, `.dll` on Windows) beside the addon, and only the CUDA module depends on
+the CUDA runtime. Engaging CUDA needs the NVIDIA driver plus the CUDA 13 runtime
+libraries (cudart and cuBLAS) resolvable at load time; hosts that cannot resolve
+them skip the module and fall back to Vulkan or CPU. The engine prefers CUDA
+when both GPU backends are usable.
 
-A CUDA build's module targets **compute capability 7.5 and newer**, with
-native code for Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6),
-Ada (8.9), Hopper (9.0) and Blackwell (12.0, 12.1). Anything newer JIT-compiles
-from the bundled 8.0 PTX on first use, a one-off compile the driver caches.
-Volta and Pascal fall outside CUDA 13's support entirely, so they have no code
-path here: the backend skips such devices at registration and the addon falls
-back to Vulkan or CPU.
+On x64 a CUDA build's module targets **compute capability 7.5 and newer**, with
+native code for Turing (7.5 — RTX 20xx, GTX 16xx, T4), Ampere (8.0, 8.6), Ada
+(8.9), Hopper (9.0), and Blackwell (12.0, 12.1). Anything newer JIT-compiles
+from the bundled 8.0 PTX on first use, a one-off compile the driver caches. On
+linux-arm64 the native set is Jetson Orin (8.7), Grace-Hopper (9.0), and
+GB10 / DGX Spark (12.1), with discrete Ampere+ cards and newer parts covered
+through the bundled 8.0 PTX. Volta and Pascal fall outside CUDA 13's support
+entirely, so they have no code path here: the backend skips such devices at
+registration and the addon falls back to Vulkan or CPU.
 
 To build the native addon from source in a repository checkout:
 

--- a/packages/audiogen-ggml/index.js
+++ b/packages/audiogen-ggml/index.js
@@ -280,6 +280,7 @@ const ACESTEP_GENERATE_KEYS = [
     'guidanceScale',
     'audioCoverStrength',
     'coverNoiseStrength',
+    'generateLrc',
     'computeQualityScore',
     'rewriteQuery'
 ];
@@ -493,6 +494,7 @@ class AudioGen {
     _destroyed;
     _cancelPromise;
     _cancellingResponse;
+    _lastLrc;
     _cancelTerminalResolve;
     _lastUnderstand;
     constructor(options = {}) {
@@ -555,6 +557,7 @@ class AudioGen {
         this._cancelPromise = null;
         this._cancellingResponse = null;
         this._cancelTerminalResolve = null;
+        this._lastLrc = undefined;
     }
     /** Create the native engine and load its GGUF files. Idempotent. */
     async load() {
@@ -677,6 +680,7 @@ class AudioGen {
             throw this._lifecycleError();
         }
         const addon = this._requireAddon();
+        this._lastLrc = undefined;
         this._lastUnderstand = undefined;
         const response = this._job.start();
         let accepted;
@@ -757,6 +761,20 @@ class AudioGen {
         if (opts.normalizeLoudness !== undefined && typeof opts.normalizeLoudness !== 'boolean') {
             throw invalidInput('normalizeLoudness must be a boolean');
         }
+        if (opts.generateLrc !== undefined && typeof opts.generateLrc !== 'boolean') {
+            throw invalidInput('generateLrc must be a boolean');
+        }
+        if (opts.generateLrc === true) {
+            if (taskType !== undefined && taskType !== 'text2music') {
+                throw invalidInput("generateLrc requires taskType 'text2music'");
+            }
+            if (opts.lyrics === '[Instrumental]') {
+                throw invalidInput('generateLrc requires lyrics to align');
+            }
+            if (opts.simpleMode !== true && (opts.lyrics === undefined || opts.lyrics === '')) {
+                throw invalidInput('generateLrc requires lyrics to align');
+            }
+        }
         if (opts.computeQualityScore !== undefined && typeof opts.computeQualityScore !== 'boolean') {
             throw invalidInput('computeQualityScore must be a boolean');
         }
@@ -814,6 +832,7 @@ class AudioGen {
             simpleMode: opts.simpleMode,
             rewriteQuery: opts.rewriteQuery,
             normalizeLoudness: opts.normalizeLoudness,
+            generateLrc: opts.generateLrc,
             computeQualityScore: opts.computeQualityScore,
             seed: optionalFiniteNumber(opts.seed, 'seed', true),
             vocalLanguage: opts.vocalLanguage,
@@ -981,10 +1000,12 @@ class AudioGen {
             return;
         }
         if (d.outputArray) {
+            this._lastLrc = typeof d.lrc === 'string' ? d.lrc : undefined;
             this._job.output({
                 outputArray: d.outputArray,
                 sampleRate: d.sampleRate ?? 0,
-                channels: d.channels ?? 0
+                channels: d.channels ?? 0,
+                ...(this._lastLrc !== undefined ? { lrc: this._lastLrc } : {})
             });
             return;
         }
@@ -1012,6 +1033,8 @@ class AudioGen {
                 ...(typeof d.gpuFallbackReason === 'number'
                     ? { gpuFallbackReason: d.gpuFallbackReason }
                     : {}),
+                ...(typeof d.lyricsScore === 'number' ? { lyricsScore: d.lyricsScore } : {}),
+                ...(this._lastLrc !== undefined ? { lrc: this._lastLrc } : {}),
                 ...(typeof d.qualityScore === 'number' ? { qualityScore: d.qualityScore } : {}),
                 ...(this._lastUnderstand !== undefined ? { understand: this._lastUnderstand } : {})
             };

--- a/packages/audiogen-ggml/scripts/__tests__/build-backends.test.js
+++ b/packages/audiogen-ggml/scripts/__tests__/build-backends.test.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const packageRoot = path.resolve(__dirname, '..', '..')
+const cmakeSource = fs.readFileSync(path.join(packageRoot, 'CMakeLists.txt'), 'utf8')
+const vcpkgManifest = JSON.parse(fs.readFileSync(path.join(packageRoot, 'vcpkg.json'), 'utf8'))
+
+const CUDA_OPTION = 'ENABLE_CUDA'
+const CUDA_FEATURE = 'cuda'
+const GGML_PORT = 'ggml-speech'
+const SPEECH_PORT = 'speech-cpp'
+const DESKTOP_PLATFORM = '!(osx | ios | android)'
+
+function namedDependencies(dependencies, name) {
+  return dependencies.filter((dependency) => dependency.name === name)
+}
+
+function cudaSpeechDependency() {
+  return namedDependencies(vcpkgManifest.features[CUDA_FEATURE].dependencies, SPEECH_PORT)[0]
+}
+
+test('the CUDA build remains opt-in', () => {
+  assert.match(cmakeSource, new RegExp(`option\\(${CUDA_OPTION} "[^"]+" OFF\\)`))
+  assert.match(
+    cmakeSource,
+    new RegExp(
+      `if\\(${CUDA_OPTION}\\)\\s*\\n\\s*list\\(APPEND VCPKG_MANIFEST_FEATURES "${CUDA_FEATURE}"\\)`
+    )
+  )
+})
+
+test('the CUDA feature targets supported desktop platforms', () => {
+  const dependency = cudaSpeechDependency()
+
+  assert.deepEqual(dependency.features, [CUDA_FEATURE])
+  assert.equal(dependency['default-features'], false)
+  assert.equal(dependency.platform, DESKTOP_PLATFORM)
+})
+
+test('the hybrid backend dependency floors match the reviewed speech stack', () => {
+  const ggmlDependency = namedDependencies(vcpkgManifest.dependencies, GGML_PORT)[0]
+  const speechDependencies = namedDependencies(vcpkgManifest.dependencies, SPEECH_PORT)
+
+  assert.equal(ggmlDependency['version>='], '2026-09-09')
+  assert.equal(ggmlDependency['default-features'], false)
+  assert.equal(cudaSpeechDependency()['version>='], '2026-09-04#1')
+  assert.equal(
+    speechDependencies.every((dependency) => dependency['version>='] === '2026-09-04#1'),
+    true
+  )
+})
+
+test('the Windows CUDA build stages runtime-loaded backend modules', () => {
+  assert.match(cmakeSource, /\(WIN32 AND ENABLE_CUDA\)/)
+  assert.match(cmakeSource, /qvac-speech-ggml-\*\.dll/)
+  assert.equal(/CUDA::/.test(cmakeSource), false)
+})

--- a/packages/audiogen-ggml/scripts/__tests__/build-backends.test.js
+++ b/packages/audiogen-ggml/scripts/__tests__/build-backends.test.js
@@ -36,6 +36,7 @@ test('the CUDA build remains opt-in', () => {
 test('the CUDA feature targets supported desktop platforms', () => {
   const dependency = cudaSpeechDependency()
 
+  assert.equal(vcpkgManifest.features[CUDA_FEATURE].supports, DESKTOP_PLATFORM)
   assert.deepEqual(dependency.features, [CUDA_FEATURE])
   assert.equal(dependency['default-features'], false)
   assert.equal(dependency.platform, DESKTOP_PLATFORM)

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -9,8 +9,13 @@
       "version>=": "1.4.4#3"
     },
     {
+      "name": "ggml-speech",
+      "version>=": "2026-09-09",
+      "default-features": false
+    },
+    {
       "name": "speech-cpp",
-      "version>=": "2026-09-03#1",
+      "version>=": "2026-09-04#1",
       "default-features": false,
       "features": [
         "audiogen",
@@ -20,7 +25,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-03#1",
+      "version>=": "2026-09-04#1",
       "default-features": false,
       "features": [
         "audiogen",
@@ -31,7 +36,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-03#1",
+      "version>=": "2026-09-04#1",
       "default-features": false,
       "features": [
         "audiogen",
@@ -46,7 +51,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-03#1",
+          "version>=": "2026-09-04#1",
           "default-features": false,
           "features": [
             "cuda"
@@ -66,7 +71,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-03#1",
+          "version>=": "2026-09-04#1",
           "default-features": false,
           "features": [
             "vulkan"

--- a/packages/audiogen-ggml/vcpkg.json
+++ b/packages/audiogen-ggml/vcpkg.json
@@ -48,6 +48,7 @@
   "features": {
     "cuda": {
       "description": "Enable CUDA GPU acceleration",
+      "supports": "!(osx | ios | android)",
       "dependencies": [
         {
           "name": "speech-cpp",


### PR DESCRIPTION
## Summary

- extend opt-in AudioGen CUDA builds from linux-x64 to linux-arm64 and win32-x64
- stage CUDA, Vulkan, and CPU backend DLLs beside the Windows addon for runtime loading and graceful fallback
- align the speech-cpp and ggml-speech floors with the CUDA stack used by the ASR implementation under review
- document the supported targets and add build-configuration regression coverage
- keep published prebuilds CUDA-free

## Validation

- AudioGen unit tests: 163 passed
- build and script tests: 20 passed
- package contract tests: 61 passed
- TypeScript typecheck and declaration checks passed
- JavaScript formatting and lint checks passed
- TypeScript lint passed
- git diff whitespace check passed

## Notes

The implementation follows the runtime-loaded backend approach already merged for TTS and currently exercised by QVAC-24728 for ASR. CUDA remains an explicit ENABLE_CUDA source-build option; systems without a usable NVIDIA stack continue falling back to Vulkan or CPU.
