### PR TITLE
QVAC-21681 feat: add manual blob core rotation

### DIFF
--- a/packages/registry-server/docs/BLOB_CORE_ROTATION.md
+++ b/packages/registry-server/docs/BLOB_CORE_ROTATION.md
@@ -4,6 +4,20 @@ Blob-core rotation directs future model ingests to a new Hyperblobs core. Existi
 models keep their original `blobBinding` and remain readable from their recorded
 core keys.
 
+## Availability assumption
+
+Rotation changes only the per-indexer blob core used for future model payloads. It
+does not rotate the Autobase metadata view or change `QVAC_REGISTRY_CORE_KEY`.
+Keep the registry available throughout the procedure by restarting one indexer at
+a time and confirming its health before continuing.
+
+`check:blob-cores` queries that stable metadata view through the normal registry
+client. It is an inventory command, not a peer-availability check, so do not use an
+empty result to diagnose registry connectivity. The procedure requires healthy
+indexers before each inventory; if the registry health checks fail, stop the
+rollout and restore metadata availability first. A test that removes every
+metadata peer does not model this rotation procedure.
+
 ## Rotate the indexers
 
 1. Record the current core inventory:

--- a/packages/registry-server/docs/BLOB_CORE_ROTATION.md
+++ b/packages/registry-server/docs/BLOB_CORE_ROTATION.md
@@ -1,0 +1,46 @@
+# Model Blob-Core Rotation
+
+Blob-core rotation directs future model ingests to a new Hyperblobs core. Existing
+models keep their original `blobBinding` and remain readable from their recorded
+core keys.
+
+## Rotate the indexers
+
+1. Record the current core inventory:
+
+   ```bash
+   npm run check:blob-cores -- --json
+   ```
+
+2. Pause model ingestion until every indexer has restarted. This prevents writes
+   from landing in different generations during the rollout.
+
+3. Choose a generation that has never been used before. For the planned
+   2026-09-10 rollout, add this to `.env` on every indexer:
+
+   ```bash
+   QVAC_BLOB_CORE_GENERATION=2026-09-10
+   ```
+
+4. Reload one indexer at a time and wait for it to report healthy before moving to
+   the next:
+
+   ```bash
+   pm2 reload registry --update-env
+   curl -fsS http://127.0.0.1:9210/metrics | grep '^qvac_registry_is_indexer 1$'
+   pm2 logs registry --lines 50 --nostream | grep 'active blob core ready'
+   ```
+
+   The startup log should report the label `models-2026-09-10` and its core key.
+
+5. Resume ingestion and add a canary model through the normal model-ingestion
+   workflow.
+
+6. Run the inventory again. Confirm that it contains a new core key, then download
+   one model from before the rotation and the canary model through the normal
+   registry client.
+
+Do not remove old Corestore data. Rotation limits future growth; it does not
+migrate, delete, compact, or reclaim historical blobs. Reusing a generation—or
+unsetting the variable to return to `models`—resumes writes to an existing core.
+Production blind-peer reseeding is handled separately.

--- a/packages/registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -279,6 +279,10 @@ After all writers are indexers:
 
 ## Operations
 
+### Rotating Model Blob Cores
+
+Follow the [model blob-core rotation runbook](BLOB_CORE_ROTATION.md).
+
 ### Adding an Indexer
 
 Full walkthrough: add **Server 2** to a running **Server 1** cluster.
@@ -688,17 +692,18 @@ Use Holepunch's pre-built [Grafana dashboard](https://grafana.com/grafana/dashbo
 
 ### Environment Variables
 
