### PR TITLE
QVAC-24893 fix[skiplog]: stop cross-file request-registry pollution in the inference test suite

### DIFF
--- a/packages/inference/test/audio-gen-plugin.test.ts
+++ b/packages/inference/test/audio-gen-plugin.test.ts
@@ -167,6 +167,7 @@ test('audioGen plugin operation yields indeterminate LM progress', async (t) => 
     done: false
   })
   t.is((await stream.next()).value?.done, true)
+  t.ok((await stream.next()).done, 'the stream is exhausted, releasing the request')
 })
 
 test('audioGen terminal diagnostics report a GPU fallback reason, or omit it', async (t) => {

--- a/packages/inference/test/world-concurrency.test.ts
+++ b/packages/inference/test/world-concurrency.test.ts
@@ -24,7 +24,8 @@ test('world admission: a second world request on the same model is rejected, not
     'overlapping world request is refused'
   )
 
-  t.is(registry.list().length, 1, 'the refused request left no slot behind')
+  const held = registry.list().filter((entry) => entry.modelId === 'world-model')
+  t.is(held.length, 1, 'the refused request left no slot behind')
 })
 
 test('world admission: a different model is unaffected', async (t) => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `packages/inference`'s brittle suite fails locally with `world admission: a second world request on the same model is rejected, not queued` (1741/1742).
- The suite shares one process across test files, and `getRequestRegistry()` is a process-wide singleton. `audioGen plugin operation yields indeterminate LM progress` leaves `audio-gen-request-indeterminate-progress` registered as `running` for the rest of the run: `audioGenStream` holds its slot with `await using`, which only disposes when the generator returns, and the test asserts on the terminal event's own `done` field without exhausting the iterator.
- The world test counts every entry in the registry, so it sees 2 instead of 1 and fails.
- CI misses it on file order alone: `brittle-bare` expands its glob in filesystem enumeration order, and on the CI runner the world test runs before the audiogen test. On macOS the order is reversed. Nothing pins it, so an added or renamed test file can flip CI red on an unrelated PR.

## 📝 How does it solve it?

- Drain the audiogen stream with a final `next()` so the generator returns and releases its request slot.
- Scope the world admission count to its own `modelId` instead of counting every in-flight request, so the assertion tests the policy rather than global state and cannot be broken by a leak elsewhere.

## 🧪 How was it tested?

- `bun run build:test && bunx brittle-bare 'test/dist/test/**/*.test.js'` in `packages/inference`: 1742/1742 tests, 6346/6346 asserts, in the file order that previously failed.
- Confirmed the failure is pre-existing on `main` (1741/1742, same test) and that `world-concurrency.test.js` passes in isolation on both branches.
