### PR TITLE
QVAC-24907 fix: keep the desktop-only fit subprocess out of mobile bundles

### DIFF
--- a/packages/sdk/src/expo/plugins/withMobileBundle.ts
+++ b/packages/sdk/src/expo/plugins/withMobileBundle.ts
@@ -16,6 +16,14 @@ const { withDangerousMod } = configPlugins
 /** Modules to defer from mobile bundles (not available at bundle time) */
 const DEFERRED_MODULES = ['expo-file-system', 'react-native-bare-kit']
 
+/**
+ * Desktop-only modules deferred so bare-pack stops walking into them. They back
+ * the advisory fit check, which mobile refuses at runtime, but the imports are
+ * static and pull in `bare-process` -> `bare-posix`, which ships no
+ * `android-arm64` prebuild and fails bundle verification.
+ */
+const MOBILE_UNSUPPORTED_MODULES = ['bare-runtime/spawn', '@qvac/model-fit/process']
+
 const MOBILE_HOSTS = ['android-arm64', 'ios-arm64', 'ios-arm64-simulator', 'ios-x64-simulator']
 
 type BareKitLinkerPaths = {
@@ -42,7 +50,11 @@ function withMobileBundle(config: ExpoConfig): ExpoConfig {
       console.log('🕚 QVAC: No config found, generating default bundle (all plugins)...')
     }
 
-    const deferredModules = [...DEFERRED_MODULES, `${sdkPackage.name}/worker.mobile.bundle`]
+    const deferredModules = [
+      ...DEFERRED_MODULES,
+      ...MOBILE_UNSUPPORTED_MODULES,
+      `${sdkPackage.name}/worker.mobile.bundle`
+    ]
     const linkerPaths = await runBundler(projectRoot, sdkPackage.dir, configPath, deferredModules)
 
     const generatedBundle = path.join(projectRoot, 'qvac', 'worker.bundle.js')
@@ -201,7 +213,7 @@ function patchBareKitLinkers(projectRoot: string, qvacSdkPath: string): BareKitL
   return { android: androidLinkerPath, ios: iosLinkerPath }
 }
 
-export { MOBILE_HOSTS, patchBareKitLinkers, runIOSAddonLinker }
+export { MOBILE_HOSTS, MOBILE_UNSUPPORTED_MODULES, patchBareKitLinkers, runIOSAddonLinker }
 export type { BareKitLinkerPaths }
 
 export default withMobileBundle

--- a/packages/sdk/test/with-mobile-bundle.test.ts
+++ b/packages/sdk/test/with-mobile-bundle.test.ts
@@ -4,12 +4,17 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   MOBILE_HOSTS,
+  MOBILE_UNSUPPORTED_MODULES,
   patchBareKitLinkers,
   runIOSAddonLinker
 } from '@/expo/plugins/withMobileBundle'
 
 test('MOBILE_HOSTS: canonical mobile host set', (t) => {
   t.alike(MOBILE_HOSTS, ['android-arm64', 'ios-arm64', 'ios-arm64-simulator', 'ios-x64-simulator'])
+})
+
+test('MOBILE_UNSUPPORTED_MODULES: desktop-only fit subprocess stays out of mobile bundles', (t) => {
+  t.alike(MOBILE_UNSUPPORTED_MODULES, ['bare-runtime/spawn', '@qvac/model-fit/process'])
 })
 
 test('patchBareKitLinkers: returns paths for patched platforms', (t) => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Every mobile app build through `withQvacSDK` fails in `expo prebuild`: `BUNDLE_VERIFICATION_FAILED … Missing prebuild: bare-posix@1.0.1 for android-arm64`. Blocks the whole mobile e2e lane ([run 34459632086](https://github.com/tetherto/qvac/actions/runs/34459632086) — `[android] build` and `[ios] build`) and blocks the 0.19.1 release.
- Regression from #4010, which added `@qvac/model-fit` + `bare-runtime` to `@qvac/inference`. `run-isolated-fit.ts` imports `bare-runtime/spawn`, whose `imports` map resolves `process` → `bare-process@4.5.1`, which unconditionally requires `bare-posix`. `bare-posix` deliberately ships no `android-arm64` prebuild — its `exports` route `android` (and `win32`) to a JS fallback.
- Mobile can never run that code: `runAdvisoryFitCheck` returns early via `isMobile`, and `runIsolatedFit` refuses via `isAndroid`/`isIOS`. The imports are static, so bare-pack walks the subtree regardless.
- iOS fails on the `android-arm64` host too, because `MOBILE_HOSTS` is a fixed list and does not depend on `modRequest.platform`.

## 📝 How does it solve it?

- Defer `bare-runtime/spawn` and `@qvac/model-fit/process` from mobile bundles only, so bare-pack stops traversing into them.
- Desktop is untouched: `bundleSdk` is called without this list there, and the advisory fit check keeps working.
- Also keeps `@qvac/model-fit` (~100 MB of `android-arm64` prebuilds) from being linked into the APK/IPA for a subprocess mobile cannot spawn.

## 🧪 How was it tested?

- Reproduced and verified against real `bare-pack` output: packed a probe entry importing `bare-runtime/spawn` from the e2e consumer tree with all four `MOBILE_HOSTS` and `--linked`.

  | | `bare-posix` | `bare-process` | `bare-runtime` |
  |---|---|---|---|
  | without `--defer` | present | present | present |
  | with `--defer bare-runtime/spawn` | **0** | **0** | **0** |

  Only a single `deferred:bare-runtime/spawn` reference remains, and `verifyBundle` on that bundle returns `Native addon verification passed`.
- `bun run test/with-mobile-bundle.test.ts` — 5/5 pass, including a new assertion pinning the deferred set.
- `npx lunte` and `prettier --check` clean on the changed files.
- Not yet run: a full `expo prebuild --platform android` against a post-#4010 inference build — that is what the e2e run on this PR will confirm.

## Follow-up (not in this PR)

- Deferring works only while the fit check is desktop-only. Once mobile depends on `@qvac/model-fit` (0.20), `bare-process` is legitimately back in the mobile graph and `bare-posix` will fail verification again. The verifier needs to become platform-aware: bare-pack already records the per-platform edge (`"bare-posix": { "android": ".../unsupported.js", "default": ".../index.js" }`), but `checkPrebuilds` requires a prebuild for every host regardless. Tracked separately.
- The `desktop-linux` timeout in the same e2e run is unrelated to this change (`audio-gen-*` hanging past the 60-minute step limit) and is not fixed here.