-| Variable                   | Description                                                                                |
-| -------------------------- | ------------------------------------------------------------------------------------------ |
-| `QVAC_AUTOBASE_KEY`        | Autobase bootstrap key (auto-generated on first run)                                       |
-| `QVAC_REGISTRY_CORE_KEY`   | Registry view key (auto-generated on first run)                                            |
-| `QVAC_ADDITIONAL_INDEXERS` | Comma-separated writer local keys to promote to indexers                                   |
-| `QVAC_REMOVE_INDEXERS`     | Comma-separated writer local keys to remove from quorum (one-shot, clean up after restart) |
-| `QVAC_ALLOWED_WRITER_KEYS` | Comma-separated hex keys allowed to call add-model RPC                                     |
-| `QVAC_INDEXER_KEYS`        | Comma-separated z32 indexer public keys for authenticated CI RPC connections (see below)   |
-| `QVAC_BLIND_PEER_KEYS`     | Comma-separated blind peer public keys for replication                                     |
-| `QVAC_PRIMARY_KEY`         | Optional: Deterministic key generation (testing only)                                      |
-| `QVAC_WRITER_PRIMARY_KEY`  | Optional: Deterministic writer key (testing only)                                          |
+| Variable                    | Description                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `QVAC_AUTOBASE_KEY`         | Autobase bootstrap key (auto-generated on first run)                                       |
+| `QVAC_REGISTRY_CORE_KEY`    | Registry view key (auto-generated on first run)                                            |
+| `QVAC_ADDITIONAL_INDEXERS`  | Comma-separated writer local keys to promote to indexers                                   |
+| `QVAC_REMOVE_INDEXERS`      | Comma-separated writer local keys to remove from quorum (one-shot, clean up after restart) |
+| `QVAC_ALLOWED_WRITER_KEYS`  | Comma-separated hex keys allowed to call add-model RPC                                     |
+| `QVAC_INDEXER_KEYS`         | Comma-separated z32 indexer public keys for authenticated CI RPC connections (see below)   |
+| `QVAC_BLIND_PEER_KEYS`      | Comma-separated blind peer public keys for replication                                     |
+| `QVAC_BLOB_CORE_GENERATION` | Generation suffix for the active model blob core; unset uses the legacy `models` core      |
+| `QVAC_PRIMARY_KEY`          | Optional: Deterministic key generation (testing only)                                      |
+| `QVAC_WRITER_PRIMARY_KEY`   | Optional: Deterministic writer key (testing only)                                          |
 
 ### Command Reference
 

--- a/packages/registry-server/lib/config.js
+++ b/packages/registry-server/lib/config.js
@@ -8,6 +8,8 @@ const { getEnv, updateEnvFile } = require('../utils/env')
 
 const AUTOBASE_ENV_KEY = ENV_KEYS.QVAC_AUTOBASE_KEY || 'QVAC_AUTOBASE_KEY'
 const REGISTRY_CORE_KEY = ENV_KEYS.QVAC_REGISTRY_CORE_KEY || 'QVAC_REGISTRY_CORE_KEY'
