### PR TITLE
QVAC-24306 feat[api]: integrate Pocket TTS into Fabric

### DIFF
--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/inference/.gitignore
+++ b/packages/inference/.gitignore
@@ -1,2 +1,4 @@
 dist
 bun.lock
+
+/test/pocket-dist/

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -155,7 +155,8 @@
     "test": "npm run build:test && brittle-bare 'test/dist/test/**/*.test.js'",
     "test:bare": "npm run test",
     "check-models": "bare ./dist/models/update-models/index.js --check",
-    "update-models": "bare ./dist/models/update-models/index.js && prettier --write src/models/registry/models.ts src/models/registry/resource-profiles.ts"
+    "update-models": "bare ./dist/models/update-models/index.js && prettier --write src/models/registry/models.ts src/models/registry/resource-profiles.ts",
+    "test:pocket": "tsc -p test/pocket/tsconfig.json && tsc-alias -p test/pocket/tsconfig.json --resolve-full-paths && brittle-bare test/pocket-dist/test/pocket/*.test.js"
   },
   "engines": {
     "bare": "^1.30.3"
@@ -273,6 +274,7 @@
     "prettier": "^3.9.4",
     "prettier-config-holepunch": "^2.0.0",
     "tsc-alias": "^1.8.17",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "@types/node": "^24.2.1"
   }
 }

--- a/packages/inference/src/plugins/builtin/tts-ggml/ops/request-lifecycle.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/ops/request-lifecycle.ts
@@ -1,0 +1,80 @@
+import { getModel } from '@/runtime/model-registry'
+import { getRequestRegistry } from '@/runtime/request-context'
+import { generateRandomRequestId } from '@/runtime/request-id'
+import { InferenceCancelledError } from '@/errors/index'
+
+/** Own the model until its stream and any native cancellation have drained. */
+export async function* withTtsRequest<T, R>(
+  request: { modelId: string; requestId?: string },
+  run: (ensureActive: () => Promise<void>) => AsyncGenerator<T, R>
+): AsyncGenerator<T, R> {
+  await using ctx = await getRequestRegistry().begin({
+    requestId: request.requestId ?? generateRandomRequestId(),
+    kind: 'tts',
+    modelId: request.modelId
+  })
+  if (ctx.signal.aborted) throw new InferenceCancelledError(ctx.requestId)
+  let model: ReturnType<typeof getModel> | undefined
+  const cancel = async () => {
+    if (!model) return
+    // Pocket's JS wrapper must also invalidate pending text and drain native
+    // terminal callbacks before the next request can use this model.
+    if ('cancel' in model && typeof model.cancel === 'function') {
+      await (model.cancel as () => Promise<void>).call(model)
+    } else if (model.addon?.cancel) {
+      await model.addon.cancel()
+    }
+  }
+  let cancellation: Promise<void> | undefined
+  const onAbort = () => {
+    cancellation = cancel()
+    // Await and surface rejection in finally, avoiding an unhandled rejection
+    // while the stream is still unwinding.
+    void cancellation.catch(() => {})
+  }
+  ctx.signal.addEventListener('abort', onAbort, { once: true })
+  // Call immediately after an awaited model.run*() returns. An abort may
+  // have reached the addon before that startup dispatched its native job.
+  const ensureActive = async () => {
+    if (ctx.signal.aborted) {
+      await cancel()
+      throw new InferenceCancelledError(ctx.requestId)
+    }
+  }
+  let source: AsyncGenerator<T, R> | undefined
+  let completed = false
+  try {
+    model = getModel(request.modelId)
+    source = run(ensureActive)
+    for (;;) {
+      if (ctx.signal.aborted) throw new InferenceCancelledError(ctx.requestId)
+      const next = await source.next()
+      if (ctx.signal.aborted) throw new InferenceCancelledError(ctx.requestId)
+      if (next.done) {
+        completed = true
+        return next.value
+      }
+      yield next.value
+    }
+  } catch (error) {
+    if (ctx.signal.aborted) throw new InferenceCancelledError(ctx.requestId)
+    ctx.state = 'failed'
+    throw error
+  } finally {
+    ctx.signal.removeEventListener('abort', onAbort)
+    try {
+      try {
+        await cancellation
+        if (!completed) {
+          if (!ctx.signal.aborted && ctx.state !== 'failed') ctx.state = 'cancelled'
+          await cancel()
+        }
+      } finally {
+        await source?.return(undefined as never)
+      }
+    } catch (error) {
+      ctx.state = 'failed'
+      throw error
+    }
+  }
+}

