### PR TITLE
QVAC-24493 QVAC-24494 feat[mod]: asr-ggml consumes Nemotron Vulkan and CUDA coverage (speech-cpp 2026-09-10)

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -52,6 +52,13 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ### Changed
 
+- Raise the `speech-cpp` floor to 2026-09-10. Nemotron 3.5 ASR streaming is
+  now validated on Vulkan and CUDA: the encoder and the fused transducer
+  decode run on the GPU at all five cache-aware operating points, with
+  engine parity tests against NeMo references at each of them. The window
+  also extends the Parakeet Core ML offline-encoder path used by the
+  `coreml` build on Apple platforms.
+
 - Raise the `speech-cpp` floor to 2026-09-09 (ggml-speech 2026-09-09#1).
   Parakeet CPU transcription is 2.2 to 2.6x faster on x86 desktops: the TDT
   decoder runs as ggml graphs instead of a host loop, positional projections

--- a/packages/asr-ggml/vcpkg-configuration.json
+++ b/packages/asr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "dca20a940d85d6741285c888b53bd10da29c0723",
+    "baseline": "5872ca5c6da926923b3d9831d9c898e00bdb43cd",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/asr-ggml/vcpkg-configuration.json
+++ b/packages/asr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "5872ca5c6da926923b3d9831d9c898e00bdb43cd",
+    "baseline": "dca20a940d85d6741285c888b53bd10da29c0723",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/asr-ggml/vcpkg.json
+++ b/packages/asr-ggml/vcpkg.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-09",
+      "version>=": "2026-09-10",
       "default-features": false,
       "features": [
         "whisper",
@@ -29,7 +29,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-09",
+      "version>=": "2026-09-10",
       "default-features": false,
       "features": [
         "whisper",
@@ -41,7 +41,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-09",
+      "version>=": "2026-09-10",
       "default-features": false,
       "features": [
         "whisper",
@@ -66,7 +66,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-09",
+          "version>=": "2026-09-10",
           "default-features": false,
           "features": [
             "cuda"


### PR DESCRIPTION
Consume the speech-cpp `2026-09-10` pin ([qvac-registry-vcpkg#363](https://github.com/tetherto/qvac-registry-vcpkg/pull/363)) carrying Nemotron GPU coverage from both:

- **QVAC-24493** ([qvac-fabric-speech.cpp#237](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/237)) — Nemotron 3.5 streaming on Vulkan, parity-tested against NeMo references at all five cache-aware operating points (80/160/320/560/1120 ms).
- **QVAC-24494** ([qvac-fabric-speech.cpp#238](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/238)) — the same coverage on CUDA.

Both validated on an RTX 3090 with no engine changes needed; encoder and fused transducer decode run fully on the GPU on both backends.

## Changes

- `vcpkg.json`: all four `speech-cpp` floors (`osx|ios`, `android`, desktop, and the `cuda` feature) raised `2026-09-09` -> `2026-09-10` in lockstep. `ggml-speech` floor unchanged — the pinned `2026-09-09#1` already carries the Vulkan fused LSTM-cell / transducer-step kernels the engine uses. The default-registry baseline is untouched.
- `CHANGELOG.md`: entry under `[Unreleased]`.

No JS or addon code changes; the existing relational floor tests (`scripts/__tests__/build-backends.test.js`) cover the lockstep raise.

## Validation

- Full prebuild matrix preflighted against this exact registry commit via a forked-registry dispatch before #363 merged: [run 34483891439](https://github.com/tetherto/qvac/actions/runs/34483891439) — linux x64/arm64, win32-x64, darwin x64/arm64, iOS device + simulators, all green.
- Engine-level parity evidence in the two ext-lib PRs.
