### PR TITLE
chore[skiplog|notask]: backmerge release-test-suite-0.12.0 — version bump, changelog

### DIFF
--- a/packages/test-suite/CHANGELOG.md
+++ b/packages/test-suite/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.12.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.12.0
+
+One new selection option. `run:producer` can now add named tests on top of whatever a suite already selected — a combination the existing options could not express.
+
+---
+
+## New APIs
+
+### Add specific tests on top of a suite with `--include`
+
+`--suite`, `--exclude-suite` and `--filter` all compose with AND: each one narrows what the previous left. That makes "run this suite, plus these particular tests" impossible to ask for. `--suite=smoke --filter=parakeet` returns the intersection — the handful of parakeet tests that happen to be tagged smoke — when what was wanted was the union.
+
+`--include` takes a comma-separated list of test ids and unions them back in after the other options have had their say:
+
+```bash
+# Before — the intersection, a few tests at best and often none.
+qvac-test run:producer --suite=smoke --filter=parakeet
+
+# After — the whole smoke suite plus these three, whatever their tags.
+qvac-test run:producer --suite=smoke \
+  --include=parakeet-tdt-mp3,parakeet-ctc-wav,parakeet-unified-mp3
+```
+
+Three behaviours are worth knowing.
+
+It matches **exact ids, not prefixes**. This is the opposite of `--filter`, where `model-load-llm` also drags in `model-load-llm-load-mode-none`. With `--include` an id selects that test and nothing else, so adding one case to a suite run cannot quietly pull in its neighbours.
+
+An id that matches nothing **fails the run**. Naming a test and then getting a green run that never executed it is the opposite of what was meant, so the mistake surfaces immediately instead of being silently dropped.
+
+An empty value is a **no-op**. Callers — CI templates in particular — can pass the flag unconditionally without special-casing the empty case.
+
+`run:local:*` forwards the option too, so the same selection works when driving a run locally.
+
+Internally the selection rules moved out of the producer command into a pure `selectTests()` helper, so suite, exclude, filter and include compose in one place rather than being spread across the command.
+
 ## [0.11.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.1

--- a/packages/test-suite/changelog/0.12.0/CHANGELOG.md
+++ b/packages/test-suite/changelog/0.12.0/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.12.0
+
+Release Date: 2026-09-10
+
+## 🔌 API
+
+- Add --include to run:producer. (see PR [#4302](https://github.com/tetherto/qvac/pull/4302)) - See [API changes](./api.md)
+

--- a/packages/test-suite/changelog/0.12.0/CHANGELOG_LLM.md
+++ b/packages/test-suite/changelog/0.12.0/CHANGELOG_LLM.md
@@ -1,0 +1,36 @@
+# QVAC Test Suite v0.12.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.12.0
+
+One new selection option. `run:producer` can now add named tests on top of whatever a suite already selected — a combination the existing options could not express.
+
+---
+
+## New APIs
+
+### Add specific tests on top of a suite with `--include`
+
+`--suite`, `--exclude-suite` and `--filter` all compose with AND: each one narrows what the previous left. That makes "run this suite, plus these particular tests" impossible to ask for. `--suite=smoke --filter=parakeet` returns the intersection — the handful of parakeet tests that happen to be tagged smoke — when what was wanted was the union.
+
+`--include` takes a comma-separated list of test ids and unions them back in after the other options have had their say:
+
+```bash
+# Before — the intersection, a few tests at best and often none.
+qvac-test run:producer --suite=smoke --filter=parakeet
+
+# After — the whole smoke suite plus these three, whatever their tags.
+qvac-test run:producer --suite=smoke \
+  --include=parakeet-tdt-mp3,parakeet-ctc-wav,parakeet-unified-mp3
+```
+
+Three behaviours are worth knowing.
+
+It matches **exact ids, not prefixes**. This is the opposite of `--filter`, where `model-load-llm` also drags in `model-load-llm-load-mode-none`. With `--include` an id selects that test and nothing else, so adding one case to a suite run cannot quietly pull in its neighbours.
+
+An id that matches nothing **fails the run**. Naming a test and then getting a green run that never executed it is the opposite of what was meant, so the mistake surfaces immediately instead of being silently dropped.
+
+An empty value is a **no-op**. Callers — CI templates in particular — can pass the flag unconditionally without special-casing the empty case.
+
+`run:local:*` forwards the option too, so the same selection works when driving a run locally.
+
+Internally the selection rules moved out of the producer command into a pure `selectTests()` helper, so suite, exclude, filter and include compose in one place rather than being spread across the command.

--- a/packages/test-suite/changelog/0.12.0/api.md
+++ b/packages/test-suite/changelog/0.12.0/api.md
@@ -1,0 +1,24 @@
+# 🔌 API Changes v0.12.0
+
+## Add --include to run:producer
+
+PR: [#4302](https://github.com/tetherto/qvac/pull/4302)
+
+```bash
+# Before: the intersection — the 4 parakeet tests that happen to be tagged smoke.
+qvac-test run:producer --suite=smoke --filter=parakeet
+
+# After: the union — the smoke suite plus these three tests, whatever their tags.
+qvac-test run:producer --suite=smoke \
+  --include=parakeet-tdt-mp3,parakeet-ctc-wav,parakeet-unified-mp3
+```
+
+```
+🏷️  Including suites: smoke
+➕ Also running 3 explicitly requested test(s): system-resources-capabilities, …
+📋 Filtered: 109 of 513 tests
+   system-resources     3/3 (100%)
+```
+
+---
+

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/test-suite",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Generic distributed testing framework for multi-platform execution",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/test-suite@0.12.0` on `main`, per [gitflow.md](../blob/main/docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- https://github.com/tetherto/qvac/pull/4383

## Files

- `packages/test-suite/package.json` — version `0.11.1` → `0.12.0`
- `packages/test-suite/changelog/0.12.0/` — `CHANGELOG.md`, `CHANGELOG_LLM.md`, `api.md`
- `packages/test-suite/CHANGELOG.md` — aggregated changelog, new section only (`+37 / -0`)

`NOTICE` is not included: it was regenerated and came out byte-identical to the committed file.

## Verification

- Cherry-picked with `-x`, so the release commit SHA is recorded in the message
- `git diff --stat origin/main..HEAD` lists exactly the five files above — release metadata only, nothing broader
- No conflicts during the cherry-pick
- Not a no-op: the simulated cherry-pick tree differs from `main`'s current tree