--- a/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech-stream.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech-stream.ts
@@ -103,7 +103,8 @@ function buildRunStreamingOptions(
 
 export async function* textToSpeechStream(
   params: TextToSpeechStreamRequest,
-  inputStream: AsyncIterable<Buffer>
+  inputStream: AsyncIterable<Buffer>,
+  ensureActive?: () => Promise<void>
 ): AsyncGenerator<TtsOpYield, { modelExecutionMs: number; stats?: TtsStats }, unknown> {
   const request = textToSpeechStreamRequestSchema.parse(params)
 
@@ -124,6 +125,8 @@ export async function* textToSpeechStream(
     textSource,
     Object.keys(streamOpts).length > 0 ? streamOpts : undefined
   )
+
+  await ensureActive?.()
 
   for await (const data of response.iterate()) {
     // lunte-disable-next-line eqeqeq -- `== null` intentionally matches null and undefined

--- a/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/ops/text-to-speech.ts
@@ -36,7 +36,8 @@ function hasRunStream(model: unknown): model is RunStreamModel {
 }
 
 export async function* textToSpeech(
-  params: TtsRequest
+  params: TtsRequest,
+  ensureActive?: () => Promise<void>
 ): AsyncGenerator<TtsOpYield, { modelExecutionMs: number; stats?: TtsStats }> {
   const request = ttsRequestSchema.parse(params)
   const {
@@ -73,6 +74,7 @@ export async function* textToSpeech(
         : undefined
 
     const response = await model.runStream(text, streamOpts)
+    await ensureActive?.()
 
     if (!stream) {
       let completeBuffer: number[] = []
@@ -113,6 +115,7 @@ export async function* textToSpeech(
     ...(stream ? { streamOutput: true } : {}),
     ...parlerJobOptions
   })) as unknown as TtsResponse
+  await ensureActive?.()
 
   if (!stream) {
     let completeBuffer: number[] = []

--- a/packages/inference/src/plugins/builtin/tts-ggml/plugin.ts
+++ b/packages/inference/src/plugins/builtin/tts-ggml/plugin.ts
@@ -1,3 +1,4 @@
+import { withTtsRequest } from './ops/request-lifecycle'
 import ttsAddonLogging from '@qvac/tts-ggml/addonLogging'
 import TTSGgml from '@qvac/tts-ggml'
 import {
@@ -16,6 +17,8 @@ import {
   type PluginModelResult,
   type ResolveContext,
   type ResolveResult,
+  type TtsPocketLoadConfig,
+  type TtsPocketRuntimeConfig,
   type TtsAudio8LoadConfig,
   type TtsChatterboxLoadConfig,
   type TtsCosyvoice3LoadConfig,
@@ -182,6 +185,80 @@ function lavasrFiles(artifacts: Record<string, string | undefined>) {
   return {
     ...(lavasrEnhancer ? { lavasrEnhancer } : {}),
     ...(lavasrDenoiser ? { lavasrDenoiser } : {})
+  }
+}
+
+async function resolvePocketConfig(
+  config: TtsPocketLoadConfig,
+  ctx: ResolveContext
+): Promise<ResolveResult<TtsRuntimeConfig>> {
+  const { mimiModelSrc, frontendSrc, voiceSrc, referenceAudioSrc, ...runtime } = config
+  if (!mimiModelSrc || !frontendSrc || !!voiceSrc === !!referenceAudioSrc) {
+    throw new TtsArtifactsRequiredError(
+      'Pocket requires Mimi, frontend, and exactly one voice or reference WAV'
+    )
+  }
+  const [mimiPath, frontendPath, voicePath, referenceAudioPath] = await Promise.all([
+    ctx.resolveModelPath(mimiModelSrc),
+    ctx.resolveModelPath(frontendSrc),
+    voiceSrc ? ctx.resolveModelPath(voiceSrc) : Promise.resolve(undefined),
+    referenceAudioSrc ? ctx.resolveModelPath(referenceAudioSrc) : Promise.resolve(undefined)
+  ])
+  return {
+    config: runtime,
+    artifacts: {
+      mimiPath,
+      frontendPath,
+      ...(voicePath ? { voicePath } : {}),
+      ...(referenceAudioPath ? { referenceAudioPath } : {})
+    }
+  }
+}
+
+function createPocketModel(
+  modelId: string,
+  config: TtsPocketRuntimeConfig,
+  params: CreateModelParams,
+  artifacts: Record<string, string | undefined>
+): PluginModelResult {
+  const { mimiPath, frontendPath, voicePath, referenceAudioPath } = artifacts
+  if (!params.modelPath || !mimiPath || !frontendPath || !!voicePath === !!referenceAudioPath) {
+    throw new TtsArtifactsRequiredError(
+      'Pocket requires FlowLM, Mimi, frontend, and exactly one voice or reference WAV'
+    )
+  }
+  const logger = createStreamLogger(modelId, ModelType.ttsGgml)
+  registerAddonLogger(modelId, ModelType.ttsGgml, logger)
+  const { language, useGPU, outputSampleRate } = config
+  return {
+    model: new TTSGgml({
+      engine: TTSGgml.ENGINE_POCKET,
+      files: {
+        pocketFlowModel: params.modelPath,
+        pocketMimiModel: mimiPath,
+        pocketFrontend: frontendPath,
+        ...(voicePath ? { pocketVoice: voicePath } : {})
+      },
+      ...(referenceAudioPath ? { referenceAudio: referenceAudioPath } : {}),
+      ...(config.threads !== undefined ? { threads: config.threads } : {}),
+      ...(config.nCtx !== undefined ? { nCtx: config.nCtx } : {}),
+      ...(config.maxTokens !== undefined ? { maxTokens: config.maxTokens } : {}),
+      ...(config.steps !== undefined ? { steps: config.steps } : {}),
+      ...(config.seed !== undefined ? { seed: config.seed } : {}),
+      ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
+      ...(config.noiseClamp !== undefined ? { noiseClamp: config.noiseClamp } : {}),
+      ...(config.eosThreshold !== undefined ? { eosThreshold: config.eosThreshold } : {}),
+      ...(config.framesAfterEos !== undefined ? { framesAfterEos: config.framesAfterEos } : {}),
+
+      config: {
+        language: language ?? 'en',
+        useGPU: useGPU ?? false,
+        ...(outputSampleRate !== undefined ? { outputSampleRate } : {})
+      },
+      logger,
+      opts: { stats: true },
+      exclusiveRun: true
+    })
   }
 }
 
@@ -450,6 +527,7 @@ export const ttsPlugin = definePlugin({
     const { ttsEngine } = cfg as { ttsEngine?: string }
 
     // Same default as the former onnx-tts plugin: omitting `ttsEngine` → Chatterbox.
+    if (ttsEngine === 'pocket') return resolvePocketConfig(cfg as TtsPocketLoadConfig, ctx)
     if (ttsEngine === 'parler') {
       return resolveParlerConfig(cfg as TtsParlerLoadConfig)
     }
@@ -469,6 +547,9 @@ export const ttsPlugin = definePlugin({
     const config = (params.modelConfig ?? {}) as TtsRuntimeConfig
     const artifacts = params.artifacts ?? {}
 
+    if (config.ttsEngine === 'pocket') {
+      return createPocketModel(params.modelId, config, params, artifacts)
+    }
     if (config.ttsEngine === 'parler') {
       return createParlerModel(params.modelId, config, params)
     }
@@ -493,7 +574,9 @@ export const ttsPlugin = definePlugin({
       cancel: { scope: 'model', hard: true },
 
       handler: async function* (request) {
-        const stream = textToSpeech(request)
+        const stream = withTtsRequest(request, (ensureActive) =>
+          textToSpeech(request, ensureActive)
+        )
         try {
           let result = await stream.next()
 
@@ -537,7 +620,9 @@ export const ttsPlugin = definePlugin({
       cancel: { scope: 'model', hard: true },
 
       handler: async function* (request, inputStream) {
-        const stream = textToSpeechStream(request, inputStream)
+        const stream = withTtsRequest(request, (ensureActive) =>
+          textToSpeechStream(request, inputStream, ensureActive)
+        )
         try {
           let result = await stream.next()
 

--- a/packages/inference/src/runtime/request-context.ts
+++ b/packages/inference/src/runtime/request-context.ts
@@ -129,6 +129,8 @@ function installDefaultPolicies(r: RequestRegistry): void {
     maxQueueDepthPerModel: 64,
     sharedSlotGroup: LLAMACPP_COMPLETION_SLOT_GROUP
   })
+  // TTS owns one native job per model, including duplex input and cancellation.
+  r.policy({ kind: 'tts', maxConcurrentPerModel: 1, onOverflow: 'queue', maxQueueDepthPerModel: 64 })
   // ACE-Step owns one active job per model. Starting another run replaces the
   // addon's active response, and model-scoped cancel targets that single active
   // job. Keep the registry authoritative by admitting one AudioGen request per

--- a/packages/inference/src/schemas/text-to-speech.ts
+++ b/packages/inference/src/schemas/text-to-speech.ts
@@ -527,12 +527,31 @@ const ttsAudio8RuntimeConfigShape = {
 
 export const ttsAudio8RuntimeConfigSchema = z.object(ttsAudio8RuntimeConfigShape)
 
+// Pocket English 2026-04 uses a CPU FlowLM + Mimi pipeline. The main
+// modelSrc is flow-lm.gguf; companion artifacts are resolved before activation.
+export const ttsPocketRuntimeConfigSchema = z.object({
+  ttsEngine: z.literal('pocket'),
+  language: z.literal('en').default('en'),
+  useGPU: z.literal(false).optional(),
+  threads: z.number().int().min(1).max(1024).optional(),
+  nCtx: z.number().int().min(1).max(8192).optional(),
+  maxTokens: z.number().int().min(1).max(1024).optional(),
+  steps: z.number().int().min(1).max(64).optional(),
+  seed: z.number().int().min(0).max(4294967295).optional(),
+  temperature: z.number().finite().min(0).max(10).optional(),
+  noiseClamp: z.number().finite().min(0).max(3.402823466e38).optional(),
+  eosThreshold: z.number().finite().min(-3.402823466e38).max(3.402823466e38).optional(),
+  framesAfterEos: z.number().int().min(-1).max(100).optional(),
+  outputSampleRate: z.number().int().min(8000).max(192000).optional()
+})
+
 export const ttsRuntimeConfigSchema = z.discriminatedUnion('ttsEngine', [
   ttsChatterboxRuntimeConfigSchema,
   ttsSupertonicRuntimeConfigSchema,
   ttsParlerRuntimeConfigSchema,
   ttsCosyvoice3RuntimeConfigSchema,
-  ttsAudio8RuntimeConfigSchema
+  ttsAudio8RuntimeConfigSchema,
+  ttsPocketRuntimeConfigSchema
 ])
 
 // Optional LavaSR post-processing model sources, shared across engines. Supply
@@ -699,15 +718,44 @@ function refineChatterboxTokenizerAssets(
   }
 }
 
+export const ttsPocketLoadConfigSchema = ttsPocketRuntimeConfigSchema.extend({
+  mimiModelSrc: modelSrcInputSchema,
+  frontendSrc: modelSrcInputSchema,
+  voiceSrc: modelSrcInputSchema.optional(),
+  referenceAudioSrc: modelSrcInputSchema.optional()
+})
+
+function validatePocketVoice(
+  config: {
+    ttsEngine?: unknown
+    voiceSrc?: unknown
+    referenceAudioSrc?: unknown
+  },
+  ctx: z.RefinementCtx
+) {
+  if (
+    config.ttsEngine === 'pocket' &&
+    (config.voiceSrc === undefined) === (config.referenceAudioSrc === undefined)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['voiceSrc'],
+      message: 'Pocket requires exactly one voiceSrc or referenceAudioSrc'
+    })
+  }
+}
+
 export const ttsLoadConfigSchema = z
   .discriminatedUnion('ttsEngine', [
     ttsChatterboxLoadConfigSchema,
     ttsSupertonicLoadConfigSchema,
     ttsParlerLoadConfigSchema,
     ttsCosyvoice3LoadConfigSchema,
-    ttsAudio8LoadConfigSchema
+    ttsAudio8LoadConfigSchema,
+    ttsPocketLoadConfigSchema
   ])
   .superRefine(refineChatterboxTokenizerAssets)
+  .superRefine(validatePocketVoice)
 
 // === Legacy ONNX modelConfig fields (deprecated) ===
 //
@@ -749,9 +797,11 @@ export const ttsConfigSchema = z
     ttsSupertonicLoadConfigSchema.extend(legacyTtsOnnxFieldsShape).strict(),
     ttsParlerLoadConfigSchema.strict(),
     ttsCosyvoice3LoadConfigSchema.strict(),
-    ttsAudio8LoadConfigSchema.strict()
+    ttsAudio8LoadConfigSchema.strict(),
+    ttsPocketLoadConfigSchema.strict()
   ])
   .superRefine(refineChatterboxTokenizerAssets)
+  .superRefine(validatePocketVoice)
 
 const ttsClientParamsShape = {
   modelId: z.string(),
@@ -880,3 +930,6 @@ export interface TextToSpeechStreamSession {
   destroy(): void
   [Symbol.asyncIterator](): AsyncIterator<TextToSpeechStreamResponse>
 }
+
+export type TtsPocketLoadConfig = z.infer<typeof ttsPocketLoadConfigSchema>
+export type TtsPocketRuntimeConfig = z.infer<typeof ttsPocketRuntimeConfigSchema>

--- a/packages/inference/test/pocket/pocket-schemas.test.ts
+++ b/packages/inference/test/pocket/pocket-schemas.test.ts
@@ -1,0 +1,62 @@
+import test from 'brittle'
+import { ttsConfigSchema, ttsRuntimeConfigSchema } from '@/schemas/text-to-speech'
+const base = {
+  ttsEngine: 'pocket',
+  mimiModelSrc: '/mimi.gguf',
+  frontendSrc: '/frontend.json',
+  voiceSrc: '/voice.gguf'
+}
+test('Pocket accepts bundle descriptors, defaults English and preserves unsigned seeds', (t) => {
+  const parsed = ttsConfigSchema.parse({
+    ...base,
+    seed: 4294967295,
+    temperature: 0
+  })
+  t.is('language' in parsed ? parsed.language : undefined, 'en')
+  t.is(parsed.ttsEngine, 'pocket')
+  t.is(
+    ttsConfigSchema.safeParse({
+      ...base,
+      mimiModelSrc: { src: '/mimi.gguf', sha256Checksum: 'abc' }
+    }).success,
+    true
+  )
+  t.is(ttsRuntimeConfigSchema.safeParse({ ttsEngine: 'pocket' }).success, true)
+})
+test("Pocket rejects wrong engines' settings, numeric overflow and ambiguous voice sources", (t) => {
+  for (const change of [
+    { useGPU: true },
+    { language: 'fr' },
+    { seed: -1 },
+    { seed: 4294967296 },
+    { seed: 1.5 },
+    { temperature: NaN },
+    { temperature: Infinity },
+    { steps: 0 },
+    { nCtx: 8193 },
+    { outputSampleRate: 7999 },
+    { outputSampleRate: 44100.5 },
+    { voice: 'F1' },
+    { streamChunkTokens: 10 },
+    { ttsSpeed: 1 },
+    { threads: 0 },
+    { maxTokens: 0 },
+    { voiceSrc: undefined },
+    { referenceAudioSrc: '/voice.wav' },
+    { mimiModelSrc: undefined }
+  ]) {
+    t.is(
+      ttsConfigSchema.safeParse({ ...base, ...change }).success,
+      false,
+      String(Object.keys(change))
+    )
+  }
+  t.is(
+    ttsConfigSchema.safeParse({
+      ...base,
+      voiceSrc: undefined,
+      referenceAudioSrc: '/voice.wav'
+    }).success,
+    true
+  )
+})

--- a/packages/inference/test/pocket/pocket-tts.test.ts
+++ b/packages/inference/test/pocket/pocket-tts.test.ts
@@ -1,0 +1,109 @@
+import test from 'brittle'
+import { ttsConfigSchema } from '@/schemas/text-to-speech'
+import { ttsPlugin } from '@/plugins/builtin/tts-ggml/plugin'
+import type TTSGgml from '@qvac/tts-ggml'
+import { registerModel, unregisterModel, type AnyModel } from '@/runtime/model-registry'
+import { textToSpeech } from '@/plugins/builtin/tts-ggml/ops/text-to-speech'
+import { ModelType } from '@/schemas'
+import env from 'bare-env'
+
+const bundle = env['QVAC_POCKET_MODEL_DIR']
+const loadConfig = (root: string) =>
+  ttsConfigSchema.parse({
+    ttsEngine: 'pocket',
+    mimiModelSrc: root + '/mimi.gguf',
+    frontendSrc: root + '/frontend.json',
+    voiceSrc: root + '/voice.gguf',
+    seed: 4294967295,
+    temperature: 0,
+    outputSampleRate: 24000
+  })
+
+test('Pocket SDK resolves companion descriptors and strips download fields', async (t) => {
+  const config = loadConfig('/models/pocket')
+  const paths: unknown[] = []
+  const result = await ttsPlugin.resolveConfig!(config, {
+    resolveModelPath: async (src) => {
+      paths.push(src)
+      return String(src)
+    },
+    modelSrc: '/models/pocket/flow-lm.gguf',
+    modelType: 'tts-ggml'
+  })
+  t.is(paths.length, 3)
+  t.absent('referenceAudioPath' in (result.artifacts ?? {}))
+  t.absent('voiceSrc' in result.config)
+  t.absent('mimiModelSrc' in result.config)
+  t.absent('frontendSrc' in result.config)
+  const { model } = ttsPlugin.createModel({
+    modelId: 'pocket-resolve-test',
+    modelPath: '/models/pocket/flow-lm.gguf',
+    modelConfig: result.config,
+    artifacts: result.artifacts as Record<string, string>
+  })
+  const params = (
+    model as unknown as { _buildTtsParams(): Record<string, unknown> }
+  )._buildTtsParams()
+  t.is(params['pocketMimiModelPath'], '/models/pocket/mimi.gguf')
+  t.is(params['pocketFrontendPath'], '/models/pocket/frontend.json')
+  t.is(params['pocketVoicePath'], '/models/pocket/voice.gguf')
+  t.is(params['seed'], 4294967295)
+})
+
+test(
+  'Pocket SDK plugin generates real audio through textToSpeech',
+  { skip: !bundle },
+  async (t) => {
+    const root = bundle!
+    const modelId = 'pocket-sdk-integration'
+    const result = await ttsPlugin.resolveConfig!(loadConfig(root), {
+      resolveModelPath: async (src) => String(src),
+      modelSrc: root + '/flow-lm.gguf',
+      modelType: 'tts-ggml'
+    })
+    const created = ttsPlugin.createModel({
+      modelId,
+      modelPath: root + '/flow-lm.gguf',
+      modelConfig: result.config,
+      artifacts: Object.fromEntries(
+        Object.entries(result.artifacts ?? {}).filter(
+          (entry): entry is [string, string] => typeof entry[1] === 'string'
+        )
+      )
+    })
+    const model = created.model as unknown as TTSGgml
+    try {
+      await model.load()
+      registerModel(modelId, {
+        model: created.model as unknown as AnyModel,
+        path: root,
+        config: result.config,
+        modelType: ModelType.ttsGgml
+      })
+      for (const stream of [false, true]) {
+        const synthesis = textToSpeech({
+          modelId,
+          inputType: 'text',
+          type: 'textToSpeech',
+          text: 'Hello from Pocket TTS in Fabric.',
+          stream,
+          sentenceStream: false
+        })
+        let samples = 0
+        let chunks = 0
+        let step = await synthesis.next()
+        while (!step.done) {
+          samples += step.value.buffer.length
+          if (step.value.buffer.length) chunks++
+          step = await synthesis.next()
+        }
+        t.ok(samples > 24000)
+        t.is(step.value.stats?.totalSamples, samples)
+        t.ok(stream ? chunks > 1 : chunks === 1)
+      }
+    } finally {
+      unregisterModel(modelId)
+      await model.destroy()
+    }
+  }
+)

--- a/packages/inference/test/pocket/request-lifecycle.test.ts
+++ b/packages/inference/test/pocket/request-lifecycle.test.ts
@@ -1,0 +1,287 @@
+import Buffer from 'bare-buffer'
+import test from 'brittle'
+import { withTtsRequest } from '@/plugins/builtin/tts-ggml/ops/request-lifecycle'
+import { getRequestRegistry } from '@/runtime/request-context'
+import { registerModel, unregisterModel, type AnyModel } from '@/runtime/model-registry'
+import { ModelType } from '@/schemas'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+function register(id: string, model: unknown) {
+  registerModel(id, {
+    model: model as AnyModel,
+    path: id,
+    config: {},
+    modelType: ModelType.ttsGgml
+  })
+}
+
+test('TTS cancellation before admission never runs or cancels the shared model', async (t) => {
+  const modelId = 'tts-before'
+  let touched = false
+  register(modelId, {
+    cancel: async () => {
+      touched = true
+    }
+  })
+  getRequestRegistry().cancel({ requestId: 'tts-before-request' })
+  const source = withTtsRequest({ modelId, requestId: 'tts-before-request' }, async function* () {
+    touched = true
+    yield 1
+  })
+  try {
+    await t.exception(source.next(), /cancel/i)
+    t.is(touched, false)
+  } finally {
+    unregisterModel(modelId)
+  }
+})
+
+test('TTS holds admission through native cancellation and does not cancel its successor', async (t) => {
+  t.timeout(5000)
+  const modelId = 'tts-drain'
+  const releaseCancel = deferred()
+  let cancels = 0
+  let successorStarted = false
+  register(modelId, {
+    cancel: async () => {
+      cancels++
+      await releaseCancel.promise
+    }
+  })
+  const first = withTtsRequest({ modelId, requestId: 'tts-drain-first' }, async function* () {
+    yield 1
+    yield 2
+  })
+  const second = withTtsRequest({ modelId, requestId: 'tts-drain-second' }, async function* () {
+    successorStarted = true
+    yield 3
+  })
+  try {
+    t.is((await first.next()).value, 1)
+    const nextSecond = second.next()
+    t.is(getRequestRegistry().cancel({ requestId: 'tts-drain-first' }), 1)
+    const cancelled = t.exception(first.next(), /cancel/i)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    t.is(successorStarted, false, 'successor waits for cancellation barrier')
+    releaseCancel.resolve()
+    await cancelled
+    t.is((await nextSecond).value, 3)
+    const atStart = cancels
+    t.is((await second.next()).done, true)
+    t.is(cancels, atStart, 'completed successor was not cancelled')
+  } finally {
+    releaseCancel.resolve()
+    await first.return(undefined)
+    await second.return(undefined)
+    unregisterModel(modelId)
+  }
+})
+
+test('TTS queued cancellation leaves the active model untouched', async (t) => {
+  t.timeout(5000)
+  const modelId = 'tts-queued'
+  let cancels = 0
+  let queuedRan = false
+  register(modelId, {
+    cancel: async () => {
+      cancels++
+    }
+  })
+  const active = withTtsRequest({ modelId, requestId: 'tts-queued-active' }, async function* () {
+    yield 1
+  })
+  const queued = withTtsRequest({ modelId, requestId: 'tts-queued-waiter' }, async function* () {
+    queuedRan = true
+    yield 2
+  })
+  try {
+    await active.next()
+    const waiting = queued.next()
+    getRequestRegistry().cancel({ requestId: 'tts-queued-waiter' })
+    await t.exception(waiting, /cancel/i)
+    t.is(queuedRan, false)
+    t.is(cancels, 0)
+    t.is((await active.next()).done, true)
+  } finally {
+    await active.return(undefined)
+    await queued.return(undefined)
+    unregisterModel(modelId)
+  }
+})
+
+test('TTS consumer abandonment cancels and closes the source, using addon fallback', async (t) => {
+  const modelId = 'tts-abandoned'
+  let cancelled = false
+  let closed = false
+  register(modelId, {
+    addon: {
+      cancel: async () => {
+        cancelled = true
+      }
+    }
+  })
+  const source = withTtsRequest({ modelId }, async function* () {
+    try {
+      yield 1
+      yield 2
+    } finally {
+      closed = true
+    }
+  })
+  try {
+    await source.next()
+    await source.return(undefined)
+    t.is(cancelled, true)
+    t.is(closed, true)
+    t.is(getRequestRegistry().cancel({ modelId, kind: 'tts' }), 0)
+  } finally {
+    unregisterModel(modelId)
+  }
+})
+
+// Exercise the production op boundaries, not just the lifecycle helper.
+import { textToSpeech } from '@/plugins/builtin/tts-ggml/ops/text-to-speech'
+import { textToSpeechStream } from '@/plugins/builtin/tts-ggml/ops/text-to-speech-stream'
+
+for (const mode of ['plain', 'sentence', 'duplex'] as const) {
+  test(`TTS ${mode} cancellation during asynchronous startup stops the later job`, async (t) => {
+    t.timeout(5000)
+    const modelId = `tts-startup-${mode}`
+    const entered = deferred()
+    const start = deferred()
+    let active = false
+    let iterated = false
+    let cancelledAfterStart = false
+    const run = async () => {
+      entered.resolve()
+      await start.promise
+      active = true
+      return {
+        iterate: async function* () {
+          iterated = true
+          // No text arrives in this fixture; without the startup abort check,
+          // the duplex response would wait here indefinitely.
+          await new Promise<void>(() => {})
+          yield { outputArray: [1] }
+        }
+      }
+    }
+    register(modelId, {
+      run,
+      runStream: run,
+      runStreaming: run,
+      cancel: async () => {
+        if (active) {
+          active = false
+          cancelledAfterStart = true
+        }
+      }
+    })
+    const requestId = `tts-startup-request-${mode}`
+    const source = withTtsRequest({ modelId, requestId }, (ensureActive) =>
+      mode === 'duplex'
+        ? textToSpeechStream(
+            {
+              type: 'textToSpeechStream',
+              modelId,
+              inputType: 'text'
+            },
+            {
+              async *[Symbol.asyncIterator]() {
+                yield Buffer.from('hello')
+              }
+            },
+            ensureActive
+          )
+        : textToSpeech(
+            {
+              type: 'textToSpeech',
+              modelId,
+              inputType: 'text',
+              text: 'Hello',
+              stream: true,
+              sentenceStream: mode === 'sentence'
+            },
+            ensureActive
+          )
+    )
+    try {
+      const rejected = t.exception(source.next(), /cancel/i)
+      await entered.promise
+      t.is(getRequestRegistry().cancel({ requestId }), 1)
+      start.resolve()
+      await rejected
+      t.is(active, false)
+      t.is(cancelledAfterStart, true)
+      t.is(iterated, false, 'does not wait for output after cancelled startup')
+      t.is(getRequestRegistry().cancel({ modelId, kind: 'tts' }), 0)
+    } finally {
+      start.resolve()
+      unregisterModel(modelId)
+    }
+  })
+}
+
+test('TTS cancellation failure still closes the source and releases admission', async (t) => {
+  const modelId = 'tts-cancel-failure'
+  let closed = false
+  register(modelId, {
+    cancel: async () => {
+      throw new Error('cancel failed')
+    }
+  })
+  const source = withTtsRequest({ modelId }, async function* () {
+    try {
+      yield 1
+    } finally {
+      closed = true
+    }
+  })
+  try {
+    await source.next()
+    await t.exception(source.return(undefined), /cancel failed/)
+    t.is(closed, true)
+    t.is(getRequestRegistry().cancel({ modelId, kind: 'tts' }), 0)
+    const successor = withTtsRequest({ modelId }, async function* () {
+      return 9
+    })
+    t.is((await successor.next()).value, 9)
+  } finally {
+    unregisterModel(modelId)
+  }
+})
+
+for (const failure of ['source', 'cleanup'] as const) {
+  test(`TTS ${failure} errors report failed lifecycle state and release admission`, async (t) => {
+    const modelId = `tts-error-${failure}`
+    const requestId = `tts-error-request-${failure}`
+    register(modelId, { cancel: async () => {} })
+    const source = withTtsRequest({ modelId, requestId }, async function* () {
+      try {
+        yield 1
+        if (failure === 'source') throw new Error('source failure')
+      } finally {
+        if (failure === 'cleanup') throw new Error('cleanup failure')
+      }
+    })
+    try {
+      await source.next()
+      const context = getRequestRegistry().get(requestId)!
+      await t.exception(failure === 'source' ? source.next() : source.return(undefined), /failure/)
+      t.is(context.state, 'failed')
+      t.is(getRequestRegistry().get(requestId), null)
+      const successor = withTtsRequest({ modelId }, async function* () {
+        return 7
+      })
+      t.is((await successor.next()).value, 7)
+    } finally {
+      unregisterModel(modelId)
+    }
+  })
+}

--- a/packages/inference/test/pocket/tsconfig.json
+++ b/packages/inference/test/pocket/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "./*.test.ts",
+    "../../src/types/**/*"
+  ],
+  "exclude": [
+    "../dist",
+    "../pocket-dist",
+    "../../node_modules"
+  ],
+  "compilerOptions": {
+    "outDir": "../pocket-dist",
+    "rootDir": "../..",
+    "noEmit": false,
+    "noEmitOnError": true,
+    "allowImportingTsExtensions": false,
+    "declaration": false,
+    "declarationMap": false,
+    "types": [
+      "node"
+    ]
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true
+  }
+}

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./constants": {
       "types": "./dist/constants.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -209,7 +209,8 @@
     "contract:export": "tsx ./scripts/export-contract.ts",
     "contract:check": "tsx ./scripts/export-contract.ts --check",
     "check:resource-collectors": "tsx ./scripts/check-resource-collectors-packaging.ts",
-    "changelog:generate": "node ../../scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk && prettier --write changelog"
+    "changelog:generate": "node ../../scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk && prettier --write changelog",
+    "test:pocket:node": "node scripts/run-pocket-node-test.js"
   },
   "dependencies": {
     "@qvac/audiogen-ggml": "^0.3.2",

--- a/packages/sdk/scripts/pocket-node-test.js
+++ b/packages/sdk/scripts/pocket-node-test.js
@@ -1,0 +1,138 @@
+// Run after building @qvac/inference and @qvac/sdk and resolving import aliases.
+// Exercises the normal Node SDK transport and its spawned Bare worker.
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import test from 'node:test'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const bundleInput = process.env['QVAC_POCKET_MODEL_DIR']
+if (!bundleInput) {
+  throw new Error('QVAC_POCKET_MODEL_DIR is required; this test must not skip inference')
+}
+const bundle = path.resolve(bundleInput)
+const build = path.join(root, 'dist/src')
+const home = fs.mkdtempSync(path.join(os.tmpdir(), 'qvac-pocket-node-'))
+process.env['QVAC_WORKER_PATH'] = path.join(root, 'scripts/pocket-test-worker.js')
+process.env['QVAC_POCKET_TEST_HOME'] = home
+process.env['QVAC_CONFIG_PATH'] = path.join(home, 'qvac.config.json')
+fs.writeFileSync(
+  process.env['QVAC_CONFIG_PATH'],
+  JSON.stringify({ cacheDirectory: path.join(home, 'cache') })
+)
+fs.writeFileSync(
+  path.join(home, 'package.json'),
+  JSON.stringify({ name: 'pocket-ipc-test', private: true })
+)
+process.chdir(home)
+const load = (name) => import(pathToFileURL(path.join(build, name)).href)
+const { loadModel, unloadModel, textToSpeech, textToSpeechStream, cancel, close } =
+  await load('index.js')
+const { getWorkerLifeSignal } = await load('client/rpc/node-rpc-client.js')
+const { ModelType } = await import('@qvac/inference/surface')
+
+test('Pocket public Node client over worker IPC', { timeout: 60000 }, async (t) => {
+  // Node's test timeout does not unwind a hung await into finally.
+  // Register teardown before load so cancellation also closes its worker.
+  let shutdownPromise
+  const shutdown = () => (shutdownPromise ??= close())
+  const onAbort = () => {
+    void shutdown().catch((error) => {
+      console.error('Pocket IPC shutdown failed', error)
+      process.exitCode = 1
+    })
+  }
+  t.signal.addEventListener('abort', onAbort, { once: true })
+  t.after(async () => {
+    t.signal.removeEventListener('abort', onAbort)
+    await shutdown()
+  })
+  const modelId = await loadModel({
+    modelType: ModelType.ttsGgml,
+    modelSrc: path.join(bundle, 'flow-lm.gguf'),
+    modelConfig: {
+      ttsEngine: 'pocket',
+      language: 'en',
+      useGPU: false,
+      threads: 1,
+      temperature: 0,
+      mimiModelSrc: path.join(bundle, 'mimi.gguf'),
+      frontendSrc: path.join(bundle, 'frontend.json'),
+      voiceSrc: path.join(bundle, 'voice.gguf'),
+      outputSampleRate: 24000
+    }
+  })
+  assert.ok(modelId)
+  const text = 'Hello! Pocket TTS now speaks through the Fabric client.'
+  let reference
+  await t.test('batch and stream preserve PCM across serialization', async () => {
+    const batch = textToSpeech({ modelId, text, stream: false })
+    reference = await batch.buffer
+    assert.equal(await batch.done, true)
+    assert.ok(reference.length > 24000 && reference.some((sample) => sample !== 0))
+    const stream = textToSpeech({ modelId, text, stream: true })
+    const pcm = []
+    for await (const sample of stream.bufferStream) pcm.push(sample)
+    assert.equal(await stream.done, true)
+    assert.equal(pcm.length, reference.length)
+    assert.ok(pcm.every((sample, i) => Math.abs(sample - reference[i]) <= 4))
+  })
+  await t.test('duplex emits audio while text input is still open', async () => {
+    const session = await textToSpeechStream({
+      modelId,
+      inputType: 'text',
+      accumulateSentences: false
+    })
+    try {
+      session.write('Hello from Pocket. ')
+      const iterator = session[Symbol.asyncIterator]()
+      let samples = 0
+      while (!samples) {
+        const next = await iterator.next()
+        assert.equal(next.done, false)
+        samples += next.value.buffer.length
+      }
+      session.end()
+      while (!(await iterator.next()).done) {
+        /* drain */
+      }
+      assert.ok(samples > 0)
+    } finally {
+      session.destroy()
+    }
+  })
+  await t.test('cancel terminates an active stream and permits recovery', async () => {
+    const response = textToSpeech({
+      modelId,
+      text: text.repeat(10),
+      stream: true
+    })
+    const iterator = response.bufferStream[Symbol.asyncIterator]()
+    for (;;) {
+      const next = await iterator.next()
+      assert.equal(next.done, false)
+      if (next.value !== 0) break
+    }
+    await cancel({ modelId, kind: 'tts' })
+    try {
+      while (!(await iterator.next()).done) {
+        /* drain queued samples */
+      }
+    } catch (error) {
+      assert.match(String(error), /cancel|abort/i)
+    }
+    assert.equal(await response.done.catch(() => false), false)
+    const recovered = textToSpeech({ modelId, text, stream: false })
+    const pcm = await recovered.buffer
+    assert.equal(await recovered.done, true)
+    assert.equal(pcm.length, reference.length)
+    assert.ok(pcm.every((sample, i) => Math.abs(sample - reference[i]) <= 4))
+  })
+  await unloadModel({ modelId, autoClose: false })
+  const life = getWorkerLifeSignal()
+  assert.ok(life && !life.aborted)
+  await close()
+  assert.equal(life.aborted, true, 'closing the client ends its worker lifecycle')
+})

--- a/packages/sdk/scripts/pocket-test-worker.js
+++ b/packages/sdk/scripts/pocket-test-worker.js
@@ -1,0 +1,17 @@
+// Bare bootstrap for the real worker process spawned by the Node SDK client.
+import Module from 'bare-module'
+import path from 'bare-path'
+import fs from 'bare-fs'
+import env from 'bare-env'
+import { fileURLToPath, pathToFileURL } from 'bare-url'
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const home = env['QVAC_POCKET_TEST_HOME']
+if (!home) throw new Error('QVAC_POCKET_TEST_HOME is required for isolated IPC validation')
+const config = JSON.parse(Bare.argv[2])
+config.HOME_DIR = home
+Bare.argv[2] = JSON.stringify(config)
+const imports = JSON.parse(fs.readFileSync(path.join(root, 'bare-imports.json'), 'utf8'))
+Module.load(pathToFileURL(path.join(root, 'scripts/pocket-worker-entry.js')), null, {
+  imports,
+  conditions: ['bare', 'import']
+})

--- a/packages/sdk/scripts/pocket-worker-entry.js
+++ b/packages/sdk/scripts/pocket-worker-entry.js
@@ -1,0 +1,7 @@
+// Uses the normal SDK worker transport with only the TTS plugin registered.
+import { initializeWorker, ensureRPCSetup } from '../dist/src/worker/lifecycle.js'
+import { registerPlugin } from '@qvac/inference/plugins'
+import { ttsPlugin } from '@qvac/inference/tts-ggml/plugin'
+initializeWorker()
+registerPlugin(ttsPlugin)
+ensureRPCSetup()

--- a/packages/sdk/scripts/run-pocket-node-test.js
+++ b/packages/sdk/scripts/run-pocket-node-test.js
@@ -1,0 +1,58 @@
+// Supervise the test separately: native worker shutdown can block indefinitely.
+import { spawn, spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function runSupervised(script, { deadlineMs = 75000 } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script], {
+      stdio: 'inherit',
+      detached: process.platform !== 'win32'
+    })
+    let failed = false
+    const stopTree = () => {
+      if (!child.pid) return
+      if (process.platform === 'win32') {
+        spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], {
+          stdio: 'ignore',
+          timeout: 5000
+        })
+      } else {
+        try {
+          process.kill(-child.pid, 'SIGKILL')
+        } catch (error) {
+          if (error.code !== 'ESRCH') throw error
+        }
+      }
+    }
+    const abort = () => {
+      failed = true
+      stopTree()
+    }
+    const deadline = setTimeout(() => {
+      console.error('Pocket IPC test exceeded its shutdown deadline')
+      abort()
+    }, deadlineMs)
+    process.once('SIGINT', abort)
+    process.once('SIGTERM', abort)
+    const finish = (code) => {
+      clearTimeout(deadline)
+      process.removeListener('SIGINT', abort)
+      process.removeListener('SIGTERM', abort)
+      // Also reap workers left behind by an unexpected test-process exit.
+      stopTree()
+      resolve(failed ? 1 : (code ?? 1))
+    }
+    child.once('error', (error) => {
+      console.error('Could not start Pocket IPC test', error)
+      finish(1)
+    })
+    child.once('exit', finish)
+  })
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exitCode = await runSupervised(
+    fileURLToPath(new URL('./pocket-node-test.js', import.meta.url))
+  )
+}

--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -40,7 +40,15 @@ configure_file(${VCPKG_INSTALLED_PATH}/tools/lint-cpp/hooks/pre-commit
                ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit COPYONLY)
 
 find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "inference-addon-cpp/ModelInterfaces.hpp")
-find_package(tts-cpp CONFIG REQUIRED)
+find_package(tts-cpp CONFIG REQUIRED COMPONENTS pocket)
+# Older configs may not implement component checks. Reject those explicitly.
+if(NOT tts-cpp_pocket_FOUND)
+  message(FATAL_ERROR
+    "tts-ggml requires a tts-cpp package containing Pocket TTS. "
+    "The selected registry source pin is too old. Install the updated "
+    "speech repository's engines/tts and set tts-cpp_DIR to its "
+    "share/tts-cpp directory; see README.md for local build instructions.")
+endif()
 find_package(mecab CONFIG REQUIRED)
 # Pull in ggml directly (in addition to the transitive
 # find_package(ggml) that tts-cppConfig.cmake already does) so the
@@ -133,7 +141,39 @@ if(((ANDROID OR UNIX) AND NOT APPLE) OR (WIN32 AND ENABLE_CUDA))
   endif()
 endif()
 
+# Developer builds may consume the shared speech ggml package on macOS.
+# Package its dylibs alongside the addon, using cmake-bare's SONAME-aware
+# install rules; the module's @loader_path rpath already points here.
+if(APPLE)
+  foreach(_library ggml::ggml ggml::ggml-base ggml::ggml-cpu tts-cpp::tts-cpp)
+    if(TARGET ${_library})
+      get_target_property(_library_type ${_library} TYPE)
+      if(_library_type STREQUAL "SHARED_LIBRARY")
+        list(APPEND BACKEND_DL_LIBS INSTALL TARGET ${_library})
+      elseif(_library_type STREQUAL "UNKNOWN_LIBRARY")
+        # ggml-config.cmake uses UNKNOWN IMPORTED targets even for dylibs.
+        # Preserve the complete symlink chain so the versioned LC_ID_DYLIB
+        # names resolve without depending on the developer's install prefix.
+        get_target_property(_dylib ${_library} IMPORTED_LOCATION)
+        if(_dylib MATCHES "\\.dylib$")
+          list(APPEND BACKEND_DYLIB_FILES "${_dylib}")
+          while(IS_SYMLINK "${_dylib}")
+            get_filename_component(_dylib_dir "${_dylib}" DIRECTORY)
+            file(READ_SYMLINK "${_dylib}" _dylib_link)
+            get_filename_component(_dylib "${_dylib_link}" ABSOLUTE BASE_DIR "${_dylib_dir}")
+            list(APPEND BACKEND_DYLIB_FILES "${_dylib}")
+          endwhile()
+        endif()
+      endif()
+    endif()
+  endforeach()
+endif()
+
 add_bare_module(tts-ggml EXPORTS ${BACKEND_DL_LIBS})
+if(BACKEND_DYLIB_FILES)
+  list(REMOVE_DUPLICATES BACKEND_DYLIB_FILES)
+  install(FILES ${BACKEND_DYLIB_FILES} DESTINATION ${BACKENDS_SUBDIR_VALUE})
+endif()
 
 # Stage every loose MODULE backend (Vulkan / OpenCL on Android, CUDA on desktop, ...)
 # into the same per-host/per-module subdir cmake-bare's INSTALL TARGET
@@ -164,6 +204,7 @@ target_sources(
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/parler/ParlerModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/supertonic/SupertonicModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/cosyvoice/CosyvoiceModel.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/pocket/PocketModel.cpp
 )
 
 target_include_directories(

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -1048,3 +1048,7 @@ OpenCL; Xclipse and Mali use Vulkan).
 ## License
 
 Apache-2.0.  See [LICENSE](./LICENSE).
+
+## Pocket TTS
+
+See [Pocket TTS](docs/pocket-tts.md) for model conversion, addon/SDK usage, supported controls and validation commands.

--- a/packages/tts-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/tts-ggml/addon/src/addon/AddonJs.hpp
@@ -23,6 +23,7 @@
 #include "model-interface/cosyvoice/CosyvoiceModel.hpp"
 #include "model-interface/parler/ParlerModel.hpp"
 #include "model-interface/supertonic/SupertonicModel.hpp"
+#include "model-interface/pocket/PocketModel.hpp"
 
 namespace qvac::ttsggml::addon_js {
 
@@ -33,6 +34,7 @@ using chatterbox::ChatterboxModel;
 using cosyvoice::CosyvoiceModel;
 using parler::ParlerModel;
 using supertonic::SupertonicModel;
+using pocket::PocketModel;
 
 struct JsAudioOutputHandler
     : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
@@ -104,7 +106,10 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   //      enhancer) — always the final emitted rate when set;
   //   2. 48000 when the LavaSR enhancer is active (it always emits 48 kHz);
   //   3. the engine's native rate.
-  if (engineType == EngineType::Supertonic) {
+  if (engineType == EngineType::Pocket) {
+    auto pm = make_unique<PocketModel>(adapter.buildPocketConfig(configurationParams, env));
+    sampleRate = pm->sampleRate(); model = std::move(pm);
+  } else if (engineType == EngineType::Supertonic) {
     auto cfg = adapter.buildSupertonicConfig(configurationParams, env);
     const bool enhanced = !cfg.enhancerGgufPath.empty();
     const int outSr = cfg.outputSampleRate.value_or(0);
@@ -171,6 +176,16 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
     throw qvac_errors::StatusError(
         qvac_errors::general_error::InvalidArgument,
         "Unknown input type: " + type);
+  }
+
+  if (dynamic_cast<PocketModel*>(&instance.addonCpp->model.get())) {
+    PocketModel::AnyInput modelInput;
+    modelInput.text = js::String(env, jsInput).as<std::string>(env);
+    auto queue = instance.addonCpp->outputQueue;
+    modelInput.chunkCallback = [queue](std::vector<int16_t>&& pcm, int index, bool last) {
+      queue->queueResult(std::any(StreamingPcmChunk{std::move(pcm), index, last}));
+    };
+    return instance.runJob(std::any(std::move(modelInput)));
   }
 
   if (dynamic_cast<SupertonicModel*>(&instance.addonCpp->model.get())) {
@@ -277,6 +292,14 @@ inline js_value_t* reload(js_env_t* env, js_callback_info_t* info) try {
   AddonJs& instance = JsInterface::getInstance(env, args.get(0, "instance"));
   auto configurationParams = args.getJsObject(1, "configurationParams");
   JSAdapter adapter;
+
+  if (dynamic_cast<PocketModel*>(&instance.addonCpp->model.get())) {
+    auto config = adapter.buildPocketConfig(configurationParams, env);
+    return js::JsAsyncTask::run(env,
+        [addon = instance.addonCpp, config = std::move(config)]() mutable {
+          dynamic_cast<PocketModel&>(addon->model.get()).reload(std::move(config));
+        });
+  }
 
   if (auto* st = dynamic_cast<SupertonicModel*>(&instance.addonCpp->model.get())) {
     auto newCfg = adapter.buildSupertonicConfig(configurationParams, env);

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -1,6 +1,7 @@
 #include "js-interface/JSAdapter.hpp"
 
 #include <optional>
+#include <cmath>
 #include <string>
 
 #include "inference-addon-cpp/Errors.hpp"
@@ -80,6 +81,7 @@ EngineType JSAdapter::readEngineType(
     js::Object configurationParams, js_env_t* env) {
   const std::string explicitType =
       readOptionalString(configurationParams, env, "engineType");
+  if (explicitType == "pocket") return EngineType::Pocket;
   if (explicitType == "chatterbox") return EngineType::Chatterbox;
   if (explicitType == "supertonic") return EngineType::Supertonic;
   if (explicitType == "cosyvoice3")
@@ -91,8 +93,8 @@ EngineType JSAdapter::readEngineType(
   if (!explicitType.empty()) {
     throw qvac_errors::StatusError(
         general_error::InvalidArgument,
-        "engineType must be 'chatterbox', 'supertonic', 'cosyvoice3', 'parler' "
-        "or 'audio8' (got '" +
+        "engineType must be 'chatterbox', 'supertonic', 'cosyvoice3', 'parler', "
+        "'audio8' or 'pocket' (got '" +
             explicitType + "')");
   }
 
@@ -353,4 +355,41 @@ JSAdapter::buildCosyvoiceConfig(js::Object configurationParams, js_env_t* env) {
       readOptionalString(configurationParams, env, "lavasrDenoiserPath");
   return cfg;
 }
+
+pocket::PocketConfig JSAdapter::buildPocketConfig(js::Object params, js_env_t* env) {
+  pocket::PocketConfig cfg; auto& o = cfg.options;
+  o.flow_lm_path = readOptionalString(params, env, "pocketFlowModelPath");
+  o.mimi_path = readOptionalString(params, env, "pocketMimiModelPath");
+  o.frontend_path = readOptionalString(params, env, "pocketFrontendPath");
+  o.voice_path = readOptionalString(params, env, "pocketVoicePath");
+  o.reference_audio_path = readOptionalString(params, env, "referenceAudio");
+  // Validate before narrowing JS doubles to C++ integers/floats. Numeric strings
+  // and fractional/out-of-range integers are deliberately not coerced.
+  const auto number = [&](const char* key, double fallback, double min, double max, bool integer = true) {
+    auto* value = params.getProperty(env, key);
+    if (js::is<js::Undefined>(env, value)) return fallback;
+    if (!js::is<js::Number>(env, value))
+      throw qvac_errors::StatusError(general_error::InvalidArgument, std::string(key)+" must be a number");
+    const double n = js::Number::fromValue(value).as<double>(env);
+    if (!std::isfinite(n) || n < min || n > max || (integer && std::floor(n) != n))
+      throw qvac_errors::StatusError(general_error::InvalidArgument, std::string("invalid Pocket ")+key);
+    return n;
+  };
+  o.n_threads = number("threads", o.n_threads, 1, 1024);
+  o.context = number("nCtx", o.context, 1, 8192);
+  o.max_tokens = number("maxTokens", o.max_tokens, 1, 1024);
+  o.steps = number("steps", o.steps, 1, 64);
+  o.frames_after_eos = number("framesAfterEos", o.frames_after_eos, -1, 100);
+  o.seed = number("seed", o.seed, 0, 4294967295.0);
+  o.output_sample_rate = number("outputSampleRate", o.output_sample_rate, 8000, 192000);
+  o.temperature = number("temperature", o.temperature, 0, 10, false);
+  o.noise_clamp = number("noiseClamp", o.noise_clamp, 0, 3.402823466e38, false);
+  o.eos_threshold = number("eosThreshold", o.eos_threshold, -3.402823466e38, 3.402823466e38, false);
+  const auto language = readOptionalString(params, env, "language");
+  if ((!language.empty() && language != "en") || readOptionalBool(params, env, "useGPU").value_or(false) ||
+      number("nGpuLayers", 0, 0, 0) != 0)
+    throw qvac_errors::StatusError(general_error::InvalidArgument, "Pocket currently supports English on CPU");
+  return cfg;
+}
+
 }

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.hpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.hpp
@@ -12,6 +12,7 @@
 #include "model-interface/cosyvoice/CosyvoiceConfig.hpp"
 #include "model-interface/parler/ParlerConfig.hpp"
 #include "model-interface/supertonic/SupertonicConfig.hpp"
+#include "model-interface/pocket/PocketConfig.hpp"
 
 namespace qvac::ttsggml {
 
@@ -21,11 +22,14 @@ enum class EngineType {
   Cosyvoice,
   Parler,
   Audio8,
+  Pocket,
 };
 
 class JSAdapter {
 public:
   JSAdapter() = default;
+  pocket::PocketConfig buildPocketConfig(
+      qvac_lib_inference_addon_cpp::js::Object configurationParams, js_env_t* env);
 
   EngineType readEngineType(
       qvac_lib_inference_addon_cpp::js::Object configurationParams,

--- a/packages/tts-ggml/addon/src/model-interface/pocket/PocketConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/pocket/PocketConfig.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <tts-cpp/pocket/engine.h>
+
+namespace qvac::ttsggml::pocket {
+struct PocketConfig {
+  tts_cpp::pocket::EngineOptions options;
+};
+}

--- a/packages/tts-ggml/addon/src/model-interface/pocket/PocketModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/pocket/PocketModel.cpp
@@ -1,0 +1,119 @@
+#include "model-interface/pocket/PocketModel.hpp"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <stdexcept>
+#include "addon/TTSErrors.hpp"
+#include "inference-addon-cpp/Errors.hpp"
+
+namespace qvac::ttsggml::pocket {
+namespace {
+using qvac_errors::StatusError;
+using qvac_errors::createTTSError;
+using qvac_errors::tts_error::TTSErrorCode;
+namespace general_error = qvac_errors::general_error;
+struct BusyGuard {
+  std::atomic_bool& flag;
+  explicit BusyGuard(std::atomic_bool& f) : flag(f) {
+    bool expected = false;
+    if (!flag.compare_exchange_strong(expected, true))
+      throw StatusError(general_error::InvalidArgument, "PocketModel: operation already in progress");
+  }
+  ~BusyGuard() { flag.store(false); }
+};
+std::shared_ptr<tts_cpp::pocket::Engine> makeEngine(const PocketConfig& cfg) {
+  try { return std::make_shared<tts_cpp::pocket::Engine>(cfg.options); }
+  catch (const std::exception& e) {
+    throw createTTSError(TTSErrorCode::InitializationFailed, std::string("PocketModel::load: ") + e.what());
+  }
+}
+}
+PocketModel::PocketModel(PocketConfig config)
+    : cfg_(std::move(config)), sampleRate_(cfg_.options.output_sample_rate) {
+  const auto& o = cfg_.options;
+  if (o.flow_lm_path.empty() || o.mimi_path.empty() || o.frontend_path.empty() ||
+      o.voice_path.empty() == o.reference_audio_path.empty())
+    throw StatusError(general_error::InvalidArgument,
+        "Pocket requires FlowLM, Mimi, frontend, and exactly one prepared voice or reference WAV");
+  if (sampleRate_ < 8000 || sampleRate_ > 192000)
+    throw StatusError(general_error::InvalidArgument, "outputSampleRate must be 8000..192000");
+}
+void PocketModel::load() {
+  BusyGuard guard(busy_);
+  { std::lock_guard lock(mutex_); if (engine_) return; }
+  auto engine = makeEngine(cfg_);
+  std::lock_guard lock(mutex_); engine_ = std::move(engine);
+}
+void PocketModel::unload() {
+  BusyGuard guard(busy_);
+  std::lock_guard lock(mutex_); engine_.reset();
+}
+void PocketModel::reload(PocketConfig config) {
+  BusyGuard guard(busy_);
+  // Native output handlers capture the sample rate at creation. JS reload
+  // recreates the instance when changing this value.
+  if (config.options.output_sample_rate != sampleRate_)
+    throw StatusError(general_error::InvalidArgument, "recreate PocketModel to change outputSampleRate");
+  auto engine = makeEngine(config); // retain the previous usable model on failure
+  std::lock_guard lock(mutex_); cfg_ = std::move(config); engine_ = std::move(engine);
+}
+bool PocketModel::isLoaded() const {
+  std::lock_guard lock(mutex_); return bool(engine_);
+}
+void PocketModel::cancel() const {
+  cancelEpoch_.fetch_add(1);
+  std::shared_ptr<tts_cpp::pocket::Engine> engine;
+  { std::lock_guard lock(mutex_); engine = engine_; }
+  if (engine) engine->cancel();
+}
+std::any PocketModel::process(const std::any& input) {
+  const auto* request = std::any_cast<AnyInput>(&input);
+  if (!request) throw StatusError(general_error::InvalidArgument, "PocketModel requires AnyInput");
+  BusyGuard guard(busy_);
+  const auto epoch = cancelEpoch_.load();
+  std::shared_ptr<tts_cpp::pocket::Engine> engine;
+  { std::lock_guard lock(mutex_); engine = engine_; stats_.clear(); }
+  if (!engine) throw createTTSError(TTSErrorCode::InitializationFailed, "PocketModel is not loaded");
+  Output output; int index = 0; int64_t samples = 0;
+  double firstAudioMs = 0;
+  const auto begin = std::chrono::steady_clock::now();
+  const auto elapsed = [&] { return std::chrono::duration<double>(std::chrono::steady_clock::now()-begin).count(); };
+  try {
+    const auto result = engine->synthesize_stream(request->text, [&](const float* pcm, size_t n, int rate) {
+      if (cancelEpoch_.load() != epoch) return false;
+      if (rate != sampleRate_) throw std::runtime_error("unexpected native output sample rate");
+      Output chunk(n);
+      for (size_t i = 0; i < n; ++i) {
+        if (!std::isfinite(pcm[i])) throw std::runtime_error("non-finite audio sample");
+        chunk[i] = static_cast<int16_t>(std::lround(std::clamp(pcm[i], -1.0f, 1.0f)*32767.0f));
+      }
+      if (!samples) firstAudioMs = elapsed()*1000;
+      samples += n;
+      if (request->chunkCallback) request->chunkCallback(std::move(chunk), index++, false);
+      else output.insert(output.end(), chunk.begin(), chunk.end());
+      return cancelEpoch_.load() == epoch;
+    });
+    if (result.cancelled || cancelEpoch_.load() != epoch) throw std::runtime_error("synthesis cancelled");
+    if (request->chunkCallback) request->chunkCallback({}, index, true);
+  } catch (const std::exception& e) {
+    throw createTTSError(TTSErrorCode::SynthesisFailed, std::string("pocket.synthesize: ") + e.what());
+  }
+  const double seconds = elapsed(), duration = double(samples)/sampleRate_;
+  {
+    std::lock_guard lock(mutex_);
+    stats_.emplace_back("totalTime", seconds);
+    stats_.emplace_back("firstAudioMs", firstAudioMs);
+    stats_.emplace_back("audioDurationMs", duration*1000);
+    stats_.emplace_back("totalSamples", samples);
+    stats_.emplace_back("realTimeFactor", duration > 0 ? seconds/duration : 0.0);
+    stats_.emplace_back("tokensPerSecond", seconds > 0 ? request->text.size()/seconds : 0.0);
+    stats_.emplace_back("backendDevice", int64_t(0));
+    stats_.emplace_back("backendId", int64_t(0));
+    stats_.emplace_back("gpuUnsupported", int64_t(0));
+  }
+  return request->chunkCallback ? std::any{} : std::any(std::move(output));
+}
+qvac_lib_inference_addon_cpp::RuntimeStats PocketModel::runtimeStats() const {
+  std::lock_guard lock(mutex_); return stats_;
+}
+}

--- a/packages/tts-ggml/addon/src/model-interface/pocket/PocketModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/pocket/PocketModel.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <any>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+#include "inference-addon-cpp/ModelInterfaces.hpp"
+#include "inference-addon-cpp/RuntimeStats.hpp"
+#include "model-interface/pocket/PocketConfig.hpp"
+
+namespace qvac::ttsggml::pocket {
+class PocketModel : public qvac_lib_inference_addon_cpp::model::IModel,
+                    public qvac_lib_inference_addon_cpp::model::IModelCancel,
+                    public qvac_lib_inference_addon_cpp::model::IModelAsyncLoad {
+public:
+  using Output = std::vector<int16_t>;
+  // Streaming sends PCM immediately, then an empty isLast=true marker on success.
+  using ChunkCallback = std::function<void(Output&&, int, bool)>;
+  struct AnyInput { std::string text; ChunkCallback chunkCallback; };
+  explicit PocketModel(PocketConfig config);
+  ~PocketModel() noexcept override = default;
+  std::string getName() const override { return "PocketModel"; }
+  std::any process(const std::any& input) override;
+  qvac_lib_inference_addon_cpp::RuntimeStats runtimeStats() const override;
+  void cancel() const override;
+  void load();
+  void unload();
+  void reload(PocketConfig config);
+  bool isLoaded() const;
+  int sampleRate() const { return sampleRate_; }
+  void waitForLoadInitialization() override { load(); }
+  void setWeightsForFile(const std::string&,
+      std::unique_ptr<std::basic_streambuf<char>>&&) override {}
+private:
+  PocketConfig cfg_;
+  const int sampleRate_;
+  mutable std::mutex mutex_;
+  std::shared_ptr<tts_cpp::pocket::Engine> engine_;
+  std::atomic_bool busy_{false};
+  mutable std::atomic<uint64_t> cancelEpoch_{0};
+  qvac_lib_inference_addon_cpp::RuntimeStats stats_;
+};
+}

--- a/packages/tts-ggml/docs/pocket-tts.md
+++ b/packages/tts-ggml/docs/pocket-tts.md
@@ -121,6 +121,33 @@ while remaining faster than playback (the 70-second passage took 16.0 seconds
 versus 13.0 seconds with one step, excluding model loading). These were single
 renders after warmup, rather than repeated benchmark measurements.
 
+### Why choose four steps for audio quality?
+
+Pocket's flow sampler transforms noise into the next audio latent. One step
+predicts a single update over the full interval from 0 to 1. Four steps use
+four quarter-interval updates, evaluating the flow network again on the
+updated latent each time. This gives the model intermediate refinement
+opportunities instead of relying on one full-interval prediction. It is a
+mechanistic reason to try additional steps when a take has an artifact, not
+proof that the reported sound was caused by a particular numerical error.
+
+The recommendation here is supported by the controlled listening result:
+the same text, voice, seed and temperature produced an audible artifact with
+one step in both Fabric and upstream, while the four-step take sounded clean
+to the listener. Use `steps: 4` when avoiding this artifact matters more than
+minimum generation latency. Keep `steps: 1` for the upstream performance
+default. The other eleven files in the listening set had no reported artifact;
+this is evidence of an improvement for one take, not a general quality score.
+
+Only the flow sampling stage repeats; text/voice conditioning and Mimi audio
+decoding are not each run four times. That is why the observed total latency
+increase was about 20–25%, rather than fourfold:
+
+| Passage | One-step generation | Four-step generation |
+| --- | ---: | ---: |
+| Original sentence (2.64 s audio) | 0.46 s | 0.56 s |
+| Extended story (69.92 s audio) | 13.03 s | 15.96 s |
+
 ## Validation
 
 Build native prebuilds using the package's pinned vcpkg registry, then build

--- a/packages/tts-ggml/docs/pocket-tts.md
+++ b/packages/tts-ggml/docs/pocket-tts.md
@@ -176,8 +176,13 @@ The full current inference TypeScript build has existing errors in safe-fetch,
 AudioGen and sdcpp. Focused Pocket compilation uses `noEmitOnError` and passes;
 the current SDK compiles. Physical iOS / Android audio validation and mobile
 SDK transport validation remain outside the measured coverage. Native CI
-builds succeed for Android and iOS; Linux/Windows compile but the unchanged
-`test-supertonic-fit-params` fails its CPU-refusal expectation.
+builds succeed for Android and iOS. The Linux/Windows Supertonic fit-test
+failure was traced to [speech PR #229](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/229),
+which enabled fused graphs on CPU builds without pointwise BLAS while the test
+retained its old CPU-refusal expectation. [Speech PR #240](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/240)
+corrects the test and fit documentation without changing synthesis or fit dispatch.
+The corrected test passes locally with and without Accelerate; Linux CI passes.
+Windows CI validation is pending.
 
 
 ## Dependency pins and measured performance
@@ -188,7 +193,7 @@ This change pins the registry baseline and Git reference to
 the version database available before its registry PR merges; baseline alone
 only selects minimum versions and otherwise vcpkg reads the default branch's
 version database. See the [vcpkg registry reference documentation](https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-configuration-json#registry-reference).
-The source and registry changes are draft PRs
+The source and registry changes are tracked in PRs
 [qvac-fabric-speech.cpp#240](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/240)
 and [qvac-registry-vcpkg#364](https://github.com/tetherto/qvac-registry-vcpkg/pull/364).
 

--- a/packages/tts-ggml/docs/pocket-tts.md
+++ b/packages/tts-ggml/docs/pocket-tts.md
@@ -29,7 +29,7 @@ const model = new TTSGgml({
   threads: 1,
   seed: 1234,
   temperature: 0.3,
-  steps: 1
+  steps: 4
 })
 try {
   await model.load()
@@ -101,6 +101,21 @@ English only; CPU only; `threads` defaults to one per worker (two workers).
 supports 8–192 kHz. Other engines' sampling, emotional, speed, GPU and
 LavaSR settings are rejected instead of silently ignored.
 
+Fabric defaults to four sampling steps, including SDK calls that omit `steps`.
+An explicit `steps: 1` (or addon `numInferenceSteps: 1`) retains the faster
+one-step setting. The native CLI and upstream reference still default to one
+step; use `--steps 4` when comparing them with Fabric's default.
+
+In a listening comparison of six prompts from 0.88 to 70 seconds, the listener
+reported an artifact on “speech” only in the one-step render of “Hello! We can
+generate speech with Fabric.” The four-step render was clean to that listener.
+The faster native build and earlier build produced nearly identical PCM, and
+matched-noise PyTorch synthesis also closely matched Fabric. This supports a
+sampling-quality adjustment; it does not establish that four steps prevent all
+artifacts. On an Apple M2, the paired renders took about 20–25% longer at four
+steps, while remaining faster than playback (the 70-second passage took 16.0
+seconds versus 13.0 seconds with one step, excluding model loading).
+
 ## Validation
 
 Build native prebuilds using the package's pinned vcpkg registry, then build
@@ -116,7 +131,7 @@ configuration, cache and worker are bounded by a process supervisor. The
 inference and addon real-model tests skip when their model variable is absent;
 pass it explicitly when validating synthesis.
 
-The current macOS port passes eight native Pocket tests, 282 addon unit tests,
+The current macOS port passes eight native Pocket tests, 283 addon unit tests,
 the real addon and inference tests, and four public SDK transport tests. The
 current pinned iOS Simulator Bare Kit worklet also passes 58 assertions and
 generates a valid WAV (Bare 1.29.4, iOS 18.6).
@@ -147,7 +162,8 @@ and [qvac-registry-vcpkg#364](https://github.com/tetherto/qvac-registry-vcpkg/pu
 
 The final native benchmark links the exact libraries installed by the pinned
 registry and normal addon build. It uses Apple M2 CPU, one thread per worker,
-two workers, one warmup and three measured runs per prompt. Medians:
+two workers, **one sampling step**, one warmup and three measured runs per
+prompt. These recorded results predate Fabric's four-step default. Medians:
 
 | Prompt | Upstream generation | Fabric generation | Upstream / Fabric audio length |
 | --- | ---: | ---: | ---: |

--- a/packages/tts-ggml/docs/pocket-tts.md
+++ b/packages/tts-ggml/docs/pocket-tts.md
@@ -29,7 +29,7 @@ const model = new TTSGgml({
   threads: 1,
   seed: 1234,
   temperature: 0.3,
-  steps: 4
+  steps: 1
 })
 try {
   await model.load()
@@ -101,20 +101,25 @@ English only; CPU only; `threads` defaults to one per worker (two workers).
 supports 8–192 kHz. Other engines' sampling, emotional, speed, GPU and
 LavaSR settings are rejected instead of silently ignored.
 
-Fabric defaults to four sampling steps, including SDK calls that omit `steps`.
-An explicit `steps: 1` (or addon `numInferenceSteps: 1`) retains the faster
-one-step setting. The native CLI and upstream reference still default to one
-step; use `--steps 4` when comparing them with Fabric's default.
+Fabric defaults to one sampling step, matching the native CLI and upstream
+reference, including SDK calls that omit `steps`. An explicit `steps: 4` (or
+addon `numInferenceSteps: 4`) offers a quality option at additional compute
+cost; use `--steps 4` for an equivalent native CLI comparison.
 
 In a listening comparison of six prompts from 0.88 to 70 seconds, the listener
 reported an artifact on “speech” only in the one-step render of “Hello! We can
-generate speech with Fabric.” The four-step render was clean to that listener.
-The faster native build and earlier build produced nearly identical PCM, and
-matched-noise PyTorch synthesis also closely matched Fabric. This supports a
-sampling-quality adjustment; it does not establish that four steps prevent all
-artifacts. On an Apple M2, the paired renders took about 20–25% longer at four
-steps, while remaining faster than playback (the 70-second passage took 16.0
-seconds versus 13.0 seconds with one step, excluding model loading).
+generate speech with Fabric.” The listener also heard the artifact in the
+upstream PyTorch one-step reproduction with matching random inputs, while the
+four-step render sounded clean. The faster native build and earlier build
+produced nearly identical PCM, and matched-noise PyTorch synthesis closely
+matched Fabric. These findings support an upstream sampling artifact for this
+take, not a Fabric-specific one-step implementation bug. Four steps mitigated
+this example; they are not a guarantee against all artifacts or a port fix.
+
+On an Apple M2, the paired renders took about 20–25% longer at four steps,
+while remaining faster than playback (the 70-second passage took 16.0 seconds
+versus 13.0 seconds with one step, excluding model loading). These were single
+renders after warmup, rather than repeated benchmark measurements.
 
 ## Validation
 
@@ -163,7 +168,7 @@ and [qvac-registry-vcpkg#364](https://github.com/tetherto/qvac-registry-vcpkg/pu
 The final native benchmark links the exact libraries installed by the pinned
 registry and normal addon build. It uses Apple M2 CPU, one thread per worker,
 two workers, **one sampling step**, one warmup and three measured runs per
-prompt. These recorded results predate Fabric's four-step default. Medians:
+prompt, matching Fabric's default. Medians:
 
 | Prompt | Upstream generation | Fabric generation | Upstream / Fabric audio length |
 | --- | ---: | ---: | ---: |

--- a/packages/tts-ggml/docs/pocket-tts.md
+++ b/packages/tts-ggml/docs/pocket-tts.md
@@ -1,0 +1,183 @@
+# Pocket TTS
+
+Pocket is an English, CPU-only TTS engine implemented in the Fabric speech
+library. It streams PCM16 audio through the existing addon, inference plugin
+and public SDK APIs. Python is used only to convert weights and benchmark the
+upstream reference; it is not needed for synthesis in Fabric.
+
+## Model bundle
+
+Convert the supported Kyutai English 2026-04 checkpoint using
+`engines/tts/scripts/convert-pocket-to-gguf.py` in qvac-fabric-speech.cpp.
+The bundle contains `flow-lm.gguf`, `mimi.gguf`, `frontend.json` and `voice.gguf`.
+The native repository's `engines/tts/docs/pocket-tts.md` documents conversion,
+asset revisions, validation, CLI usage and the benchmark scripts.
+
+The public checkpoint without voice cloning works with a prepared voice
+embedding. Reference-WAV conditioning requires weights with a functioning
+Mimi encoder; the public checkpoint with zero encoder weights is rejected
+for that operation. Do not advertise voice cloning from those weights.
+
+## Addon usage
+
+```js
+const TTSGgml = require('@qvac/tts-ggml')
+const model = new TTSGgml({
+  engine: 'pocket',
+  files: { modelDir: '/absolute/path/to/pocket-bundle' },
+  config: { language: 'en', useGPU: false },
+  threads: 1,
+  seed: 1234,
+  temperature: 0.3,
+  steps: 1
+})
+try {
+  await model.load()
+  const response = await model.run({ input: 'Hello from Pocket TTS in Fabric.' })
+  for await (const chunk of response.iterate()) {
+    // chunk.outputArray: Int16Array; chunk.sampleRate defaults to 24000.
+    // Feed samples to an audio device or collect them in a WAV file.
+  }
+} finally {
+  await model.destroy()
+}
+```
+
+`npm run example:pocket -- /absolute/bundle "Hello from Fabric." /tmp/pocket.wav`
+saves a playable WAV. The addon also accepts explicit `files.pocketFlowModel`,
+`files.pocketMimiModel`, `files.pocketFrontend` and `files.pocketVoice` paths.
+
+`run()` streams native chunks without sentence splitting, including when
+`streamOutput: true` is requested. `runStream()` explicitly splits sentences;
+`runStreaming()` accepts incremental text. `cancel()` invalidates pending text
+and waits for native completion before another request is admitted.
+A `run()` AbortSignal also stops native work. Invalid reload options or failed
+replacement activation preserve the previously loaded model. Overlapping
+lifecycle operations are rejected; `unload()` permits a later load/reload,
+while `destroy()` is terminal.
+
+## Public SDK usage
+
+```js
+import { loadModel, textToSpeech, unloadModel, close } from '@qvac/sdk'
+const root = '/absolute/path/to/pocket-bundle'
+const modelId = await loadModel({
+  modelType: 'tts-ggml',
+  modelSrc: `${root}/flow-lm.gguf`,
+  modelConfig: {
+    ttsEngine: 'pocket',
+    language: 'en',
+    useGPU: false,
+    mimiModelSrc: `${root}/mimi.gguf`,
+    frontendSrc: `${root}/frontend.json`,
+    voiceSrc: `${root}/voice.gguf`,
+    threads: 1,
+    seed: 1234,
+    outputSampleRate: 24000
+  }
+})
+try {
+  const response = textToSpeech({ modelId, text: 'Hello from Fabric.', stream: false })
+  const pcm = await response.buffer
+  await response.done
+  // pcm contains PCM16 samples at the configured output sample rate.
+} finally {
+  await unloadModel({ modelId, autoClose: false })
+  await close()
+}
+```
+
+Companion sources use the standard model-source resolver, including local paths
+and descriptors. For reference conditioning supply `referenceAudioSrc` instead
+of `voiceSrc`. The schema requires exactly one. Each model admits one active
+TTS request; queued requests wait until cancellation and native callbacks drain.
+
+## Supported controls
+
+English only; CPU only; `threads` defaults to one per worker (two workers).
+`seed` accepts unsigned 32-bit integers. `temperature`, `steps`, `nCtx`,
+`maxTokens`, `noiseClamp`, `eosThreshold`, `framesAfterEos` and
+`outputSampleRate` are validated before native loading. Output resampling
+supports 8–192 kHz. Other engines' sampling, emotional, speed, GPU and
+LavaSR settings are rejected instead of silently ignored.
+
+## Validation
+
+Build native prebuilds using the package's pinned vcpkg registry, then build
+TypeScript in `@qvac/tts-ggml`, `@qvac/inference` and `@qvac/sdk`.
+Set `QVAC_POCKET_MODEL_DIR` to the converted bundle for real-model tests:
+
+- In the addon: `npm run test:pocket`; set `QVAC_POCKET_AUDIO_OUTPUT` to save WAV.
+- In inference: `npm run test:pocket` (schema, lifecycle and real-plugin tests).
+- In SDK: `npm run test:pocket:node` (public APIs over a real Bare worker/socket).
+
+The SDK test requires model assets rather than skipping. Its owned temporary
+configuration, cache and worker are bounded by a process supervisor. The
+inference and addon real-model tests skip when their model variable is absent;
+pass it explicitly when validating synthesis.
+
+The current macOS port passes eight native Pocket tests, 282 addon unit tests,
+the real addon and inference tests, and four public SDK transport tests. The
+current pinned iOS Simulator Bare Kit worklet also passes 58 assertions and
+generates a valid WAV (Bare 1.29.4, iOS 18.6).
+Adversarial review covered native math/asset validation in the speech repository
+and addon request/lifecycle races, cancellation, reload and test cleanup here.
+Audio checks cover sample validity, clipping and automated transcription;
+these are not subjective naturalness ratings.
+
+The full current inference TypeScript build has existing errors in safe-fetch,
+AudioGen and sdcpp. Focused Pocket compilation uses `noEmitOnError` and passes;
+the current SDK compiles. Physical iOS / Android audio validation and mobile
+SDK transport validation remain outside the measured coverage. Native CI
+builds succeed for Android and iOS; Linux/Windows compile but the unchanged
+`test-supertonic-fit-params` fails its CPU-refusal expectation.
+
+
+## Dependency pins and measured performance
+
+This change pins the registry baseline and Git reference to
+`7a70a0c301c155beb85e985c542f8b0ccd090e10`, selecting speech-cpp
+2026-09-10#1 and ggml-speech 2026-09-09#1. The explicit `reference` makes
+the version database available before its registry PR merges; baseline alone
+only selects minimum versions and otherwise vcpkg reads the default branch's
+version database. See the [vcpkg registry reference documentation](https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-configuration-json#registry-reference).
+The source and registry changes are draft PRs
+[qvac-fabric-speech.cpp#240](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/240)
+and [qvac-registry-vcpkg#364](https://github.com/tetherto/qvac-registry-vcpkg/pull/364).
+
+The final native benchmark links the exact libraries installed by the pinned
+registry and normal addon build. It uses Apple M2 CPU, one thread per worker,
+two workers, one warmup and three measured runs per prompt. Medians:
+
+| Prompt | Upstream generation | Fabric generation | Upstream / Fabric audio length |
+| --- | ---: | ---: | ---: |
+| Short | 0.94 s | 0.98 s | 5.52 / 5.52 s |
+| Numbers | 1.23 s | 1.42 s | 7.36 / 7.44 s |
+| Punctuation | 1.18 s | 1.24 s | 6.88 / 6.72 s |
+| Accented names | 1.23 s | 1.38 s | 7.20 / 7.36 s |
+| Long | 6.16 s | 6.55 s | 36.32 / 36.48 s |
+
+Fabric RTF is 0.178–0.191 (about 5.2–5.6× real time), versus upstream
+0.167–0.172. Generation time is 5–16% above upstream across these prompts.
+First audio arrives in 74–116 ms in Fabric versus 53–69 ms upstream.
+Loading takes 0.23–0.31 seconds during the matrix; an earlier first launch
+measured 9.61 seconds, so warmed launch timings do not establish cold-cache
+startup performance. The previous manual development build was slower; these
+final numbers supersede its approximately 2× slowdown.
+These are native steady-state measurements; public SDK startup/IPC latency
+is additional. Seeds do not produce equivalent randomness across the two
+implementations at temperature 0.3. All ten WAVs pass signal checks. ASR
+recovers short and punctuation prompts exactly, shares the long prompt's
+single assistance/assistants mismatch, and finds a contraction difference in
+the accented-name prompt. The earlier zero-temperature follow-up resolves
+that contraction and gives matching transcriptions. No subjective listening
+score or equal-naturalness claim is made.
+
+
+To reproduce the packaged iOS worklet after building the simulator prebuild,
+run `python3 scripts/run-pocket-ios-worklet.py --help`. The runner needs a
+booted arm64 simulator, the bundle, Bare Kit, bare-pack >= 2 and bare-link >= 3.
+It resolves pnpm package paths canonically, uses the actual TTS framework,
+and leaves a fresh output directory containing logs, result JSON and WAV.
+It neither boots/shuts down a simulator nor edits an app checkout. Functional
+coverage runs with brittle's optional Node-only coverage reporter deferred.

--- a/packages/tts-ggml/docs/pocket-tts.md
+++ b/packages/tts-ggml/docs/pocket-tts.md
@@ -177,12 +177,9 @@ AudioGen and sdcpp. Focused Pocket compilation uses `noEmitOnError` and passes;
 the current SDK compiles. Physical iOS / Android audio validation and mobile
 SDK transport validation remain outside the measured coverage. Native CI
 builds succeed for Android and iOS. The Linux/Windows Supertonic fit-test
-failure was traced to [speech PR #229](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/229),
-which enabled fused graphs on CPU builds without pointwise BLAS while the test
-retained its old CPU-refusal expectation. [Speech PR #240](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/240)
-corrects the test and fit documentation without changing synthesis or fit dispatch.
-The corrected test passes locally with and without Accelerate; Linux CI passes.
-Windows CI validation is pending.
+regression introduced by [speech PR #229](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/229)
+is addressed independently in [speech PR #242](https://github.com/tetherto/qvac-fabric-speech.cpp/pull/242).
+That fix is separate from the Pocket TTS source change and does not change runtime behavior.
 
 
 ## Dependency pins and measured performance

--- a/packages/tts-ggml/examples/pocket-tts.js
+++ b/packages/tts-ggml/examples/pocket-tts.js
@@ -1,0 +1,51 @@
+'use strict'
+
+// bare examples/pocket-tts.js /absolute/bundle "Text to speak." /absolute/output.wav
+// Convert the bundle with the speech repository's convert-pocket-to-gguf.py.
+const TTSGgml = require('../')
+const { createWav } = require('./wav-helper')
+const path = require('bare-path')
+const process = require('bare-process')
+global.process = process
+
+async function main() {
+  const [, , bundle, text = 'Hello from Pocket TTS in Fabric.', output = 'pocket-output.wav'] =
+    global.Bare.argv
+  if (!bundle) throw new Error('Usage: pocket-tts.js <bundle-directory> [text] [output.wav]')
+  const model = new TTSGgml({
+    engine: TTSGgml.ENGINE_POCKET,
+    files: { modelDir: path.resolve(bundle) },
+    config: { language: 'en', useGPU: false },
+    threads: 1,
+    seed: 1234,
+    steps: 1,
+    opts: { stats: true }
+  })
+  try {
+    const start = Date.now()
+    await model.load()
+    console.log('Load milliseconds:', Date.now() - start)
+    const response = await model.run({ input: text })
+    const chunks = []
+    let rate = 24000
+    for await (const chunk of response.iterate()) {
+      rate = chunk.sampleRate
+      if (chunk.outputArray.length) chunks.push(chunk.outputArray)
+    }
+    const pcm = new Int16Array(chunks.reduce((n, c) => n + c.length, 0))
+    let offset = 0
+    for (const chunk of chunks) {
+      pcm.set(chunk, offset)
+      offset += chunk.length
+    }
+    createWav(pcm, rate, path.resolve(output))
+    console.log(JSON.stringify(response.stats, null, 2))
+    console.log('Saved:', path.resolve(output))
+  } finally {
+    await model.destroy()
+  }
+}
+main().catch((err) => {
+  console.error(err)
+  global.Bare.exit(1)
+})

--- a/packages/tts-ggml/examples/pocket-tts.js
+++ b/packages/tts-ggml/examples/pocket-tts.js
@@ -18,7 +18,7 @@ async function main() {
     config: { language: 'en', useGPU: false },
     threads: 1,
     seed: 1234,
-    steps: 4,
+    steps: 1, // Set to 4 for the slower quality option.
     opts: { stats: true }
   })
   try {

--- a/packages/tts-ggml/examples/pocket-tts.js
+++ b/packages/tts-ggml/examples/pocket-tts.js
@@ -18,7 +18,7 @@ async function main() {
     config: { language: 'en', useGPU: false },
     threads: 1,
     seed: 1234,
-    steps: 1,
+    steps: 4,
     opts: { stats: true }
   })
   try {

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -6,6 +6,7 @@ declare const ENGINE_SUPERTONIC = "supertonic";
 declare const ENGINE_COSYVOICE3 = "cosyvoice3";
 declare const ENGINE_PARLER = "parler";
 declare const ENGINE_AUDIO8 = "audio8";
+declare const ENGINE_POCKET = "pocket";
 declare const COSYVOICE_DIALECTS: {
     readonly cantonese: "广东话";
     readonly northeastern: "东北话";
@@ -53,7 +54,7 @@ declare const EMOTIONS: readonly ["command", "anger", "narration", "conversation
 declare const PACES: readonly ["slow", "moderate", "fast"];
 type Emotion = (typeof EMOTIONS)[number];
 type Pace = (typeof PACES)[number];
-type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC | typeof ENGINE_COSYVOICE3 | typeof ENGINE_PARLER | typeof ENGINE_AUDIO8;
+type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC | typeof ENGINE_COSYVOICE3 | typeof ENGINE_PARLER | typeof ENGINE_AUDIO8 | typeof ENGINE_POCKET;
 /**
  * Model file paths for the GGML TTS backend. Engine is auto-detected
  * from these fields (Chatterbox vs Supertonic) unless overridden via
@@ -61,6 +62,10 @@ type EngineType = typeof ENGINE_CHATTERBOX | typeof ENGINE_SUPERTONIC | typeof E
  * through to the native layer as-is.
  */
 interface TTSGgmlFiles {
+    pocketFlowModel?: string;
+    pocketMimiModel?: string;
+    pocketFrontend?: string;
+    pocketVoice?: string;
     /**
      * Bundle root. For Chatterbox, expected to contain
      * `chatterbox-t3-turbo.gguf` + `chatterbox-s3gen.gguf` (turbo) or
@@ -272,6 +277,11 @@ interface Audio8VoiceFields {
     referenceText?: string;
 }
 interface TTSGgmlOptions extends ParlerDescriptionFields, Audio8VoiceFields, TTSConditioningFields {
+    /** Pocket: generation/context controls; native sampling uses a portable RNG. */
+    maxTokens?: number;
+    noiseClamp?: number;
+    eosThreshold?: number;
+    framesAfterEos?: number;
     files?: TTSGgmlFiles;
     config?: TTSGgmlRuntimeConfig;
     logger?: object;
@@ -517,6 +527,7 @@ declare class TTSGgml {
     static readonly ENGINE_COSYVOICE3 = "cosyvoice3";
     static readonly ENGINE_PARLER = "parler";
     static readonly ENGINE_AUDIO8 = "audio8";
+    static readonly ENGINE_POCKET = "pocket";
     opts: object;
     exclusiveRun: boolean;
     logger: object;
@@ -527,6 +538,12 @@ declare class TTSGgml {
     private _ttsInferenceQueueWaiter;
     private _sentenceStreamCtx;
     private _config;
+    private _pocketJobPending;
+    private _pocketCancelPromise;
+    private _pocketLifecycleInProgress;
+    private _pocketParams;
+    private _pocketOptions;
+    private _pocketFiles;
     private _lazySessionLoading;
     private _outputSampleRate;
     private _engineType;
@@ -644,6 +661,7 @@ declare class TTSGgml {
     getApiDefinition(): string;
     getState(): InferenceState;
     load(..._args: unknown[]): Promise<void>;
+    private _loadModel;
     /**
      * Run text-to-speech. With `{ streamOutput: true }`, splits `input` into
      * chunks and emits PCM through `response.onUpdate` for each chunk.
@@ -696,6 +714,7 @@ declare class TTSGgml {
     private _assignLavasrParams;
     private _createAddon;
     unload(): Promise<void>;
+    private _unloadModel;
     destroy(): Promise<void>;
     private _runInternal;
     private _mergeSentenceStreamStats;
@@ -706,6 +725,11 @@ declare class TTSGgml {
     private _handleAddonOutput;
     private _enrichStreamChunk;
     private _handleAddonStats;
+    private _waitPocketCancel;
+    private _withPocketLifecycle;
+    private _checkPocketReload;
+    private _checkPocketRequest;
+    private _dispatchJob;
     cancel(): Promise<void>;
     private _failAndClearActiveResponse;
     /** Everything reload() may overwrite, so a rejected reload can undo itself. */
@@ -720,6 +744,7 @@ declare class TTSGgml {
      * reload is not validated against state the caller never accepted.
      */
     private _applyReloadableConfig;
+    private _reloadPocket;
     reload(newConfig?: Record<string, unknown>): Promise<void>;
     /**
      * The voice a reload lands on. Same rule as _mergeAudio8Voice and

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -371,7 +371,7 @@ interface TTSGgmlOptions extends ParlerDescriptionFields, Audio8VoiceFields, TTS
     voice?: string;
     /** Alias for `voice` for compatibility with `@qvac/tts-onnx`. */
     voiceName?: string;
-    /** Supertonic CFM steps (0 uses GGUF default); Pocket sampling steps (1–64, default 4). */
+    /** Supertonic CFM steps (0 uses GGUF default); Pocket sampling steps (1–64, default 1). */
     steps?: number;
     /** Alias for `steps` for compatibility with `@qvac/tts-onnx`. */
     numInferenceSteps?: number;

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -371,7 +371,7 @@ interface TTSGgmlOptions extends ParlerDescriptionFields, Audio8VoiceFields, TTS
     voice?: string;
     /** Alias for `voice` for compatibility with `@qvac/tts-onnx`. */
     voiceName?: string;
-    /** Supertonic vector-estimator CFM steps. 0 uses the GGUF default. */
+    /** Supertonic CFM steps (0 uses GGUF default); Pocket sampling steps (1–64, default 4). */
     steps?: number;
     /** Alias for `steps` for compatibility with `@qvac/tts-onnx`. */
     numInferenceSteps?: number;

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -36,11 +36,15 @@ var __importStar = (this && this.__importStar) || (function () {
 const bareOs = require("bare-os");
 const path = require("bare-path");
 const fs = require("bare-fs");
-const QvacLogger = require("@qvac/logging");
+const loggingModule = require("@qvac/logging");
+// Published logging releases expose a CJS constructor; the workspace exposes
+// an ESM default. Bare require(ESM) returns a namespace without __esModule.
+const QvacLogger = typeof loggingModule === "function" ? loggingModule : loggingModule.default;
 /* eslint-enable @typescript-eslint/no-require-imports */
 const infer_base_1 = require("@qvac/infer-base");
 const tts_1 = require("./tts");
 const errorModule = __importStar(require("./lib/error"));
+const pocketConfig_1 = require("./lib/pocketConfig");
 const textChunker_1 = require("./lib/textChunker");
 const textStreamAccumulator_1 = require("./lib/textStreamAccumulator");
 const { platform } = bareOs;
@@ -54,6 +58,7 @@ const ENGINE_SUPERTONIC = "supertonic";
 const ENGINE_COSYVOICE3 = "cosyvoice3";
 const ENGINE_PARLER = "parler";
 const ENGINE_AUDIO8 = "audio8";
+const ENGINE_POCKET = "pocket";
 const MIN_OUTPUT_SAMPLE_RATE = 8000;
 const MAX_OUTPUT_SAMPLE_RATE = 192000;
 const CHATTERBOX_T3_TURBO = "chatterbox-t3-turbo.gguf";
@@ -247,6 +252,7 @@ const ENGINE_EMOTIONS = {
     [ENGINE_COSYVOICE3]: ["anger", "happy", "neutral", "sad"],
     [ENGINE_SUPERTONIC]: [],
     [ENGINE_CHATTERBOX]: [],
+    [ENGINE_POCKET]: [],
     [ENGINE_AUDIO8]: [],
 };
 const ENGINE_PACES = {
@@ -254,6 +260,7 @@ const ENGINE_PACES = {
     [ENGINE_COSYVOICE3]: PACES, // slow/fast -> instruct; moderate -> none
     [ENGINE_SUPERTONIC]: PACES, // mapped onto the duration multiplier
     [ENGINE_CHATTERBOX]: [], // time-stretch only; use `speed`
+    [ENGINE_POCKET]: [],
     [ENGINE_AUDIO8]: [], // no rate control at all
 };
 // Which channels an engine can change per call. Supertonic takes its pace
@@ -264,6 +271,7 @@ const ENGINE_PER_CALL_CONDITIONING = {
     [ENGINE_COSYVOICE3]: CONDITIONING_KEYS,
     [ENGINE_SUPERTONIC]: [],
     [ENGINE_CHATTERBOX]: [],
+    [ENGINE_POCKET]: [],
     [ENGINE_AUDIO8]: [],
 };
 function normalizeError(error) {
@@ -565,6 +573,10 @@ function normalizeGgmlFiles(files) {
         return {};
     return {
         modelDir: firstNonEmpty(files.modelDir),
+        pocketFlowModel: firstNonEmpty(files.pocketFlowModel),
+        pocketMimiModel: firstNonEmpty(files.pocketMimiModel),
+        pocketFrontend: firstNonEmpty(files.pocketFrontend),
+        pocketVoice: firstNonEmpty(files.pocketVoice),
         t3Model: firstNonEmpty(files.t3Model, files.t3ModelPath, files.t3),
         s3genModel: firstNonEmpty(files.s3genModel, files.s3genModelPath, files.s3gen),
         supertonicModel: firstNonEmpty(files.supertonicModel, files.supertonicModelPath, files.supertonic),
@@ -592,13 +604,16 @@ function detectEngineType(engine, files) {
         engine === ENGINE_SUPERTONIC ||
         engine === ENGINE_COSYVOICE3 ||
         engine === ENGINE_PARLER ||
-        engine === ENGINE_AUDIO8) {
+        engine === ENGINE_AUDIO8 ||
+        engine === ENGINE_POCKET) {
         return engine;
     }
     if (engine != null && engine !== "") {
         throw new Error("tts-ggml: 'engine' option must be 'chatterbox', 'supertonic', " +
-            `'cosyvoice3', 'parler' or 'audio8' (got '${String(engine)}')`);
+            `'cosyvoice3', 'parler', 'audio8' or 'pocket' (got '${String(engine)}')`);
     }
+    if (files.pocketFlowModel || files.pocketMimiModel)
+        return ENGINE_POCKET;
     // Explicit CosyVoice3 files/dir take precedence over shared-modelDir sniffing.
     if (files.cosyvoiceModelDir || files.cosyvoiceLlmModel) {
         return ENGINE_COSYVOICE3;
@@ -627,6 +642,8 @@ function detectEngineType(engine, files) {
             return ENGINE_PARLER;
         if (findAudio8InDir(files.modelDir, AUDIO8_LM_RE))
             return ENGINE_AUDIO8;
+        if (fileExistsSafe(path.join(files.modelDir, "flow-lm.gguf")))
+            return ENGINE_POCKET;
     }
     return ENGINE_CHATTERBOX;
 }
@@ -839,6 +856,7 @@ class TTSGgml {
     static ENGINE_COSYVOICE3 = ENGINE_COSYVOICE3;
     static ENGINE_PARLER = ENGINE_PARLER;
     static ENGINE_AUDIO8 = ENGINE_AUDIO8;
+    static ENGINE_POCKET = ENGINE_POCKET;
     opts;
     exclusiveRun;
     logger;
@@ -849,6 +867,12 @@ class TTSGgml {
     _ttsInferenceQueueWaiter;
     _sentenceStreamCtx;
     _config;
+    _pocketJobPending = null;
+    _pocketCancelPromise = null;
+    _pocketLifecycleInProgress = false;
+    _pocketParams = null;
+    _pocketOptions = {};
+    _pocketFiles = {};
     _lazySessionLoading;
     _outputSampleRate;
     _engineType;
@@ -920,7 +944,7 @@ class TTSGgml {
         this._sentenceStreamCtx = null;
         this._ttsInferenceQueueWaiter = Promise.resolve();
         this._job = (0, infer_base_1.createJobHandler)({
-            cancel: () => this._optionalAddon()?.cancel(),
+            cancel: () => this._engineType === ENGINE_POCKET ? this.cancel() : this._optionalAddon()?.cancel(),
         });
         this._runExclusive = this.exclusiveRun
             ? (0, infer_base_1.exclusiveRunQueue)()
@@ -932,6 +956,14 @@ class TTSGgml {
         this._lazySessionLoading = resolveDefaultLazySessionLoading(options.lazySessionLoading);
         this._outputSampleRate = validateOutputSampleRate(this._config.outputSampleRate);
         this._engineType = detectEngineType(options.engine, normalizedFiles);
+        if (this._engineType === ENGINE_POCKET) {
+            if (normalizedFiles.lavasrEnhancer || normalizedFiles.lavasrDenoiser) {
+                throw new Error("Pocket does not support LavaSR enhancement or denoising");
+            }
+            this._pocketFiles = normalizedFiles;
+            this._pocketOptions = { ...options };
+            this._pocketParams = (0, pocketConfig_1.buildPocketParams)(normalizedFiles, options, this._config);
+        }
         this._resolveEngineAndModelPaths(normalizedFiles);
         this._mecabDictPath = firstNonEmpty(options.mecabDictPath, options.mecabDictDir, normalizedFiles.mecabDictDir);
         this._cangjieTsvPath = firstNonEmpty(options.cangjieTsvPath, normalizedFiles.cangjieTsvPath);
@@ -950,6 +982,8 @@ class TTSGgml {
     }
     _resolveEngineAndModelPaths(files) {
         this._voicesDir = files.voicesDir;
+        if (this._engineType === ENGINE_POCKET)
+            return;
         if (this._engineType === ENGINE_COSYVOICE3) {
             // CosyVoice3 discovers its sub-model GGUFs from a model directory; the
             // native engine resolves the individual components. Explicit
@@ -1110,7 +1144,7 @@ class TTSGgml {
         this._assertSamplerOptionSupport();
     }
     _assertSamplerOptionSupport() {
-        if (SAMPLING_ENGINES.includes(this._engineType))
+        if (this._engineType === ENGINE_POCKET || SAMPLING_ENGINES.includes(this._engineType))
             return;
         const sampling = setOptionNames({
             temperature: this._temperature,
@@ -1320,6 +1354,9 @@ class TTSGgml {
     }
     async load(..._args) {
         void _args;
+        return this._withPocketLifecycle(() => this._loadModel());
+    }
+    async _loadModel() {
         if (this.state.destroyed) {
             throw new QvacErrorAddonTTSGgml({
                 code: ERR_CODES.FAILED_TO_LOAD,
@@ -1328,14 +1365,16 @@ class TTSGgml {
         }
         if (this.state.configLoaded || this.state.weightsLoaded) {
             this._getLogger().info("Reload requested - unloading existing model first");
-            await this.unload();
+            await this._unloadModel();
         }
         await this._load();
         this.state.configLoaded = true;
         this.state.weightsLoaded = true;
     }
     async run(input) {
-        if (input?.streamOutput === true) {
+        await this._waitPocketCancel();
+        this._checkPocketReload();
+        if (input?.streamOutput === true && this._engineType !== ENGINE_POCKET) {
             if (typeof input.input !== "string" ||
                 input.input.trim().length === 0) {
                 throw new QvacErrorAddonTTSGgml({
@@ -1359,7 +1398,13 @@ class TTSGgml {
      * `run({ input: text, streamOutput: true, ...options })`.
      */
     async runStream(text, options = {}) {
+        await this._waitPocketCancel();
+        this._checkPocketReload();
         const normalized = options == null || typeof options !== "object" ? {} : options;
+        if (this._engineType === ENGINE_POCKET) {
+            const run = () => this._runStreamOrchestrator(text, normalized, this._resolveJobFields(normalized, "runStream"));
+            return this.exclusiveRun ? this._enqueueExclusiveTtsResponse(run) : run();
+        }
         return this.run({
             input: text,
             streamOutput: true,
@@ -1377,6 +1422,8 @@ class TTSGgml {
      * small streamed fragments are coalesced.
      */
     async runStreaming(textStream, options = {}) {
+        await this._waitPocketCancel();
+        this._checkPocketReload();
         const jobFields = this._resolveJobFields(options, "runStreaming");
         const streamOptions = this._resolveRunStreamingOptions(textStream, options);
         let normalized = this._normalizeTextStream(textStream);
@@ -1467,6 +1514,7 @@ class TTSGgml {
         });
     }
     _runTextStreamOrchestrator(source, jobFields) {
+        this._checkPocketRequest();
         const response = this._job.start();
         this._sentenceStreamCtx = {
             textStreamMode: true,
@@ -1477,7 +1525,10 @@ class TTSGgml {
             chunkResolver: null,
             jobFields,
         };
+        const context = this._sentenceStreamCtx;
         void this._sentenceStreamTextIterableDrive().catch((error) => {
+            if (context !== this._sentenceStreamCtx)
+                return;
             this._rejectActiveChunk(error);
             this._sentenceStreamCtx = null;
             this._job.fail(normalizeError(error));
@@ -1493,6 +1544,8 @@ class TTSGgml {
         }
         try {
             for await (const piece of context.asyncTextSource) {
+                if (context !== this._sentenceStreamCtx)
+                    return;
                 const text = String(piece).trim();
                 if (text.length === 0)
                     continue;
@@ -1501,7 +1554,9 @@ class TTSGgml {
                 const done = new Promise((resolve, reject) => {
                     context.chunkResolver = { resolve, reject };
                 });
-                await this._requireAddon().runJob({
+                // Dispatch may fail before the completion promise is awaited.
+                void done.catch(() => { });
+                await this._dispatchJob({
                     type: "text",
                     input: text,
                     ...(context.jobFields ?? {}),
@@ -1510,11 +1565,15 @@ class TTSGgml {
             }
         }
         catch (error) {
+            if (context !== this._sentenceStreamCtx)
+                return;
             this._rejectActiveChunk(error);
             this._sentenceStreamCtx = null;
             this._job.fail(normalizeError(error));
             return;
         }
+        if (context !== this._sentenceStreamCtx)
+            return;
         const current = this._sentenceStreamCtx;
         const chunks = current?.chunks || [];
         const accumulator = current?.acc || emptyStreamAccumulator();
@@ -1537,6 +1596,7 @@ class TTSGgml {
         return this._engineType === ENGINE_AUDIO8;
     }
     _runStreamOrchestrator(text, options, jobFields) {
+        this._checkPocketRequest();
         const chunks = (0, textChunker_1.splitTtsText)(String(text), {
             language: this._config.language,
             locale: options.locale,
@@ -1548,6 +1608,7 @@ class TTSGgml {
                 adds: "chunked synthesis: text produced no chunks after split",
             });
         }
+        this._checkPocketRequest();
         const response = this._job.start();
         this._sentenceStreamCtx = {
             chunks,
@@ -1556,7 +1617,10 @@ class TTSGgml {
             chunkResolver: null,
             jobFields,
         };
+        const context = this._sentenceStreamCtx;
         void this._sentenceStreamDriveBody().catch((error) => {
+            if (context !== this._sentenceStreamCtx)
+                return;
             this._rejectActiveChunk(error);
             this._sentenceStreamCtx = null;
             this._job.fail(normalizeError(error));
@@ -1568,17 +1632,23 @@ class TTSGgml {
         if (!context || context.textStreamMode)
             return;
         for (let index = 0; index < context.chunks.length; index++) {
+            if (context !== this._sentenceStreamCtx)
+                return;
             context.chunkIdx = index;
             const done = new Promise((resolve, reject) => {
                 context.chunkResolver = { resolve, reject };
             });
-            await this._requireAddon().runJob({
+            // Dispatch may fail before the completion promise is awaited.
+            void done.catch(() => { });
+            await this._dispatchJob({
                 type: "text",
                 input: context.chunks[index],
                 ...(context.jobFields ?? {}),
             });
             await done;
         }
+        if (context !== this._sentenceStreamCtx)
+            return;
         this._sentenceStreamCtx = null;
     }
     async _load() {
@@ -1599,6 +1669,8 @@ class TTSGgml {
         }
     }
     _buildTtsParams() {
+        if (this._pocketParams)
+            return { ...this._pocketParams };
         if (this._engineType === ENGINE_SUPERTONIC) {
             return this._buildSupertonicParams();
         }
@@ -1891,27 +1963,62 @@ class TTSGgml {
         return new tts_1.TTSInterface(binding, configuration, outputCallback);
     }
     async unload() {
+        return this._withPocketLifecycle(() => this._unloadModel());
+    }
+    async _unloadModel() {
         await this.cancel();
         this._failAndClearActiveResponse("Model was unloaded");
         const addon = this._optionalAddon();
-        if (addon)
-            await addon.destroyInstance();
-        this.state.configLoaded = false;
-        this.state.weightsLoaded = false;
+        try {
+            if (addon)
+                await addon.destroyInstance();
+        }
+        finally {
+            if (this.addon === addon) {
+                this.addon = null;
+                this.state.configLoaded = false;
+                this.state.weightsLoaded = false;
+            }
+        }
     }
     async destroy() {
-        await this.unload();
-        this.state.destroyed = true;
+        return this._withPocketLifecycle(async () => {
+            await this._unloadModel();
+            this.state.destroyed = true;
+        });
     }
     async _runInternal(input) {
+        await this._waitPocketCancel();
+        this._checkPocketRequest();
         const jobFields = this._resolveJobFields(input, "run");
+        const signal = input?.signal;
+        const pocketSignal = this._engineType === ENGINE_POCKET && signal && !signal.aborted ? signal : undefined;
         const response = this._job.start({
-            signal: input?.signal,
+            signal: pocketSignal ? undefined : signal,
         });
-        if (input?.signal?.aborted)
+        if (signal?.aborted)
             return response;
+        if (pocketSignal) {
+            const onAbort = () => {
+                if (this._job.active !== response)
+                    return;
+                const reason = pocketSignal.reason;
+                const error = reason instanceof Error ? reason : new Error(typeof reason === "string" ? `Aborted: ${reason}` : "Aborted");
+                // Preserve the caller's reason while stopping native work. Cancellation
+                // retains the completion barrier until its terminal callback arrives.
+                try {
+                    response.failed(error);
+                }
+                finally {
+                    void this.cancel().catch((error) => this._getLogger().error("Pocket abort cancellation failed", error));
+                }
+            };
+            pocketSignal.addEventListener("abort", onAbort, { once: true });
+            const detach = () => pocketSignal.removeEventListener("abort", onAbort);
+            void response.await().then(detach, detach);
+        }
         try {
-            await this._requireAddon().runJob({
+            await this._dispatchJob({
                 type: input.type || "text",
                 input: input.input,
                 ...(jobFields ?? {}),
@@ -1949,6 +2056,11 @@ class TTSGgml {
             this._job.end();
     }
     _addonOutputCallback(_addon, event, data, error) {
+        if (this._pocketJobPending && ((typeof error === "string" && error.length > 0) || isStatsEvent(data))) {
+            const pending = this._pocketJobPending;
+            this._pocketJobPending = null;
+            pending.resolve();
+        }
         if (typeof error === "string" && error.length > 0) {
             this._handleAddonError(error);
         }
@@ -1998,7 +2110,7 @@ class TTSGgml {
             enriched.sampleRate = data.sampleRate;
         }
         if (!context.textStreamMode) {
-            enriched.isLast = index >= context.chunks.length - 1;
+            enriched.isLast = index >= context.chunks.length - 1 && data.isLast !== false;
         }
         return enriched;
     }
@@ -2019,10 +2131,83 @@ class TTSGgml {
             this._endJobWithStats(computeSentenceStreamStats(context.chunks, context.acc, this._pacesOnFrames()));
         }
     }
+    async _waitPocketCancel() {
+        if (this._engineType === ENGINE_POCKET && this._pocketCancelPromise)
+            await this._pocketCancelPromise;
+    }
+    async _withPocketLifecycle(action) {
+        if (this._engineType !== ENGINE_POCKET)
+            return action();
+        await this._waitPocketCancel();
+        this._checkPocketReload();
+        this._pocketLifecycleInProgress = true;
+        try {
+            await action();
+        }
+        finally {
+            this._pocketLifecycleInProgress = false;
+        }
+    }
+    _checkPocketReload() {
+        if (this._pocketLifecycleInProgress)
+            throw new Error("Pocket lifecycle operation is already in progress");
+    }
+    _checkPocketRequest() {
+        if (this._engineType === ENGINE_POCKET) {
+            if (this.state.destroyed)
+                throw new Error("Pocket instance was destroyed");
+            if (!this.state.weightsLoaded || !this._optionalAddon())
+                throw new Error("Pocket model is not loaded");
+        }
+        if (this._engineType === ENGINE_POCKET && (this._job.active || this._pocketJobPending)) {
+            throw new Error("Pocket synthesis is already in progress");
+        }
+        this._checkPocketReload();
+    }
+    async _dispatchJob(input) {
+        const addon = this._requireAddon();
+        if (this._engineType !== ENGINE_POCKET)
+            return addon.runJob(input);
+        if (this._pocketJobPending)
+            throw new Error("Pocket native job is already in progress");
+        let resolve = () => { };
+        const promise = new Promise((done) => { resolve = done; });
+        const pending = { promise, resolve };
+        this._pocketJobPending = pending;
+        try {
+            await addon.runJob(input);
+        }
+        catch (error) {
+            if (this._pocketJobPending === pending)
+                this._pocketJobPending = null;
+            resolve();
+            throw error;
+        }
+    }
     async cancel() {
         const addon = this._optionalAddon();
-        if (addon?.cancel)
-            await addon.cancel();
+        if (this._engineType !== ENGINE_POCKET) {
+            if (addon?.cancel)
+                await addon.cancel();
+            return;
+        }
+        if (this._pocketCancelPromise)
+            return this._pocketCancelPromise;
+        const pending = this._pocketJobPending;
+        this._pocketCancelPromise = (async () => {
+            this._failAndClearActiveResponse("Synthesis cancelled");
+            if (addon?.cancel)
+                await addon.cancel();
+            // Joining the worker can precede delivery of its terminal callback.
+            if (pending)
+                await pending.promise;
+        })();
+        try {
+            await this._pocketCancelPromise;
+        }
+        finally {
+            this._pocketCancelPromise = null;
+        }
     }
     _failAndClearActiveResponse(reason) {
         this._rejectActiveChunk(reason instanceof Error ? reason : new Error(reason));
@@ -2172,8 +2357,50 @@ class TTSGgml {
             throw error;
         }
     }
+    async _reloadPocket(newConfig) {
+        await this._waitPocketCancel();
+        this._checkPocketReload();
+        if (this.state.destroyed)
+            throw new Error("Pocket instance was destroyed");
+        const options = { ...this._pocketOptions, ...newConfig };
+        const config = { ...this._config, ...newConfig };
+        const params = (0, pocketConfig_1.buildPocketParams)(this._pocketFiles, options, config);
+        this._pocketLifecycleInProgress = true;
+        let replacement = null;
+        try {
+            replacement = this._createAddon(params, this._addonOutputCallback.bind(this));
+            await replacement.activate();
+            const previous = this._optionalAddon();
+            if (previous)
+                await this.cancel();
+            this._failAndClearActiveResponse("Model was reloaded");
+            this.addon = replacement;
+            replacement = null;
+            this._pocketParams = params;
+            this._pocketOptions = options;
+            this._config.language = "en";
+            this._config.useGPU = false;
+            this._outputSampleRate = typeof params.outputSampleRate === "number" ? params.outputSampleRate : null;
+            this._config.outputSampleRate = this._outputSampleRate ?? undefined;
+            this.state.configLoaded = true;
+            this.state.weightsLoaded = true;
+            if (previous)
+                await previous.destroyInstance();
+        }
+        finally {
+            try {
+                if (replacement)
+                    await replacement.destroyInstance();
+            }
+            finally {
+                this._pocketLifecycleInProgress = false;
+            }
+        }
+    }
     async reload(newConfig = {}) {
         this._getLogger().debug("Reloading addon with new configuration", newConfig);
+        if (this._engineType === ENGINE_POCKET)
+            return this._reloadPocket(newConfig);
         const parameters = this._applyReloadableConfig(newConfig);
         await this.cancel();
         this._failAndClearActiveResponse("Model was reloaded");

--- a/packages/tts-ggml/lib/pocketConfig.d.ts
+++ b/packages/tts-ggml/lib/pocketConfig.d.ts
@@ -1,0 +1,10 @@
+import type { TTSConfigurationParams } from "../tts";
+interface PocketFiles {
+    modelDir?: string;
+    pocketFlowModel?: string;
+    pocketMimiModel?: string;
+    pocketFrontend?: string;
+    pocketVoice?: string;
+}
+export declare function buildPocketParams(files: PocketFiles, optionInput: object, configInput: object): TTSConfigurationParams;
+export {};

--- a/packages/tts-ggml/lib/pocketConfig.js
+++ b/packages/tts-ggml/lib/pocketConfig.js
@@ -1,0 +1,70 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildPocketParams = buildPocketParams;
+/* eslint-disable @typescript-eslint/no-require-imports -- Bare CommonJS module. */
+const path = require("bare-path");
+// Keep JS and native validation aligned. In particular, never bitwise-coerce
+// the unsigned seed or accept non-finite/fractional numeric settings.
+function buildPocketParams(files, optionInput, configInput) {
+    const options = optionInput;
+    const config = configInput;
+    const root = files.modelDir;
+    const asset = (value, name) => value || (root ? path.join(root, name) : '');
+    const params = {
+        engineType: 'pocket',
+        pocketFlowModelPath: asset(files.pocketFlowModel, 'flow-lm.gguf'),
+        pocketMimiModelPath: asset(files.pocketMimiModel, 'mimi.gguf'),
+        pocketFrontendPath: asset(files.pocketFrontend, 'frontend.json'),
+        pocketVoicePath: files.pocketVoice || (options.referenceAudio ? '' : asset(undefined, 'voice.gguf')),
+        referenceAudio: typeof options.referenceAudio === 'string' ? options.referenceAudio : '',
+        language: 'en',
+        useGPU: false
+    };
+    if (options.referenceAudio !== undefined && typeof options.referenceAudio !== 'string')
+        throw new Error('Pocket referenceAudio must be a path string');
+    if (config.language !== undefined && config.language !== 'en')
+        throw new Error('Pocket currently supports English (en) only');
+    if (config.useGPU !== undefined && config.useGPU !== false)
+        throw new Error('Pocket currently supports CPU only (useGPU: false)');
+    if (options.nGpuLayers !== undefined && options.nGpuLayers !== 0)
+        throw new Error('Pocket requires nGpuLayers: 0');
+    for (const key of ['voice', 'voiceName', 'voiceDir', 'speed', 'noiseNpyPath', 'kvCacheType', 'streamChunkTokens', 'streamFirstChunkTokens', 'cfmSteps', 'cfgRate', 'streamLeftContextTokens', 'promptText', 'referenceText', 'instruct', 'description', 'voiceDescription', 'emotion', 'pace', 'pitch', 'expressivity', 'noise', 'reverb', 'quality', 'greedy', 'topK', 'topP', 'maxFrames', 'minNewTokens', 'normalizeNumbers', 'enhancer', 'denoiser']) {
+        if (options[key] !== undefined)
+            throw new Error('Pocket does not support ' + key);
+    }
+    if (options.steps !== undefined && options.numInferenceSteps !== undefined && options.steps !== options.numInferenceSteps) {
+        throw new Error('Pocket steps conflicts with numInferenceSteps');
+    }
+    const specs = {
+        threads: [1, 1024],
+        nCtx: [1, 8192],
+        maxTokens: [1, 1024],
+        steps: [1, 64],
+        framesAfterEos: [-1, 100],
+        seed: [0, 4294967295],
+        temperature: [0, 10, false],
+        noiseClamp: [0, 3.402823466e38, false],
+        eosThreshold: [-3.402823466e38, 3.402823466e38, false],
+        outputSampleRate: [8000, 192000]
+    };
+    for (const [key, [min, max, integer = true]] of Object.entries(specs)) {
+        const value = key === 'outputSampleRate'
+            ? config.outputSampleRate
+            : key === 'steps' ? (options.steps === undefined ? options.numInferenceSteps : options.steps) : options[key];
+        if (value === undefined)
+            continue;
+        if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max || (integer && !Number.isInteger(value))) {
+            throw new Error('Invalid Pocket ' + key + ': expected ' + (integer ? 'an integer' : 'a number') + ' between ' + min + ' and ' + max);
+        }
+        params[key] = value;
+    }
+    for (const key of ['pocketFlowModelPath', 'pocketMimiModelPath', 'pocketFrontendPath']) {
+        if (typeof params[key] !== 'string' || !params[key])
+            throw new Error('Pocket requires ' + key);
+    }
+    if (typeof params.pocketVoicePath !== 'string' || typeof params.referenceAudio !== 'string' ||
+        !!params.pocketVoicePath === !!params.referenceAudio) {
+        throw new Error('Pocket requires exactly one prepared voice file or referenceAudio WAV');
+    }
+    return params;
+}

--- a/packages/tts-ggml/lib/pocketConfig.js
+++ b/packages/tts-ggml/lib/pocketConfig.js
@@ -19,9 +19,9 @@ function buildPocketParams(files, optionInput, configInput) {
         referenceAudio: typeof options.referenceAudio === 'string' ? options.referenceAudio : '',
         language: 'en',
         useGPU: false,
-        // Fabric's listening default. Explicit steps/numInferenceSteps below
-        // can still select the upstream one-step setting for lower latency.
-        steps: 4
+        // Match the upstream/native default. Four steps remain an explicit
+        // quality option through steps or numInferenceSteps below.
+        steps: 1
     };
     if (options.referenceAudio !== undefined && typeof options.referenceAudio !== 'string')
         throw new Error('Pocket referenceAudio must be a path string');

--- a/packages/tts-ggml/lib/pocketConfig.js
+++ b/packages/tts-ggml/lib/pocketConfig.js
@@ -18,7 +18,10 @@ function buildPocketParams(files, optionInput, configInput) {
         pocketVoicePath: files.pocketVoice || (options.referenceAudio ? '' : asset(undefined, 'voice.gguf')),
         referenceAudio: typeof options.referenceAudio === 'string' ? options.referenceAudio : '',
         language: 'en',
-        useGPU: false
+        useGPU: false,
+        // Fabric's listening default. Explicit steps/numInferenceSteps below
+        // can still select the upstream one-step setting for lower latency.
+        steps: 4
     };
     if (options.referenceAudio !== undefined && typeof options.referenceAudio !== 'string')
         throw new Error('Pocket referenceAudio must be a path string');

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qvac/tts-ggml",
   "version": "0.8.1",
-  "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 engines from tts-cpp)",
+  "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 + Pocket engines from tts-cpp)",
   "addon": true,
   "engines": {
     "bare": ">=1.19.0"
@@ -57,7 +57,9 @@
     "setup:venv": "bash scripts/setup-venv.sh",
     "convert-models": "bash scripts/convert-models.sh",
     "setup-models": "bash scripts/setup-venv.sh && bash scripts/convert-models.sh",
-    "download-models:registry": "node scripts/download-tts-ggml-models.js"
+    "download-models:registry": "node scripts/download-tts-ggml-models.js",
+    "example:pocket": "bare examples/pocket-tts.js",
+    "test:pocket": "npm run build:ts && brittle-bare test/integration/pocket.integration.test.js"
   },
   "files": [
     "addonLogging.js",
@@ -86,7 +88,8 @@
     "test/utils/textMetrics.js",
     "test/data/sentences-medium.js",
     "test/data/sentences-long.js",
-    "LICENSE"
+    "LICENSE",
+    "docs"
   ],
   "exports": {
     "./package": "./package.json",

--- a/packages/tts-ggml/scripts/prepare-pocket-worklet.cjs
+++ b/packages/tts-ggml/scripts/prepare-pocket-worklet.cjs
@@ -1,0 +1,81 @@
+'use strict'
+// Resolve pnpm's real package locations before traversing imports. Bare's
+// pack/link tools otherwise search beside the logical node_modules symlink.
+const fs = require('node:fs')
+const path = require('node:path')
+const { createRequire } = require('node:module')
+const { fileURLToPath, pathToFileURL } = require('node:url')
+const [source, output, modules] = process.argv.slice(2)
+const tooling = createRequire(fs.realpathSync(path.join(modules, 'bare-pack', 'package.json')))
+const pack = tooling('bare-pack')
+const traverse = tooling('bare-module-traverse')
+const packFs = tooling('./lib/fs')
+const link = require(path.join(modules, 'bare-link'))
+const hosts = ['ios-arm64-simulator']
+
+const canonical = (url) =>
+  url.protocol === 'file:' ? pathToFileURL(fs.realpathSync(fileURLToPath(url))) : url
+
+async function main() {
+  const bundle = await pack(
+    pathToFileURL(path.join(source, 'test/mobile/pocket-worklet.cjs')),
+    {
+      hosts,
+      linked: true,
+      // This functional worklet does not enable brittle's Node-only coverage reporter.
+      defer: ['bare-cov'],
+      resolve: (entry, parent, options) => traverse.resolve.bare(entry, canonical(parent), options)
+    },
+    packFs.readModule,
+    packFs.listPrefix
+  )
+  fs.writeFileSync(path.join(output, 'test.bundle'), bundle.toBuffer())
+
+  const visited = new Set()
+  async function visit(base) {
+    base = fs.realpathSync(base)
+    if (visited.has(base)) return
+    visited.add(base)
+    const pkg = JSON.parse(fs.readFileSync(path.join(base, 'package.json'), 'utf8'))
+    const req = createRequire(path.join(base, 'package.json'))
+    const dependencies = {
+      ...pkg.dependencies,
+      ...pkg.optionalDependencies,
+      ...pkg.peerDependencies
+    }
+    for (const name of Object.keys(dependencies)) {
+      const found = (req.resolve.paths(name) || [])
+        .map((dir) => path.join(dir, name))
+        .find((dir) => fs.existsSync(path.join(dir, 'package.json')))
+      if (found) await visit(found)
+      else if (
+        pkg.dependencies &&
+        name in pkg.dependencies &&
+        !(pkg.optionalDependencies && name in pkg.optionalDependencies)
+      ) {
+        throw new Error(`Missing dependency ${name} from ${base}`)
+      }
+    }
+    if (pkg.addon !== true) return
+    // Dependencies have already been visited at their canonical locations.
+    const standalone = {
+      ...pkg,
+      dependencies: {},
+      optionalDependencies: {},
+      peerDependencies: {},
+      bundleDependencies: []
+    }
+    for await (const item of link(
+      base,
+      { hosts, out: path.join(output, 'frameworks') },
+      standalone
+    )) {
+      console.log(item)
+    }
+  }
+  await visit(source)
+}
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/tts-ggml/scripts/run-pocket-ios-worklet.py
+++ b/packages/tts-ggml/scripts/run-pocket-ios-worklet.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Build a local Bare Kit host and test the installed Pocket simulator prebuild.
+
+Requires Xcode, a booted arm64 iOS Simulator, a converted model bundle,
+react-native-bare-kit with its BareKit.xcframework, and installed bare-pack /
+bare-link tooling. No app checkout is changed, no assets are downloaded, and
+no simulator is booted or shut down by this script.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import struct
+import wave
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--simulator', required=True, help='UDID of a booted iOS Simulator')
+    parser.add_argument('--bundle', type=Path, required=True)
+    parser.add_argument('--bare-kit', type=Path, required=True, help='react-native-bare-kit package directory')
+    parser.add_argument('--tool-modules', type=Path, required=True, help='node_modules containing bare-link and bare-pack')
+    parser.add_argument('--output', type=Path, required=True, help='new directory for host, frameworks and reports')
+    args = parser.parse_args()
+    source = Path(__file__).resolve().parent.parent
+    bundle, kit, modules, output = (x.resolve() for x in (args.bundle, args.bare_kit, args.tool_modules, args.output))
+    for name in ('flow-lm.gguf', 'mimi.gguf', 'frontend.json', 'voice.gguf'):
+        if not (bundle/name).is_file():
+            parser.error(f'missing model artifact: {bundle/name}')
+    framework_dir = kit/'ios/BareKit.xcframework/ios-arm64_x86_64-simulator'
+    required = [framework_dir/'BareKit.framework/BareKit', modules/'bare-pack/bin.js',
+                modules/'bare-link/index.js', source/'prebuilds/ios-arm64-simulator/qvac__tts-ggml.bare']
+    for path in required:
+        if not path.is_file():
+            parser.error(f'missing dependency: {path}')
+    devices = json.loads(subprocess.check_output(['xcrun', 'simctl', 'list', 'devices', 'booted', '--json']))
+    if not any(d['udid'] == args.simulator and d['state'] == 'Booted'
+               for group in devices['devices'].values() for d in group):
+        parser.error('the requested simulator must already be booted')
+    if output.exists():
+        parser.error('output directory already exists; use a new path to preserve prior evidence')
+    output.mkdir(parents=True)
+
+    def run(command, log, **options):
+        with (output/log).open('w') as stream:
+            subprocess.run([str(x) for x in command], cwd=source, stdout=stream,
+                           stderr=subprocess.STDOUT, check=True, **options)
+
+    pack_major = int(json.loads((modules/'bare-pack/package.json').read_text())['version'].split('.')[0])
+    link_major = int(json.loads((modules/'bare-link/package.json').read_text())['version'].split('.')[0])
+    if pack_major < 2 or link_major < 3:
+        parser.error('current pnpm workspace needs bare-pack >= 2 and bare-link >= 3')
+    run(['node', source/'scripts/prepare-pocket-worklet.cjs', source, output, modules], 'pack-link.log')
+    run(['xcrun', '--sdk', 'iphonesimulator', 'clang++', '-std=c++17',
+         '-target', 'arm64-apple-ios15.0-simulator', source/'test/mobile/pocket-worklet-host.cpp',
+         '-F', framework_dir, '-framework', 'Foundation', '-framework', 'BareKit',
+         '-Wl,-rpath,'+str(framework_dir), '-Wl,-rpath,'+str(output/'frameworks'),
+         '-o', output/'host'], 'host-build.log')
+    frameworks = sorted((output/'frameworks').glob('*.framework'))
+    env = dict(os.environ, SIMCTL_CHILD_QVAC_POCKET_MODEL_DIR=str(bundle),
+               SIMCTL_CHILD_QVAC_POCKET_AUDIO_OUTPUT=str(output/'pocket-ios-worklet.wav'))
+    run(['xcrun', 'simctl', 'spawn', args.simulator, output/'host', output/'test.bundle',
+         *(p/p.stem for p in frameworks)], 'run.log', env=env)
+    lines = (output/'run.log').read_text().splitlines()
+    results = [json.loads(line.removeprefix('WORKLET_RESULT '))
+               for line in lines if line.startswith('WORKLET_RESULT ')]
+    if len(results) != 1 or results[0].get('passed') is not True or results[0].get('assertions', 0) <= 0:
+        raise RuntimeError('worklet did not return one successful non-skipped test result')
+    with wave.open(str(output/'pocket-ios-worklet.wav'), 'rb') as wav:
+        rate, channels, width, frames = wav.getframerate(), wav.getnchannels(), wav.getsampwidth(), wav.getnframes()
+        if rate != 24000 or channels != 1 or width != 2 or frames <= 0:
+            raise RuntimeError('invalid worklet WAV format')
+        pcm = [sample[0] for sample in struct.iter_unpack('<h', wav.readframes(frames))]
+        if len(pcm) != frames or not any(pcm):
+            raise RuntimeError('worklet WAV is truncated or silent')
+    result = results[0]
+    result['audio'] = dict(file='pocket-ios-worklet.wav', sample_rate=rate, frames=frames,
+                          duration_seconds=frames/rate, peak=max(abs(s) for s in pcm)/32768,
+                          clipping_fraction=sum(s in (-32768, 32767) for s in pcm)/frames,
+                          reference='Hello! We can generate speech with Fabric.')
+    result.update(simulator=args.simulator, scope='packaged addon in standalone iOS Simulator Bare Kit worklet')
+    (output/'result.json').write_text(json.dumps(result, indent=2)+'\n')
+    (output/'tap.log').write_text('\n'.join(result['tap'])+'\n')
+    print(f"Pocket iOS worklet passed {result['assertions']} assertions. Report: {output/'result.json'}")
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -667,7 +667,7 @@ interface TTSGgmlOptions
   voice?: string;
   /** Alias for `voice` for compatibility with `@qvac/tts-onnx`. */
   voiceName?: string;
-  /** Supertonic CFM steps (0 uses GGUF default); Pocket sampling steps (1–64, default 4). */
+  /** Supertonic CFM steps (0 uses GGUF default); Pocket sampling steps (1–64, default 1). */
   steps?: number;
   /** Alias for `steps` for compatibility with `@qvac/tts-onnx`. */
   numInferenceSteps?: number;

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -2,7 +2,11 @@
 import bareOs = require("bare-os");
 import path = require("bare-path");
 import fs = require("bare-fs");
-import QvacLogger = require("@qvac/logging");
+import loggingModule = require("@qvac/logging");
+import type { LoggerInterface, QvacLogger as QvacLoggerType } from "@qvac/logging";
+// Published logging releases expose a CJS constructor; the workspace exposes
+// an ESM default. Bare require(ESM) returns a namespace without __esModule.
+const QvacLogger = typeof loggingModule === "function" ? loggingModule : loggingModule.default;
 /* eslint-enable @typescript-eslint/no-require-imports */
 import {
   createJobHandler,
@@ -15,10 +19,12 @@ import {
 import {
   TTSInterface,
   type TTSBinding,
+  type TTSJobData,
   type TTSConfigurationParams,
   type TTSOutputCallback,
 } from "./tts";
 import * as errorModule from "./lib/error";
+import { buildPocketParams } from "./lib/pocketConfig";
 import { splitTtsText } from "./lib/textChunker";
 import {
   accumulateTextStream,
@@ -38,6 +44,7 @@ const ENGINE_SUPERTONIC = "supertonic";
 const ENGINE_COSYVOICE3 = "cosyvoice3";
 const ENGINE_PARLER = "parler";
 const ENGINE_AUDIO8 = "audio8";
+const ENGINE_POCKET = "pocket";
 const MIN_OUTPUT_SAMPLE_RATE = 8000;
 const MAX_OUTPUT_SAMPLE_RATE = 192000;
 const CHATTERBOX_T3_TURBO = "chatterbox-t3-turbo.gguf";
@@ -283,7 +290,8 @@ type EngineType =
   | typeof ENGINE_SUPERTONIC
   | typeof ENGINE_COSYVOICE3
   | typeof ENGINE_PARLER
-  | typeof ENGINE_AUDIO8;
+  | typeof ENGINE_AUDIO8
+  | typeof ENGINE_POCKET;
 
 // Per-engine supported subsets, mirroring controls::supported_emotions() /
 // supported_paces(). An empty list means the engine has no such control.
@@ -294,6 +302,7 @@ const ENGINE_EMOTIONS: Record<EngineType, readonly Emotion[]> = {
   [ENGINE_COSYVOICE3]: ["anger", "happy", "neutral", "sad"],
   [ENGINE_SUPERTONIC]: [],
   [ENGINE_CHATTERBOX]: [],
+  [ENGINE_POCKET]: [],
   [ENGINE_AUDIO8]: [],
 };
 
@@ -302,6 +311,7 @@ const ENGINE_PACES: Record<EngineType, readonly Pace[]> = {
   [ENGINE_COSYVOICE3]: PACES, // slow/fast -> instruct; moderate -> none
   [ENGINE_SUPERTONIC]: PACES, // mapped onto the duration multiplier
   [ENGINE_CHATTERBOX]: [], // time-stretch only; use `speed`
+  [ENGINE_POCKET]: [],
   [ENGINE_AUDIO8]: [], // no rate control at all
 };
 
@@ -316,6 +326,7 @@ const ENGINE_PER_CALL_CONDITIONING: Record<
   [ENGINE_COSYVOICE3]: CONDITIONING_KEYS,
   [ENGINE_SUPERTONIC]: [],
   [ENGINE_CHATTERBOX]: [],
+  [ENGINE_POCKET]: [],
   [ENGINE_AUDIO8]: [],
 };
 
@@ -326,6 +337,10 @@ const ENGINE_PER_CALL_CONDITIONING: Record<
  * through to the native layer as-is.
  */
 interface TTSGgmlFiles {
+  pocketFlowModel?: string;
+  pocketMimiModel?: string;
+  pocketFrontend?: string;
+  pocketVoice?: string;
   /**
    * Bundle root. For Chatterbox, expected to contain
    * `chatterbox-t3-turbo.gguf` + `chatterbox-s3gen.gguf` (turbo) or
@@ -558,6 +573,11 @@ interface TTSGgmlOptions
   extends ParlerDescriptionFields,
     Audio8VoiceFields,
     TTSConditioningFields {
+  /** Pocket: generation/context controls; native sampling uses a portable RNG. */
+  maxTokens?: number;
+  noiseClamp?: number;
+  eosThreshold?: number;
+  framesAfterEos?: number;
   files?: TTSGgmlFiles;
   config?: TTSGgmlRuntimeConfig;
   logger?: object;
@@ -713,6 +733,10 @@ interface TTSGgmlOptions
 }
 
 interface NormalizedFiles {
+  pocketFlowModel?: string;
+  pocketMimiModel?: string;
+  pocketFrontend?: string;
+  pocketVoice?: string;
   modelDir?: string;
   t3Model?: string;
   s3genModel?: string;
@@ -776,6 +800,7 @@ interface TTSOutputChunk {
 
 interface NativeOutputChunk {
   outputArray: Int16Array;
+  isLast?: boolean;
   sampleRate?: number;
 }
 
@@ -1253,6 +1278,10 @@ function normalizeGgmlFiles(
   if (files == null || typeof files !== "object") return {};
   return {
     modelDir: firstNonEmpty(files.modelDir),
+    pocketFlowModel: firstNonEmpty(files.pocketFlowModel),
+    pocketMimiModel: firstNonEmpty(files.pocketMimiModel),
+    pocketFrontend: firstNonEmpty(files.pocketFrontend),
+    pocketVoice: firstNonEmpty(files.pocketVoice),
     t3Model: firstNonEmpty(
       files.t3Model,
       files.t3ModelPath,
@@ -1328,16 +1357,18 @@ function detectEngineType(
     engine === ENGINE_SUPERTONIC ||
     engine === ENGINE_COSYVOICE3 ||
     engine === ENGINE_PARLER ||
-    engine === ENGINE_AUDIO8
+    engine === ENGINE_AUDIO8 ||
+    engine === ENGINE_POCKET
   ) {
     return engine;
   }
   if (engine != null && engine !== "") {
     throw new Error(
       "tts-ggml: 'engine' option must be 'chatterbox', 'supertonic', " +
-        `'cosyvoice3', 'parler' or 'audio8' (got '${String(engine)}')`,
+        `'cosyvoice3', 'parler', 'audio8' or 'pocket' (got '${String(engine)}')`,
     );
   }
+  if (files.pocketFlowModel || files.pocketMimiModel) return ENGINE_POCKET;
   // Explicit CosyVoice3 files/dir take precedence over shared-modelDir sniffing.
   if (files.cosyvoiceModelDir || files.cosyvoiceLlmModel) {
     return ENGINE_COSYVOICE3;
@@ -1359,6 +1390,7 @@ function detectEngineType(
     if (hasSupertonic) return ENGINE_SUPERTONIC;
     if (findParlerInDir(files.modelDir)) return ENGINE_PARLER;
     if (findAudio8InDir(files.modelDir, AUDIO8_LM_RE)) return ENGINE_AUDIO8;
+    if (fileExistsSafe(path.join(files.modelDir, "flow-lm.gguf"))) return ENGINE_POCKET;
   }
   return ENGINE_CHATTERBOX;
 }
@@ -1655,6 +1687,7 @@ class TTSGgml {
   static readonly ENGINE_COSYVOICE3 = ENGINE_COSYVOICE3;
   static readonly ENGINE_PARLER = ENGINE_PARLER;
   static readonly ENGINE_AUDIO8 = ENGINE_AUDIO8;
+  static readonly ENGINE_POCKET = ENGINE_POCKET;
 
   opts: object;
   exclusiveRun: boolean;
@@ -1667,6 +1700,12 @@ class TTSGgml {
   private _ttsInferenceQueueWaiter: Promise<void>;
   private _sentenceStreamCtx: SentenceStreamContext | null;
   private _config: TTSGgmlRuntimeConfig;
+  private _pocketJobPending: { promise: Promise<void>; resolve: () => void } | null = null;
+  private _pocketCancelPromise: Promise<void> | null = null;
+  private _pocketLifecycleInProgress = false;
+  private _pocketParams: TTSConfigurationParams | null = null;
+  private _pocketOptions: Record<string, unknown> = {};
+  private _pocketFiles: NormalizedFiles = {};
   private _lazySessionLoading: boolean;
   private _outputSampleRate: number | null;
   private _engineType: EngineType;
@@ -1730,7 +1769,7 @@ class TTSGgml {
     this.opts = options.opts || {};
     this.exclusiveRun = !!options.exclusiveRun;
     this.logger = new QvacLogger(
-      options.logger as QvacLogger.LoggerInterface | undefined,
+      options.logger as LoggerInterface | undefined,
     );
     this.state = {
       configLoaded: false,
@@ -1741,7 +1780,7 @@ class TTSGgml {
     this._sentenceStreamCtx = null;
     this._ttsInferenceQueueWaiter = Promise.resolve();
     this._job = createJobHandler({
-      cancel: () => this._optionalAddon()?.cancel(),
+      cancel: () => this._engineType === ENGINE_POCKET ? this.cancel() : this._optionalAddon()?.cancel(),
     });
     this._runExclusive = this.exclusiveRun
       ? exclusiveRunQueue()
@@ -1763,6 +1802,14 @@ class TTSGgml {
       options.engine,
       normalizedFiles,
     );
+    if (this._engineType === ENGINE_POCKET) {
+      if (normalizedFiles.lavasrEnhancer || normalizedFiles.lavasrDenoiser) {
+        throw new Error("Pocket does not support LavaSR enhancement or denoising");
+      }
+      this._pocketFiles = normalizedFiles;
+      this._pocketOptions = { ...options };
+      this._pocketParams = buildPocketParams(normalizedFiles, options, this._config);
+    }
     this._resolveEngineAndModelPaths(normalizedFiles);
     this._mecabDictPath = firstNonEmpty(
       options.mecabDictPath,
@@ -1810,6 +1857,7 @@ class TTSGgml {
 
   private _resolveEngineAndModelPaths(files: NormalizedFiles): void {
     this._voicesDir = files.voicesDir;
+    if (this._engineType === ENGINE_POCKET) return;
     if (this._engineType === ENGINE_COSYVOICE3) {
       // CosyVoice3 discovers its sub-model GGUFs from a model directory; the
       // native engine resolves the individual components. Explicit
@@ -2019,7 +2067,7 @@ class TTSGgml {
   }
 
   private _assertSamplerOptionSupport(): void {
-    if (SAMPLING_ENGINES.includes(this._engineType)) return;
+    if (this._engineType === ENGINE_POCKET || SAMPLING_ENGINES.includes(this._engineType)) return;
     const sampling = setOptionNames({
       temperature: this._temperature,
       topK: this._topK,
@@ -2286,6 +2334,10 @@ class TTSGgml {
 
   async load(..._args: unknown[]): Promise<void> {
     void _args;
+    return this._withPocketLifecycle(() => this._loadModel());
+  }
+
+  private async _loadModel(): Promise<void> {
     if (this.state.destroyed) {
       throw new QvacErrorAddonTTSGgml({
         code: ERR_CODES.FAILED_TO_LOAD,
@@ -2296,7 +2348,7 @@ class TTSGgml {
       this._getLogger().info(
         "Reload requested - unloading existing model first",
       );
-      await this.unload();
+      await this._unloadModel();
     }
     await this._load();
     this.state.configLoaded = true;
@@ -2318,7 +2370,9 @@ class TTSGgml {
   ): Promise<
     QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta>
   > {
-    if (input?.streamOutput === true) {
+    await this._waitPocketCancel();
+    this._checkPocketReload();
+    if (input?.streamOutput === true && this._engineType !== ENGINE_POCKET) {
       if (
         typeof input.input !== "string" ||
         input.input.trim().length === 0
@@ -2356,8 +2410,14 @@ class TTSGgml {
   ): Promise<
     QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta>
   > {
+    await this._waitPocketCancel();
+    this._checkPocketReload();
     const normalized =
       options == null || typeof options !== "object" ? {} : options;
+    if (this._engineType === ENGINE_POCKET) {
+      const run = () => this._runStreamOrchestrator(text, normalized, this._resolveJobFields(normalized, "runStream"));
+      return this.exclusiveRun ? this._enqueueExclusiveTtsResponse(run) : run();
+    }
     return this.run({
       input: text,
       streamOutput: true,
@@ -2381,6 +2441,8 @@ class TTSGgml {
   ): Promise<
     QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta>
   > {
+    await this._waitPocketCancel();
+    this._checkPocketReload();
     const jobFields = this._resolveJobFields(
       options,
       "runStreaming",
@@ -2526,6 +2588,7 @@ class TTSGgml {
     source: AsyncIterable<string>,
     jobFields?: JobFields,
   ): QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta> {
+    this._checkPocketRequest();
     const response = this._job.start() as QvacResponse<
       TTSOutputChunk & SentenceStreamChunkMeta
     >;
@@ -2538,8 +2601,10 @@ class TTSGgml {
       chunkResolver: null,
       jobFields,
     };
+    const context = this._sentenceStreamCtx;
     void this._sentenceStreamTextIterableDrive().catch(
       (error: unknown) => {
+        if (context !== this._sentenceStreamCtx) return;
         this._rejectActiveChunk(error);
         this._sentenceStreamCtx = null;
         this._job.fail(normalizeError(error));
@@ -2559,6 +2624,7 @@ class TTSGgml {
     }
     try {
       for await (const piece of context.asyncTextSource) {
+        if (context !== this._sentenceStreamCtx) return;
         const text = String(piece).trim();
         if (text.length === 0) continue;
         context.chunks.push(text);
@@ -2566,7 +2632,9 @@ class TTSGgml {
         const done = new Promise<void>((resolve, reject) => {
           context.chunkResolver = { resolve, reject };
         });
-        await this._requireAddon().runJob({
+        // Dispatch may fail before the completion promise is awaited.
+        void done.catch(() => {});
+        await this._dispatchJob({
           type: "text",
           input: text,
           ...(context.jobFields ?? {}),
@@ -2574,11 +2642,13 @@ class TTSGgml {
         await done;
       }
     } catch (error) {
+      if (context !== this._sentenceStreamCtx) return;
       this._rejectActiveChunk(error);
       this._sentenceStreamCtx = null;
       this._job.fail(normalizeError(error));
       return;
     }
+    if (context !== this._sentenceStreamCtx) return;
     const current = this._sentenceStreamCtx;
     const chunks = current?.chunks || [];
     const accumulator = current?.acc || emptyStreamAccumulator();
@@ -2613,6 +2683,7 @@ class TTSGgml {
     options: SentenceStreamOptions,
     jobFields?: JobFields,
   ): QvacResponse<TTSOutputChunk & SentenceStreamChunkMeta> {
+    this._checkPocketRequest();
     const chunks = splitTtsText(String(text), {
       language: this._config.language,
       locale: options.locale,
@@ -2624,6 +2695,7 @@ class TTSGgml {
         adds: "chunked synthesis: text produced no chunks after split",
       });
     }
+    this._checkPocketRequest();
     const response = this._job.start() as QvacResponse<
       TTSOutputChunk & SentenceStreamChunkMeta
     >;
@@ -2634,7 +2706,9 @@ class TTSGgml {
       chunkResolver: null,
       jobFields,
     };
+    const context = this._sentenceStreamCtx;
     void this._sentenceStreamDriveBody().catch((error: unknown) => {
+      if (context !== this._sentenceStreamCtx) return;
       this._rejectActiveChunk(error);
       this._sentenceStreamCtx = null;
       this._job.fail(normalizeError(error));
@@ -2646,17 +2720,21 @@ class TTSGgml {
     const context = this._sentenceStreamCtx;
     if (!context || context.textStreamMode) return;
     for (let index = 0; index < context.chunks.length; index++) {
+      if (context !== this._sentenceStreamCtx) return;
       context.chunkIdx = index;
       const done = new Promise<void>((resolve, reject) => {
         context.chunkResolver = { resolve, reject };
       });
-      await this._requireAddon().runJob({
+      // Dispatch may fail before the completion promise is awaited.
+      void done.catch(() => {});
+      await this._dispatchJob({
         type: "text",
         input: context.chunks[index],
         ...(context.jobFields ?? {}),
       });
       await done;
     }
+    if (context !== this._sentenceStreamCtx) return;
     this._sentenceStreamCtx = null;
   }
 
@@ -2682,6 +2760,7 @@ class TTSGgml {
   }
 
   private _buildTtsParams(): TTSConfigurationParams {
+    if (this._pocketParams) return { ...this._pocketParams };
     if (this._engineType === ENGINE_SUPERTONIC) {
       return this._buildSupertonicParams();
     }
@@ -2975,29 +3054,61 @@ class TTSGgml {
   }
 
   async unload(): Promise<void> {
+    return this._withPocketLifecycle(() => this._unloadModel());
+  }
+
+  private async _unloadModel(): Promise<void> {
     await this.cancel();
     this._failAndClearActiveResponse("Model was unloaded");
     const addon = this._optionalAddon();
-    if (addon) await addon.destroyInstance();
-    this.state.configLoaded = false;
-    this.state.weightsLoaded = false;
+    try {
+      if (addon) await addon.destroyInstance();
+    } finally {
+      if (this.addon === addon) {
+        this.addon = null;
+        this.state.configLoaded = false;
+        this.state.weightsLoaded = false;
+      }
+    }
   }
 
   async destroy(): Promise<void> {
-    await this.unload();
-    this.state.destroyed = true;
+    return this._withPocketLifecycle(async () => {
+      await this._unloadModel();
+      this.state.destroyed = true;
+    });
   }
 
   private async _runInternal(
     input: TTSRunInput,
   ): Promise<QvacResponse<TTSOutputChunk>> {
+    await this._waitPocketCancel();
+    this._checkPocketRequest();
     const jobFields = this._resolveJobFields(input, "run");
+    const signal = input?.signal;
+    const pocketSignal = this._engineType === ENGINE_POCKET && signal && !signal.aborted ? signal : undefined;
     const response = this._job.start({
-      signal: input?.signal,
+      signal: pocketSignal ? undefined : signal,
     }) as QvacResponse<TTSOutputChunk>;
-    if (input?.signal?.aborted) return response;
+    if (signal?.aborted) return response;
+    if (pocketSignal) {
+      const onAbort = (): void => {
+        if (this._job.active !== response) return;
+        const reason: unknown = pocketSignal.reason;
+        const error = reason instanceof Error ? reason : new Error(typeof reason === "string" ? `Aborted: ${reason}` : "Aborted");
+        // Preserve the caller's reason while stopping native work. Cancellation
+        // retains the completion barrier until its terminal callback arrives.
+        try { response.failed(error); }
+        finally {
+          void this.cancel().catch((error: unknown) => this._getLogger().error("Pocket abort cancellation failed", error));
+        }
+      };
+      pocketSignal.addEventListener("abort", onAbort, { once: true });
+      const detach = (): void => pocketSignal.removeEventListener("abort", onAbort);
+      void response.await().then(detach, detach);
+    }
     try {
-      await this._requireAddon().runJob({
+      await this._dispatchJob({
         type: input.type || "text",
         input: input.input,
         ...(jobFields ?? {}),
@@ -3043,6 +3154,11 @@ class TTSGgml {
     data: unknown,
     error: unknown,
   ): void {
+    if (this._pocketJobPending && ((typeof error === "string" && error.length > 0) || isStatsEvent(data))) {
+      const pending = this._pocketJobPending;
+      this._pocketJobPending = null;
+      pending.resolve();
+    }
     if (typeof error === "string" && error.length > 0) {
       this._handleAddonError(error);
     } else if (isAudioOutputEvent(data)) {
@@ -3100,7 +3216,7 @@ class TTSGgml {
       enriched.sampleRate = data.sampleRate;
     }
     if (!context.textStreamMode) {
-      enriched.isLast = index >= context.chunks.length - 1;
+      enriched.isLast = index >= context.chunks.length - 1 && data.isLast !== false;
     }
     return enriched;
   }
@@ -3133,9 +3249,66 @@ class TTSGgml {
     }
   }
 
+  private async _waitPocketCancel(): Promise<void> {
+    if (this._engineType === ENGINE_POCKET && this._pocketCancelPromise) await this._pocketCancelPromise;
+  }
+
+  private async _withPocketLifecycle(action: () => Promise<void>): Promise<void> {
+    if (this._engineType !== ENGINE_POCKET) return action();
+    await this._waitPocketCancel();
+    this._checkPocketReload();
+    this._pocketLifecycleInProgress = true;
+    try { await action(); }
+    finally { this._pocketLifecycleInProgress = false; }
+  }
+
+  private _checkPocketReload(): void {
+    if (this._pocketLifecycleInProgress) throw new Error("Pocket lifecycle operation is already in progress");
+  }
+
+  private _checkPocketRequest(): void {
+    if (this._engineType === ENGINE_POCKET) {
+      if (this.state.destroyed) throw new Error("Pocket instance was destroyed");
+      if (!this.state.weightsLoaded || !this._optionalAddon()) throw new Error("Pocket model is not loaded");
+    }
+    if (this._engineType === ENGINE_POCKET && (this._job.active || this._pocketJobPending)) {
+      throw new Error("Pocket synthesis is already in progress");
+    }
+    this._checkPocketReload();
+  }
+
+  private async _dispatchJob(input: TTSJobData): Promise<void> {
+    const addon = this._requireAddon();
+    if (this._engineType !== ENGINE_POCKET) return addon.runJob(input);
+    if (this._pocketJobPending) throw new Error("Pocket native job is already in progress");
+    let resolve = (): void => {};
+    const promise = new Promise<void>((done) => { resolve = done; });
+    const pending = { promise, resolve };
+    this._pocketJobPending = pending;
+    try { await addon.runJob(input); }
+    catch (error) {
+      if (this._pocketJobPending === pending) this._pocketJobPending = null;
+      resolve();
+      throw error;
+    }
+  }
+
   async cancel(): Promise<void> {
     const addon = this._optionalAddon();
-    if (addon?.cancel) await addon.cancel();
+    if (this._engineType !== ENGINE_POCKET) {
+      if (addon?.cancel) await addon.cancel();
+      return;
+    }
+    if (this._pocketCancelPromise) return this._pocketCancelPromise;
+    const pending = this._pocketJobPending;
+    this._pocketCancelPromise = (async () => {
+      this._failAndClearActiveResponse("Synthesis cancelled");
+      if (addon?.cancel) await addon.cancel();
+      // Joining the worker can precede delivery of its terminal callback.
+      if (pending) await pending.promise;
+    })();
+    try { await this._pocketCancelPromise; }
+    finally { this._pocketCancelPromise = null; }
   }
 
   private _failAndClearActiveResponse(
@@ -3320,6 +3493,38 @@ class TTSGgml {
     }
   }
 
+  private async _reloadPocket(newConfig: Record<string, unknown>): Promise<void> {
+    await this._waitPocketCancel();
+    this._checkPocketReload();
+    if (this.state.destroyed) throw new Error("Pocket instance was destroyed");
+    const options = { ...this._pocketOptions, ...newConfig };
+    const config = { ...this._config, ...newConfig };
+    const params = buildPocketParams(this._pocketFiles, options, config);
+    this._pocketLifecycleInProgress = true;
+    let replacement: TTSInterface | null = null;
+    try {
+      replacement = this._createAddon(params, this._addonOutputCallback.bind(this));
+      await replacement.activate();
+      const previous = this._optionalAddon();
+      if (previous) await this.cancel();
+      this._failAndClearActiveResponse("Model was reloaded");
+      this.addon = replacement;
+      replacement = null;
+      this._pocketParams = params;
+      this._pocketOptions = options;
+      this._config.language = "en";
+      this._config.useGPU = false;
+      this._outputSampleRate = typeof params.outputSampleRate === "number" ? params.outputSampleRate : null;
+      this._config.outputSampleRate = this._outputSampleRate ?? undefined;
+      this.state.configLoaded = true;
+      this.state.weightsLoaded = true;
+      if (previous) await previous.destroyInstance();
+    } finally {
+      try { if (replacement) await replacement.destroyInstance(); }
+      finally { this._pocketLifecycleInProgress = false; }
+    }
+  }
+
   async reload(
     newConfig: Record<string, unknown> = {},
   ): Promise<void> {
@@ -3327,6 +3532,7 @@ class TTSGgml {
       "Reloading addon with new configuration",
       newConfig,
     );
+    if (this._engineType === ENGINE_POCKET) return this._reloadPocket(newConfig);
     const parameters = this._applyReloadableConfig(newConfig);
     await this.cancel();
     this._failAndClearActiveResponse("Model was reloaded");
@@ -3429,8 +3635,8 @@ class TTSGgml {
     return (this.addon as TTSInterface | null | undefined) || null;
   }
 
-  private _getLogger(): QvacLogger {
-    return this.logger as QvacLogger;
+  private _getLogger(): QvacLoggerType {
+    return this.logger as QvacLoggerType;
   }
 }
 

--- a/packages/tts-ggml/src/index.ts
+++ b/packages/tts-ggml/src/index.ts
@@ -667,7 +667,7 @@ interface TTSGgmlOptions
   voice?: string;
   /** Alias for `voice` for compatibility with `@qvac/tts-onnx`. */
   voiceName?: string;
-  /** Supertonic vector-estimator CFM steps. 0 uses the GGUF default. */
+  /** Supertonic CFM steps (0 uses GGUF default); Pocket sampling steps (1–64, default 4). */
   steps?: number;
   /** Alias for `steps` for compatibility with `@qvac/tts-onnx`. */
   numInferenceSteps?: number;

--- a/packages/tts-ggml/src/lib/pocketConfig.ts
+++ b/packages/tts-ggml/src/lib/pocketConfig.ts
@@ -30,9 +30,9 @@ export function buildPocketParams (
     referenceAudio: typeof options.referenceAudio === 'string' ? options.referenceAudio : '',
     language: 'en',
     useGPU: false,
-    // Fabric's listening default. Explicit steps/numInferenceSteps below
-    // can still select the upstream one-step setting for lower latency.
-    steps: 4
+    // Match the upstream/native default. Four steps remain an explicit
+    // quality option through steps or numInferenceSteps below.
+    steps: 1
   }
   if (options.referenceAudio !== undefined && typeof options.referenceAudio !== 'string') throw new Error('Pocket referenceAudio must be a path string')
   if (config.language !== undefined && config.language !== 'en') throw new Error('Pocket currently supports English (en) only')

--- a/packages/tts-ggml/src/lib/pocketConfig.ts
+++ b/packages/tts-ggml/src/lib/pocketConfig.ts
@@ -29,7 +29,10 @@ export function buildPocketParams (
     pocketVoicePath: files.pocketVoice || (options.referenceAudio ? '' : asset(undefined, 'voice.gguf')),
     referenceAudio: typeof options.referenceAudio === 'string' ? options.referenceAudio : '',
     language: 'en',
-    useGPU: false
+    useGPU: false,
+    // Fabric's listening default. Explicit steps/numInferenceSteps below
+    // can still select the upstream one-step setting for lower latency.
+    steps: 4
   }
   if (options.referenceAudio !== undefined && typeof options.referenceAudio !== 'string') throw new Error('Pocket referenceAudio must be a path string')
   if (config.language !== undefined && config.language !== 'en') throw new Error('Pocket currently supports English (en) only')
@@ -72,4 +75,3 @@ export function buildPocketParams (
   }
   return params
 }
-

--- a/packages/tts-ggml/src/lib/pocketConfig.ts
+++ b/packages/tts-ggml/src/lib/pocketConfig.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- Bare CommonJS module. */
+import path = require("bare-path");
+import type { TTSConfigurationParams } from "../tts";
+
+interface PocketFiles {
+  modelDir?: string;
+  pocketFlowModel?: string;
+  pocketMimiModel?: string;
+  pocketFrontend?: string;
+  pocketVoice?: string;
+}
+
+// Keep JS and native validation aligned. In particular, never bitwise-coerce
+// the unsigned seed or accept non-finite/fractional numeric settings.
+export function buildPocketParams (
+  files: PocketFiles,
+  optionInput: object,
+  configInput: object,
+): TTSConfigurationParams {
+  const options = optionInput as Record<string, unknown>;
+  const config = configInput as Record<string, unknown>;
+  const root = files.modelDir
+  const asset = (value: string | undefined, name: string) => value || (root ? path.join(root, name) : '')
+  const params: TTSConfigurationParams = {
+    engineType: 'pocket',
+    pocketFlowModelPath: asset(files.pocketFlowModel, 'flow-lm.gguf'),
+    pocketMimiModelPath: asset(files.pocketMimiModel, 'mimi.gguf'),
+    pocketFrontendPath: asset(files.pocketFrontend, 'frontend.json'),
+    pocketVoicePath: files.pocketVoice || (options.referenceAudio ? '' : asset(undefined, 'voice.gguf')),
+    referenceAudio: typeof options.referenceAudio === 'string' ? options.referenceAudio : '',
+    language: 'en',
+    useGPU: false
+  }
+  if (options.referenceAudio !== undefined && typeof options.referenceAudio !== 'string') throw new Error('Pocket referenceAudio must be a path string')
+  if (config.language !== undefined && config.language !== 'en') throw new Error('Pocket currently supports English (en) only')
+  if (config.useGPU !== undefined && config.useGPU !== false) throw new Error('Pocket currently supports CPU only (useGPU: false)')
+  if (options.nGpuLayers !== undefined && options.nGpuLayers !== 0) throw new Error('Pocket requires nGpuLayers: 0')
+  for (const key of ['voice', 'voiceName', 'voiceDir', 'speed', 'noiseNpyPath', 'kvCacheType', 'streamChunkTokens', 'streamFirstChunkTokens', 'cfmSteps', 'cfgRate', 'streamLeftContextTokens', 'promptText', 'referenceText', 'instruct', 'description', 'voiceDescription', 'emotion', 'pace', 'pitch', 'expressivity', 'noise', 'reverb', 'quality', 'greedy', 'topK', 'topP', 'maxFrames', 'minNewTokens', 'normalizeNumbers', 'enhancer', 'denoiser']) {
+    if (options[key] !== undefined) throw new Error('Pocket does not support ' + key)
+  }
+  if (options.steps !== undefined && options.numInferenceSteps !== undefined && options.steps !== options.numInferenceSteps) {
+    throw new Error('Pocket steps conflicts with numInferenceSteps')
+  }
+  const specs: Record<string, [number, number, boolean?]> = {
+    threads: [1, 1024],
+    nCtx: [1, 8192],
+    maxTokens: [1, 1024],
+    steps: [1, 64],
+    framesAfterEos: [-1, 100],
+    seed: [0, 4294967295],
+    temperature: [0, 10, false],
+    noiseClamp: [0, 3.402823466e38, false],
+    eosThreshold: [-3.402823466e38, 3.402823466e38, false],
+    outputSampleRate: [8000, 192000]
+  }
+  for (const [key, [min, max, integer = true]] of Object.entries(specs)) {
+    const value = key === 'outputSampleRate'
+      ? config.outputSampleRate
+      : key === 'steps' ? (options.steps === undefined ? options.numInferenceSteps : options.steps) : options[key]
+    if (value === undefined) continue
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max || (integer && !Number.isInteger(value))) {
+      throw new Error('Invalid Pocket ' + key + ': expected ' + (integer ? 'an integer' : 'a number') + ' between ' + min + ' and ' + max)
+    }
+    params[key] = value
+  }
+  for (const key of ['pocketFlowModelPath', 'pocketMimiModelPath', 'pocketFrontendPath']) {
+    if (typeof params[key] !== 'string' || !params[key]) throw new Error('Pocket requires ' + key)
+  }
+  if (typeof params.pocketVoicePath !== 'string' || typeof params.referenceAudio !== 'string' ||
+      !!params.pocketVoicePath === !!params.referenceAudio) {
+    throw new Error('Pocket requires exactly one prepared voice file or referenceAudio WAV')
+  }
+  return params
+}
+

--- a/packages/tts-ggml/src/tts.ts
+++ b/packages/tts-ggml/src/tts.ts
@@ -48,7 +48,7 @@ export interface TTSBinding {
     outputCallback: TTSOutputCallback | null,
   ): object;
   activate(handle: object | null): Promise<void>;
-  runJob(handle: object | null, data: TTSJobData): void;
+  runJob(handle: object | null, data: TTSJobData): boolean | void | Promise<boolean | void>;
   loadWeights(
     handle: object | null,
     weightsData: TTSWeightData,
@@ -100,10 +100,11 @@ export class TTSInterface {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await -- preserves the established promise-returning wrapper API.
   async runJob(data: TTSJobData): Promise<void> {
     try {
-      this._binding.runJob(this._handle, data);
+      if (await this._binding.runJob(this._handle, data) === false) {
+        throw new Error("Native addon rejected the job");
+      }
     } catch (error) {
       throw new QvacErrorAddonTTSGgml({
         code: ERR_CODES.FAILED_TO_APPEND,

--- a/packages/tts-ggml/test/integration/pocket.integration.test.js
+++ b/packages/tts-ggml/test/integration/pocket.integration.test.js
@@ -43,24 +43,23 @@ module.exports = test(
         return pcm
       }
       const original = await run(24000)
-      // Cover the entire default-options -> native decoder path. The user
-      // reported an artifact on "speech" with one step in this exact prompt,
-      // and found the four-step take clean. This verifies the selected setting,
-      // not subjective quality, which still needs listening evaluation.
+      // Check that omitted steps match the explicit upstream/native default
+      // through the complete addon path. PCM parity validates configuration,
+      // not subjective quality or the absence of model-generated artifacts.
       const explicit = new TTSGgml({
         engine: 'pocket',
         files: { modelDir: bundle },
-        steps: 4
+        steps: 1
       })
       try {
         await explicit.load()
         const reference = await explicit.run({ input: text })
         const pcm = []
         for await (const chunk of reference.iterate()) pcm.push(...chunk.outputArray)
-        t.is(pcm.length, original.length, 'default and explicit four-step lengths match')
+        t.is(pcm.length, original.length, 'default and explicit one-step lengths match')
         t.ok(
           pcm.every((v, i) => Math.abs(v - original[i]) <= 4),
-          'default native PCM matches explicit four-step synthesis'
+          'default native PCM matches explicit one-step synthesis'
         )
       } finally {
         await explicit.destroy()

--- a/packages/tts-ggml/test/integration/pocket.integration.test.js
+++ b/packages/tts-ggml/test/integration/pocket.integration.test.js
@@ -43,6 +43,28 @@ module.exports = test(
         return pcm
       }
       const original = await run(24000)
+      // Cover the entire default-options -> native decoder path. The user
+      // reported an artifact on "speech" with one step in this exact prompt,
+      // and found the four-step take clean. This verifies the selected setting,
+      // not subjective quality, which still needs listening evaluation.
+      const explicit = new TTSGgml({
+        engine: 'pocket',
+        files: { modelDir: bundle },
+        steps: 4
+      })
+      try {
+        await explicit.load()
+        const reference = await explicit.run({ input: text })
+        const pcm = []
+        for await (const chunk of reference.iterate()) pcm.push(...chunk.outputArray)
+        t.is(pcm.length, original.length, 'default and explicit four-step lengths match')
+        t.ok(
+          pcm.every((v, i) => Math.abs(v - original[i]) <= 4),
+          'default native PCM matches explicit four-step synthesis'
+        )
+      } finally {
+        await explicit.destroy()
+      }
       if (process.env.QVAC_POCKET_AUDIO_OUTPUT) {
         require('../utils/wav-helper').createWav(
           new Int16Array(original),

--- a/packages/tts-ggml/test/integration/pocket.integration.test.js
+++ b/packages/tts-ggml/test/integration/pocket.integration.test.js
@@ -1,0 +1,90 @@
+'use strict'
+const test = require('brittle')
+const TTSGgml = require('../../index')
+const process = require('bare-process')
+global.process = process
+const bundle = process.env.QVAC_POCKET_MODEL_DIR
+const text = 'Hello! We can generate speech with Fabric.'
+
+// Opt in with QVAC_POCKET_MODEL_DIR pointing at the converted four-file bundle.
+module.exports = test(
+  'Pocket native addon streams, cancels, recovers and resamples on reload',
+  { skip: !bundle },
+  async (t) => {
+    const model = new TTSGgml({
+      engine: 'pocket',
+      files: { modelDir: bundle },
+      opts: { stats: true }
+    })
+    try {
+      await model.load()
+      const run = async (rate) => {
+        const response = await model.run({ input: text })
+        const pcm = []
+        const indices = []
+        let last = 0
+        for await (const chunk of response.iterate()) {
+          t.is(chunk.sampleRate, rate)
+          indices.push(chunk.chunkIndex)
+          pcm.push(...chunk.outputArray)
+          if (chunk.isLast) {
+            last++
+            t.is(chunk.outputArray.length, 0)
+          }
+        }
+        t.is(last, 1)
+        t.alike(
+          indices,
+          indices.map((_, i) => i)
+        )
+        t.is(pcm.length, response.stats.totalSamples)
+        t.ok(pcm.some((x) => x !== 0))
+        t.ok(response.stats.firstAudioMs > 0)
+        return pcm
+      }
+      const original = await run(24000)
+      if (process.env.QVAC_POCKET_AUDIO_OUTPUT) {
+        require('../utils/wav-helper').createWav(
+          new Int16Array(original),
+          24000,
+          process.env.QVAC_POCKET_AUDIO_OUTPUT
+        )
+      }
+      const response = await model.run({ input: text.repeat(5) })
+      let cancelPromise
+      const outcomePromise = response.await().then(
+        () => ({ completed: true }),
+        (error) => ({ error })
+      )
+      response.onUpdate((chunk) => {
+        if (!cancelPromise && chunk.outputArray.length) {
+          cancelPromise = response.cancel()
+          // Attach a rejection handler immediately; await the original promise
+          // below so cancellation failures still fail the integration test.
+          cancelPromise.catch(() => {})
+        }
+      })
+      const outcome = await outcomePromise
+      t.ok(cancelPromise, 'requested cancellation after first PCM')
+      if (cancelPromise) await cancelPromise
+      t.ok(
+        outcome.error && /cancel|abort/i.test(String(outcome.error)),
+        'cancelled synthesis rejects instead of completing'
+      )
+      const recovered = await run(24000)
+      t.is(recovered.length, original.length)
+      t.ok(
+        recovered.every((v, i) => Math.abs(v - original[i]) <= 4),
+        'deterministic PCM after cancellation'
+      )
+      await model.reload({ outputSampleRate: 44100 })
+      const resampled = await run(44100)
+      t.ok(Math.abs(resampled.length / 44100 - original.length / 24000) < 1 / 44100)
+      const empty = await model.run({ input: '   ' })
+      await t.exception(empty.await())
+      await run(44100)
+    } finally {
+      await model.destroy()
+    }
+  }
+)

--- a/packages/tts-ggml/test/mobile/pocket-worklet-host.cpp
+++ b/packages/tts-ggml/test/mobile/pocket-worklet-host.cpp
@@ -1,0 +1,92 @@
+// Standalone iOS Simulator host for the packaged Pocket Bare worklet test.
+// Uses the same exported Bare Kit C API as react-native-bare-kit/shared/
+// BareKitModule.cc. Keep IPC initialization after bare_worklet_start().
+// This tests a worklet process, not a signed app or a physical device.
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include <dlfcn.h>
+extern "C" {
+struct bare_worklet_s;
+using bare_worklet_t = bare_worklet_s;
+struct bare_ipc_s;
+using bare_ipc_t = bare_ipc_s;
+struct uv_buf_t {
+  char* base;
+  size_t len;
+};
+struct bare_worklet_options_t {
+  size_t memory_limit;
+  const char* assets;
+};
+int bare_worklet_alloc(bare_worklet_t**);
+int bare_worklet_init(bare_worklet_t*, const bare_worklet_options_t*);
+int bare_worklet_start(
+    bare_worklet_t*, const char*, const uv_buf_t*, int, const char*[]);
+int bare_worklet_terminate(bare_worklet_t*);
+void bare_worklet_destroy(bare_worklet_t*);
+int bare_ipc_alloc(bare_ipc_t**);
+int bare_ipc_init(bare_ipc_t*, bare_worklet_t*);
+int bare_ipc_read(bare_ipc_t*, void**, size_t*);
+void bare_ipc_destroy(bare_ipc_t*);
+}
+void check(int code, const char* stage) {
+  if (code) {
+    std::fprintf(stderr, "%s: %d\n", stage, code);
+    std::exit(2);
+  }
+}
+int main(int argc, char** argv) {
+  if (argc < 2)
+    return 2;
+  // A broken native job must not leave an orphaned simulator process if its
+  // termination path hangs. Ordinary completion exits before this deadline.
+  std::thread([] {
+    std::this_thread::sleep_for(std::chrono::seconds(120));
+    std::fprintf(stderr, "Worklet host exceeded its hard deadline\n");
+    std::_Exit(124);
+  }).detach();
+  for (int i = 2; i < argc; ++i)
+    if (!dlopen(argv[i], RTLD_NOW | RTLD_GLOBAL)) {
+      std::fprintf(stderr, "%s\n", dlerror());
+      return 3;
+    }
+  bare_worklet_t* worklet;
+  bare_ipc_t* ipc;
+  check(bare_worklet_alloc(&worklet), "worklet alloc");
+  bare_worklet_options_t options{0, nullptr};
+  check(bare_worklet_init(worklet, &options), "worklet init");
+  check(
+      bare_worklet_start(worklet, argv[1], nullptr, 0, nullptr),
+      "worklet start");
+  check(bare_ipc_alloc(&ipc), "ipc alloc");
+  check(bare_ipc_init(ipc, worklet), "ipc init");
+  std::string received;
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(90);
+  while (std::chrono::steady_clock::now() < deadline) {
+    void* data = nullptr;
+    size_t len = 0;
+    int result = bare_ipc_read(ipc, &data, &len);
+    if (result == 0)
+      received.append(static_cast<const char*>(data), len);
+    else if (result != -1) {
+      std::fprintf(stderr, "ipc read %d\n", result);
+      break;
+    }
+    if (received.find('\n') != std::string::npos)
+      break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  std::printf("WORKLET_RESULT %s\n", received.c_str());
+  std::fflush(stdout);
+  check(bare_worklet_terminate(worklet), "worklet terminate");
+  bare_ipc_destroy(ipc);
+  std::free(ipc);
+  bare_worklet_destroy(worklet);
+  std::free(worklet);
+  return received.find("\"passed\":true") != std::string::npos ? 0 : 1;
+}

--- a/packages/tts-ggml/test/mobile/pocket-worklet.cjs
+++ b/packages/tts-ggml/test/mobile/pocket-worklet.cjs
@@ -1,0 +1,47 @@
+'use strict'
+
+// Bundle with bare-pack --linked for the mobile target. The host provides
+// QVAC_POCKET_MODEL_DIR and reads one JSON result from BareKit.IPC. Exporting
+// the integration-test promise lets this worklet report completion without
+// relying on beforeExit, since the host's IPC connection keeps it alive.
+/* global BareKit, Bare */
+let sent = false
+let assertions = 0
+let failed = false
+const tap = []
+const send = (result) => {
+  if (sent) return
+  sent = true
+  BareKit.IPC.write(
+    Buffer.from(JSON.stringify({ ...result, assertions, tap, versions: Bare.versions }) + '\n')
+  )
+}
+Bare.on('uncaughtException', (error) =>
+  send({ passed: false, error: String(error.stack || error) })
+)
+Bare.on('unhandledRejection', (error) =>
+  send({ passed: false, error: String(error.stack || error) })
+)
+
+const originalLog = console.log.bind(console)
+console.log = (...args) => {
+  originalLog(...args)
+  tap.push(args.map(String).join(' '))
+  const line = String(args[0] || '')
+  if (/^\s+(?:not )?ok \d/.test(line)) assertions++
+  if (/^\s*not ok \d/.test(line)) failed = true
+}
+
+const process = require('bare-process')
+global.process = process
+if (!process.env.QVAC_POCKET_MODEL_DIR) {
+  send({
+    passed: false,
+    error: 'QVAC_POCKET_MODEL_DIR is required; mobile validation must not skip inference'
+  })
+} else {
+  Promise.resolve(require('../integration/pocket.integration.test.js')).then(
+    () => send({ passed: !failed && assertions > 0 && !Bare.exitCode }),
+    (error) => send({ passed: false, error: String(error.stack || error) })
+  )
+}

--- a/packages/tts-ggml/test/unit/parler.inference.test.js
+++ b/packages/tts-ggml/test/unit/parler.inference.test.js
@@ -65,7 +65,7 @@ test('Parler: parlerModel file path alone routes to parler engine', (t) => {
 test('Parler: invalid engine error message lists parler', (t) => {
   t.exception(
     () => new TTSGgml({ engine: 'parakeet' }),
-    /'chatterbox', 'supertonic', 'cosyvoice3', 'parler' or 'audio8'/,
+    /'chatterbox', 'supertonic', 'cosyvoice3', 'parler', 'audio8' or 'pocket'/,
     'engine validation message includes parler'
   )
 })

--- a/packages/tts-ggml/test/unit/pocket.inference.test.js
+++ b/packages/tts-ggml/test/unit/pocket.inference.test.js
@@ -1,0 +1,369 @@
+'use strict'
+const test = require('brittle')
+const TTSGgml = require('../../index')
+const { TTSInterface } = require('../../tts')
+const MockedBinding = require('../mock/MockedBinding')
+const process = require('bare-process')
+global.process = process
+const files = { modelDir: '/models/pocket' }
+const make = (options = {}) => new TTSGgml({ engine: 'pocket', files, ...options })
+
+test('Pocket bundle resolution and unsigned seed are preserved', (t) => {
+  const m = make({ seed: 4294967295, temperature: 0, steps: 1 })
+  t.is(m.getEngineType(), TTSGgml.ENGINE_POCKET)
+  t.alike(m._buildTtsParams(), {
+    engineType: 'pocket',
+    pocketFlowModelPath: '/models/pocket/flow-lm.gguf',
+    pocketMimiModelPath: '/models/pocket/mimi.gguf',
+    pocketFrontendPath: '/models/pocket/frontend.json',
+    pocketVoicePath: '/models/pocket/voice.gguf',
+    referenceAudio: '',
+    language: 'en',
+    useGPU: false,
+    seed: 4294967295,
+    temperature: 0,
+    steps: 1
+  })
+  t.is(
+    new TTSGgml({ files: { ...files, pocketFlowModel: '/custom/flow.gguf' } }).getEngineType(),
+    'pocket'
+  )
+  const ref = make({ referenceAudio: '/voice.wav' })._buildTtsParams()
+  t.is(ref.referenceAudio, '/voice.wav')
+  t.is(ref.pocketVoicePath, '')
+  t.exception(() =>
+    make({ files: { ...files, pocketVoice: '/voice.gguf' }, referenceAudio: '/voice.wav' })
+  )
+})
+
+test('Pocket rejects unsupported and malformed options before native loading', (t) => {
+  for (const options of [
+    { seed: -1 },
+    { seed: 4294967296 },
+    { seed: 1.5 },
+    { seed: '123' },
+    { steps: 0 },
+    { steps: 65 },
+    { steps: 1, numInferenceSteps: 2 },
+    { temperature: NaN },
+    { temperature: Infinity },
+    { temperature: -1 },
+    { threads: 0 },
+    { nCtx: 8193 },
+    { maxTokens: 0 },
+    { noiseClamp: -1 },
+    { framesAfterEos: 101 },
+    { eosThreshold: Infinity },
+    { speed: 1 },
+    { streamChunkTokens: 1 },
+    { voice: 'alba' },
+    { nGpuLayers: 99 },
+    { config: { useGPU: true } },
+    { config: { language: 'fr' } },
+    { config: { outputSampleRate: NaN } },
+    { config: { outputSampleRate: 24000.5 } }
+  ]) {
+    t.exception(() => make(options), String(Object.keys(options)))
+  }
+})
+
+test('Pocket invalid reload preserves configuration; valid reload forwards sample rate', async (t) => {
+  const model = make()
+  let params
+  model._createAddon = (p, cb) => {
+    params = p
+    return new TTSInterface(new MockedBinding(), p, cb)
+  }
+  await model.load()
+  await t.exception(model.reload({ useGPU: true }))
+  t.is(model._buildTtsParams().useGPU, false)
+  await model.reload({ outputSampleRate: 44100 })
+  t.is(params.outputSampleRate, 44100)
+  await model.destroy()
+})
+
+test('Pocket terminal marker is the only last event in sentence streaming', (t) => {
+  const m = make()
+  const events = []
+  m._job.output = (data) => events.push(data)
+  m._sentenceStreamCtx = { chunkIdx: 0, chunks: ['Hello.'] }
+  m._addonOutputCallback(null, null, { outputArray: new Int16Array([1]), isLast: false })
+  m._addonOutputCallback(null, null, { outputArray: new Int16Array(), isLast: true })
+  t.is(events[0].isLast, false)
+  t.is(events[1].isLast, true)
+})
+
+test('Pocket failed replacement activation preserves the loaded addon and configuration', async (t) => {
+  const model = make()
+  let attempts = 0
+  let disposed = 0
+  model._createAddon = () => ({
+    activate: async () => {
+      if (++attempts === 2) throw new Error('activation failed')
+    },
+    cancel: async () => {},
+    destroyInstance: async () => {
+      disposed++
+    }
+  })
+  await model.load()
+  const original = model.addon
+  await t.exception(model.reload({ outputSampleRate: 44100 }))
+  t.is(model.addon, original)
+  t.is(model._outputSampleRate, null)
+  t.is(disposed, 1, 'only the failed replacement was disposed')
+  t.is(model.getState().weightsLoaded, true)
+  await model.destroy()
+})
+
+test('Pocket keeps the activated replacement if old teardown fails', async (t) => {
+  const model = make()
+  let created = 0
+  model._createAddon = () => {
+    const id = ++created
+    return {
+      activate: async () => {},
+      cancel: async () => {},
+      destroyInstance: async () => {
+        if (id === 1) throw new Error('old teardown failed')
+      }
+    }
+  }
+  await model.load()
+  const previous = model.addon
+  await t.exception(model.reload({ outputSampleRate: 44100 }))
+  t.not(model.addon, previous)
+  t.is(model._outputSampleRate, 44100)
+  t.is(model.state.weightsLoaded, true)
+  await model.destroy()
+})
+
+test('Pocket invalidates delayed streaming text across reload and cancellation', async (t) => {
+  for (const action of ['reload', 'cancel']) {
+    const model = make()
+    const dispatched = []
+    model._createAddon = () => ({
+      activate: async () => {},
+      cancel: async () => {},
+      destroyInstance: async () => {},
+      runJob: async (data) => {
+        dispatched.push(data.input)
+      }
+    })
+    await model.load()
+    let release
+    const gate = new Promise((resolve) => {
+      release = resolve
+    })
+    async function* input() {
+      await gate
+      yield 'Old text must not run.'
+    }
+    const response = await model.runStreaming(input(), { accumulateSentences: false })
+    const settled = response.await().catch(() => {})
+    await model[action]()
+    release()
+    await settled
+    await new Promise((resolve) => setTimeout(resolve, 1))
+    t.alike(dispatched, [], action)
+    t.is(model._sentenceStreamCtx, null)
+    await model.destroy()
+  }
+})
+
+test('Pocket rejected native dispatch clears its completion barrier', async (t) => {
+  const model = make()
+  model._createAddon = (params, cb) => {
+    const binding = new MockedBinding()
+    binding.runJob = () => false
+    return new TTSInterface(binding, params, cb)
+  }
+  await model.load()
+  await t.exception(model.run({ input: 'Native queue is busy.' }))
+  t.is(model._pocketJobPending, null)
+  await model.cancel()
+  await model.reload({ outputSampleRate: 44100 })
+  t.is(model.state.weightsLoaded, true)
+  await model.destroy()
+})
+
+test('Pocket waits for the old terminal event before accepting a post-cancel request', async (t) => {
+  const model = make()
+  const dispatched = []
+  let callback
+  model._createAddon = (params, cb) => {
+    callback = cb
+    return {
+      activate: async () => {},
+      destroyInstance: async () => {},
+      cancel: async () => {},
+      runJob: async (data) => {
+        dispatched.push(data.input)
+      }
+    }
+  }
+  await model.load()
+  const first = await model.run({ input: 'First.' })
+  const firstDone = first.await().catch(() => {})
+  const cancelled = model.cancel()
+  const next = model.run({ input: 'Second.' })
+  await firstDone
+  await new Promise((resolve) => setTimeout(resolve, 1))
+  t.alike(dispatched, ['First.'])
+  callback(model.addon, null, null, 'Old request cancelled')
+  await cancelled
+  const second = await next
+  callback(model.addon, null, { outputArray: new Int16Array([123]), sampleRate: 24000 })
+  callback(model.addon, null, { totalTime: 0.1, totalSamples: 1 })
+  const output = await second.await()
+  t.alike(dispatched, ['First.', 'Second.'])
+  t.is(output[0].outputArray[0], 123)
+  await model.destroy()
+})
+
+test('Pocket rejects every request entry point before load and after disposal', async (t) => {
+  const model = make()
+  model._createAddon = (p, cb) => new TTSInterface(new MockedBinding(), p, cb)
+  async function* empty() {}
+  const check = async (pattern) => {
+    await t.exception(model.run({ input: 'Hello.' }), pattern)
+    await t.exception(model.runStream('Hello.'), pattern)
+    await t.exception(model.runStreaming(empty(), { accumulateSentences: false }), pattern)
+    t.is(model._job.active, null)
+  }
+  await check(/not loaded/)
+  await model.load()
+  await model.unload()
+  t.is(model.addon, null)
+  await check(/not loaded/)
+  await model.destroy()
+  await check(/destroyed/)
+})
+
+test('Pocket reload and destroy after unload never use a disposed handle', async (t) => {
+  const model = make()
+  let disposed = 0
+  model._createAddon = (p, cb) => {
+    const binding = new MockedBinding()
+    const cancel = binding.cancel.bind(binding)
+    const destroy = binding.destroyInstance.bind(binding)
+    binding.cancel = (handle) => {
+      if (!handle) throw new Error('Disposed native handle')
+      return cancel(handle)
+    }
+    binding.destroyInstance = (handle) => {
+      disposed++
+      return destroy(handle)
+    }
+    return new TTSInterface(binding, p, cb)
+  }
+  await model.load()
+  await model.unload()
+  await model.reload()
+  t.is(model.state.weightsLoaded, true)
+  await model.unload()
+  await model.destroy()
+  await model.destroy()
+  t.is(disposed, 2)
+  t.is(model.addon, null)
+})
+
+test('Pocket rejects overlapping lifecycle operations while activation is pending', async (t) => {
+  const model = make()
+  let release
+  const gate = new Promise((resolve) => {
+    release = resolve
+  })
+  let created = 0
+  let disposed = 0
+  model._createAddon = () => {
+    created++
+    return {
+      activate: () => gate,
+      cancel: async () => {},
+      destroyInstance: async () => {
+        disposed++
+      }
+    }
+  }
+  const loading = model.load()
+  await t.exception(model.load(), /already in progress/)
+  await t.exception(model.unload(), /already in progress/)
+  await t.exception(model.destroy(), /already in progress/)
+  await t.exception(model.reload(), /already in progress/)
+  t.is(created, 1)
+  release()
+  await loading
+  await model.destroy()
+  t.is(disposed, 1)
+})
+
+test('Pocket AbortSignal stops native work and drains before admitting its successor', async (t) => {
+  const model = make()
+  let callback
+  let cancels = 0
+  const dispatched = []
+  model._createAddon = (p, cb) => {
+    callback = cb
+    return {
+      activate: async () => {},
+      destroyInstance: async () => {},
+      cancel: async () => {
+        cancels++
+      },
+      runJob: async (data) => {
+        dispatched.push(data.input)
+      }
+    }
+  }
+  // Structural signal works on Bare versions without a global AbortController.
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: new Error('Caller aborted'),
+    addEventListener: (_, listener) => listeners.add(listener),
+    removeEventListener: (_, listener) => listeners.delete(listener)
+  }
+  await model.load()
+  const first = await model.run({ input: 'First.', signal })
+  const failed = t.exception(first.await(), /Caller aborted/)
+  signal.aborted = true
+  for (const listener of [...listeners]) listener()
+  await failed
+  t.is(cancels, 1)
+  const next = model.run({ input: 'Second.' })
+  await new Promise((resolve) => setTimeout(resolve, 1))
+  t.alike(dispatched, ['First.'])
+  callback(model.addon, null, null, 'Cancelled')
+  const second = await next
+  callback(model.addon, null, { outputArray: new Int16Array([1]) })
+  callback(model.addon, null, { totalTime: 0.1, totalSamples: 1 })
+  await second.await()
+  t.alike(dispatched, ['First.', 'Second.'])
+  t.is(listeners.size, 0)
+  const stale = await model.run({ input: 'Never dispatched.', signal })
+  await t.exception(stale.await(), /Caller aborted/)
+  t.is(dispatched.length, 2)
+  await model.destroy()
+})
+
+test('Pocket rejected dispatch settles both streaming APIs without unhandled rejections', async (t) => {
+  for (const method of ['runStream', 'runStreaming']) {
+    const model = make()
+    model._createAddon = () => ({
+      activate: async () => {},
+      cancel: async () => {},
+      destroyInstance: async () => {},
+      runJob: async () => {
+        throw new Error('dispatch failed')
+      }
+    })
+    await model.load()
+    const response = await model[method]('Hello.', { accumulateSentences: false })
+    await t.exception(response.await(), /dispatch failed/)
+    await new Promise((resolve) => setTimeout(resolve, 1))
+    t.is(model._pocketJobPending, null)
+    t.is(model._sentenceStreamCtx, null)
+    await model.destroy()
+  }
+})

--- a/packages/tts-ggml/test/unit/pocket.inference.test.js
+++ b/packages/tts-ggml/test/unit/pocket.inference.test.js
@@ -8,9 +8,10 @@ global.process = process
 const files = { modelDir: '/models/pocket' }
 const make = (options = {}) => new TTSGgml({ engine: 'pocket', files, ...options })
 
-test('Pocket defaults to four steps and preserves explicit sampling controls', (t) => {
-  t.is(make()._buildTtsParams().steps, 4)
+test('Pocket defaults to one step and preserves explicit sampling controls', (t) => {
+  t.is(make()._buildTtsParams().steps, 1)
   t.is(make({ steps: 1 })._buildTtsParams().steps, 1)
+  t.is(make({ steps: 4 })._buildTtsParams().steps, 4)
   t.is(make({ numInferenceSteps: 2 })._buildTtsParams().steps, 2)
   t.is(make({ steps: 8, numInferenceSteps: 8 })._buildTtsParams().steps, 8)
 })
@@ -82,12 +83,12 @@ test('Pocket invalid reload preserves configuration; valid reload forwards sampl
     return new TTSInterface(new MockedBinding(), p, cb)
   }
   await model.load()
-  t.is(params.steps, 4)
+  t.is(params.steps, 1)
   await t.exception(model.reload({ useGPU: true }))
   t.is(model._buildTtsParams().useGPU, false)
   await model.reload({ outputSampleRate: 44100 })
   t.is(params.outputSampleRate, 44100)
-  t.is(params.steps, 4)
+  t.is(params.steps, 1)
   await model.destroy()
 })
 

--- a/packages/tts-ggml/test/unit/pocket.inference.test.js
+++ b/packages/tts-ggml/test/unit/pocket.inference.test.js
@@ -8,6 +8,13 @@ global.process = process
 const files = { modelDir: '/models/pocket' }
 const make = (options = {}) => new TTSGgml({ engine: 'pocket', files, ...options })
 
+test('Pocket defaults to four steps and preserves explicit sampling controls', (t) => {
+  t.is(make()._buildTtsParams().steps, 4)
+  t.is(make({ steps: 1 })._buildTtsParams().steps, 1)
+  t.is(make({ numInferenceSteps: 2 })._buildTtsParams().steps, 2)
+  t.is(make({ steps: 8, numInferenceSteps: 8 })._buildTtsParams().steps, 8)
+})
+
 test('Pocket bundle resolution and unsigned seed are preserved', (t) => {
   const m = make({ seed: 4294967295, temperature: 0, steps: 1 })
   t.is(m.getEngineType(), TTSGgml.ENGINE_POCKET)
@@ -75,10 +82,12 @@ test('Pocket invalid reload preserves configuration; valid reload forwards sampl
     return new TTSInterface(new MockedBinding(), p, cb)
   }
   await model.load()
+  t.is(params.steps, 4)
   await t.exception(model.reload({ useGPU: true }))
   t.is(model._buildTtsParams().useGPU, false)
   await model.reload({ outputSampleRate: 44100 })
   t.is(params.outputSampleRate, 44100)
+  t.is(params.steps, 4)
   await model.destroy()
 })
 

--- a/packages/tts-ggml/tts.d.ts
+++ b/packages/tts-ggml/tts.d.ts
@@ -26,7 +26,7 @@ export type TTSOutputCallback = (addon: unknown, event: unknown, data: unknown, 
 export interface TTSBinding {
     createInstance(owner: TTSInterface, configuration: TTSConfigurationParams, outputCallback: TTSOutputCallback | null): object;
     activate(handle: object | null): Promise<void>;
-    runJob(handle: object | null, data: TTSJobData): void;
+    runJob(handle: object | null, data: TTSJobData): boolean | void | Promise<boolean | void>;
     loadWeights(handle: object | null, weightsData: TTSWeightData): void;
     cancel(handle: object | null): Promise<void>;
     destroyInstance(handle: object): Promise<void> | void;

--- a/packages/tts-ggml/tts.js
+++ b/packages/tts-ggml/tts.js
@@ -35,10 +35,11 @@ class TTSInterface {
             });
         }
     }
-    // eslint-disable-next-line @typescript-eslint/require-await -- preserves the established promise-returning wrapper API.
     async runJob(data) {
         try {
-            this._binding.runJob(this._handle, data);
+            if (await this._binding.runJob(this._handle, data) === false) {
+                throw new Error("Native addon rejected the job");
+            }
         }
         catch (error) {
             throw new error_1.QvacErrorAddonTTSGgml({

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,8 +1,9 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b9ca3b07a85cd88fdd30730c662b4c138ede1ca3",
-    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
+    "baseline": "7a70a0c301c155beb85e985c542f8b0ccd090e10",
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
+    "reference": "7a70a0c301c155beb85e985c542f8b0ccd090e10"
   },
   "registries": [
     {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,12 +10,12 @@
     },
     {
       "name": "ggml-speech",
-      "version>=": "2026-09-04#2",
+      "version>=": "2026-09-09#1",
       "default-features": false
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-04#1",
+      "version>=": "2026-09-10#1",
       "default-features": false,
       "features": [
         "tts",
@@ -25,7 +25,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-04#1",
+      "version>=": "2026-09-10#1",
       "default-features": false,
       "features": [
         "tts",
@@ -36,7 +36,7 @@
     },
     {
       "name": "speech-cpp",
-      "version>=": "2026-09-04#1",
+      "version>=": "2026-09-10#1",
       "default-features": false,
       "features": [
         "tts",
@@ -51,7 +51,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-04#1",
+          "version>=": "2026-09-10#1",
           "default-features": false,
           "features": [
             "cuda"
@@ -71,7 +71,7 @@
       "dependencies": [
         {
           "name": "speech-cpp",
-          "version>=": "2026-09-04#1",
+          "version>=": "2026-09-10#1",
           "default-features": false,
           "features": [
             "vulkan"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,7 +870,7 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0(bare-abort-controller@1.1.2)(bare-buffer@3.6.2)(bare-events@2.9.1(bare-abort-controller@1.1.2))(bare-pipe@4.2.3(bare-abort-controller@1.1.2)(bare-buffer@3.6.2))(bare-url@2.4.6)
       '@qvac/rag':
-        specifier: ^0.8.0
+        specifier: ^0.8.1
         version: link:../rag
       '@qvac/registry-client':
         specifier: ^0.6.1
@@ -993,6 +993,9 @@ importers:
       '@types/brittle':
         specifier: ^3.5.0
         version: 3.5.0
+      '@types/node':
+        specifier: ^24.2.1
+        version: 24.13.3
       bare:
         specifier: '*'
         version: 1.31.2(bare-buffer@3.6.2)(bare-console@6.2.0(bare-abort-controller@1.1.2)(bare-buffer@3.6.2)(bare-events@2.9.1(bare-abort-controller@1.1.2)))(bare-events@2.9.1(bare-abort-controller@1.1.2))(bare-runtime@1.30.3(bare-abort-controller@1.1.2)(bare-buffer@3.6.2)(bare-url@2.4.6))(bare-structured-clone@1.6.0)(bare-timers@3.2.1(bare-abort-controller@1.1.2))(bare-url@2.4.6)


### PR DESCRIPTION
Fabric cannot currently load Pocket TTS. This adds `ttsEngine: "pocket"` to the inference schema/plugin and the native addon, allowing the public SDK to generate batch, streaming and duplex PCM from a converted English FlowLM/Mimi bundle. Runtime synthesis is native C++/ggml and does not require Python.

Companion model sources resolve through the standard loader. Prepared-voice and reference-WAV inputs are mutually exclusive; reference conditioning requires encoder-enabled weights. Configuration rejects unsupported GPU, language and other-engine controls. Cancellation drains native terminal callbacks before another request is admitted; lifecycle overlap, reload failure, post-destroy requests and native dispatch failures are covered. Workspace logging/error packages gain CommonJS export access needed by the Bare addon.

Fabric defaults to one sampling step, matching the native CLI and upstream reference. Explicit `steps: 4` remains a quality option. A six-prompt paired listening set (0.88–70 seconds, same voice/seed) isolated an artifact on “speech” in one one-step take. The listener also heard it in upstream PyTorch with matching random inputs; the four-step take sounded clean. Numerical comparison found close parity with upstream and the earlier native build, with no evidence of a Fabric-specific one-step bug. Four steps cost about 20–25% more generation time in this set (70-second passage: 16.0 s vs 13.0 s). This listening result does not establish that additional steps prevent all artifacts.

Four steps are recommended when avoiding the observed artifact takes priority over minimum latency. One step predicts a single flow update from noise to the next audio latent; four steps reevaluate the flow network at successive quarter-intervals using the updated latent. Those intermediate refinements offer a plausible mechanism for the improvement heard in the controlled sample, without establishing a specific numerical defect or guaranteeing better results for every take. Only flow sampling repeats, which explains why total generation time increased about 20–25% rather than fourfold. The original 2.64-second sentence took 0.46 s at one step and 0.56 s at four steps. The implementation retains one step as the default and supports explicit four-step selection through addon and SDK configuration.

The addon pins speech-cpp and ggml-speech `2026-09-15` through merged registry baseline `f482b77ac9883192745ad16e49ed6fe0adfb14b2`, with no temporary registry reference. The source commits are the merged speech fix `a976c4d63195601fcff8bfc0c2cdf3ef36fba539` and merged ggml fix `59a0ca2c2bcd7de36c27d930f79e0c94cc0c2ff3`.

The original manual prebuild failed on Linux x64/ARM64 and Android ARM64 because Pocket directly imported `ggml_graph_plan` from a dynamically loaded CPU backend. Pocket now resolves the planner through the backend registry and preserves scratch accounting. Both source PRs are merged:

- https://github.com/tetherto/qvac-ext-ggml/pull/92
- https://github.com/tetherto/qvac-fabric-speech.cpp/pull/251

[Registry #367](https://github.com/tetherto/qvac-registry-vcpkg/pull/367) is now merged and this consumer pins its merge commit. The merged ggml commit also includes intervening CPU, Metal and Vulkan changes. [A new full TTS CI run](https://github.com/tetherto/qvac/actions/runs/34975293366) validates the exact merged pins at Fabric `49d864d2e1a2070a4cb9872cd0f62319fdb9e839`; all nine platform prebuild jobs and all seven desktop integration lanes pass, including the Linux/Android unresolved-symbol gates and the run's merge guard. Desktop coverage includes CPU, Metal, Vulkan and CUDA; CUDA synthesis is confirmed in the job logs. The final registry-baseline update preserves the exact tested speech-cpp and ggml-speech port trees and their dependency versions. macOS and iOS Simulator dependency resolution and addon builds pass again with the temporary reference removed, and the real macOS audio suite passes all 124 assertions. The [previous successful run](https://github.com/tetherto/qvac/actions/runs/34871252570) validated the earlier PR-source pins and does not cover the additional ggml changes. Static and dynamic CPU planner regression tests pass on the merged ggml; the normal pinned macOS addon build and 295 addon unit tests / 928 assertions plus 64 Node package/build tests also pass.

Validation against the preceding September 14 registry package:

- Normal pinned vcpkg/native addon builds pass on macOS and iOS Simulator.
- 295 addon unit tests / 928 assertions; 64 Node package/build tests; TypeScript, declarations, ESLint and generated-output checks pass.
- The real macOS addon passes 124 assertions, including default/explicit one-step PCM parity, cancellation/recovery, resampling, and the 100-frame EOS-tail regression.
- 14 focused inference tests / 85 assertions, including real Pocket synthesis, pass. Whole SDK build and its dependency-consistency guard pass.
- Four public Node SDK tests pass through the production Bare worker/socket: batch/stream PCM parity, duplex, cancellation/recovery and shutdown.
- The current iOS 18.6 Bare Kit worklet passes 65 assertions with the new packaged addon, including the EOS-tail regression. Both desktop and simulator produce valid 24 kHz PCM16, 2.64 seconds, with no clipping. Stream timing can change assertion counts.
- npm package contents include the Pocket wrapper/types and tested macOS/iOS binaries.

The recorded September 10 benchmark used the previous speech-cpp `2026-09-10#1` package, before the native review fixes; it has not been rerun against the updated package. It uses **one sampling step**, Apple M2, one thread per worker/two workers, and three measured runs per prompt. It matches Fabric's one-step default and gives Fabric RTF 0.178–0.191 (5.2–5.6x real time). Short: 0.98 s vs upstream 0.94 s; long: 6.55 s vs 6.16 s. First audio: 74–116 ms vs 53–69 ms. This supersedes the slower manual development-build result. All ten comparison WAVs pass signal checks; ASR and non-equivalent nonzero-temperature RNG limitations are documented.

Known validation limits: full inference compilation still reports two existing type errors in unchanged `safe-fetch.ts`; focused Pocket compilation and the whole SDK build pass. The unrelated Supertonic CI fix from speech #242 is now merged and included in the pinned native source. Physical-device/Android audio, mobile SDK transport and broad subjective quality evaluations remain outside the measured coverage. No package release or default-branch merge is included.

Ready for review; the native source fixes and registry update are merged. **SDK packaging remains a separate release dependency:** package-local Bun installs previously resolved published `@qvac/tts-ggml@0.9.0`, which lacks `ENGINE_POCKET` and `pocketFlowModel`. Local workspace audio validation uses this checkout's wrapper and rebuilt native binaries. Publish the Pocket addon with matching platform prebuilds, then raise inference/SDK dependency floors to its version before shipping the SDK integration. The current `^0.9.0` ranges are not a sufficient Pocket runtime minimum.

This update also fixes both inference formatting failures, supplies the cancellation assertion's message required by the full test typecheck, and regenerates the SDK wire contract and Python client for Pocket. Python CI Generate + test also passes at `0b01563e6`. Python regeneration/check, 28 focused generator/public-API/load-model tests, formatting, lint, and package typechecking pass locally (generator dependencies pinned by pyproject; Python 3.12 with NumPy/Pandas versions compatible with CI’s Python 3.10 target). A clean Bun 1.4.2 install confirmed the published-addon mismatch. The earlier merged baseline configured successfully on macOS and iOS; the merged source pins pass the full manual prebuild and desktop integration run. Privileged fork CI still requires the repository's per-commit `fork-ci` approval.

Usage, conversion and reproducible tests: `packages/tts-ggml/docs/pocket-tts.md`. Tracks QVAC-24306.

New addon API usage (inside an async function, with a converted local bundle):

```js
const TTSGgml = require('@qvac/tts-ggml')
const model = new TTSGgml({
  engine: TTSGgml.ENGINE_POCKET,
  files: { modelDir: '/models/pocket' },
  steps: 1
})
try {
  await model.load()
  const response = await model.run({ input: 'Hello from Pocket TTS.' })
  for await (const chunk of response.iterate()) {
    console.log(chunk.sampleRate, chunk.outputArray.length)
  }
} finally {
  await model.destroy()
}
```


Local validation against these exact merged pins also passes all 10 native Pocket tests (none skipped), with regenerated upstream numerical fixtures; 124 real macOS addon audio assertions; and 64 real iOS 18.6 Simulator Bare Kit 0.14.5 worklet assertions. Both packaged addons produce valid 24 kHz PCM16 without clipping. The inference suite passes 14 tests / 85 assertions and the public Node SDK passes all four transport tests. Six old-versus-merged audio pairs (one/four steps, 2.64–47.6 seconds) produce bit-identical PCM without clipping. All 116 selected Supertonic Metal operation tests pass against the CPU reference.
