### PR TITLE
chore[notask]: DO NOT MERGE, overlay-validate the vector-index Darwin export fix

### DIFF
--- a/packages/fabric/vcpkg-configuration.json
+++ b/packages/fabric/vcpkg-configuration.json
@@ -1,4 +1,5 @@
 {
+  "overlay-ports": ["../../vcpkg-overlays/ports"],
   "default-registry": {
     "kind": "git",
     "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",

--- a/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
+++ b/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,238 @@
+# TEMPORARY: v10297.1.2 plus the vector-index visibility fix, from a fork branch.
+# Everything below is the registry port for 10297.1.2, unmodified. Replace this
+# stanza with `REPO tetherto/qvac-fabric-llm.cpp` / `REF v${VERSION}` and delete
+# the overlay once the fix is tagged upstream and published to the registry.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO jpgaribotti/qvac-fabric-llm.cpp
+  REF 48bdb64d723afded7b1223dfbe108dd5809d00e7
+  SHA512 c8179695e06da5a51d2f7f3debf0bc5715e4c19668ebed32cf9de79214d54c139fd6d5626363222894a8ac9602a472ddcb5e3c2b465120bd3c5b0dc29f8c62b1
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+    vector-index GGML_VECTOR_INDEX
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+    hip-backend BUILD_HIP_BACKEND
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # The Android NDK ships only the C Vulkan headers; the ggml Vulkan backend
+  # additionally needs the C++ bindings (vulkan.hpp) and SPIRV-Headers, which as
+  # of b9840 ggml fetches itself via FetchContent (ggml/src/ggml-vulkan/CMakeLists.txt,
+  # `if (ANDROID)` block). The registry vcpkg-cmake sets FETCHCONTENT_FULLY_DISCONNECTED=ON
+  # globally, so allow the fetch here (same as the kleidiai path below).
+  list(APPEND PLATFORM_OPTIONS -DFETCHCONTENT_FULLY_DISCONNECTED=OFF)
+endif()
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID OR (VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS))
+  # Desktop Linux also needs GGML_BACKEND_DL=ON so that multiple GPU backends
+  # (Vulkan + HIP/ROCm) can coexist as separately-loaded modules, the same way
+  # Android dispatches CPU variants at runtime. Without DL the Linux build links
+  # a single static GPU backend and a second one (HIP) cannot be stacked.
+  # GGML_NATIVE is incompatible with DL, so CPU variants are dispatched via
+  # GGML_CPU_ALL_VARIANTS instead. Consumers must ship the core ggml/llama libs
+  # alongside their backend modules so the dynamically-linked .bare can resolve
+  # them at load time.
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# HIP/ROCm backend — opt-in via the 'hip-backend' feature (Linux + AMD only).
+# Only @qvac/vla-ggml requests it, so every other consumer builds with no HIP
+# and gains no ROCm dependency. Builds libqvac-ggml-hip.so as a standalone DL
+# module alongside Vulkan (GGML_BACKEND_DL is already ON above), so the addon
+# dlopen's whichever GPU backend BackendSelection picks at runtime. The `hip`
+# feature-dependency port forwards the system ROCm's find_package() configs.
+#
+# FAIL-SAFE: enable GGML_HIP only when a ROCm SDK is actually present. On a build
+# host without ROCm we skip HIP and build Vulkan/CPU only — the build never
+# hard-fails, and at runtime a missing HIP module just isn't loaded (the DL
+# loader skips it) so BackendSelection falls back to Vulkan/CPU. Targets gfx1151
+# (Strix Halo / Radeon 8060S); the HIP compiler + ROCM_PATH come from the build env.
+# linux-x64 only: AMD GPU hosts (Strix Halo / gfx1151) are x86_64, and the ROCm
+# dist is x64. On other arches (e.g. linux-arm64) HIP is skipped even if the
+# feature is requested — no ROCm requirement, no build break.
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND BUILD_GPU_BACKENDS AND BUILD_HIP_BACKEND)
+  # DETERMINISTIC: requesting hip-backend REQUIRES a ROCm SDK at build time. We
+  # must NOT silently skip when ROCm is absent — a host-dependent skip yields a
+  # no-HIP package with the SAME vcpkg ABI as a real HIP build, which the binary
+  # cache then conflates (cache poisoning: a no-ROCm build caches a no-HIP
+  # package that ROCm-equipped builds then restore). So ROCm present => HIP;
+  # ROCm absent => hard error (don't request hip-backend on a host without ROCm).
+  # The RUNTIME fail-safe is unchanged: an absent HIP module / non-AMD target is
+  # simply not loaded and BackendSelection falls back to Vulkan/CPU.
+  if(NOT (DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/cmake/hip/hip-config.cmake"))
+    message(FATAL_ERROR "qvac-fabric: hip-backend feature requires a ROCm SDK — set ROCM_PATH to a ROCm/TheRock install containing lib/cmake/hip/hip-config.cmake. Do not request hip-backend on a host without ROCm.")
+  endif()
+  message(STATUS "qvac-fabric: hip-backend ON — building GGML_HIP (gfx1151)")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_HIP=ON
+    -DAMDGPU_TARGETS=gfx1151
+    -DCMAKE_HIP_ARCHITECTURES=gfx1151)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+# Under GGML_BACKEND_DL the per-microarch backends ship as standalone
+# libqvac-ggml-*.so modules that the consumer dlopen's at runtime. Built with
+# -stdlib=libc++ they otherwise carry a runtime NEEDED dependency on the system
+# libc++.so.1 / libc++abi.so.1, so they silently fail to dlopen on any target
+# without libc++ installed (e.g. stock ubuntu-24.04 — no CPU backend registers,
+# inference aborts). Statically link the C++ runtime into the modules so they
+# are self-contained, matching how the addons link themselves. The module<->addon
+# boundary is the C ggml-backend ABI, so per-module libc++ copies never exchange
+# C++ objects. Linux only: Apple/iOS use Metal frameworks, Android ships
+# libc++_shared via the NDK STL, Windows uses the MSVC runtime.
+if(VCPKG_TARGET_IS_LINUX AND DL_BACKENDS)
+  string(APPEND VCPKG_LINKER_FLAGS " -static-libstdc++")
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_BUILD_APP=OFF
+    -DMTMD_VIDEO=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
+++ b/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,61 @@
+{
+  "name": "qvac-fabric",
+  "version": "10297.1.3",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "hip-backend": {
+      "description": "Build the ROCm/HIP GPU backend (libqvac-ggml-hip.so) for AMD GPUs on Linux as a DL module alongside Vulkan. Opt-in (only @qvac/vla-ggml requests it). Fail-safe: if no ROCm SDK is present at build time the HIP backend is skipped (Vulkan/CPU only). Targets gfx1151 (Strix Halo). The 'hip' dependency forwards the system ROCm find_package configs.",
+      "dependencies": [
+        {
+          "name": "hip",
+          "platform": "linux & x64"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    },
+    "vector-index": {
+      "description": "Build and install the ggml vector index library."
+    }
+  }
+}


### PR DESCRIPTION
## DO NOT MERGE

Validation only. This overlays a fork build of `qvac-fabric` so the Darwin prebuilds can be inspected before
the fix is tagged upstream and published to `qvac-registry-vcpkg`. Precedent: #4348, #4100 — opened, never
merged.

## What problem does this PR solve?

`@qvac/fabric` 0.12.0 ships Apple modules that contain the ggml vector-index code but export none of it.
Checking the published package for `ggml_vec_index_create`:

| Prebuild | Exported |
|---|---|
| linux-x64, linux-arm64, android-arm64 | all 30 `ggml_vec_index_*`, as global `T` |
| win32-x64 | yes, via the generated `.def` |
| darwin-arm64, darwin-x64, ios-arm64, both iOS simulators | **none** |

A fabric-based `@qvac/embed-llamacpp` therefore links against symbols the runtime never exposes. Because
cmake-bare links Apple modules with `-Wl,-undefined,dynamic_lookup`, the miss doesn't fail the link — it
surfaces as a SIGSEGV on first call, which is what kills the macOS integration tests on #4362.

**Cause.** `ggml-vector-index` is the only ggml target that sets `CXX_VISIBILITY_PRESET hidden`, and in a
static build `GGML_API` expands to a bare `extern`, so the public C API is compiled hidden along with the
internals. On Mach-O those definitions become private extern, and `-exported_symbols_list` cannot export a
hidden symbol even though `exports.txt` matches it with `_ggml_*`.

Ruled out along the way: this is not a whole-archive miss. The vector-index code *is* in the Darwin image
(the `"partial compaction"` literal from `ggml-vector-index.cpp` is present in both `darwin-arm64` and
`darwin-x64`), so fabric's `-force_load` worked. The export list is also being applied correctly — all 6623
exported symbols in `darwin-arm64/qvac__fabric.bare` match a pattern in `packages/fabric/exports.txt`.

## How does it solve it?

[jpgaribotti/qvac-fabric-llm.cpp@48bdb64](https://github.com/jpgaribotti/qvac-fabric-llm.cpp/commit/48bdb64d723afded7b1223dfbe108dd5809d00e7)
annotates the 30 public declarations with a `GGML_VEC_INDEX_API` macro carrying default visibility, so the
API stays exportable regardless of the preset while the implementation internals stay hidden. Windows keeps
the existing `GGML_API` behaviour, where exports are driven by the generated `.def`. The commit is
`v10297.1.2` plus that one header change, so anything CI shows is attributable to it alone.

`vcpkg-overlays/ports/qvac-fabric/` is the registry port for 10297.1.2 with only the source stanza changed
(`REPO`/`REF`/`SHA512`) and `"version"` set to `10297.1.3`; `diff` against the registry blobs shows nothing
else. Only `packages/fabric` opts in via `overlay-ports`, so every other consumer keeps resolving
`qvac-fabric` from the registry.

## Tested

- **Mechanism reproduced locally.** Compiling `ggml/src/ggml-vector-index.cpp` with
  `-fvisibility=hidden -fvisibility-inlines-hidden` yields `FUNC GLOBAL HIDDEN ggml_vec_index_create` before
  the fix and `FUNC GLOBAL DEFAULT` after it (`llvm-readelf --symbols`).
- **`REF` is the commit sha, not the branch**, so a later push to the fork cannot invalidate the recorded
  hash.
- **SHA512 is over the `/archive/<sha>.tar.gz` tarball vcpkg actually fetches** (37,502,035 bytes), not
  `gh api …/tarball/`, which hashes differently.
- `git diff --stat` is exactly 3 files, +300: the `packages/fabric/vcpkg-configuration.json` one-liner plus
  the two overlay port files.

**What to check on the green run:** download the `fabric-darwin-arm64` artifact and run
`llvm-nm --defined-only qvac__fabric.bare` — it should list all 30 `ggml_vec_index_*` entry points. Needs the
`prebuilds` label; without it `run_prebuilds` is false and the PR goes green having compiled nothing.

## Notes for reviewers

- **A green run has not necessarily built fabric.** vcpkg restores `qvac-fabric` from the binary cache on an
  ABI-hash match and then `portfile.cmake` never runs. The overlay changes the ABI hash, so it should be a
  real build — confirm `Building qvac-fabric` appears in the install log.
- **One loose end.** The same preset should hide these symbols on ELF too, yet the shipped Linux and Android
  modules export all 30, so the preset is evidently not taking effect there. The explicit attribute is robust
  either way, which is why the fix annotates the API rather than dropping the preset.
- **Follow-up, not in this PR:** fabric's post-build check counts exported engine symbols but asserts nothing
  about specific APIs, which is why this shipped unnoticed. A per-platform assertion that the built module
  exports `ggml_vec_index_create` should land with the real 0.12.1.

## Breaking changes

None.
