### PR TITLE
QVAC-24861 chore: bump @qvac/rag to ^0.8.1

### DIFF
--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -164,7 +164,7 @@
     "@qvac/error": "^0.1.1",
     "@qvac/logging": "^0.1.1",
     "@qvac/model-fit": "^0.8.0",
-    "@qvac/rag": "^0.8.0",
+    "@qvac/rag": "^0.8.1",
     "@qvac/registry-client": "^0.6.1",
     "bare-abort-controller": "^1.1.2",
     "bare-buffer": "^3.6.2",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/rag` 0.8.0 cannot open a TurboVec workspace on Windows, and cannot be built there. Both are fixed in 0.8.1 ([#4363](https://github.com/tetherto/qvac/pull/4363)).
- Inference's range accepts 0.8.0, so an install can still resolve the broken version.

## 📝 How does it solve it?

- Raise `@qvac/rag` in `packages/inference/package.json` from `^0.8.0` to `^0.8.1`, making the fix the floor rather than something the caret happens to pick up.

## 🧪 How was it tested?

- `bun run format` passes in `packages/inference`.
- Range change only; no source touched.
