### PR TITLE
test[notask]: verify test-e2e-rerun-failed end to end (do not merge)

### DIFF
--- a/packages/sdk/e2e/tests/shared/executors/error-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/error-executor.ts
@@ -106,6 +106,11 @@ export class ErrorExecutor extends AbstractModelExecutor<typeof errorTests> {
   ) as never
 
   async invalidModelId(params: InvalidModelIdParams): Promise<TestResult> {
+    // VERIFICATION ONLY — not for merge. Forces a Windows-only failure so the
+    // rerun plan has to narrow to this test on this platform alone.
+    if (process.platform === 'win32') {
+      throw new Error('forced failure for test-e2e-rerun-failed verification (windows)')
+    }
     try {
       await embed({ modelId: params.modelId, text: 'test text' })
       return { passed: false, output: 'Expected error for invalid model ID' }
@@ -153,6 +158,11 @@ export class ErrorExecutor extends AbstractModelExecutor<typeof errorTests> {
     _params: VerifyErrorCodesParams,
     expectation: Expectation
   ): Promise<TestResult> {
+    // VERIFICATION ONLY — not for merge. Forces a Linux-only failure, so the two
+    // platforms end up with different failure sets.
+    if (process.platform === 'linux') {
+      throw new Error('forced failure for test-e2e-rerun-failed verification (linux)')
+    }
     const clientCount = SDK_CLIENT_ERROR_CODES ? Object.keys(SDK_CLIENT_ERROR_CODES).length : 0
     const serverCount = SDK_SERVER_ERROR_CODES ? Object.keys(SDK_SERVER_ERROR_CODES).length : 0
     return ValidationHelpers.validate(


### PR DESCRIPTION
## ⛔ Do not merge — throwaway verification PR

Exists only to exercise the `test-e2e-rerun-failed` label end to end for
QVAC-23918 / #4217. Both branches get deleted afterwards.

**Why it cannot be done on #4217:** `on-pr-test-sdk.yml` is
`pull_request_target`, so GitHub loads it — and its local composite actions —
from the **base branch** of the PR. Confirmed on #4217 itself: its runs show only
main's four jobs (`fork-approval`, `resolve-config`, `run-tests`, `apply-label`),
never the new ones. So the feature has to already be on the base branch to run,
which is what `verify/e2e-rerun-base` is for.

## Setup

- **Base** `verify/e2e-rerun-base` — #4217's commit, plus a narrowing of the label
  path so a run is cheap: desktop only (no Device Farm), two runners instead of
  three, `--filter=error-` (5 tests, ~106 ms total measured on a real run).
- **Head** (this branch) — `error-invalid-model-id` throws on Windows only,
  `error-structured-error-code` on Linux only, so each platform records a
  different single failure.

## What is being checked

Only the GitHub Actions wiring, which fixtures cannot cover — the script logic is
already covered by the 20 tests in `policy-tests` on #4217.

1. `test-e2e-rerun-failed` before any base run → refused, "no base run" comment.
2. `test-e2e-smoke` → base run, `record-base` finds the `results-*` artifacts of
   its own run id and writes the base state comment with one failure per platform.
3. `test-e2e-rerun-failed` → plan narrows to exactly those two ids, one per
   runner; the label clears itself.
4. Push a fix, label again → the same set re-runs and goes green.