+const BLOB_CORE_GENERATION_ENV_KEY = 'QVAC_BLOB_CORE_GENERATION'
+const BLOB_CORE_GENERATION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 /**
  * Centralized configuration for QVAC Registry
@@ -46,6 +48,33 @@ class RegistryConfig {
     const defaultPath = path.resolve(process.cwd(), './model-drives')
     const result = envPath || defaultPath
     return result
+  }
+
+  /**
+   * Get the generation suffix for the active model blob core.
+   * An unset or empty generation preserves the legacy `models` core.
+   */
+  getBlobCoreGeneration(providedGeneration) {
+    const value =
+      providedGeneration !== undefined && providedGeneration !== null
+        ? providedGeneration
+        : getEnv(BLOB_CORE_GENERATION_ENV_KEY)
+
+    if (value === undefined || value === null) return null
+    if (typeof value !== 'string') {
+      throw new TypeError(`${BLOB_CORE_GENERATION_ENV_KEY} must be a string`)
+    }
+
+    const generation = value.trim()
+    if (!generation) return null
+
+    if (!BLOB_CORE_GENERATION_PATTERN.test(generation)) {
+      throw new TypeError(
+        `${BLOB_CORE_GENERATION_ENV_KEY} must contain only letters, numbers, dots, underscores, and hyphens`
+      )
+    }
+
+    return generation
   }
 
   /**

--- a/packages/registry-server/lib/registry-service.js
+++ b/packages/registry-server/lib/registry-service.js
@@ -118,6 +118,10 @@ class RegistryService extends ReadyResource {
     this.skipStorageCheck = opts.skipStorageCheck ?? false
     this.clearAfterReseed = opts.clearAfterReseed ?? false
     this.compactionIntervalMs = opts.compactionIntervalMs ?? 60 * 60 * 1000
+    this.blobCoreGeneration = this.config.getBlobCoreGeneration(opts.blobCoreGeneration)
+    this.activeBlobCoreLabel = this.blobCoreGeneration
+      ? `${BLOB_CORE_NAME}-${this.blobCoreGeneration}`
+      : BLOB_CORE_NAME
 
     this.view = null
     this.base = null
@@ -348,7 +352,15 @@ class RegistryService extends ReadyResource {
     // because `writable: true` would create a local core with the wrong key.
     if (this.base.isIndexer || this.base.localWriter) {
       try {
-        await this._getOrCreateBlobsCore(BLOB_CORE_NAME)
+        const { core } = await this._getOrCreateBlobsCore(this.activeBlobCoreLabel)
+        this.logger.info(
+          {
+            generation: this.blobCoreGeneration,
+            label: this.activeBlobCoreLabel,
+            key: IdEnc.normalize(core.key)
+          },
+          'RegistryService: active blob core ready'
+        )
       } catch (err) {
         this.logger.warn(
           { err: err.message },
@@ -502,7 +514,7 @@ class RegistryService extends ReadyResource {
     const models = await this.view.findModelsByPath({}).toArray()
     if (models.length > 0) {
       try {
-        const { core } = await this._getOrCreateBlobsCore(BLOB_CORE_NAME)
+        const { core } = await this._getOrCreateBlobsCore(this.activeBlobCoreLabel)
         await this._mirrorBlobCore(core)
       } catch (err) {
         this.logger.warn(
@@ -874,7 +886,7 @@ class RegistryService extends ReadyResource {
         )
       }
 
-      const { blobs, core } = await this._getOrCreateBlobsCore(BLOB_CORE_NAME)
+      const { blobs, core } = await this._getOrCreateBlobsCore(this.activeBlobCoreLabel)
       const pointer = await this._uploadFileToHyperblobs(blobs, localPath)
 
       await this._mirrorBlobCore(core)

--- a/packages/registry-server/package.json
+++ b/packages/registry-server/package.json
@@ -45,6 +45,7 @@
     "verify:licenses": "node scripts/verify-model-licenses.js",
     "sync:models": "node scripts/sync-models.js",
     "smoke-test": "node scripts/smoke-test-client.js",
+    "check:blob-cores": "node scripts/check-blob-cores.js",
     "test:unit": "brittle-node tests/unit/*.test.js",
     "test:integration": "brittle-node tests/integration/*.test.js",
     "test:gguf": "node scripts/test-gguf-extraction.js",

--- a/packages/registry-server/scripts/check-blob-cores.js
+++ b/packages/registry-server/scripts/check-blob-cores.js
@@ -1,0 +1,188 @@
+'use strict'
+
+const fs = require('fs').promises
+const os = require('os')
+const path = require('path')
+const IdEnc = require('hypercore-id-encoding')
+
+const { QVACRegistryClient } = require('../client')
+const RegistryConfig = require('../lib/config')
+
+function parseArgs(args = process.argv.slice(2)) {
+  const options = { json: false, registryKey: null }
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--registry-key' && args[i + 1]) {
+      options.registryKey = args[++i]
+    } else if (arg.startsWith('--registry-key=')) {
+      options.registryKey = arg.slice('--registry-key='.length)
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true
+    } else {
+      throw new TypeError(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+function createBlobCoreInventory(models) {
+  if (!Array.isArray(models)) throw new TypeError('models must be an array')
+
+  const byCore = new Map()
+  let deprecatedModelCount = 0
+  let referencedBytes = 0
+
+  for (const model of models) {
+    const binding = model?.blobBinding
+    const modelId = `${model?.path || '<unknown>'}:${model?.source || '<unknown>'}`
+
+    if (!binding) throw new TypeError(`Model ${modelId} has no blobBinding`)
+
+    const coreKey = normalizeCoreKey(binding.coreKey, modelId)
+    validateBindingNumber(binding.blockOffset, 'blockOffset', modelId)
+    validateBindingNumber(binding.blockLength, 'blockLength', modelId)
+    validateBindingNumber(binding.byteLength, 'byteLength', modelId)
+
+    let core = byCore.get(coreKey)
+    if (!core) {
+      core = {
+        coreKey,
+        modelCount: 0,
+        deprecatedModelCount: 0,
+        referencedBytes: 0,
+        referencedBlockEnd: 0
+      }
+      byCore.set(coreKey, core)
+    }
+
+    const blockEnd = binding.blockOffset + binding.blockLength
+    core.modelCount++
+    core.referencedBytes += binding.byteLength
+    core.referencedBlockEnd = Math.max(core.referencedBlockEnd, blockEnd)
+    referencedBytes += binding.byteLength
+
+    if (model.deprecated === true) {
+      core.deprecatedModelCount++
+      deprecatedModelCount++
+    }
+  }
+
+  const cores = Array.from(byCore.values()).sort((a, b) => a.coreKey.localeCompare(b.coreKey))
+
+  return {
+    summary: {
+      coreCount: cores.length,
+      modelCount: models.length,
+      deprecatedModelCount,
+      referencedBytes
+    },
+    cores
+  }
+}
+
+function normalizeCoreKey(coreKey, modelId) {
+  try {
+    if (Buffer.isBuffer(coreKey)) return IdEnc.normalize(coreKey)
+    if (typeof coreKey === 'string') return IdEnc.normalize(IdEnc.decode(coreKey))
+    if (coreKey && Array.isArray(coreKey.data)) {
+      return IdEnc.normalize(Buffer.from(coreKey.data))
+    }
+  } catch (err) {
+    throw new TypeError(`Model ${modelId} has an invalid blobBinding.coreKey`, { cause: err })
+  }
+
+  throw new TypeError(`Model ${modelId} has an invalid blobBinding.coreKey`)
+}
+
+function validateBindingNumber(value, field, modelId) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`Model ${modelId} has an invalid blobBinding.${field}`)
+  }
+}
+
+async function checkBlobCores(options = {}) {
+  const config = new RegistryConfig()
+  const registryKey = options.registryKey || config.getRegistryCoreKey()
+
+  if (!registryKey) {
+    throw new Error('Set QVAC_REGISTRY_CORE_KEY or pass --registry-key <key>')
+  }
+
+  const storage = path.join(
+    os.tmpdir(),
+    `qvac-check-blob-cores-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+  )
+  const client = new QVACRegistryClient({
+    registryCoreKey: registryKey,
+    storage,
+    logger: { level: 'error' }
+  })
+
+  try {
+    await client.ready()
+    const models = await client.findModels({}, { includeDeprecated: true })
+    return createBlobCoreInventory(models)
+  } finally {
+    await client.close().catch(() => {})
+    await fs.rm(storage, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+function printInventory(inventory) {
+  const { summary, cores } = inventory
+
+  console.log('Blob core inventory')
+  console.log(`Referenced cores: ${summary.coreCount}`)
+  console.log(`Models: ${summary.modelCount} (${summary.deprecatedModelCount} deprecated)`)
+  console.log(`Referenced bytes: ${summary.referencedBytes}`)
+
+  for (const core of cores) {
+    console.log(`\n${core.coreKey}`)
+    console.log(`  Models: ${core.modelCount} (${core.deprecatedModelCount} deprecated)`)
+    console.log(`  Referenced bytes: ${core.referencedBytes}`)
+    console.log(`  Referenced block end: ${core.referencedBlockEnd}`)
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/check-blob-cores.js [options]
+
+Options:
+  --registry-key <key>  Registry view core key (defaults to QVAC_REGISTRY_CORE_KEY)
+  --json                Print machine-readable JSON
+  --help, -h            Show this help message
+
+The command inventories blob cores referenced by registry model metadata. It does
+not connect to blob cores or download model payloads.`)
+}
+
+async function main() {
+  const options = parseArgs()
+  if (options.help) {
+    printHelp()
+    return
+  }
+
+  const inventory = await checkBlobCores(options)
+  if (options.json) console.log(JSON.stringify(inventory, null, 2))
+  else printInventory(inventory)
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`Failed to inspect blob cores: ${err.message}`)
+    process.exitCode = 1
+  })
+}
+
+module.exports = {
+  checkBlobCores,
+  createBlobCoreInventory,
+  parseArgs,
+  printInventory
+}

--- a/packages/registry-server/scripts/check-blob-cores.js
+++ b/packages/registry-server/scripts/check-blob-cores.js
@@ -124,6 +124,11 @@ async function checkBlobCores(options = {}) {
   })
 
   try {
+    // This is a metadata inventory, not a registry availability probe. Blob-core
+    // rotation leaves the Autobase view core and QVAC_REGISTRY_CORE_KEY unchanged,
+    // and the runbook keeps metadata-serving indexers online while this runs.
+    // Preserve the normal client synchronization semantics instead of requiring a
+    // live peer count, which is not evidence that the persisted view is current.
     await client.ready()
     const models = await client.findModels({}, { includeDeprecated: true })
     return createBlobCoreInventory(models)
@@ -158,7 +163,9 @@ Options:
   --help, -h            Show this help message
 
 The command inventories blob cores referenced by registry model metadata. It does
-not connect to blob cores or download model payloads.`)
+not connect to blob cores or download model payloads. It is not an availability
+check: run it while the registry indexers are healthy, as required by the rotation
+procedure. Blob-core rotation does not rotate the registry metadata view core.`)
 }
 
 async function main() {

--- a/packages/registry-server/tests/integration/blob-core-rotation.integration.test.js
+++ b/packages/registry-server/tests/integration/blob-core-rotation.integration.test.js
@@ -1,0 +1,171 @@
+'use strict'
+
+const test = require('brittle')
+const Corestore = require('corestore')
+const Hyperblobs = require('hyperblobs')
+const EventEmitter = require('events')
+const fs = require('fs').promises
+const os = require('os')
+const path = require('path')
+
+const RegistryService = require('../../lib/registry-service')
+const RegistryConfig = require('../../lib/config')
+const { AUTOBASE_NAMESPACE, QVAC_MAIN_REGISTRY } = require('../../shared/constants')
+const { waitFor } = require('../helpers/test-utils')
+
+const DISPATCH_ADD_INDEXER = `@${QVAC_MAIN_REGISTRY}/add-indexer`
+
+const noopLogger = {
+  info() {},
+  debug() {},
+  error() {},
+  warn() {}
+}
+
+test('blob core generation rotates new writes while historical blobs remain readable', async (t) => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'qvac-blob-core-rotation-'))
+  const storage = path.join(tempRoot, 'registry')
+  const fixtures = path.join(tempRoot, 'fixtures')
+  await fs.mkdir(fixtures)
+  const legacyPayload = Buffer.from('legacy-generation-payload')
+  const rotatedPayload = Buffer.from('rotated-generation-payload')
+  const legacyFixture = path.join(fixtures, 'legacy.bin')
+  const rotatedFixture = path.join(fixtures, 'rotated.bin')
+  await fs.writeFile(legacyFixture, legacyPayload)
+  await fs.writeFile(rotatedFixture, rotatedPayload)
+
+  const legacy = await createService({ storage, blobCoreGeneration: '' })
+  let rotated = null
+
+  try {
+    await legacy.service.ready()
+    await ensureIndexer(legacy.service)
+    stubDownload(legacy.service, legacyFixture)
+
+    const legacyModel = await legacy.service.addModel({
+      source: 's3://test-bucket/legacy.bin',
+      engine: '@test/engine',
+      licenseId: 'MIT'
+    })
+    await flushAutobase(legacy.service.base)
+
+    const legacyBinding = legacyModel.blobBinding
+    const autobaseBootstrap = Buffer.from(legacy.service.base.key)
+
+    t.is(legacy.service.activeBlobCoreLabel, 'models')
+    t.ok(
+      legacy.service.blobsCores.get('models').core.key.equals(legacyBinding.coreKey),
+      'legacy model points to the default models core'
+    )
+
+    await cleanupService(legacy)
+
+    rotated = await createService({
+      storage,
+      bootstrap: autobaseBootstrap,
+      blobCoreGeneration: '2026-09-10'
+    })
+    await rotated.service.ready()
+    await ensureIndexer(rotated.service)
+    stubDownload(rotated.service, rotatedFixture)
+
+    const rotatedModel = await rotated.service.addModel({
+      source: 's3://test-bucket/rotated.bin',
+      engine: '@test/engine',
+      licenseId: 'MIT'
+    })
+    await flushAutobase(rotated.service.base)
+
+    t.is(rotated.service.activeBlobCoreLabel, 'models-2026-09-10')
+    t.not(
+      legacyBinding.coreKey.toString('hex'),
+      rotatedModel.blobBinding.coreKey.toString('hex'),
+      'rotation creates a distinct writable core'
+    )
+
+    const persistedLegacy = await rotated.service.getModelByKey({
+      path: legacyModel.path,
+      source: legacyModel.source
+    })
+    const persistedRotated = await rotated.service.getModelByKey({
+      path: rotatedModel.path,
+      source: rotatedModel.source
+    })
+
+    t.alike(persistedLegacy.blobBinding, legacyBinding, 'historical blobBinding is unchanged')
+    t.ok((await readBlob(rotated.service, persistedLegacy.blobBinding)).equals(legacyPayload))
+    t.ok((await readBlob(rotated.service, persistedRotated.blobBinding)).equals(rotatedPayload))
+  } finally {
+    await cleanupService(legacy)
+    if (rotated) await cleanupService(rotated)
+    await fs.rm(tempRoot, { recursive: true, force: true })
+  }
+})
+
+async function createService({ storage, bootstrap = null, blobCoreGeneration }) {
+  const store = new Corestore(storage)
+  await store.ready()
+
+  const swarm = createSwarm()
+  const config = new RegistryConfig({ logger: noopLogger })
+  const service = new RegistryService(store.namespace(AUTOBASE_NAMESPACE), swarm, config, {
+    logger: noopLogger,
+    ackInterval: 5,
+    autobaseBootstrap: bootstrap,
+    blobCoreGeneration,
+    skipStorageCheck: true
+  })
+
+  return { service, store, swarm }
+}
+
+function createSwarm() {
+  const swarm = new EventEmitter()
+  swarm.keyPair = { publicKey: Buffer.alloc(32) }
+  swarm.join = () => {}
+  swarm.leave = () => {}
+  swarm.destroy = () => Promise.resolve()
+  return swarm
+}
+
+function stubDownload(service, fixture) {
+  service._downloadArtifact = async (sourceInfo, localPath) => {
+    await fs.copyFile(fixture, localPath)
+    return localPath
+  }
+}
+
+async function readBlob(service, binding) {
+  const core = service.blobsStore.get({ key: binding.coreKey })
+  await core.ready()
+  const blobs = new Hyperblobs(core)
+  await blobs.ready()
+
+  try {
+    return await blobs.get(binding)
+  } finally {
+    await blobs.close()
+    await core.close()
+  }
+}
+
+async function ensureIndexer(service) {
+  if (service.base.isIndexer) return
+  await service._appendOperation(DISPATCH_ADD_INDEXER, { key: service.base.local.key })
+  // lunte-disable-next-line require-await
+  await waitFor(async () => service.base.isIndexer === true, 15000)
+}
+
+async function flushAutobase(base) {
+  for (let i = 0; i < 3; i++) {
+    await base.update()
+    if (base.localWriter && base.localWriter.core.length > 0) await base.ack()
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+}
+
+async function cleanupService({ service, store, swarm }) {
+  if (service?.opened) await service.close().catch(() => {})
+  if (swarm) await swarm.destroy().catch(() => {})
+  if (store) await store.close().catch(() => {})
+}

--- a/packages/registry-server/tests/unit/check-blob-cores.test.js
+++ b/packages/registry-server/tests/unit/check-blob-cores.test.js
@@ -1,0 +1,118 @@
+'use strict'
+
+const test = require('brittle')
+const IdEnc = require('hypercore-id-encoding')
+
+const { createBlobCoreInventory, parseArgs } = require('../../scripts/check-blob-cores')
+
+test('createBlobCoreInventory groups active and deprecated models by core', (t) => {
+  const firstCore = Buffer.alloc(32, 1)
+  const secondCore = Buffer.alloc(32, 2)
+
+  const inventory = createBlobCoreInventory([
+    model('first.bin', firstCore, { blockOffset: 0, blockLength: 2, byteLength: 100 }),
+    model('second.bin', firstCore, {
+      blockOffset: 2,
+      blockLength: 3,
+      byteLength: 200,
+      deprecated: true
+    }),
+    model('third.bin', secondCore, { blockOffset: 4, blockLength: 2, byteLength: 300 })
+  ])
+
+  t.alike(inventory.summary, {
+    coreCount: 2,
+    modelCount: 3,
+    deprecatedModelCount: 1,
+    referencedBytes: 600
+  })
+  const expectedCores = [
+    {
+      coreKey: IdEnc.normalize(firstCore),
+      modelCount: 2,
+      deprecatedModelCount: 1,
+      referencedBytes: 300,
+      referencedBlockEnd: 5
+    },
+    {
+      coreKey: IdEnc.normalize(secondCore),
+      modelCount: 1,
+      deprecatedModelCount: 0,
+      referencedBytes: 300,
+      referencedBlockEnd: 6
+    }
+  ].sort((a, b) => a.coreKey.localeCompare(b.coreKey))
+
+  t.alike(inventory.cores, expectedCores)
+})
+
+test('createBlobCoreInventory accepts encoded and JSON Buffer core keys', (t) => {
+  const core = Buffer.alloc(32, 3)
+  const inventory = createBlobCoreInventory([
+    model('encoded.bin', IdEnc.normalize(core), { byteLength: 10 }),
+    model('json-buffer.bin', core.toJSON(), { blockOffset: 1, byteLength: 20 })
+  ])
+
+  t.is(inventory.summary.coreCount, 1)
+  t.is(inventory.cores[0].coreKey, IdEnc.normalize(core))
+  t.is(inventory.cores[0].referencedBytes, 30)
+})
+
+test('createBlobCoreInventory reports an empty registry', (t) => {
+  t.alike(createBlobCoreInventory([]), {
+    summary: {
+      coreCount: 0,
+      modelCount: 0,
+      deprecatedModelCount: 0,
+      referencedBytes: 0
+    },
+    cores: []
+  })
+})
+
+test('createBlobCoreInventory rejects malformed blob bindings', async (t) => {
+  await t.exception.all(
+    () => createBlobCoreInventory([{ path: 'missing.bin', source: 's3' }]),
+    /has no blobBinding/
+  )
+  await t.exception.all(
+    () => createBlobCoreInventory([model('bad-key.bin', 'not-a-core-key')]),
+    /invalid blobBinding.coreKey/
+  )
+  await t.exception.all(
+    () => createBlobCoreInventory([model('bad-offset.bin', Buffer.alloc(32), { blockOffset: -1 })]),
+    /invalid blobBinding.blockOffset/
+  )
+})
+
+test('parseArgs accepts human and JSON inventory options', async (t) => {
+  t.alike(parseArgs(['--registry-key', 'abc', '--json']), {
+    json: true,
+    registryKey: 'abc'
+  })
+  t.alike(parseArgs(['--registry-key=def', '--help']), {
+    json: false,
+    registryKey: 'def',
+    help: true
+  })
+  await t.exception.all(() => parseArgs(['--unknown']), /Unknown argument/)
+})
+
+function model(name, coreKey, overrides = {}) {
+  const { deprecated = false, ...bindingOverrides } = overrides
+
+  return {
+    path: `test/${name}`,
+    source: 's3',
+    deprecated,
+    blobBinding: {
+      coreKey,
+      blockOffset: 0,
+      blockLength: 1,
+      byteOffset: 0,
+      byteLength: 1,
+      sha256: 'unused',
+      ...bindingOverrides
+    }
+  }
+}

--- a/packages/registry-server/tests/unit/config.test.js
+++ b/packages/registry-server/tests/unit/config.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const test = require('brittle')
+
+const RegistryConfig = require('../../lib/config')
+
+const ENV_KEY = 'QVAC_BLOB_CORE_GENERATION'
+
+test('RegistryConfig defaults blob core generation to legacy core', (t) => {
+  withEnv(t, ENV_KEY, undefined)
+
+  const config = new RegistryConfig()
+
+  t.is(config.getBlobCoreGeneration(), null)
+  t.is(config.getBlobCoreGeneration(''), null)
+  t.is(config.getBlobCoreGeneration('   '), null)
+})
+
+test('RegistryConfig reads and trims blob core generation', (t) => {
+  withEnv(t, ENV_KEY, '  2026-09-10  ')
+
+  const config = new RegistryConfig()
+
+  t.is(config.getBlobCoreGeneration(), '2026-09-10')
+})
+
+test('RegistryConfig explicit blob core generation overrides environment', (t) => {
+  withEnv(t, ENV_KEY, 'environment-generation')
+
+  const config = new RegistryConfig()
+
+  t.is(config.getBlobCoreGeneration('provided-generation'), 'provided-generation')
+})
+
+test('RegistryConfig rejects invalid blob core generations', async (t) => {
+  withEnv(t, ENV_KEY, undefined)
+
+  const config = new RegistryConfig()
+
+  await t.exception.all(
+    () => config.getBlobCoreGeneration('2026/09/10'),
+    /QVAC_BLOB_CORE_GENERATION must contain only/
+  )
+  await t.exception.all(
+    () => config.getBlobCoreGeneration(2),
+    /QVAC_BLOB_CORE_GENERATION must be a string/
+  )
+})
+
+function withEnv(t, key, value) {
+  const previous = process.env[key]
+
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+
+  t.teardown(() => {
+    if (previous === undefined) delete process.env[key]
+    else process.env[key] = previous
+  })
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Registry indexers append model payloads to one long-lived blob core, so operators cannot cap future growth without changing storage metadata or disrupting historical downloads.
- Operators need a controlled rollout and a metadata-only view of the blob cores still referenced by registry entries.

## 📝 How does it solve it?

- Adds `QVAC_BLOB_CORE_GENERATION`; an unset value preserves the legacy `models` core, while a generation selects a stable `models-<generation>` core after restart.
- Keeps existing `blobBinding` records unchanged and leaves production blob distribution and reseeding to the separate operational workflow.
- Adds a historical-core inventory command and a concise rotation runbook for the planned `2026-09-10` rollout.
- Clarifies that the inventory reads the unchanged Autobase metadata view during a healthy rolling rollout and is not a peer-availability probe.
- Records the new core keys for production reseeding before validating historical and canary downloads through the normal client.

## 🧪 How was it tested?

- Full registry-server unit suite: 68/68 tests, 186/186 assertions.
- Full registry-server integration suite: 32/32 tests, 149/149 assertions.
- Added focused rotation/readback and inventory/configuration coverage.
- Ran a two-indexer rolling-rotation scenario with separate Corestores: ingested models before and after rotation, confirmed four distinct core bindings, and downloaded all four artifacts through uncached clients with matching SHA-256 checksums.
- Lint, Prettier, syntax checks, and `git diff --check` pass.
