### PR TITLE
chore[notask]: release @qvac/test-suite 0.11.2

### DIFF
--- a/packages/test-suite/CHANGELOG.md
+++ b/packages/test-suite/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [0.11.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.2
+
+One new selection option. `run:producer` can now add named tests on top of whatever a suite already selected — a combination the existing options could not express.
+
+---
+
+## New APIs
+
+### Add specific tests on top of a suite with `--include`
+
+`--suite`, `--exclude-suite` and `--filter` all compose with AND: each one narrows what the previous left. That makes "run this suite, plus these particular tests" impossible to ask for. `--suite=smoke --filter=parakeet` returns the intersection — the handful of parakeet tests that happen to be tagged smoke — when what was wanted was the union.
+
+`--include` takes a comma-separated list of test ids and unions them back in after the other options have had their say:
+
+```bash
+# Before — the intersection, a few tests at best and often none.
+qvac-test run:producer --suite=smoke --filter=parakeet
+
+# After — the whole smoke suite plus these three, whatever their tags.
+qvac-test run:producer --suite=smoke \
+  --include=parakeet-tdt-mp3,parakeet-ctc-wav,parakeet-unified-mp3
+```
+
+Three behaviours are worth knowing.
+
+It matches **exact ids, not prefixes**. This is the opposite of `--filter`, where `model-load-llm` also drags in `model-load-llm-load-mode-none`. With `--include` an id selects that test and nothing else, so adding one case to a suite run cannot quietly pull in its neighbours.
+
+An id that matches nothing **fails the run**. Naming a test and then getting a green run that never executed it is the opposite of what was meant, so the mistake surfaces immediately instead of being silently dropped.
+
+An empty value is a **no-op**. Callers — CI templates in particular — can pass the flag unconditionally without special-casing the empty case.
+
+`run:local:*` forwards the option too, so the same selection works when driving a run locally.
+
+Internally the selection rules moved out of the producer command into a pure `selectTests()` helper, so suite, exclude, filter and include compose in one place rather than being spread across the command.
+
 ## [0.11.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.1

--- a/packages/test-suite/changelog/0.11.2/CHANGELOG.md
+++ b/packages/test-suite/changelog/0.11.2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.11.2
+
+Release Date: 2026-09-10
+
+## 🔌 API
+
+- Add --include to run:producer. (see PR [#4302](https://github.com/tetherto/qvac/pull/4302)) - See [API changes](./api.md)
+

--- a/packages/test-suite/changelog/0.11.2/CHANGELOG_LLM.md
+++ b/packages/test-suite/changelog/0.11.2/CHANGELOG_LLM.md
@@ -1,0 +1,36 @@
+# QVAC Test Suite v0.11.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/test-suite/v/0.11.2
+
+One new selection option. `run:producer` can now add named tests on top of whatever a suite already selected — a combination the existing options could not express.
+
+---
+
+## New APIs
+
+### Add specific tests on top of a suite with `--include`
+
+`--suite`, `--exclude-suite` and `--filter` all compose with AND: each one narrows what the previous left. That makes "run this suite, plus these particular tests" impossible to ask for. `--suite=smoke --filter=parakeet` returns the intersection — the handful of parakeet tests that happen to be tagged smoke — when what was wanted was the union.
+
+`--include` takes a comma-separated list of test ids and unions them back in after the other options have had their say:
+
+```bash
+# Before — the intersection, a few tests at best and often none.
+qvac-test run:producer --suite=smoke --filter=parakeet
+
+# After — the whole smoke suite plus these three, whatever their tags.
+qvac-test run:producer --suite=smoke \
+  --include=parakeet-tdt-mp3,parakeet-ctc-wav,parakeet-unified-mp3
+```
+
+Three behaviours are worth knowing.
+
+It matches **exact ids, not prefixes**. This is the opposite of `--filter`, where `model-load-llm` also drags in `model-load-llm-load-mode-none`. With `--include` an id selects that test and nothing else, so adding one case to a suite run cannot quietly pull in its neighbours.
+
+An id that matches nothing **fails the run**. Naming a test and then getting a green run that never executed it is the opposite of what was meant, so the mistake surfaces immediately instead of being silently dropped.
+
+An empty value is a **no-op**. Callers — CI templates in particular — can pass the flag unconditionally without special-casing the empty case.
+
+`run:local:*` forwards the option too, so the same selection works when driving a run locally.
+
+Internally the selection rules moved out of the producer command into a pure `selectTests()` helper, so suite, exclude, filter and include compose in one place rather than being spread across the command.

--- a/packages/test-suite/changelog/0.11.2/api.md
+++ b/packages/test-suite/changelog/0.11.2/api.md
@@ -1,0 +1,24 @@
+# 🔌 API Changes v0.11.2
+
+## Add --include to run:producer
+
+PR: [#4302](https://github.com/tetherto/qvac/pull/4302)
+
+```bash
+# Before: the intersection — the 4 parakeet tests that happen to be tagged smoke.
+qvac-test run:producer --suite=smoke --filter=parakeet
+
+# After: the union — the smoke suite plus these three tests, whatever their tags.
+qvac-test run:producer --suite=smoke \
+  --include=parakeet-tdt-mp3,parakeet-ctc-wav,parakeet-unified-mp3
+```
+
+```
+🏷️  Including suites: smoke
+➕ Also running 3 explicitly requested test(s): system-resources-capabilities, …
+📋 Filtered: 109 of 513 tests
+   system-resources     3/3 (100%)
+```
+
+---
+

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/test-suite",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Generic distributed testing framework for multi-platform execution",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 🎯 What problem does this solve?

Patch release of `@qvac/test-suite`, carrying one change: #4302 (QVAC-24505) adds `run:producer --include=<ids>`. That change is on `main` but unpublished, so no consumer can use the option yet.

**Why patch and not minor.** #4302 is `feat[api]` — additive and non-breaking — so strict semver would say minor. It ships on the `0.11.x` line by choice, keeping `0.12.0` free. There is precedent for a feature in a patch here: `sdk` 0.8.1 and `sdk` 0.17.1 both carry a `Features` section.

## 📝 How is it solved?

- `packages/test-suite/package.json` → `0.11.2`
- `packages/test-suite/changelog/0.11.2/` with `CHANGELOG.md`, `CHANGELOG_LLM.md` and `api.md`
- Root `CHANGELOG.md` rebuilt from the version folders, so it prefers the human-readable file

**Changelog base.** Discovery used `--base-commit=7f8c8d192 --base-version=0.11.1`. That is the skill's patch rule (base = the latest tag) expressed as a commit reachable from `main`: `test-suite-v0.11.1` sits on `release-test-suite-0.11.1`, so it is not an ancestor of `main` and the generator rejects it by design (`Base reference … is not an ancestor of HEAD`). `7f8c8d192` is where 0.11.1's metadata landed on `main`, and it carries version `0.11.1`, so the range resolves to exactly #4302.

## 🧪 How was this verified?

- `NOTICE` regenerated via `qv-notice-generate` (88 JS dependencies scanned, `NOTICE_LOG.txt` 0 entries) and byte-identical to the committed file, so it is not part of this release. Consistent with the input not moving: `packages/test-suite/package.json` is unchanged between 7f8c8d192 and `main` apart from this bump.
- The publish workflow's gate: `grep -cE "^## \[0.11.2\]" packages/test-suite/CHANGELOG.md` → 1.
- Root `CHANGELOG.md` diff is `+37 / -0` — purely the new section, no churn in the 0.11.0/0.11.1 sections, and versions stay in descending order.
- `prettier --check` clean on the hand-authored `changelog/0.11.2/CHANGELOG_LLM.md`.

Not verified locally: `check` / `typecheck` / `build`. This checkout has no installed dependencies and the repo moved to a single pnpm workspace in #4341, so verifying locally means a full root `pnpm install`. `SDK Pod Checks` runs those three on this PR and is a required gate, so CI is the authority. The release commit touches no source — only the version field and changelog files.

## 🚀 Workflow / Publish Changes

None. Publishing runs through `trigger-reusable-lib-test-suite.yml`.

Note for reviewers: `publish-release-npm` uses `environment: npm`, which carries a required-reviewer rule — the publish job waits for approval after this merges.

## 🔄 Migration Notes

None. `0.11.2` only adds an option; `--suite`, `--exclude-suite` and `--filter` behave exactly as before, and omitting `--include` (or passing it empty) changes nothing.

After this merges, backmerge the version bump and changelog into `main` — companion PR below.
