### PR TITLE
QVAC-24703 asr-ggml: consume the Parakeet CPU speedups (speech-cpp 2026-09-09)

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -52,6 +52,16 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ### Changed
 
+- Raise the `speech-cpp` floor to 2026-09-09 (ggml-speech 2026-09-09#1).
+  Parakeet CPU transcription is 2.2 to 2.6x faster on x86 desktops: the TDT
+  decoder runs as ggml graphs instead of a host loop, positional projections
+  are cached per graph, and the encoder drops several full-tensor copies.
+  ggml now builds with tinyBLAS on linux-x64 and darwin-arm64, and the
+  linux-x64 prebuild ships the per-arch CPU backend modules beside the addon
+  (AVX-512 hosts no longer run the AVX2 kernels), the same hybrid layout the
+  cuda build already used. The window also carries the memory-fit preflight
+  APIs, the hybrid RNN-T head, and Nemotron OpenCL support.
+
 - Raise the `speech-cpp` floor to 2026-09-03. Silero VAD now honors
   `use_gpu`: the compute backends match the weight placement, fixing the
   ggml_backend_sched abort ("pre-allocated tensor in a buffer that cannot

--- a/packages/asr-ggml/CMakeLists.txt
+++ b/packages/asr-ggml/CMakeLists.txt
@@ -7,9 +7,10 @@ option(ENABLE_COVERAGE "Enable coverage" OFF)
 # speech-cpp dependencies in vcpkg.json. CUDA is opt-in because it needs
 # nvcc on the build host; published prebuilds ship without it, and the
 # runtime needs only the NVIDIA driver plus resolvable CUDA runtime
-# libraries. On linux-x64, linux-arm64 and win32-x64 the cuda feature
-# flips the ggml-speech port into hybrid GGML_BACKEND_DL mode: every
-# backend (CPU variants, Vulkan, CUDA) arrives as a runtime-loadable
+# libraries. Every linux-x64 and linux-arm64 build of the ggml-speech
+# port, and win32-x64 with the cuda feature, runs in hybrid
+# GGML_BACKEND_DL mode: every backend (CPU variants, Vulkan, CUDA when
+# enabled) arrives as a runtime-loadable
 # MODULE (.so / .dll) that the loose-file pickup below stages next to
 # the .bare, and only the CUDA module links the CUDA runtime, so hosts
 # that cannot resolve it skip it and fall back to Vulkan or CPU. No
@@ -102,7 +103,7 @@ message(STATUS "Building asr-ggml with BACKENDS_SUBDIR='${BACKENDS_SUBDIR_VALUE}
 #   2. Loose MODULE files that ggml-config deliberately omits from
 #      GGML_AVAILABLE_BACKENDS' IMPORTED set (Vulkan + OpenCL on
 #      Android; CPU variants + Vulkan + CUDA on hybrid desktop builds:
-#      linux-arm64, linux-x64 / win32-x64 with ASR_CUDA) — the loader
+#      linux-arm64, every linux-x64 build, win32-x64 with ASR_CUDA) — the loader
 #      picks them up at runtime via `ggml_backend_load_all_from_path()`.
 # Hybrid-mode caveat: the ggml-speech vcpkg port builds Android with
 # GGML_BACKEND_DL=ON + GGML_CPU_STATIC=ON, so only the CPU backend

--- a/packages/asr-ggml/README.md
+++ b/packages/asr-ggml/README.md
@@ -512,10 +512,11 @@ gated behind the `ASR_CUDA` CMake option — supported on linux-x64,
 linux-arm64 and win32-x64. Published prebuilds do not enable it; build it
 yourself with `npm run build:cuda` (or `bare-make generate -D ASR_CUDA=ON`),
 which adds the `cuda` feature to the `speech-cpp` dependency and turns on
-`GGML_CUDA`. On these platforms the cuda feature flips ggml into hybrid
-dynamically-loaded backend mode: the CPU-variant, Vulkan, and CUDA backends
-ship as runtime-loaded modules (`.so` on Linux, `.dll` on Windows) next to
-the addon, and only the CUDA module depends on the CUDA runtime. Engaging
+`GGML_CUDA`. Every linux-x64 and linux-arm64 build, and win32-x64 with the
+cuda feature, uses ggml's hybrid dynamically-loaded backend mode: the
+per-arch CPU-variant and Vulkan backends ship as runtime-loaded modules
+(`.so` on Linux, `.dll` on Windows) next to the addon, the cuda builds add
+the CUDA module, and only that module depends on the CUDA runtime. Engaging
 CUDA requires the NVIDIA driver plus the CUDA 13 runtime libraries (cudart
 and cuBLAS) resolvable at load time; hosts that cannot resolve them —
 including CPU-only and non-NVIDIA machines — skip the module and fall back

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -12,12 +12,12 @@
     },
     {
       "name": "ggml-speech",
-      "version>=": "2026-09-09",
+      "version>=": "2026-09-09#1",
       "default-features": false
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-04#1",
+      "version>=": "2026-09-09",
       "default-features": false,
       "features": [
         "whisper",
@@ -29,7 +29,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-04#1",
+      "version>=": "2026-09-09",
       "default-features": false,
       "features": [
         "whisper",
@@ -41,7 +41,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-04#1",
+      "version>=": "2026-09-09",
       "default-features": false,
       "features": [
         "whisper",
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-04#1",
+          "version>=": "2026-09-09",
           "default-features": false,
           "features": [
             "cuda"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Parakeet CPU transcription trailed audio.cpp and transcribe.cpp by up to 2x on x86 and Apple silicon. The engine side landed in tetherto/qvac-fabric-speech.cpp#227 and the port side in tetherto/qvac-registry-vcpkg#360 (speech-cpp 2026-09-09, ggml-speech 2026-09-09#1), but the addon still pins speech-cpp 2026-09-03#2.

## 📝 How does it solve it?

- Raise the `speech-cpp` floor to 2026-09-09 on the three platform blocks and the cuda feature; ggml-speech 2026-09-09#1 follows through the port's own floor.
- What the new pin brings: TDT decode as ggml graphs instead of a host loop, cached positional projections, fewer encoder copies, tinyBLAS on linux-x64 and darwin-arm64, and the per-arch CPU backend modules on every linux-x64 build (before, only the cuda build shipped them). Measured on the engine: 2.2 to 2.6x on the 7950X3D and the Ryzen AI MAX+ 395 at q8_0, transcripts identical on every GPU path.
- The window also carries the memory-fit preflight APIs, the hybrid RNN-T head and Nemotron OpenCL support; public headers are additions only, so no addon source change.
- README and the CMake comments now say every linux-x64 build uses the hybrid dynamically-loaded layout; the loose `libqvac-speech-ggml-*.so` pickup that stages the modules beside the addon is unchanged, it was already exercised by the cuda builds.
- CHANGELOG entry under Unreleased. No package version bump (dependency floor only, as in #4247).

## 🧪 How was it tested?

- `vcpkg install --dry-run` in the addon resolves speech-cpp 2026-09-09 and ggml-speech 2026-09-09#1 from the registry at the merged git-trees.
- Local darwin-arm64 build of the addon against those port trees links, and the built ggml-cpu library carries the tinyBLAS symbols.
- The linux-x64 hybrid layout (CPU-variant + Vulkan modules staged beside the addon without cuda) needs the on-PR prebuild and integration lanes.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218302561663750