### PR TITLE
chore[skiplog|notask]: backmerge release-sdk-0.19.1 — version bump, changelog, NOTICE

### DIFF
--- a/docs/website/content/docs/reference/release-notes/index.mdx
+++ b/docs/website/content/docs/reference/release-notes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK Release Notes — v0.19.x (latest)
-description: Release notes for QVAC SDK v0.19.0.
+description: Lists all releases from v0.19.0 to v0.19.1.
 ---
 
 <include>./v0.19.x.mdx</include>

--- a/docs/website/content/docs/reference/release-notes/v0.19.x.mdx
+++ b/docs/website/content/docs/reference/release-notes/v0.19.x.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK Release Notes — v0.19.x
-description: Release notes for QVAC SDK v0.19.0.
+description: Lists all releases from v0.19.0 to v0.19.1.
 ---
 
 ## v0.19.0
@@ -268,3 +268,78 @@ PARAKEET_UNIFIED_0_6B_Q8_0
 QWEN3_8_FLASH_NEXT_177B_MULTIMODAL_UD_Q2_K_XL_SHARD
 QWEN3_8_FLASH_NEXT_177B_MULTIMODAL_UD_Q4_K_XL_SHARD
 ```
+
+## v0.19.1
+
+### @qvac/sdk
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.19.1
+
+QVAC SDK 0.19.1 is a patch on the 0.19 line. Completion stats now report prompt-processing throughput, `deleteCache({ auto: true })` reclaims automatic KV caches without touching named ones, and `assessModelFit` can refuse a model from a computed floor when no calibration applies. Mobile `withQvacSDK` bundles no longer pull in the desktop-only fit subprocess, and `@qvac/rag` `^0.8.1` is the floor so Windows TurboVec installs the fixed package.
+
+`@qvac/sdk`, `@qvac/inference`, and `tetherto-qvac-sdk` all ship at 0.19.1. Install `@qvac/sdk` and `@qvac/inference` together at this version.
+
+#### New APIs
+
+##### Prompt-processing throughput
+
+`CompletionStats.promptTokensPerSecond` is the addon's prefill (prompt-processing) rate. `tokensPerSecond` remains decode throughput. Both fields are optional; they appear on `completionStats` events and on the aggregated `final.stats` for single and batch completions. The Python client models include the same field.
+
+```typescript
+const run = completion({ modelId, history, stream: true })
+const stats = await run.stats
+
+stats?.tokensPerSecond // decode throughput
+stats?.promptTokensPerSecond // prompt-processing (prefill) throughput
+```
+
+##### Reclaim automatic KV caches
+
+`deleteCache({ auto: true })` drops every automatic cache that no in-flight turn is holding. Named, caller-owned caches are left alone. `{ all: true }` still deletes everything, including named caches.
+
+```typescript
+import { deleteCache } from '@qvac/sdk'
+
+await deleteCache({ auto: true })
+```
+
+##### Computed floor when no calibration applies
+
+On platforms without a calibration fixture, `assessModelFit` used to return `unknown` even when the artifact plus KV cache already exceeded the budget. It now falls back to a computed floor (artifact bytes plus the llama.cpp KV cache at the narrowest default width). Over budget is `likely-too-large`; otherwise the verdict stays `unknown`. This path never returns `likely-fits`.
+
+Android compares the floor to the `system-memory` budget. iOS compares it to the `process-memory` budget, which now uses the per-process allowance from `bare-os`. Discrete GPUs without coefficients stay `unknown`.
+
+New result fields: `evidence` (`calibration` | `computed-only`) and `floorBytes`.
+
+```typescript
+import { assessModelFit, QWEN3_8B_INST_Q4_K_M } from '@qvac/sdk'
+
+const result = await assessModelFit({
+  models: [
+    {
+      model: QWEN3_8B_INST_Q4_K_M,
+      workload: { kind: 'llm', contextTokens: 8192 }
+    }
+  ]
+})
+
+result.verdict // "likely-fits" | "likely-too-large" | "unknown"
+result.evidence // "calibration" | "computed-only"
+result.floorBytes
+
+if (result.evidence === "computed-only" && result.verdict === "unknown") {
+  // uncalibrated, not a near-miss
+}
+```
+
+The assess-model-fit doc now includes a platform support matrix and a table of every `unknown` reason.
+
+#### Features
+
+iOS `sample.memory.processAvailableBytes` is sourced from `bare-os` `availableMemory()` so the `process-memory` budget can form. Other platforms leave that metric unavailable.
+
+#### Bug Fixes
+
+`withQvacSDK` mobile bundles defer `bare-runtime/spawn` and `@qvac/model-fit/process`, so expo prebuild no longer fails looking for a `bare-posix` android-arm64 prebuild that does not exist. Desktop advisory fit is unchanged.
+
+`@qvac/inference` now requires `@qvac/rag` `^0.8.1`. 0.8.0 could not open a TurboVec workspace on Windows.

--- a/docs/website/src/lib/versions.ts
+++ b/docs/website/src/lib/versions.ts
@@ -40,7 +40,7 @@ export interface VersionedSection {
 
 export const API_SECTION: VersionedSection = {
   basePath: '/reference/api',
-  latest: 'v0.19.0',
+  latest: 'v0.19.1',
   latestSeries: 'v0.19.x',
   versions: [
     { label: 'v0.19.x (latest)', value: 'v0.19.x', isLatest: true },
@@ -60,7 +60,7 @@ export const API_SECTION: VersionedSection = {
 
 export const RELEASE_NOTES_SECTION: VersionedSection = {
   basePath: '/reference/release-notes',
-  latest: 'v0.19.0',
+  latest: 'v0.19.1',
   latestSeries: 'v0.19.x',
   versions: [
     { label: 'v0.19.x (latest)', value: 'v0.19.x', isLatest: true },

--- a/packages/inference/NOTICE
+++ b/packages/inference/NOTICE
@@ -670,7 +670,7 @@ JavaScript Dependencies
     https://github.com/tetherto/qvac
   @qvac/model-fit@0.8.0
     https://github.com/tetherto/qvac
-  @qvac/rag@0.8.0
+  @qvac/rag@0.8.1
     https://github.com/tetherto/qvac
   @qvac/registry-client@0.6.1
     https://github.com/tetherto/qvac
@@ -690,7 +690,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-ansi-escapes
   bare-assert@1.2.0
     https://github.com/holepunchto/bare-assert
-  bare-buffer@3.7.0
+  bare-buffer@3.7.1
     https://github.com/holepunchto/bare-buffer
   bare-cpu-info@0.1.1
     https://github.com/holepunchto/bare-cpu-info
@@ -710,29 +710,29 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-fs
   bare-gpu-info@0.1.1
     https://github.com/holepunchto/bare-gpu-info
-  bare-hrtime@2.1.1
+  bare-hrtime@2.1.2
     https://github.com/holepunchto/bare-hrtime
   bare-http-parser@2.1.4
     https://github.com/holepunchto/bare-http-parser
   bare-http1@4.6.1
     https://github.com/holepunchto/bare-http1
-  bare-https@3.0.0
+  bare-https@3.1.0
     https://github.com/holepunchto/bare-https
-  bare-inspect@3.1.5
+  bare-inspect@3.1.10
     https://github.com/holepunchto/bare-inspect
   bare-mime@1.0.0
     https://github.com/holepunchto/bare-mime
-  bare-module-resolve@1.12.4
+  bare-module-resolve@1.12.5
     https://github.com/holepunchto/bare-module-resolve
   bare-net@2.3.3
     https://github.com/holepunchto/bare-net
   bare-os@3.9.3
     https://github.com/holepunchto/bare-os
-  bare-path@3.1.1
+  bare-path@3.1.2
     https://github.com/holepunchto/bare-path
   bare-performance@2.1.1
     https://github.com/holepunchto/bare-performance
-  bare-pipe@4.2.3
+  bare-pipe@4.3.1
     https://github.com/holepunchto/bare-pipe
   bare-posix@1.0.1
     https://github.com/holepunchto/bare-posix
@@ -760,11 +760,11 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-tcp
   bare-tls@3.1.9
     https://github.com/holepunchto/bare-tls
-  bare-tty@5.1.2
+  bare-tty@5.2.1
     https://github.com/holepunchto/bare-tty
-  bare-type@1.1.0
+  bare-type@1.1.1
     https://github.com/holepunchto/bare-type
-  bare-url@2.5.2
+  bare-url@2.5.4
     https://github.com/holepunchto/bare-url
   bare-zlib@1.4.1
     https://github.com/holepunchto/bare-zlib
@@ -782,7 +782,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/events-universal
   fd-lock@2.2.0
     https://github.com/holepunchto/fd-lock
-  fs-native-extensions@1.5.0
+  fs-native-extensions@1.5.1
     https://github.com/holepunchto/fs-native-extensions
   hyperblobs@2.12.1
     https://github.com/holepunchto/hyperblobs
@@ -798,13 +798,13 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdb
   hyperdht-address@1.1.1
     https://github.com/holepunchto/hyperdht-address
-  hyperdht-stats@1.10.0
+  hyperdht-stats@1.11.0
     https://github.com/holepunchto/hyperdht-stats
   hyperdispatch@1.6.0
     https://github.com/holepunchto/hyperdispatch
   hyperdrive@13.3.3
     https://github.com/holepunchto/hyperdrive
-  hyperschema@1.22.0
+  hyperschema@1.24.0
     https://github.com/holepunchto/hyperschema
   hyperswarm-stats@1.3.1
     https://github.com/holepunchto/hyperswarm-stats
@@ -828,7 +828,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/rache
   refcounter@1.0.0
     https://github.com/holepunchto/refcounter
-  require-addon@1.2.0
+  require-addon@1.3.0
     https://github.com/holepunchto/require-addon
   require-asset@1.2.2
     https://github.com/holepunchto/require-asset
@@ -900,7 +900,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/hypercore-crypto
   hyperdht@6.33.2
     https://github.com/holepunchto/hyperdht
-  hyperswarm@4.17.0
+  hyperswarm@4.17.1
     https://github.com/holepunchto/hyperswarm
   is-options@1.0.2
     https://github.com/mafintosh/is-options
@@ -916,7 +916,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/nat-sampler
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
-  protomux@3.11.0
+  protomux@3.12.0
     https://github.com/holepunchto/protomux
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
@@ -968,6 +968,6 @@ JavaScript Dependencies
     https://github.com/mafintosh/xache
   z32@1.1.0
     https://github.com/mafintosh/z32
-  zod@4.4.3
+  zod@4.6.1
     https://github.com/colinhacks/zod
 

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/inference",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Bare-only in-process core of the QVAC SDK. Runs inference directly on the Bare runtime with explicit plugin assembly and no RPC, worker, or subprocess layer.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/sdk_version.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/sdk_version.py
@@ -5,6 +5,6 @@ connects to must be this version. Sourced from packages/sdk/package.json.
 
 from __future__ import annotations
 
-SDK_VERSION = "0.19.0"
+SDK_VERSION = "0.19.1"
 
 __all__ = ["SDK_VERSION"]

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -56,7 +56,7 @@ result.verdict // "likely-fits" | "likely-too-large" | "unknown"
 result.evidence // "calibration" | "computed-only"
 result.floorBytes
 
-if (result.evidence === "computed-only" && result.verdict === "unknown") {
+if (result.evidence === 'computed-only' && result.verdict === 'unknown') {
   // uncalibrated, not a near-miss
 }
 ```
@@ -384,25 +384,25 @@ QVAC SDK 0.18.0 adds VisionPsy Nano multimodal constants, Audio8 and CosyVoice3 
 **Before:**
 
 ```typescript
-import { loadModel, TOOLS_MODE } from "@qvac/sdk";
+import { loadModel, TOOLS_MODE } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic },
-});
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic }
+})
 ```
 
 **After:**
 
 ```typescript
-import { loadModel } from "@qvac/sdk";
+import { loadModel } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, tools: true },
-});
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, tools: true }
+})
 ```
 
 Existing automatic KV-cache prefixes that were primed under dynamic tools mode are not reusable; the next turn rebuilds the prefix.
@@ -414,13 +414,13 @@ Existing automatic KV-cache prefixes that were primed under dynamic tools mode a
 **Before:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: "very fast" });
+textToSpeech({ modelId, text, pace: 'very fast' })
 ```
 
 **After:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: "fast" });
+textToSpeech({ modelId, text, pace: 'fast' })
 ```
 
 ## New APIs
@@ -430,12 +430,10 @@ textToSpeech({ modelId, text, pace: "fast" });
 One loaded LLM can run several `completion` calls at once. A new request takes a free slot without waiting for the whole batch to drain. Cancelling one request leaves the others running, and each result reports its own timings. Single-slot models and fine-tuning stay one-at-a-time.
 
 ```typescript
-const runs = prompts.map((p) =>
-  completion({ modelId, history: p, stream: true }),
-);
-const outputs = await Promise.all(runs.map((r) => r.final));
+const runs = prompts.map((p) => completion({ modelId, history: p, stream: true }))
+const outputs = await Promise.all(runs.map((r) => r.final))
 
-await cancel({ requestId: runs[0].requestId });
+await cancel({ requestId: runs[0].requestId })
 ```
 
 ### loadModel fallbackSrc
@@ -443,12 +441,12 @@ await cancel({ requestId: runs[0].requestId });
 If the primary `modelSrc` cannot be fetched, `loadModel` retries from `fallbackSrc` (URL or local path) so callers do not have to build their own origin failover.
 
 ```typescript
-import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  fallbackSrc: "https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf",
-});
+  fallbackSrc: 'https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf'
+})
 ```
 
 ### AudioGen Cover From a Source Track
@@ -458,14 +456,14 @@ AudioGen can now generate a cover from source audio, not only a text caption. Pa
 ```typescript
 const cover = audioGen({
   modelId,
-  caption: "orchestral arrangement with dramatic strings",
-  lyrics: "[Instrumental]",
-  taskType: "cover-nofsq",
-  sourceAudio: "/path/to/source.wav",
-  referenceAudio: "/path/to/reference.mp3",
+  caption: 'orchestral arrangement with dramatic strings',
+  lyrics: '[Instrumental]',
+  taskType: 'cover-nofsq',
+  sourceAudio: '/path/to/source.wav',
+  referenceAudio: '/path/to/reference.mp3',
   audioCoverStrength: 1,
-  coverNoiseStrength: 0.75,
-});
+  coverNoiseStrength: 0.75
+})
 ```
 
 ### CosyVoice3 TTS
@@ -476,17 +474,17 @@ Load CosyVoice3 with `ttsEngine: "cosyvoice3"`. Companion files download with th
 const modelId = await loadModel({
   modelSrc: TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0,
   modelConfig: {
-    ttsEngine: "cosyvoice3",
-    instruct: { dialect: "cantonese" },
-    seed: 42,
-  },
-});
+    ttsEngine: 'cosyvoice3',
+    instruct: { dialect: 'cantonese' },
+    seed: 42
+  }
+})
 const result = textToSpeech({
   modelId,
-  text: "Hey there!",
+  text: 'Hey there!',
   stream: false,
-  emotion: "happy",
-});
+  emotion: 'happy'
+})
 ```
 
 ### Audio8 TTS
@@ -497,13 +495,13 @@ Audio8 is a multilingual LM + codec stack with optional zero-shot cloning via re
 await loadModel({
   modelSrc: TTS_LM_MULTILINGUAL_AUDIO8_Q8_0,
   modelConfig: {
-    ttsEngine: "audio8",
+    ttsEngine: 'audio8',
     audio8CodecDecoderModelSrc: TTS_CODEC_DECODER_AUDIO8_Q8_0,
     audio8CodecEncoderModelSrc: TTS_CODEC_ENCODER_AUDIO8_Q8_0,
-    referenceAudioSrc: "file:///path/to/voice.wav",
-    referenceText: "Exactly what the recording says.",
-  },
-});
+    referenceAudioSrc: 'file:///path/to/voice.wav',
+    referenceText: 'Exactly what the recording says.'
+  }
+})
 ```
 
 ### Streaming Transcription Stats
@@ -511,12 +509,12 @@ await loadModel({
 `transcribeStream` sessions now expose `stats` after the stream ends (`audioDuration`, `realTimeFactor`).
 
 ```typescript
-const session = await transcribeStream({ modelId });
+const session = await transcribeStream({ modelId })
 for await (const event of session) {
   // streamed events
 }
-const stats = await session.stats;
-console.log(stats?.audioDuration, stats?.realTimeFactor);
+const stats = await session.stats
+console.log(stats?.audioDuration, stats?.realTimeFactor)
 ```
 
 ### Vision image_no_upscale
@@ -525,13 +523,13 @@ VisionPsy (and other llama.cpp multimodal loads) can set `image_no_upscale: "on"
 
 ```typescript
 await loadModel({
-  modelType: "llm",
+  modelType: 'llm',
   modelSrc: VISIONPSY_NANO_460M_MULTIMODAL_Q4_K_M,
   modelConfig: {
     projectionModelSrc: MMPROJ_VISIONPSY_NANO_460M_MULTIMODAL_Q8_0,
-    image_no_upscale: "on",
-  },
-});
+    image_no_upscale: 'on'
+  }
+})
 ```
 
 ## Features
@@ -933,13 +931,13 @@ Image generation now supports Ideogram 4 through the `sdcpp-generation` model ty
 ```typescript
 const modelId = await loadModel({
   modelSrc: IDEOGRAM_MODEL_URL,
-  modelType: "sdcpp-generation",
+  modelType: 'sdcpp-generation',
   modelConfig: {
     llmModelSrc: QWEN3_VL_MODEL_URL,
     vaeModelSrc: VAE_MODEL_URL,
-    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL,
-  },
-});
+    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL
+  }
+})
 ```
 
 ### Per-Phase Diffusion Timing Stats
@@ -947,12 +945,12 @@ const modelId = await loadModel({
 Diffusion results now include a per-phase timing breakdown, so you can see where generation time goes — conditioning, the denoising loop, VAE decode, post-processing, and overall throughput.
 
 ```typescript
-const { stats } = await result;
-console.log(stats.conditionerMs); // prompt conditioning time (ms)
-console.log(stats.denoiseMs); // denoising loop time (ms)
-console.log(stats.vaeMs); // VAE decode time (ms)
-console.log(stats.postProcessMs); // encode/upscale/mux time (ms)
-console.log(stats.stepsPerSecond); // denoising throughput (steps/s)
+const { stats } = await result
+console.log(stats.conditionerMs) // prompt conditioning time (ms)
+console.log(stats.denoiseMs) // denoising loop time (ms)
+console.log(stats.vaeMs) // VAE decode time (ms)
+console.log(stats.postProcessMs) // encode/upscale/mux time (ms)
+console.log(stats.stepsPerSecond) // denoising throughput (steps/s)
 ```
 
 ### Python SDK Client
@@ -983,19 +981,19 @@ async with Client() as client:
 The VLA SDK now exposes GR00T as a first-class model, including its registry entry, hyperparameters, and helpers. GR00T uses a patch-based image input mode: when `hparams.imageInputMode` is `"patches"`, each camera image is supplied as a pre-patchified float buffer. A runnable usage example and desktop e2e ship alongside it.
 
 ```typescript
-import { loadModel, vlaHparams, vla, vlaPadState } from "@qvac/sdk";
+import { loadModel, vlaHparams, vla, vlaPadState } from '@qvac/sdk'
 
-const modelId = await loadModel({ modelSrc, modelType: "ggml-vla" });
-const { hparams } = await vlaHparams({ modelId });
+const modelId = await loadModel({ modelSrc, modelType: 'ggml-vla' })
+const { hparams } = await vlaHparams({ modelId })
 
-if (hparams.imageInputMode === "patches") {
+if (hparams.imageInputMode === 'patches') {
   // GR00T: each images[] entry is a pre-patchified buffer of imagePatchElems floats
   const images = Array.from(
     { length: hparams.numCameras },
-    () => new Float32Array(hparams.imagePatchElems),
-  );
-  const state = vlaPadState(robotState, hparams.maxStateDim);
-  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim);
+    () => new Float32Array(hparams.imagePatchElems)
+  )
+  const state = vlaPadState(robotState, hparams.maxStateDim)
+  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim)
 
   const { actions, actionDim, chunkSize } = await vla({
     modelId,
@@ -1005,8 +1003,8 @@ if (hparams.imageInputMode === "patches") {
     state,
     tokens, // Qwen3-VL tokens, length hparams.tokenizerMaxLength
     mask,
-    noise,
-  });
+    noise
+  })
 }
 ```
 
@@ -1149,41 +1147,37 @@ QVAC SDK 0.15.0 introduces single-job batch completion for running many prompts 
 `batchCompletion` runs many prompts through a single loaded model in one job, streaming per-prompt deltas and returning ordered results. Each prompt can carry its own history, generation parameters, and optional per-prompt tools or MCP-sourced tools.
 
 ```typescript
-import {
-  batchCompletion,
-  loadModel,
-  LLAMA_3_2_1B_INST_Q4_0,
-} from "@qvac/sdk";
+import { batchCompletion, loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, parallel: 4 },
-});
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, parallel: 4 }
+})
 
 const run = batchCompletion({
   modelId,
   prompts: [
     {
-      id: "a",
-      history: [{ role: "user", content: "Reply with only APPLE." }],
-      generationParams: { temp: 0, predict: 16 },
+      id: 'a',
+      history: [{ role: 'user', content: 'Reply with only APPLE.' }],
+      generationParams: { temp: 0, predict: 16 }
     },
     {
-      id: "b",
-      history: [{ role: "user", content: "What's the weather in Paris?" }],
+      id: 'b',
+      history: [{ role: 'user', content: "What's the weather in Paris?" }],
       tools: [getWeatherTool], // optional per-prompt tools
-      generationParams: { temp: 0, predict: 64 },
-    },
-  ],
-});
+      generationParams: { temp: 0, predict: 64 }
+    }
+  ]
+})
 
 for await (const { id, event } of run.events) {
-  if (event.type === "contentDelta") process.stdout.write(`[${id}] ${event.text}`);
+  if (event.type === 'contentDelta') process.stdout.write(`[${id}] ${event.text}`)
 }
 
-const results = await run.results; // ordered, all-or-nothing on stream-level failure
-const stats = await run.stats; // batch-level CompletionStats | undefined
+const results = await run.results // ordered, all-or-nothing on stream-level failure
+const stats = await run.stats // batch-level CompletionStats | undefined
 ```
 
 ### GPU Placement for Multimodal Vision Encoders
@@ -1195,9 +1189,9 @@ await loadModel({
   modelSrc: SMOLVLM2_500M_MULTIMODAL_Q8_0,
   modelConfig: {
     projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
-    "mmproj-use-gpu": true, // true = GPU, false = CPU; omit to auto-select
-  },
-});
+    'mmproj-use-gpu': true // true = GPU, false = CPU; omit to auto-select
+  }
+})
 ```
 
 ## Features
@@ -1208,14 +1202,14 @@ Supertonic TTS gains optional LavaSR post-processing: an enhancer and a denoiser
 
 ```typescript
 await sdk.loadModel({
-  ttsEngine: "supertonic",
+  ttsEngine: 'supertonic',
   modelSrc: TTS_MULTILINGUAL_SUPERTONIC3_Q8_0.src,
   // LavaSR post-processing (both optional)
   lavasrDenoiserModelSrc: TTS_DENOISER_LAVASR_FP16.src,
   lavasrEnhancerModelSrc: TTS_ENHANCER_LAVASR_FP16.src,
   // Supertonic-only output sample rate (8000-192000 Hz)
-  outputSampleRate: 48000,
-});
+  outputSampleRate: 48000
+})
 ```
 
 ### Japanese and Chinese Chatterbox TTS
@@ -1228,30 +1222,30 @@ import {
   TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_MECAB_IPADIC_CHATTERBOX,
-  TTS_CANGJIE_ZH_CHATTERBOX,
-} from "@qvac/sdk";
+  TTS_CANGJIE_ZH_CHATTERBOX
+} from '@qvac/sdk'
 
 // Japanese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "ja",
+    ttsEngine: 'chatterbox',
+    language: 'ja',
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX,
-  },
-});
+    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX
+  }
+})
 
 // Chinese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "zh",
+    ttsEngine: 'chatterbox',
+    language: 'zh',
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX,
-  },
-});
+    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX
+  }
+})
 ```
 
 ## Bug Fixes
@@ -1313,7 +1307,7 @@ The SDK and its native backends (llama.cpp / ggml) no longer print to the consol
 
 ```typescript
 // SDK and native logs printed to the console by default.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
 // → console fills with SDK + native output
 ```
 
@@ -1321,7 +1315,7 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
 
 ```typescript
 // Silent by default — no console output.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
 
 // Opt in:
 //   qvac.config.json → { "loggerConsoleOutput": true }                          // SDK logs
@@ -1337,14 +1331,14 @@ The bundled `bare-process` shim has been removed in favor of Bare primitives. Co
 
 ```typescript
 // process available as a global
-process.exit(0);
+process.exit(0)
 ```
 
 **After:**
 
 ```typescript
-import process from "bare-process";
-process.exit(0);
+import process from 'bare-process'
+process.exit(0)
 ```
 
 ### OCR Now Runs on GGML
@@ -1358,14 +1352,14 @@ The SDK's OCR path moves from ONNX to GGML-OCR 0.4.0. The legacy ONNX OCR model 
 `subscribeServerLogs` registers a single handler that receives all server-side logs, removing the need for per-ID `loggingStream()` calls.
 
 ```typescript
-import { subscribeServerLogs } from "@qvac/sdk";
+import { subscribeServerLogs } from '@qvac/sdk'
 
 const unsubscribe = subscribeServerLogs((log) => {
-  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
-});
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`)
+})
 
 // later
-unsubscribe();
+unsubscribe()
 ```
 
 ### Field-Level Validation Errors
@@ -1373,13 +1367,13 @@ unsubscribe();
 Invalid input now produces readable, field-level errors instead of opaque failures. A `RequestValidationFailedError` carries a message that points at the offending field.
 
 ```typescript
-import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
 
 try {
-  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } })
 } catch (err) {
   if (err instanceof RequestValidationFailedError) {
-    console.error(err.message);
+    console.error(err.message)
     // Invalid request:
     // ✖ Unrecognized key: "dtx_size"
     //   → at modelConfig
@@ -1394,20 +1388,20 @@ Completions can now cap or disable the reasoning channel per request or at load 
 ```typescript
 // Per-request: cap the reasoning channel at 128 tokens for a single run()
 await session.run({
-  history: [{ role: "user", content: "Solve this step by step" }],
-  reasoning_budget: 128, // -1 = unrestricted, 0 = disabled, N = cap at N tokens
-});
+  history: [{ role: 'user', content: 'Solve this step by step' }],
+  reasoning_budget: 128 // -1 = unrestricted, 0 = disabled, N = cap at N tokens
+})
 
 // Load-time default
-await loadModel(src, { reasoning_budget: 256 });
+await loadModel(src, { reasoning_budget: 256 })
 ```
 
 ```typescript
 // Drop this turn's reasoning block from the KV cache after generation
 await model.completion({
   history,
-  generationParams: { remove_thinking_from_context: true },
-});
+  generationParams: { remove_thinking_from_context: true }
+})
 ```
 
 The same `remove_thinking_from_context` flag is accepted on the CLI's OpenAI-compatible `/v1/chat/completions` request body.
@@ -1419,9 +1413,9 @@ A new `image_tile_mode` config controls how multimodal images are tiled before i
 ```typescript
 await loadModel({
   modelSrc: QWEN3_5_VL_MODEL,
-  modelType: "llamacpp-completion",
-  modelConfig: { image_tile_mode: "sequential" }, // "disabled" | "batched" | "sequential" (default: "sequential")
-});
+  modelType: 'llamacpp-completion',
+  modelConfig: { image_tile_mode: 'sequential' } // "disabled" | "batched" | "sequential" (default: "sequential")
+})
 ```
 
 ### Per-Engine TTS Language Validation and More Languages
@@ -1433,24 +1427,24 @@ import {
   TTS_CHATTERBOX_LANGUAGES,
   TTS_SUPERTONIC_LANGUAGES,
   type TtsChatterboxLanguage,
-  type TtsSupertonicLanguage,
-} from "@qvac/sdk";
+  type TtsSupertonicLanguage
+} from '@qvac/sdk'
 
 await loadModel({
   modelSrc: TTS_T3_TURBO_EN_CHATTERBOX_Q8_0,
-  modelType: "tts-ggml",
+  modelType: 'tts-ggml',
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "en",
+    ttsEngine: 'chatterbox',
+    language: 'en',
     s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX.src,
     streamChunkTokens: 25,
     streamFirstChunkTokens: 10,
     cfmSteps: 1,
     threads: 8,
     nGpuLayers: 99,
-    seed: 42,
-  },
-});
+    seed: 42
+  }
+})
 ```
 
 ### Parakeet 0.8 Runtime Fields and Explicit BCI Embedder Loading
@@ -1462,10 +1456,10 @@ const modelId = await loadModel({
   modelSrc: BCI_WINDOWED,
   modelConfig: {
     embedderModelSrc: BCI_EMBEDDER,
-    whisperConfig: { language: "en", temperature: 0.0 },
-    bciConfig: { day_idx: 1 },
-  },
-});
+    whisperConfig: { language: 'en', temperature: 0.0 },
+    bciConfig: { day_idx: 1 }
+  }
+})
 ```
 
 ## Bug Fixes
@@ -1642,20 +1636,20 @@ QVAC SDK 0.13.0 broadens the SDK across video, neural-signal transcription, robo
 The video API now supports image-to-video generation for Wan image-to-video pipelines. Consumers can provide an initial frame through `init_image` and control denoising with `strength`, making it possible to animate a source image instead of generating entirely from text.
 
 ```typescript
-import fs from "node:fs";
-import { video } from "@qvac/sdk";
+import fs from 'node:fs'
+import { video } from '@qvac/sdk'
 
-const firstFrame = fs.readFileSync("portrait.png");
+const firstFrame = fs.readFileSync('portrait.png')
 const { outputs } = video({
   modelId,
-  mode: "img2vid",
-  prompt: "the subject slowly turns and smiles, cinematic lighting",
+  mode: 'img2vid',
+  prompt: 'the subject slowly turns and smiles, cinematic lighting',
   init_image: firstFrame,
-  strength: 0.85,
-});
+  strength: 0.85
+})
 
-const buffers = await outputs;
-fs.writeFileSync("output.avi", buffers[0]);
+const buffers = await outputs
+fs.writeFileSync('output.avi', buffers[0])
 ```
 
 This change also moves video dimension validation to the SDK schema boundary. Width and height now need to be multiples of 16, so invalid dimensions fail before they reach the native addon.
@@ -1663,13 +1657,13 @@ This change also moves video dimension validation to the SDK schema boundary. Wi
 **Before:**
 
 ```typescript
-video({ modelId, mode: "txt2vid", prompt: "...", width: 520, height: 264 });
+video({ modelId, mode: 'txt2vid', prompt: '...', width: 520, height: 264 })
 ```
 
 **After:**
 
 ```typescript
-video({ modelId, mode: "txt2vid", prompt: "...", width: 528, height: 272 });
+video({ modelId, mode: 'txt2vid', prompt: '...', width: 528, height: 272 })
 ```
 
 ## Worker Failures Are Now Typed SDK Errors
@@ -1677,15 +1671,15 @@ video({ modelId, mode: "txt2vid", prompt: "...", width: 528, height: 272 });
 Bare worker crashes and SDK shutdown now surface as structured RPC errors instead of ambiguous failures. Applications can distinguish an unexpected worker death from an in-flight request that was cancelled because the SDK is closing.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
 
 try {
-  await sdk.embed({ modelId, text: "hi" });
+  await sdk.embed({ modelId, text: 'hi' })
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
-    console.error(err.exitCode, err.exitSignal);
+    console.error(err.exitCode, err.exitSignal)
   } else if (err instanceof WorkerShutdownError) {
-    console.error("The SDK closed while this request was in flight.");
+    console.error('The SDK closed while this request was in flight.')
   }
 }
 ```
@@ -1695,18 +1689,18 @@ try {
 The new Electron Forge plugin helps packaged desktop apps include only the native addon trees needed by their QVAC configuration. This reduces accidental bundling of unused prebuilds and keeps app packages closer to the target platform set.
 
 ```typescript
-const QvacForgePlugin = require("@qvac/sdk/electron-forge");
+const QvacForgePlugin = require('@qvac/sdk/electron-forge')
 
 module.exports = {
-  packagerConfig: { name: "MyApp" },
+  packagerConfig: { name: 'MyApp' },
   plugins: [
     new QvacForgePlugin({
-      configPath: "./qvac.config.json",
-      hosts: ["darwin-arm64", "darwin-x64"],
-      logLevel: "info",
-    }),
-  ],
-};
+      configPath: './qvac.config.json',
+      hosts: ['darwin-arm64', 'darwin-x64'],
+      logLevel: 'info'
+    })
+  ]
+}
 ```
 
 ## Completion and Transcription Metadata Are More Precise
@@ -1718,10 +1712,10 @@ Whisper transcription metadata now exposes backend and GPU stats in the final st
 ```typescript
 for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) {
   if (ev.done && ev.stats) {
-    console.log(ev.stats.backendDevice);
-    console.log(ev.stats.backendId);
-    console.log(ev.stats.gpuMemTotalMb);
-    console.log(ev.stats.gpuMemFreeMb);
+    console.log(ev.stats.backendDevice)
+    console.log(ev.stats.backendId)
+    console.log(ev.stats.gpuMemTotalMb)
+    console.log(ev.stats.gpuMemFreeMb)
   }
 }
 ```
@@ -1731,29 +1725,29 @@ for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) 
 The SDK now includes BCI transcription backed by whisper.cpp. It supports both batch transcription from a `.bin` path or `Uint8Array`, and streaming duplex sessions over neural-signal chunks.
 
 ```typescript
-import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from "@qvac/sdk";
+import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from '@qvac/sdk'
 
-const modelId = await loadModel({ modelSrc: BCI_WINDOWED });
-const text = await bciTranscribe({ modelId, neuralData: "./signal.bin" });
+const modelId = await loadModel({ modelSrc: BCI_WINDOWED })
+const text = await bciTranscribe({ modelId, neuralData: './signal.bin' })
 
-const session = await bciTranscribeStream({ modelId, emit: "delta" });
-session.write(chunk);
-session.end();
+const session = await bciTranscribeStream({ modelId, emit: 'delta' })
+session.write(chunk)
+session.end()
 
 for await (const token of session) {
-  process.stdout.write(token);
+  process.stdout.write(token)
 }
 ```
 
 This release also integrates the pi05 VLA model path for robot-action inference. The VLA API can inspect model hparams, preprocess camera frames, and run action generation with the required image, token, mask, and noise inputs.
 
 ```typescript
-import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from "@qvac/sdk";
+import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from '@qvac/sdk'
 
-const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: "ggml-vla" });
-const { hparams } = await vlaHparams({ modelId });
-const size = hparams.visionImageSize;
-const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }));
+const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: 'ggml-vla' })
+const { hparams } = await vlaHparams({ modelId })
+const size = hparams.visionImageSize
+const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }))
 
 const { actions } = await vla({
   modelId,
@@ -1763,8 +1757,8 @@ const { actions } = await vla({
   state: new Float32Array(0),
   tokens,
   mask,
-  noise,
-});
+  noise
+})
 ```
 
 ## Runtime Fixes and Dependency Cleanup
@@ -1816,9 +1810,9 @@ This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk
 React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
 
 ```typescript
-import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
+import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk/models'
 // or on Bare-only clients:
-import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
+import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/bare-sdk/models'
 ```
 
 ## Bug Fixes
@@ -1847,10 +1841,10 @@ v0.12.1 introduces two structured RPC errors that propagate from the worker brid
 - `WorkerShutdownError` — the SDK is shutting down (`sdk.close()` was called) while this request was still in flight. Safe to swallow on intentional teardown; surfaces an actionable label for callers who want to log it.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
 
 try {
-  await sdk.embed({ modelId, text: "hi" });
+  await sdk.embed({ modelId, text: 'hi' })
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
     // err.exitCode, err.exitSignal — worker died, decide whether to respawn.
@@ -1887,27 +1881,27 @@ The SDK TTS plugin now targets `@qvac/tts-ggml` instead of `@qvac/tts-onnx`. The
 ```typescript
 await loadModel({
   modelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
-  modelType: "tts",
+  modelType: 'tts',
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "en",
+    ttsEngine: 'chatterbox',
+    language: 'en',
     ttsSpeechEncoderSrc: TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX.src,
     ttsEmbedTokensSrc: TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX.src,
     ttsConditionalDecoderSrc: TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX.src,
-    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
-  },
-});
+    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src
+  }
+})
 ```
 
 **After:**
 
 ```typescript
-import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from "@qvac/sdk";
+import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from '@qvac/sdk'
 
 await loadModel({
   modelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX,
-  modelType: "tts",
-});
+  modelType: 'tts'
+})
 ```
 
 New registry constants cover Chatterbox and Supertonic variants in GGUF form (`TTS_S3GEN_*`, `TTS_T3_*`, `TTS_*_SUPERTONIC_*`).
@@ -1920,26 +1914,26 @@ Building on the 0.11.0 single-file GGUF migration, Parakeet now targets `@qvac/t
 
 ```typescript
 await loadModel({
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "tdt",
+    modelType: 'tdt',
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR,
-  },
-});
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR
+  }
+})
 ```
 
 **After:**
 
 ```typescript
-import { PARAKEET_TDT_0_6B_V3_Q8_0 } from "@qvac/sdk";
+import { PARAKEET_TDT_0_6B_V3_Q8_0 } from '@qvac/sdk'
 
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: "parakeet",
-});
+  modelType: 'parakeet'
+})
 ```
 
 ### `@qvac/bare-sdk` requires explicit plugin registration
@@ -1949,25 +1943,25 @@ Bare consumers that previously called `getRPC()` against the full `@qvac/sdk` wo
 **Before:**
 
 ```typescript
-import { getRPC } from "@qvac/sdk";
+import { getRPC } from '@qvac/sdk'
 
-const rpc = await getRPC();
-await rpc.loadModel({ /* any built-in modelType works */ });
+const rpc = await getRPC()
+await rpc.loadModel({/* any built-in modelType works */})
 ```
 
 **After:**
 
 ```typescript
-import { plugins } from "@qvac/bare-sdk";
-import { nmtPlugin } from "@qvac/bare-sdk/nmtcpp-translation/plugin";
-import { llmPlugin } from "@qvac/bare-sdk/llamacpp-completion/plugin";
+import { plugins } from '@qvac/bare-sdk'
+import { nmtPlugin } from '@qvac/bare-sdk/nmtcpp-translation/plugin'
+import { llmPlugin } from '@qvac/bare-sdk/llamacpp-completion/plugin'
 
-const sdk = plugins([nmtPlugin, llmPlugin]);
+const sdk = plugins([nmtPlugin, llmPlugin])
 
 await sdk.loadModel({
   modelSrc: BERGAMOT_EN_FR,
-  modelType: "nmt",
-});
+  modelType: 'nmt'
+})
 ```
 
 Install matching addon packages (`@qvac/translation-nmtcpp`, `@qvac/llm-llamacpp`, etc.) alongside `@qvac/bare-sdk`. `@qvac/sdk` remains the right choice for Node and Expo apps that want the full default worker.
@@ -1989,20 +1983,20 @@ import {
   vlaHparams,
   vlaPreprocessImage,
   vlaPadState,
-  SMOLVLA_LIBERO_VISION_Q8,
-} from "@qvac/sdk";
+  SMOLVLA_LIBERO_VISION_Q8
+} from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: SMOLVLA_LIBERO_VISION_Q8,
-  modelType: "vla",
-  modelConfig: { backend: "auto" },
-});
+  modelType: 'vla',
+  modelConfig: { backend: 'auto' }
+})
 
-const { hparams } = await vlaHparams({ modelId });
+const { hparams } = await vlaHparams({ modelId })
 const image = vlaPreprocessImage(pixels, width, height, {
-  size: hparams.visionImageSize,
-});
-const state = vlaPadState(robotState, hparams.maxStateDim);
+  size: hparams.visionImageSize
+})
+const state = vlaPadState(robotState, hparams.maxStateDim)
 
 const { actions, actionDim, chunkSize } = await vla({
   modelId,
@@ -2011,8 +2005,8 @@ const { actions, actionDim, chunkSize } = await vla({
   imgHeight: hparams.visionImageSize,
   state,
   tokens,
-  mask,
-});
+  mask
+})
 ```
 
 ### Image classification
@@ -2020,14 +2014,14 @@ const { actions, actionDim, chunkSize } = await vla({
 Classify JPEG/PNG buffers or raw RGB bytes with bundled MobileNetV3-Small or a custom GGUF:
 
 ```typescript
-import { loadModel, classify } from "@qvac/sdk";
+import { loadModel, classify } from '@qvac/sdk'
 
 const modelId = await loadModel({
-  modelType: "classification",
-  modelConfig: { topK: 3 },
-});
+  modelType: 'classification',
+  modelConfig: { topK: 3 }
+})
 
-const results = await classify({ modelId, image: jpegBytes });
+const results = await classify({ modelId, image: jpegBytes })
 // → [{ label: "food", confidence: 0.91 }, ...]
 ```
 
@@ -2036,24 +2030,24 @@ const results = await classify({ modelId, image: jpegBytes });
 Generate video frames from text prompts using WAN models:
 
 ```typescript
-import { video } from "@qvac/sdk";
+import { video } from '@qvac/sdk'
 
 const run = video({
   modelId,
-  mode: "txt2vid",
-  prompt: "a cat surfing a wave at sunset",
+  mode: 'txt2vid',
+  prompt: 'a cat surfing a wave at sunset',
   width: 480,
   height: 832,
   video_frames: 17,
   fps: 16,
-  steps: 20,
-});
+  steps: 20
+})
 
 for await (const tick of run.progressStream) {
-  console.log(`step ${tick.step}/${tick.totalSteps}`);
+  console.log(`step ${tick.step}/${tick.totalSteps}`)
 }
 
-const frames = await run.outputs;
+const frames = await run.outputs
 ```
 
 ### `@qvac/sdk/commands` for bundling and verification
@@ -2061,14 +2055,14 @@ const frames = await run.outputs;
 Programmatic access to worker bundling and prebuild verification — the same primitives `qvac bundle` and `qvac verify bundle` use:
 
 ```typescript
-import { bundleSdk, verifyBundle } from "@qvac/sdk/commands";
+import { bundleSdk, verifyBundle } from '@qvac/sdk/commands'
 
-await bundleSdk({ projectRoot: process.cwd(), configPath: "./qvac.config.json" });
+await bundleSdk({ projectRoot: process.cwd(), configPath: './qvac.config.json' })
 await verifyBundle({
   projectRoot: process.cwd(),
-  addonsSource: "./qvac/worker.bundle.js",
-  hosts: ["android-arm64", "ios-arm64"],
-});
+  addonsSource: './qvac/worker.bundle.js',
+  hosts: ['android-arm64', 'ios-arm64']
+})
 ```
 
 ### RAG cancellation detection
@@ -2076,7 +2070,7 @@ await verifyBundle({
 Detect cancelled RAG operations without importing `@qvac/rag/errors`:
 
 ```typescript
-import { RAG_ERROR_CODES } from "@qvac/sdk";
+import { RAG_ERROR_CODES } from '@qvac/sdk'
 
 if (err.code === RAG_ERROR_CODES.OPERATION_CANCELLED) {
   // ingest was cancelled
@@ -2100,17 +2094,15 @@ Expo config plugins resolve `@qvac/sdk` from ancestor `node_modules` directories
 LLM completion now surfaces real input token counts in stats and throws a typed `ContextOverflowError` when the prompt exceeds the model context window — including across the Bare RPC boundary:
 
 ```typescript
-import { ContextOverflowError } from "@qvac/sdk";
+import { ContextOverflowError } from '@qvac/sdk'
 
-const run = sdk.completion({ /* ... */ });
+const run = sdk.completion({/* ... */})
 try {
-  const final = await run.final;
-  console.log(final.stats?.promptTokens);
+  const final = await run.final
+  console.log(final.stats?.promptTokens)
 } catch (err) {
   if (err instanceof ContextOverflowError) {
-    console.warn(
-      `prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`,
-    );
+    console.warn(`prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`)
   }
 }
 ```
@@ -2189,20 +2181,20 @@ override.
 **Before (Bare):**
 
 ```typescript
-import { unloadModel } from "@qvac/sdk";
+import { unloadModel } from '@qvac/sdk'
 
-await unloadModel({ modelId });
+await unloadModel({ modelId })
 // RPC connection closed → Bare worker host terminated.
 ```
 
 **After (Bare):**
 
 ```typescript
-import { unloadModel } from "@qvac/sdk";
+import { unloadModel } from '@qvac/sdk'
 
-await unloadModel({ modelId });
+await unloadModel({ modelId })
 // Worker survives; opt in to closing explicitly:
-await unloadModel({ modelId, autoClose: true });
+await unloadModel({ modelId, autoClose: true })
 ```
 
 ### Parakeet plugin moves to the 0.4.0 single-file GGUF API
@@ -2219,24 +2211,24 @@ Sortformer from GGUF metadata.
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_ENCODER_INT8,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
-  },
-});
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8
+  }
+})
 
 await loadModel({
   modelSrc: PARAKEET_CTC_FP32,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "ctc",
+    modelType: 'ctc',
     parakeetCtcModelSrc: PARAKEET_CTC_FP32,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
-  },
-});
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
+  }
+})
 ```
 
 **After:**
@@ -2244,13 +2236,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: "parakeet",
-});
+  modelType: 'parakeet'
+})
 
 await loadModel({
   modelSrc: PARAKEET_CTC_0_6B_Q8_0,
-  modelType: "parakeet",
-});
+  modelType: 'parakeet'
+})
 ```
 
 The new GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`,
@@ -2269,47 +2261,47 @@ hatch.
 **Before — downloadAsset:**
 
 ```typescript
-import { downloadAsset, cancel } from "@qvac/sdk";
+import { downloadAsset, cancel } from '@qvac/sdk'
 
-const op = downloadAsset({ assetSrc, onProgress });
-await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
+const op = downloadAsset({ assetSrc, onProgress })
+await cancel({ operation: 'downloadAsset', downloadKey: assetSrc.key, clearCache: true })
 ```
 
 **After — downloadAsset:** the decorated promise now exposes `op.requestId`
 synchronously, and `clearCache` is honoured on the `requestId` path.
 
 ```typescript
-import { downloadAsset, cancel } from "@qvac/sdk";
+import { downloadAsset, cancel } from '@qvac/sdk'
 
-const op = downloadAsset({ assetSrc, onProgress });
-await cancel({ requestId: op.requestId, clearCache: true });
+const op = downloadAsset({ assetSrc, onProgress })
+await cancel({ requestId: op.requestId, clearCache: true })
 ```
 
 **Before — rag:**
 
 ```typescript
-import { ragIngest, cancel } from "@qvac/sdk";
+import { ragIngest, cancel } from '@qvac/sdk'
 
-ragIngest({ workspace: "my-workspace", documents });
-await cancel({ operation: "rag", workspace: "my-workspace" });
+ragIngest({ workspace: 'my-workspace', documents })
+await cancel({ operation: 'rag', workspace: 'my-workspace' })
 ```
 
 **After — rag (primary path, by `requestId`):**
 
 ```typescript
-import { ragIngest, cancel } from "@qvac/sdk";
+import { ragIngest, cancel } from '@qvac/sdk'
 
-const op = ragIngest({ workspace: "my-workspace", documents });
-await cancel({ requestId: op.requestId });
+const op = ragIngest({ workspace: 'my-workspace', documents })
+await cancel({ requestId: op.requestId })
 ```
 
 **After — rag (broad escape hatch, no `requestId` to hand):**
 
 ```typescript
-import { cancel } from "@qvac/sdk";
+import { cancel } from '@qvac/sdk'
 
 // Cancel every in-flight RAG operation running on the embedding model:
-await cancel({ modelId: ragEmbeddingModelId, kind: "rag" });
+await cancel({ modelId: ragEmbeddingModelId, kind: 'rag' })
 ```
 
 Every other `cancel(...)` shape still works: `cancel({ operation: "inference",
@@ -2329,33 +2321,26 @@ network round-trip. The pattern covers `completion`, `loadModel`, `embed`,
 the three cancellable RAG ops (`ragIngest`, `ragSaveEmbeddings`, `ragReindex`).
 
 ```typescript
-import {
-  completion,
-  loadModel,
-  embed,
-  downloadAsset,
-  ragIngest,
-  cancel,
-} from "@qvac/sdk";
+import { completion, loadModel, embed, downloadAsset, ragIngest, cancel } from '@qvac/sdk'
 
-const run = completion({ modelId, history });
-console.log(run.requestId);
+const run = completion({ modelId, history })
+console.log(run.requestId)
 
-const op = loadModel({ modelSrc: "..." });
-console.log(op.requestId);                    // synchronously, before await
-const modelId = await op;                     // legacy unwrap still works
+const op = loadModel({ modelSrc: '...' })
+console.log(op.requestId) // synchronously, before await
+const modelId = await op // legacy unwrap still works
 
-const handle = embed({ modelId, text: "hello" });
-console.log(handle.requestId);
-await handle;
+const handle = embed({ modelId, text: 'hello' })
+console.log(handle.requestId)
+await handle
 
-const download = downloadAsset({ assetSrc, onProgress });
-stopButton.onclick = () => cancel({ requestId: download.requestId });
-await download;                                // rejects with InferenceCancelledError if cancelled
+const download = downloadAsset({ assetSrc, onProgress })
+stopButton.onclick = () => cancel({ requestId: download.requestId })
+await download // rejects with InferenceCancelledError if cancelled
 
-const ingest = ragIngest({ workspace: "ws-a", modelId, documents });
-console.log(ingest.requestId);
-await ingest;
+const ingest = ragIngest({ workspace: 'ws-a', modelId, documents })
+console.log(ingest.requestId)
+await ingest
 ```
 
 The non-cancellable RAG ops (`ragChunk`, `ragSearch`, `ragDeleteEmbeddings`,
@@ -2379,17 +2364,19 @@ llama.cpp addon's opaque "job already set" error into a typed framework-level
 rejection.
 
 ```typescript
-import { completion, RequestRejectedByPolicyError } from "@qvac/sdk";
+import { completion, RequestRejectedByPolicyError } from '@qvac/sdk'
 
 try {
-  const run = completion({ modelId, history });
-  for await (const event of run.events) { /* ... */ }
+  const run = completion({ modelId, history })
+  for await (const event of run.events) {
+    /* ... */
+  }
 } catch (err) {
   if (err instanceof RequestRejectedByPolicyError) {
-    showBusy({ modelId: err.modelId, reason: err.reason });
-    return;
+    showBusy({ modelId: err.modelId, reason: err.reason })
+    return
   }
-  throw err;
+  throw err
 }
 ```
 
@@ -2401,10 +2388,10 @@ modelId, kind? }`). Two new client sugars wrap the broad shape so callers don't
 have to think about the wire representation:
 
 ```typescript
-import { cancel } from "@qvac/sdk";
+import { cancel } from '@qvac/sdk'
 
-await cancel({ modelId: "llama-3.2-1b", kind: "completion" });
-await cancel({ modelId: "llama-3.2-1b" });
+await cancel({ modelId: 'llama-3.2-1b', kind: 'completion' })
+await cancel({ modelId: 'llama-3.2-1b' })
 ```
 
 ### Plugin authors: declare cancel scope per handler
@@ -2420,7 +2407,7 @@ addon-side cancel actually interrupts compute. Plugin manifests that omit the
 field still load — it's optional.
 
 ```typescript
-import { definePlugin, defineHandler } from "@qvac/sdk";
+import { definePlugin, defineHandler } from '@qvac/sdk'
 
 definePlugin({
   manifestVersion: 1,
@@ -2429,11 +2416,13 @@ definePlugin({
       requestSchema,
       responseSchema,
       streaming: true,
-      cancel: { scope: "model", hard: true },
-      handler: async function* (request, ctx) { /* ... */ },
-    }),
-  },
-});
+      cancel: { scope: 'model', hard: true },
+      handler: async function* (request, ctx) {
+        /* ... */
+      }
+    })
+  }
+})
 ```
 
 ### Multi-GPU `split-mode`, `tensor-split`, and `main-gpu` on LLM and embed
@@ -2447,24 +2436,24 @@ convention (`splitMode`, `tensorSplit`, `mainGpu`).
 // LLM
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
+  modelType: 'llm',
   modelConfig: {
-    "split-mode": "layer",        // "none" | "layer" | "row"
-    "tensor-split": "1,1",        // proportional split across GPUs
-    "main-gpu": 0,                // integer index or "integrated" | "dedicated"
-  },
-});
+    'split-mode': 'layer', // "none" | "layer" | "row"
+    'tensor-split': '1,1', // proportional split across GPUs
+    'main-gpu': 0 // integer index or "integrated" | "dedicated"
+  }
+})
 
 // Embed
 await loadModel({
   modelSrc: EMBEDDING_GEMMA_300M_Q8_0,
-  modelType: "embed",
+  modelType: 'embed',
   modelConfig: {
-    splitMode: "layer",
-    tensorSplit: "1,1",
-    mainGpu: 0,
-  },
-});
+    splitMode: 'layer',
+    tensorSplit: '1,1',
+    mainGpu: 0
+  }
+})
 ```
 
 ### Whisper VAD and end-of-turn events on `transcribeStream`
@@ -2475,23 +2464,24 @@ voice-activity probabilities and turn boundaries, so apps can build push-to-talk
 or barge-in UX without poll-the-text hacks.
 
 ```typescript
-import { transcribeStream } from "@qvac/sdk";
+import { transcribeStream } from '@qvac/sdk'
 
 const session = await transcribeStream({
-  modelId: "whisper-base",
+  modelId: 'whisper-base',
   emitVadEvents: true,
   endOfTurnSilenceMs: 800,
-  vadRunIntervalMs: 100,
-});
+  vadRunIntervalMs: 100
+})
 
 for await (const event of session) {
-  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
-  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
-  else if (event.type === "text") process.stdout.write(event.text);
+  if (event.type === 'vad') console.log('speaking:', event.speaking, event.probability)
+  else if (event.type === 'endOfTurn')
+    console.log('turn ended after', event.silenceDurationMs, 'ms')
+  else if (event.type === 'text') process.stdout.write(event.text)
 }
 
-session.write(audioChunk);
-session.end();
+session.write(audioChunk)
+session.end()
 ```
 
 `TranscribeStreamEvent`, `VadStateEvent`, `EndOfTurnEvent`, and
@@ -2510,20 +2500,20 @@ const session = await transcribeStream({
   modelId,
   parakeetStreamingConfig: {
     chunkMs: 1000,
-    emitPartials: true,
-  },
-});
+    emitPartials: true
+  }
+})
 
-ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
+ffmpeg.stdout.on('data', (chunk: Buffer) => session.write(chunk))
 
 for await (const event of session) {
   switch (event.type) {
-    case "text":
-      process.stdout.write(event.text);
-      break;
-    case "endOfTurn":
-      console.log("\n[endOfTurn] turn boundary detected\n");
-      break;
+    case 'text':
+      process.stdout.write(event.text)
+      break
+    case 'endOfTurn':
+      console.log('\n[endOfTurn] turn boundary detected\n')
+      break
   }
 }
 ```
@@ -2547,16 +2537,16 @@ framing; Gemma4 covers the native
 `<|tool_call>call:NAME{key:<|"|>val<|"|>,...}<tool_call|>` framing.
 
 ```typescript
-import { completion, type ToolDialect } from "@qvac/sdk";
+import { completion, type ToolDialect } from '@qvac/sdk'
 
 const result = completion({
-  modelId,                         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: "harmony",          // optional explicit override
-});
+  toolDialect: 'harmony' // optional explicit override
+})
 
-const dialect: ToolDialect = "harmony";
+const dialect: ToolDialect = 'harmony'
 ```
 
 Qwen3.5 / Qwen3.6 and Gemma4 are auto-detected from the model name; the parsers
@@ -2572,19 +2562,19 @@ unrestricted, `0` = disabled. The SDK exposes it both as a load-time default on
 `LlmConfig` and as a per-request override on `GenerationParams`.
 
 ```typescript
-import { loadModel, completion } from "@qvac/sdk";
+import { loadModel, completion } from '@qvac/sdk'
 
 const modelId = await loadModel({
-  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
-  modelType: "llm",
-  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
-});
+  modelSrc: '/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf',
+  modelType: 'llm',
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 }
+})
 
 const run = completion({
   modelId,
-  history: [{ role: "user", content: "Think step by step." }],
-  generationParams: { reasoning_budget: 0 }, // override per-request
-});
+  history: [{ role: 'user', content: 'Think step by step.' }],
+  generationParams: { reasoning_budget: 0 } // override per-request
+})
 ```
 
 The same bump fixes a regression where `system_prompt` (a JS-only
@@ -2602,26 +2592,26 @@ per-call `lora` field that takes an absolute filesystem path. A new load-time
 model or applied per-call (`"auto" | "immediately" | "at_runtime"`).
 
 ```typescript
-const refA = fs.readFileSync("scientist-a.jpg");
-const refB = fs.readFileSync("scientist-b.jpg");
+const refA = fs.readFileSync('scientist-a.jpg')
+const refB = fs.readFileSync('scientist-b.jpg')
 const { outputs } = diffusion({
   modelId,
-  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
+  prompt: 'a portrait using most visual traits from @image1 and the eyes from @image2',
   init_images: [refA, refB],
   width: 768,
-  height: 768,
-});
+  height: 768
+})
 
 const { outputs: loraOutputs } = diffusion({
   modelId,
-  prompt: "a watercolor cat",
-  lora: "/home/user/loras/watercolor.safetensors",
-});
+  prompt: 'a watercolor cat',
+  lora: '/home/user/loras/watercolor.safetensors'
+})
 
 await loadModel(modelSrc, {
-  modelType: "diffusion",
-  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
-});
+  modelType: 'diffusion',
+  modelConfig: { prediction: 'flux2_flow', lora_apply_mode: 'immediately' }
+})
 ```
 
 Relative LoRA paths are rejected: the SDK runs across processes with differing
@@ -2640,46 +2630,47 @@ without standing up a full diffusion pipeline.
 // Post-step upscale during diffusion
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: "diffusion",
+  modelType: 'diffusion',
   modelConfig: {
-    prediction: "v",
+    prediction: 'v',
     upscaler: {
-      type: "esrgan",
-      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
-      tile_size: 128,
-    },
-  },
-});
+      type: 'esrgan',
+      model_src:
+        'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth',
+      tile_size: 128
+    }
+  }
+})
 
 const { outputs } = diffusion({
   modelId,
-  prompt: "an illustrated red fox portrait",
+  prompt: 'an illustrated red fox portrait',
   width: 128,
   height: 128,
-  upscale: { repeats: 2 },
-});
+  upscale: { repeats: 2 }
+})
 ```
 
 ```typescript
 // Standalone upscale — no diffusion model required
-import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from '@qvac/sdk'
 
 const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
-  modelType: "diffusion",
+  modelType: 'diffusion',
   modelConfig: {
-    mode: "upscale",
-    upscaler: { tile_size: 128 },
-  },
-});
+    mode: 'upscale',
+    upscaler: { tile_size: 128 }
+  }
+})
 
 const { outputs, stats } = upscale({
   modelId,
-  image: pngBytes,        // Uint8Array (PNG/JPEG)
-  repeats: 1,             // each pass multiplies dims by the model's native scale factor
-});
+  image: pngBytes, // Uint8Array (PNG/JPEG)
+  repeats: 1 // each pass multiplies dims by the model's native scale factor
+})
 
-const [upscaledPng] = await outputs;
-console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+const [upscaledPng] = await outputs
+console.log(await stats) // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
 ```
 
 Calling `upscale()` against a model that wasn't loaded with `mode: "upscale"`
@@ -2830,10 +2821,10 @@ The DHT routing table is still populated lazily as `dht.connect()` issues lookup
 
 Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
 
-| Build              | Mean connection time | p50    | p95    |
-| ------------------ | -------------------- | ------ | ------ |
-| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
-| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
+| Build              | Mean connection time | p50   | p95   |
+| ------------------ | -------------------- | ----- | ----- |
+| v0.10.1 (baseline) | 3.82s                | 3.71s | 4.94s |
+| v0.10.2 (this fix) | 1.18s                | 1.12s | 1.49s |
 
 That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
 
@@ -2852,16 +2843,16 @@ This patch release adds a new tool-call dialect for OpenAI's `gpt-oss` (Harmony)
 `completion()` now supports a fourth tool-call dialect, `"harmony"`, used by OpenAI's `gpt-oss` family of models. The new dialect is wired into the same streaming/event surface as the existing dialects (`hermes`, `pythonic`, `json`), so tool calls emitted in Harmony frames are parsed and surfaced through the standard `CompletionEvent` stream. `gpt-oss-20b-Q4_K_M` auto-routes to the Harmony dialect; the `toolDialect` parameter is available as an explicit override on any model.
 
 ```typescript
-import { completion, type ToolDialect } from "@qvac/sdk";
+import { completion, type ToolDialect } from '@qvac/sdk'
 
 const run = completion({
-  modelId,                 // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: "harmony",  // optional explicit override
-});
+  toolDialect: 'harmony' // optional explicit override
+})
 
-const dialect: ToolDialect = "harmony";
+const dialect: ToolDialect = 'harmony'
 // ToolDialect is now "hermes" | "pythonic" | "json" | "harmony"
 ```
 
@@ -2960,20 +2951,22 @@ captured thinking and structured tool framing.
 **Before:**
 
 ```typescript
-const result = completion({ modelId, history, stream: true });
-for await (const token of result.tokenStream) { /* ... */ }
-const stats = await result.stats;
+const result = completion({ modelId, history, stream: true })
+for await (const token of result.tokenStream) {
+  /* ... */
+}
+const stats = await result.stats
 ```
 
 **After:**
 
 ```typescript
-const run = completion({ modelId, history, stream: true, captureThinking: true });
+const run = completion({ modelId, history, stream: true, captureThinking: true })
 for await (const event of run.events) {
-  if (event.type === "contentDelta") process.stdout.write(event.text);
-  if (event.type === "toolCall") console.log(event.call.name);
+  if (event.type === 'contentDelta') process.stdout.write(event.text)
+  if (event.type === 'toolCall') console.log(event.call.name)
 }
-const result = await run.final;
+const result = await run.final
 // result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
 ```
 
@@ -2995,35 +2988,35 @@ and `pluginInvokeStream` paths still surface `PLUGIN_HANDLER_NOT_FOUND` as befor
 **Before:**
 
 ```typescript
-import type { LoadModelOptions } from "@qvac/sdk";
+import type { LoadModelOptions } from '@qvac/sdk'
 
 const opts: LoadModelOptions = {
-  modelSrc: "/path/foo",
-  modelType: "my-custom-plugin",
-  modelConfig: { whatever: 1 },
-};
-await loadModel(opts);
+  modelSrc: '/path/foo',
+  modelType: 'my-custom-plugin',
+  modelConfig: { whatever: 1 }
+}
+await loadModel(opts)
 ```
 
 **After:**
 
 ```typescript
-import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
+import type { LoadCustomPluginModelOptions } from '@qvac/sdk'
 
-const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
-  modelSrc: "/path/foo",
-  modelType: "my-custom-plugin",
-  modelConfig: { whatever: 1 },
-};
-await loadModel(opts);
+const opts: LoadCustomPluginModelOptions<'my-custom-plugin'> = {
+  modelSrc: '/path/foo',
+  modelType: 'my-custom-plugin',
+  modelConfig: { whatever: 1 }
+}
+await loadModel(opts)
 // Or just drop the annotation — TS picks the right overload.
 ```
 
 ```typescript
-import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+import { SDK_SERVER_ERROR_CODES } from '@qvac/sdk'
 
 try {
-  await transcribe({ modelId: llmModelId /* ... */ });
+  await transcribe({ modelId: llmModelId /* ... */ })
 } catch (e) {
   if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
     // Includes requested operation, loaded model type, supported operations,
@@ -3043,7 +3036,9 @@ the field name changed.
 ```typescript
 onProgress: (progress) => {
   if (progress.onnxInfo) {
-    console.log(`[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`);
+    console.log(
+      `[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`
+    )
   }
 }
 ```
@@ -3053,7 +3048,9 @@ onProgress: (progress) => {
 ```typescript
 onProgress: (progress) => {
   if (progress.fileSetInfo) {
-    console.log(`[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`);
+    console.log(
+      `[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`
+    )
   }
 }
 ```
@@ -3083,12 +3080,12 @@ delegated models defer to the provider. Useful for preflighting a built-in SDK c
 before issuing the RPC.
 
 ```typescript
-import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
+import { getLoadedModelInfo, transcribe } from '@qvac/sdk'
 
-const info = await getLoadedModelInfo({ modelId });
+const info = await getLoadedModelInfo({ modelId })
 
-if (info.isDelegated || info.handlers.includes("transcribeStream")) {
-  await transcribe({ modelId /* ... */ });
+if (info.isDelegated || info.handlers.includes('transcribeStream')) {
+  await transcribe({ modelId /* ... */ })
 }
 ```
 
@@ -3100,31 +3097,31 @@ schema-valid JSON. The output is guaranteed to parse against the supplied JSON S
 ```typescript
 const run = completion({
   modelId,
-  history: [{ role: "user", content: "Extract: I'm Alice, 30, data engineer." }],
+  history: [{ role: 'user', content: "Extract: I'm Alice, 30, data engineer." }],
   stream: true,
   responseFormat: {
-    type: "json_schema",
+    type: 'json_schema',
     json_schema: {
-      name: "Person",
+      name: 'Person',
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
-          name: { type: "string" },
-          age: { type: "integer" },
-          occupation: { type: "string" },
+          name: { type: 'string' },
+          age: { type: 'integer' },
+          occupation: { type: 'string' }
         },
-        required: ["name", "age", "occupation"],
-        additionalProperties: false,
-      },
-    },
-  },
-});
+        required: ['name', 'age', 'occupation'],
+        additionalProperties: false
+      }
+    }
+  }
+})
 
 for await (const event of run.events) {
-  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === 'contentDelta') process.stdout.write(event.text)
 }
-const final = await run.final;
-JSON.parse(final.contentText); // schema-valid
+const final = await run.final
+JSON.parse(final.contentText) // schema-valid
 ```
 
 ### Dynamic tools mode
@@ -3135,29 +3132,35 @@ addon trims the previous tool block from the KV cache so rotation is free — no
 invalidate the cache or pin the tool set per-session.
 
 ```typescript
-import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: "llm",
+  modelType: 'llm',
   modelConfig: {
     ctx_size: 4096,
     tools: true,
-    toolsMode: TOOLS_MODE.dynamic,
-  },
-});
+    toolsMode: TOOLS_MODE.dynamic
+  }
+})
 
 // Turn 1 — weather tools.
 const turn1 = completion({
-  modelId, history, kvCache, stream: true,
-  tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
-});
+  modelId,
+  history,
+  kvCache,
+  stream: true,
+  tools: [{ name: 'get_weather', description: '...', parameters: weatherSchema }]
+})
 
 // Turn 2 — same kvCache, different tools. Free rotation.
 const turn2 = completion({
-  modelId, history, kvCache, stream: true,
-  tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
-});
+  modelId,
+  history,
+  kvCache,
+  stream: true,
+  tools: [{ name: 'get_horoscope', description: '...', parameters: horoscopeSchema }]
+})
 ```
 
 ### Tool-call dialect routing
@@ -3169,12 +3172,15 @@ fine-tunes that emit native pythonic headers, which the auto-router defaults to 
 for empirical reasons.
 
 ```typescript
-import { completion, type ToolDialect } from "@qvac/sdk";
+import { completion, type ToolDialect } from '@qvac/sdk'
 
 const result = completion({
-  modelId, history, tools, stream: true,
-  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
-});
+  modelId,
+  history,
+  tools,
+  stream: true,
+  toolDialect: 'pythonic' // "hermes" | "pythonic" | "json"
+})
 ```
 
 ### img2img for diffusion models
@@ -3184,13 +3190,13 @@ SD/SDXL, and in-context conditioning on FLUX.2. `strength` controls how much of 
 source is preserved on SD/SDXL; FLUX.2 ignores it (the path is purely conditional).
 
 ```typescript
-const initImage = new Uint8Array(fs.readFileSync("input.png"));
+const initImage = new Uint8Array(fs.readFileSync('input.png'))
 const { outputs } = diffusion({
   modelId,
-  prompt: "oil painting style, vibrant colors",
+  prompt: 'oil painting style, vibrant colors',
   init_image: initImage,
-  strength: 0.5, // 0 = keep source, 1 = ignore source
-});
+  strength: 0.5 // 0 = keep source, 1 = ignore source
+})
 ```
 
 ### Sentence-level TTS streaming
@@ -3203,22 +3209,22 @@ exposes the int16 PCM samples plus the source sentence and chunk index.
 ```typescript
 const session = await textToSpeechStream({
   modelId: ttsModelId,
-  inputType: "text",
+  inputType: 'text',
   accumulateSentences: true,
-  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
-  flushAfterMs: 400,
-});
+  sentenceDelimiterPreset: 'latin', // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400
+})
 
-(async () => {
+;(async () => {
   for await (const delta of completion({ modelId: llmModelId /* ... */ }).tokenStream) {
-    session.write(delta);
+    session.write(delta)
   }
-  session.end();
-})();
+  session.end()
+})()
 
 for await (const chunk of session) {
   // chunk.buffer / chunk.chunkIndex / chunk.sentenceChunk
-  if (chunk.done) break;
+  if (chunk.done) break
 }
 ```
 
@@ -3230,9 +3236,9 @@ flag — enabling proper subtitle generation and timeline alignment instead of r
 concatenation.
 
 ```typescript
-const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true });
+const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true })
 for (const s of segments) {
-  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`)
 }
 ```
 
@@ -3243,12 +3249,12 @@ suspend/resume races. A new `state()` API reports the current lifecycle phase:
 `active`, `suspending`, `suspended`, or `resuming`.
 
 ```typescript
-import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
+import { state, suspend, resume, type LifecycleState } from '@qvac/sdk'
 
-await suspend();
-const current: LifecycleState = await state();
-if (current !== "active") {
-  await resume();
+await suspend()
+const current: LifecycleState = await state()
+if (current !== 'active') {
+  await resume()
 }
 ```
 
@@ -3259,12 +3265,12 @@ Two new SDK config knobs cover slow/unstable links: `registryDownloadMaxRetries`
 extends the per-block stream timeout beyond the default 60s.
 
 ```typescript
-import { setSDKConfig } from "@qvac/sdk";
+import { setSDKConfig } from '@qvac/sdk'
 
 setSDKConfig({
   registryDownloadMaxRetries: 5,
-  registryStreamTimeoutMs: 180_000,
-});
+  registryStreamTimeoutMs: 180_000
+})
 ```
 
 ### Auto KV-cache: replay the canonical assistant turn
@@ -3276,14 +3282,16 @@ guarantee a cache hit. Tool-call turns aren't auto-cached today and omit the fie
 fall back to `final.contentText` in that case.
 
 ```typescript
-const run = completion({ modelId, history, kvCache: true });
-for await (const _ of run.tokenStream) { /* stream */ }
-const final = await run.final;
+const run = completion({ modelId, history, kvCache: true })
+for await (const _ of run.tokenStream) {
+  /* stream */
+}
+const final = await run.final
 const nextHistory = [
   ...history,
-  { role: "assistant", content: final.cacheableAssistantContent ?? final.contentText },
-  { role: "user", content: "follow-up question" },
-];
+  { role: 'assistant', content: final.cacheableAssistantContent ?? final.contentText },
+  { role: 'user', content: 'follow-up question' }
+]
 ```
 
 ### LLM-addon cache API plumbed through SDK
@@ -3432,22 +3440,22 @@ The `ping()` API has been replaced by `heartbeat()`, which supports both local a
 **Before:**
 
 ```typescript
-import { ping } from "@qvac/sdk";
-const pong = await ping();
+import { ping } from '@qvac/sdk'
+const pong = await ping()
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from "@qvac/sdk";
+import { heartbeat } from '@qvac/sdk'
 
 // Local heartbeat (replaces ping)
-await heartbeat();
+await heartbeat()
 
 // Delegated heartbeat — check if a remote provider is alive
 await heartbeat({
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
-});
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
+})
 ```
 
 ---
@@ -3459,22 +3467,22 @@ await heartbeat({
 The SDK now supports LoRA finetuning of loaded LLM models. Training runs can be started, paused, resumed, cancelled, and inspected — all through a single `finetune()` function. Progress streams provide real-time loss and step metrics.
 
 ```typescript
-import { finetune } from "@qvac/sdk";
+import { finetune } from '@qvac/sdk'
 
 const handle = finetune({
   modelId,
   options: {
-    trainDatasetDir: "./dataset/train",
-    validation: { type: "dataset", path: "./dataset/eval" },
-    outputParametersDir: "./artifacts/lora",
-    numberOfEpochs: 2,
-  },
-});
+    trainDatasetDir: './dataset/train',
+    validation: { type: 'dataset', path: './dataset/eval' },
+    outputParametersDir: './artifacts/lora',
+    numberOfEpochs: 2
+  }
+})
 
 for await (const progress of handle.progressStream) {
-  console.log(progress.global_steps, progress.loss);
+  console.log(progress.global_steps, progress.loss)
 }
-const result = await handle.result;
+const result = await handle.result
 ```
 
 Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` to let the addon auto-detect whether to start fresh or resume.
@@ -3484,26 +3492,26 @@ Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` t
 Stable Diffusion models are now integrated as a first-class SDK capability. Load a diffusion model and generate images with step-by-step progress tracking.
 
 ```typescript
-import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from "@qvac/sdk";
+import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: "diffusion",
-  modelConfig: { prediction: "v" },
-});
+  modelType: 'diffusion',
+  modelConfig: { prediction: 'v' }
+})
 
 const { progressStream, outputs, stats } = diffusion({
   modelId,
-  prompt: "a cat sitting on a windowsill",
+  prompt: 'a cat sitting on a windowsill',
   width: 512,
   height: 512,
-  steps: 20,
-});
+  steps: 20
+})
 
 for await (const { step, totalSteps } of progressStream) {
-  console.log(`${step}/${totalSteps}`);
+  console.log(`${step}/${totalSteps}`)
 }
-const buffers = await outputs;
+const buffers = await outputs
 ```
 
 ### Duplex Streaming Transcription (`transcribeStream`)
@@ -3511,16 +3519,16 @@ const buffers = await outputs;
 A new bidirectional streaming API lets you feed audio incrementally and receive transcription segments as speech is detected, enabling real-time voice interfaces.
 
 ```typescript
-import { transcribeStream } from "@qvac/sdk";
+import { transcribeStream } from '@qvac/sdk'
 
-const session = await transcribeStream({ modelId });
-session.write(audioChunk);
-session.end();
+const session = await transcribeStream({ modelId })
+session.write(audioChunk)
+session.end()
 
 for await (const text of session) {
-  console.log(text);
+  console.log(text)
 }
-session.destroy();
+session.destroy()
 ```
 
 The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern still works but logs a deprecation warning — use `transcribe()` for batch transcription.
@@ -3530,10 +3538,10 @@ The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern sti
 Mobile and desktop apps can now cleanly suspend and resume SDK operations when the app enters the background or foreground, preventing resource leaks and stale state.
 
 ```typescript
-import { suspend, resume } from "@qvac/sdk";
+import { suspend, resume } from '@qvac/sdk'
 
-await suspend(); // app going to background
-await resume();  // app returning to foreground
+await suspend() // app going to background
+await resume() // app returning to foreground
 ```
 
 ### Delegated Cancellation
@@ -3541,15 +3549,15 @@ await resume();  // app returning to foreground
 Remote inference and downloads running on a delegation provider can now be cancelled from the consumer side.
 
 ```typescript
-import { cancel } from "@qvac/sdk";
+import { cancel } from '@qvac/sdk'
 
-await cancel({ operation: "inference", modelId: "delegated-model-id" });
+await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
 
 await cancel({
-  operation: "downloadAsset",
-  downloadKey: "download-key",
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
-});
+  operation: 'downloadAsset',
+  downloadKey: 'download-key',
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
+})
 ```
 
 ### Delegation Health Check Timeout
@@ -3559,14 +3567,14 @@ A new `healthCheckTimeout` option on the delegate config lets you control how lo
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
+  modelType: 'llm',
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000,
-  },
-});
+    healthCheckTimeout: 2000
+  }
+})
 ```
 
 ### Addon Stats Across All Operations
@@ -3574,8 +3582,8 @@ await loadModel({
 All inference operations now return detailed performance stats from the underlying addons. Completion, transcription, translation, TTS, and embedding responses all include stats like `tokensPerSecond`, `timeToFirstToken`, `audioDuration`, and the new `backendDevice` field (`"cpu"` or `"gpu"`).
 
 ```typescript
-const { embedding, stats } = await embed({ modelId, text: "hello" });
-console.log(stats?.backendDevice); // "cpu" | "gpu"
+const { embedding, stats } = await embed({ modelId, text: 'hello' })
+console.log(stats?.backendDevice) // "cpu" | "gpu"
 ```
 
 ---
@@ -3698,22 +3706,22 @@ The `ping()` function has been replaced by `heartbeat()`, which extends health c
 **Before:**
 
 ```typescript
-import { ping } from "@qvac/sdk";
-const pong = await ping();
+import { ping } from '@qvac/sdk'
+const pong = await ping()
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from "@qvac/sdk";
+import { heartbeat } from '@qvac/sdk'
 
 // Local heartbeat (replaces ping)
-await heartbeat();
+await heartbeat()
 
 // Delegated heartbeat — verify a remote provider is reachable
 await heartbeat({
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
-});
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
+})
 ```
 
 ---
@@ -3727,14 +3735,14 @@ Delegated model loading now supports an optional `healthCheckTimeout` parameter.
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: "llm",
+  modelType: 'llm',
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000, // optional, defaults to 1500ms
-  },
-});
+    healthCheckTimeout: 2000 // optional, defaults to 1500ms
+  }
+})
 ```
 
 ### Delegated Cancellation
@@ -3743,14 +3751,14 @@ Cancel operations now route automatically to remote providers when the target mo
 
 ```typescript
 // Cancel delegated inference (routes automatically via model registry)
-await cancel({ operation: "inference", modelId: "delegated-model-id" });
+await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
 
 // Cancel delegated remote download
 await cancel({
-  operation: "downloadAsset",
-  downloadKey: "download-key",
-  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
-});
+  operation: 'downloadAsset',
+  downloadKey: 'download-key',
+  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
+})
 ```
 
 ---
@@ -3795,11 +3803,11 @@ The embedding addon no longer accepts the raw tab-delimited config string. Use t
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: "embeddings",
+  modelType: 'embeddings',
   modelConfig: {
-    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
-  },
-});
+    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
+  }
+})
 ```
 
 **After:**
@@ -3807,13 +3815,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: "embeddings",
+  modelType: 'embeddings',
   modelConfig: {
     gpuLayers: 99,
-    device: "gpu",
-    batchSize: 1024,
-  },
-});
+    device: 'gpu',
+    batchSize: 1024
+  }
+})
 ```
 
 ### Companion Model Sources Moved Into `modelConfig`
@@ -3824,76 +3832,76 @@ Top-level companion source fields (`projectionModelSrc`, `vadModelSrc`, `srcVoca
 
 ```typescript
 await loadModel({
-  modelType: "llm",
-  modelSrc: ".../model.gguf",
-  projectionModelSrc: ".../mmproj.gguf",
-});
+  modelType: 'llm',
+  modelSrc: '.../model.gguf',
+  projectionModelSrc: '.../mmproj.gguf'
+})
 
 await loadModel({
-  modelType: "whisper",
-  modelSrc: ".../model.bin",
-  vadModelSrc: ".../vad.bin",
-});
+  modelType: 'whisper',
+  modelSrc: '.../model.bin',
+  vadModelSrc: '.../vad.bin'
+})
 
 await loadModel({
-  modelType: "nmt",
-  modelSrc: ".../model.intgemm.alphas.bin",
-  srcVocabSrc: ".../srcvocab.spm",
-  dstVocabSrc: ".../trgvocab.spm",
-});
+  modelType: 'nmt',
+  modelSrc: '.../model.intgemm.alphas.bin',
+  srcVocabSrc: '.../srcvocab.spm',
+  dstVocabSrc: '.../trgvocab.spm'
+})
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelType: "llm",
-  modelSrc: ".../model.gguf",
+  modelType: 'llm',
+  modelSrc: '.../model.gguf',
   modelConfig: {
-    projectionModelSrc: ".../mmproj.gguf",
-  },
-});
+    projectionModelSrc: '.../mmproj.gguf'
+  }
+})
 
 await loadModel({
-  modelType: "whisper",
-  modelSrc: ".../model.bin",
+  modelType: 'whisper',
+  modelSrc: '.../model.bin',
   modelConfig: {
-    vadModelSrc: ".../vad.bin",
-  },
-});
+    vadModelSrc: '.../vad.bin'
+  }
+})
 
 await loadModel({
-  modelType: "nmt",
-  modelSrc: ".../model.intgemm.alphas.bin",
+  modelType: 'nmt',
+  modelSrc: '.../model.intgemm.alphas.bin',
   modelConfig: {
-    srcVocabSrc: ".../srcvocab.spm",
-    dstVocabSrc: ".../trgvocab.spm",
-  },
-});
+    srcVocabSrc: '.../srcvocab.spm',
+    dstVocabSrc: '.../trgvocab.spm'
+  }
+})
 ```
 
 Additionally, custom plugins must now provide a `loadConfigSchema`. For plugins that accept any config, use a passthrough schema:
 
 ```typescript
 const myPlugin: QvacPlugin = {
-  modelType: "my-plugin",
-  displayName: "My Plugin",
-  addonPackage: "@my/addon",
+  modelType: 'my-plugin',
+  displayName: 'My Plugin',
+  addonPackage: '@my/addon',
   loadConfigSchema: z.object({}).catchall(z.unknown()),
   createModel: (params) => ({ model, loader }),
-  handlers: {},
-};
+  handlers: {}
+}
 ```
 
 ### Parakeet Model Constants Renamed
 
 All existing Parakeet model constants now include a variant prefix (`TDT_`) to distinguish them from the new CTC and Sortformer variants. This is a find-and-replace migration:
 
-| Old Constant | New Constant |
-|---|---|
-| `PARAKEET_ENCODER_*` | `PARAKEET_TDT_ENCODER_*` |
-| `PARAKEET_DECODER_*` | `PARAKEET_TDT_DECODER_*` |
-| `PARAKEET_VOCAB` | `PARAKEET_TDT_VOCAB` |
+| Old Constant              | New Constant                  |
+| ------------------------- | ----------------------------- |
+| `PARAKEET_ENCODER_*`      | `PARAKEET_TDT_ENCODER_*`      |
+| `PARAKEET_DECODER_*`      | `PARAKEET_TDT_DECODER_*`      |
+| `PARAKEET_VOCAB`          | `PARAKEET_TDT_VOCAB`          |
 | `PARAKEET_PREPROCESSOR_*` | `PARAKEET_TDT_PREPROCESSOR_*` |
 
 ---
@@ -3910,24 +3918,24 @@ import {
   PARAKEET_TDT_ENCODER_DATA_FP32,
   PARAKEET_TDT_DECODER_FP32,
   PARAKEET_TDT_VOCAB,
-  PARAKEET_TDT_PREPROCESSOR_FP32,
-} from "@qvac/sdk";
+  PARAKEET_TDT_PREPROCESSOR_FP32
+} from '@qvac/sdk'
 
 const modelId = await loadModel({
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelSrc: PARAKEET_TDT_ENCODER_FP32,
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
     parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
-  },
-});
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32
+  }
+})
 
-const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
+const stream = transcribeStream({ modelId, audioInput: './audio.mp3' })
 for await (const chunk of stream) {
-  process.stdout.write(chunk);
+  process.stdout.write(chunk)
 }
 ```
 
@@ -3940,21 +3948,21 @@ Translate between language pairs that don't have a direct model by chaining thro
 ```typescript
 await loadModel({
   modelSrc: BERGAMOT_ES_EN,
-  modelType: "nmt",
+  modelType: 'nmt',
   modelConfig: {
-    engine: "Bergamot",
-    from: "es",
-    to: "it",
+    engine: 'Bergamot',
+    from: 'es',
+    to: 'it',
     pivotModel: {
       modelSrc: BERGAMOT_EN_IT,
       beamsize: 4,
       temperature: 0.3,
       topk: 100,
       normalize: 1,
-      lengthpenalty: 1.2,
-    },
-  },
-});
+      lengthpenalty: 1.2
+    }
+  }
+})
 ```
 
 ### SDK Profiler
@@ -3962,28 +3970,25 @@ await loadModel({
 A built-in profiler lets you measure SDK operation performance at runtime. Enable it globally or on a per-call basis:
 
 ```typescript
-import { profiler } from "@qvac/sdk";
+import { profiler } from '@qvac/sdk'
 
 profiler.enable({
-  mode: "verbose",
-  includeServerBreakdown: true,
-});
+  mode: 'verbose',
+  includeServerBreakdown: true
+})
 
 // Run operations, then export results
-console.log(profiler.exportSummary());
-console.log(profiler.exportTable());
-console.log(profiler.exportJSON({ includeRecentEvents: true }));
+console.log(profiler.exportSummary())
+console.log(profiler.exportTable())
+console.log(profiler.exportJSON({ includeRecentEvents: true }))
 
-profiler.disable();
+profiler.disable()
 ```
 
 Per-call profiling control is also available on `embed`, `completion`, `transcribe`, `translate`, `ragSearch`, and `invokePlugin`:
 
 ```typescript
-await embed(
-  { modelId, text: "hello" },
-  { profiling: { enabled: true } },
-);
+await embed({ modelId, text: 'hello' }, { profiling: { enabled: true } })
 ```
 
 ---
@@ -3999,15 +4004,15 @@ The SDK now supports two additional Parakeet model variants beyond the existing 
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_CTC_FP32_1,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "ctc",
+    modelType: 'ctc',
     parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
     parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
-  },
-});
-const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
+  }
+})
+const text = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
 ```
 
 **Sortformer diarization** for speaker identification:
@@ -4015,13 +4020,13 @@ const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_SORTFORMER_FP32,
-  modelType: "parakeet",
+  modelType: 'parakeet',
   modelConfig: {
-    modelType: "sortformer",
-    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
-  },
-});
-const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+    modelType: 'sortformer',
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32
+  }
+})
+const diarization = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
 // Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
 ```
 
@@ -4050,20 +4055,24 @@ The profiler now captures detailed load/download metrics and stream profiling da
 ### Added Models
 
 **OCR:**
+
 - `OCR_DETECTOR_DB_MOBILENET_V3_LARGE`
 - `OCR_DETECTOR_DB_RESNET50`
 - `OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL`
 - `OCR_RECOGNIZER_PARSEQ`
 
 **Parakeet (CTC):**
+
 - `PARAKEET_CTC_FP32`, `PARAKEET_CTC_DATA_FP32`, `PARAKEET_CTC_VOCAB`, `PARAKEET_CTC_INT8`, `PARAKEET_CTC_CONFIG`
 - `PARAKEET_CTC_FP32_1`, `PARAKEET_CTC_DATA_FP32_1`, `PARAKEET_CTC_TOKENIZER`
 
 **Parakeet (Sortformer / EOU):**
+
 - `PARAKEET_SORTFORMER_FP32`
 - `PARAKEET_EOU_ENCODER_FP32`, `PARAKEET_EOU_DECODER_FP32`, `PARAKEET_EOU_TOKENIZER`
 
 **Parakeet (TDT — renamed from unprefixed):**
+
 - `PARAKEET_TDT_ENCODER_FP32`, `PARAKEET_TDT_ENCODER_DATA_FP32`, `PARAKEET_TDT_DECODER_FP32`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_FP32`
 - `PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_PREPROCESSOR_INT8`
 
@@ -4105,30 +4114,30 @@ Model constant names have been normalized for consistency. If your code referenc
 
 ```typescript
 // Before
-import { BERGAMOT_AREN } from "@qvac/sdk";
+import { BERGAMOT_AREN } from '@qvac/sdk'
 
 // After
-import { BERGAMOT_AR_EN } from "@qvac/sdk";
+import { BERGAMOT_AR_EN } from '@qvac/sdk'
 ```
 
 **Whisper models** have simplified names without author/repo prefixes:
 
 ```typescript
 // Before
-import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from "@qvac/sdk";
+import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from '@qvac/sdk'
 
 // After
-import { WHISPER_EN_BASE_Q0F16 } from "@qvac/sdk";
+import { WHISPER_EN_BASE_Q0F16 } from '@qvac/sdk'
 ```
 
 **LLM models** have normalized version prefixes:
 
 ```typescript
 // Before
-import { QWEN_3_1_7B_INST_Q4 } from "@qvac/sdk";
+import { QWEN_3_1_7B_INST_Q4 } from '@qvac/sdk'
 
 // After
-import { QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+import { QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
 ```
 
 ### HyperdriveItem Type Renamed to RegistryItem
@@ -4137,10 +4146,10 @@ The model metadata type has been renamed and restructured to support the new reg
 
 ```typescript
 // Before
-import type { HyperdriveItem } from "@qvac/sdk";
+import type { HyperdriveItem } from '@qvac/sdk'
 
 // After
-import type { RegistryItem } from "@qvac/sdk";
+import type { RegistryItem } from '@qvac/sdk'
 ```
 
 The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
@@ -4154,26 +4163,22 @@ The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replace
 Discover and search models directly through the SDK without needing a separate registry client package.
 
 ```typescript
-import {
-  modelRegistryList,
-  modelRegistrySearch,
-  modelRegistryGetModel,
-} from "@qvac/sdk";
+import { modelRegistryList, modelRegistrySearch, modelRegistryGetModel } from '@qvac/sdk'
 
 // List all available models
-const models = await modelRegistryList();
+const models = await modelRegistryList()
 
 // Search by engine type
-const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
+const llmModels = await modelRegistrySearch({ engine: '@qvac/llm-llamacpp' })
 
 // Search by text filter
-const whisperModels = await modelRegistrySearch({ filter: "whisper" });
+const whisperModels = await modelRegistrySearch({ filter: 'whisper' })
 
 // Search by quantization
-const q4Models = await modelRegistrySearch({ quantization: "q4" });
+const q4Models = await modelRegistrySearch({ quantization: 'q4' })
 
 // Get a specific model by path
-const model = await modelRegistryGetModel(registryPath, registrySource);
+const model = await modelRegistryGetModel(registryPath, registrySource)
 ```
 
 ### Plugin System
@@ -4181,22 +4186,22 @@ const model = await modelRegistryGetModel(registryPath, registrySource);
 Build custom model integrations with the new plugin architecture. Plugins support both request/reply and streaming patterns.
 
 ```typescript
-import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from '@qvac/sdk'
 
 // Invoke a plugin handler
 const result = await invokePlugin<MyResponse>({
   modelId,
-  handler: "myHandler",
-  params: { key: "value" },
-});
+  handler: 'myHandler',
+  params: { key: 'value' }
+})
 
 // Stream responses from a plugin
 for await (const chunk of invokePluginStream<MyStreamResponse>({
   modelId,
-  handler: "myStreamHandler",
-  params: { key: "value" },
+  handler: 'myStreamHandler',
+  params: { key: 'value' }
 })) {
-  console.log(chunk.result);
+  console.log(chunk.result)
 }
 ```
 
@@ -4207,25 +4212,25 @@ Clone voices from reference audio samples with the new Chatterbox engine.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: "tts",
+  modelType: 'tts',
   modelConfig: {
-    ttsEngine: "chatterbox",
-    language: "en",
+    ttsEngine: 'chatterbox',
+    language: 'en',
     ttsTokenizerSrc,
     ttsSpeechEncoderSrc,
     ttsEmbedTokensSrc,
     ttsConditionalDecoderSrc,
     ttsLanguageModelSrc,
-    referenceAudioSrc, // Your voice sample
-  },
-});
+    referenceAudioSrc // Your voice sample
+  }
+})
 
 const audio = await textToSpeech({
   modelId,
-  text: "Hello in a cloned voice!",
-  inputType: "text",
-  stream: false,
-});
+  text: 'Hello in a cloned voice!',
+  inputType: 'text',
+  stream: false
+})
 ```
 
 ### Supertonic TTS Engine (General Purpose)
@@ -4235,19 +4240,19 @@ High-quality text-to-speech with adjustable speed and inference steps.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: "tts",
+  modelType: 'tts',
   modelConfig: {
-    ttsEngine: "supertonic",
-    language: "en",
+    ttsEngine: 'supertonic',
+    language: 'en',
     ttsTokenizerSrc,
     ttsTextEncoderSrc,
     ttsLatentDenoiserSrc,
     ttsVoiceDecoderSrc,
     ttsVoiceSrc,
-    ttsSpeed: 1.0,           // Playback speed
-    ttsNumInferenceSteps: 5, // Quality vs speed tradeoff
-  },
-});
+    ttsSpeed: 1.0, // Playback speed
+    ttsNumInferenceSteps: 5 // Quality vs speed tradeoff
+  }
+})
 ```
 
 ### CLI SDK Path Option
@@ -4271,10 +4276,10 @@ Model downloads now use `downloadBlob` for more efficient direct registry fetchi
 The `close()` function is now properly async and awaitable for clean shutdown:
 
 ```typescript
-import { close } from "@qvac/sdk";
+import { close } from '@qvac/sdk'
 
 // Now returns a Promise
-await close();
+await close()
 ```
 
 ### Engine-Addon Mapping Utilities
@@ -4282,10 +4287,10 @@ await close();
 Map between engine names and addon types:
 
 ```typescript
-import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
+import { resolveCanonicalEngine, getAddonFromEngine } from '@qvac/sdk'
 
-const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
-const addon = getAddonFromEngine("llamacpp-completion");     // "llm"
+const engine = resolveCanonicalEngine('@qvac/llm-llamacpp') // "llamacpp-completion"
+const addon = getAddonFromEngine('llamacpp-completion') // "llm"
 ```
 
 ---
@@ -4364,9 +4369,9 @@ The RAG system has been restructured for better control and flexibility. The mai
 ```typescript
 await ragSaveEmbeddings({
   modelId,
-  documents: ["Doc 1", "Doc 2"],
-  chunk: false,
-});
+  documents: ['Doc 1', 'Doc 2'],
+  chunk: false
+})
 ```
 
 **After:**
@@ -4387,6 +4392,7 @@ await ragSaveEmbeddings({
 ```
 
 Other RAG changes:
+
 - `ragSaveEmbeddings` no longer returns `droppedIndices`
 - `ragDeleteEmbeddings` now returns `void` instead of `boolean` (throws on failure)
 - `ragDeleteEmbeddings` no longer requires `modelId` (uses cached workspace)
@@ -4400,35 +4406,35 @@ No more string-based config! Use typed properties for embedding model configurat
 
 ```typescript
 await loadModel({
-  modelSrc: "embed-model.gguf",
-  modelType: "embeddings",
+  modelSrc: 'embed-model.gguf',
+  modelType: 'embeddings',
   modelConfig: {
-    config: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
-  },
-});
+    config: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
+  }
+})
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelSrc: "embed-model.gguf",
-  modelType: "embeddings",
+  modelSrc: 'embed-model.gguf',
+  modelType: 'embeddings',
   modelConfig: {
     gpuLayers: 99,
-    device: "gpu",
-    batchSize: 1024,
-  },
-});
+    device: 'gpu',
+    batchSize: 1024
+  }
+})
 
 // Escape hatch for advanced CLI control
 await loadModel({
-  modelSrc: "embed-model.gguf",
-  modelType: "embeddings",
+  modelSrc: 'embed-model.gguf',
+  modelType: 'embeddings',
   modelConfig: {
-    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
-  },
-});
+    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
+  }
+})
 ```
 
 ### Translation Engine Must Be Specified
@@ -4440,9 +4446,9 @@ Loading translation models now requires an explicit `engine` field for type-safe
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: "nmt",
-  modelConfig: { from: "en", to: "it" },
-});
+  modelType: 'nmt',
+  modelConfig: { from: 'en', to: 'it' }
+})
 ```
 
 **After:**
@@ -4450,13 +4456,13 @@ const modelId = await loadModel({
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: "nmt",
+  modelType: 'nmt',
   modelConfig: {
-    engine: "Opus",  // Required: "Opus" | "Bergamot" | "IndicTrans"
-    from: "en",
-    to: "it",
-  },
-});
+    engine: 'Opus', // Required: "Opus" | "Bergamot" | "IndicTrans"
+    from: 'en',
+    to: 'it'
+  }
+})
 ```
 
 ---
@@ -4468,28 +4474,28 @@ const modelId = await loadModel({
 A new translation engine option with support for batch translation and automatic vocabulary file derivation.
 
 ```typescript
-import { loadModel, translate, BERGAMOT_ENFR } from "@qvac/sdk";
+import { loadModel, translate, BERGAMOT_ENFR } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: BERGAMOT_ENFR,
-  modelType: "nmt",
+  modelType: 'nmt',
   modelConfig: {
-    engine: "Bergamot",
-    from: "en",
-    to: "fr",
-    normalize: 1,  // Bergamot-specific option
-  },
-});
+    engine: 'Bergamot',
+    from: 'en',
+    to: 'fr',
+    normalize: 1 // Bergamot-specific option
+  }
+})
 
 // Batch translation
 const result = translate({
   modelId,
-  text: ["Hello world", "How are you?"],
-  modelType: "nmt",
-  stream: false,
-});
+  text: ['Hello world', 'How are you?'],
+  modelType: 'nmt',
+  stream: false
+})
 
-const translated = await result.text;
+const translated = await result.text
 // "Bonjour le monde\nComment allez-vous?"
 ```
 
@@ -4506,23 +4512,23 @@ The SDK now uses import maps internally, improving compatibility across Node.js,
 Extract text from images with bounding boxes and confidence scores.
 
 ```typescript
-import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from "@qvac/sdk";
+import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from '@qvac/sdk'
 
 const modelId = await loadModel({
   modelSrc: OCR_CRAFT_LATIN_RECOGNIZER,
-  modelType: "ocr",
-  modelConfig: { langList: ["en"] },
-});
+  modelType: 'ocr',
+  modelConfig: { langList: ['en'] }
+})
 
 // Get all text blocks at once
-const { blocks, done } = ocr({ modelId, image: "/path/to/image.png" });
-const result = await blocks;
-await done;
+const { blocks, done } = ocr({ modelId, image: '/path/to/image.png' })
+const result = await blocks
+await done
 
 // Or stream blocks as they're detected
-const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true });
+const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true })
 for await (const blocks of blockStream) {
-  console.log(blocks);
+  console.log(blocks)
   // [{ text: "Hello", bbox: [10, 20, 100, 50], confidence: 0.95 }]
 }
 ```
@@ -4534,15 +4540,15 @@ Load large models split across multiple files, from URLs or archives.
 ```typescript
 // Pattern-based sharded URLs (auto-detects shard pattern)
 await loadModel({
-  modelSrc: "https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf",
-  modelType: "llm",
-});
+  modelSrc: 'https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf',
+  modelType: 'llm'
+})
 
 // Archive-based shards (.tar.gz, .tar, .tgz)
 await loadModel({
-  modelSrc: "https://huggingface.co/user/model/resolve/main/model.tar.gz",
-  modelType: "llm",
-});
+  modelSrc: 'https://huggingface.co/user/model/resolve/main/model.tar.gz',
+  modelType: 'llm'
+})
 ```
 
 ### Device-Specific Model Configuration
@@ -4619,13 +4625,13 @@ The SDK now uses a config file instead of the `setConfig()` API. This simplifies
 **Before:**
 
 ```typescript
-import { setConfig, loadModel } from "@qvac/sdk";
+import { setConfig, loadModel } from '@qvac/sdk'
 
 await setConfig({
-  cacheDirectory: "/custom/cache/path",
-});
+  cacheDirectory: '/custom/cache/path'
+})
 
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
 ```
 
 **After:**
@@ -4639,10 +4645,10 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
 ```
 
 ```typescript
-import { loadModel } from "@qvac/sdk";
+import { loadModel } from '@qvac/sdk'
 
 // Config automatically loaded at initialization!
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
 ```
 
 #### Config Resolution Order
@@ -4655,31 +4661,31 @@ The SDK searches for configuration in this order:
 
 #### Supported Formats
 
-| Format     | Filename           | Notes                        |
-| ---------- | ------------------ | ---------------------------- |
-| JSON       | `qvac.config.json` | Simplest option              |
-| JavaScript | `qvac.config.js`   | Use `export default`         |
+| Format     | Filename           | Notes                         |
+| ---------- | ------------------ | ----------------------------- |
+| JSON       | `qvac.config.json` | Simplest option               |
+| JavaScript | `qvac.config.js`   | Use `export default`          |
 | TypeScript | `qvac.config.ts`   | Fully typed with `QvacConfig` |
 
 **TypeScript example:**
 
 ```typescript
 // qvac.config.ts
-import type { QvacConfig } from "@qvac/sdk";
+import type { QvacConfig } from '@qvac/sdk'
 
 const config: QvacConfig = {
-  cacheDirectory: "/custom/cache/path",
-  swarmRelays: ["relay-key-1", "relay-key-2"],
-};
+  cacheDirectory: '/custom/cache/path',
+  swarmRelays: ['relay-key-1', 'relay-key-2']
+}
 
-export default config;
+export default config
 ```
 
 #### Migration Steps
 
 1. Remove all `setConfig()` calls from your code
 2. Create a config file in your project root
-3. *(Optional)* For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
+3. _(Optional)_ For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
 
 ---
 
@@ -4689,14 +4695,14 @@ Some model constants have been renamed for clarity, and duplicate constants have
 
 **Changes:**
 
-| Before                     | After                                             |
-| -------------------------- | ------------------------------------------------- |
-| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                                |
-| `WHISPER_NORWEGIAN_TINY_1` | *(removed — use `WHISPER_NORWEGIAN_TINY`)*        |
-| `WHISPER_TINY_SILERO`      | *(removed — use `WHISPER_TINY`)*                  |
-| `MARIAN_OPUS_EN_FR_Q4_0_1` | *(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)*        |
-| `MARIAN_OPUS_FR_EN_Q4_0_1` | *(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)*        |
-| `MARIAN_OPUS_IT_EN`        | *(removed — use `MARIAN_OPUS_EN_IT`)*             |
+| Before                     | After                                      |
+| -------------------------- | ------------------------------------------ |
+| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                         |
+| `WHISPER_NORWEGIAN_TINY_1` | _(removed — use `WHISPER_NORWEGIAN_TINY`)_ |
+| `WHISPER_TINY_SILERO`      | _(removed — use `WHISPER_TINY`)_           |
+| `MARIAN_OPUS_EN_FR_Q4_0_1` | _(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)_ |
+| `MARIAN_OPUS_FR_EN_Q4_0_1` | _(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)_ |
+| `MARIAN_OPUS_IT_EN`        | _(removed — use `MARIAN_OPUS_EN_IT`)_      |
 
 All model metadata and hyperdrive keys remain unchanged—only the constant names were affected.
 
@@ -4712,7 +4718,7 @@ The logging stream API has been simplified with consistent naming.
 
 ```typescript
 for await (const log of loggingStream({ modelId: myModelId })) {
-  console.log(log.message);
+  console.log(log.message)
 }
 ```
 
@@ -4720,7 +4726,7 @@ for await (const log of loggingStream({ modelId: myModelId })) {
 
 ```typescript
 for await (const log of loggingStream({ id: myModelId })) {
-  console.log(log.message);
+  console.log(log.message)
 }
 ```
 
@@ -4751,17 +4757,17 @@ You can now update a model's configuration without unloading it. Pass the existi
 ```typescript
 // Load model with initial config
 const modelId = await loadModel({
-  modelSrc: "pear://.../whisper.gguf",
-  modelType: "whisper",
-  modelConfig: { language: "en" },
-});
+  modelSrc: 'pear://.../whisper.gguf',
+  modelType: 'whisper',
+  modelConfig: { language: 'en' }
+})
 
 // Hot-reload with new config (same modelId, no reload delay)
 await loadModel({
   modelId,
-  modelType: "whisper",
-  modelConfig: { language: "es" },
-});
+  modelType: 'whisper',
+  modelConfig: { language: 'es' }
+})
 ```
 
 ---
@@ -4773,51 +4779,51 @@ The SDK now supports the Model Context Protocol (MCP) for tool integration. Pass
 **Using MCP clients:**
 
 ```typescript
-import { completion } from "@qvac/sdk";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { completion } from '@qvac/sdk'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 
 // Create and connect your MCP client
-const mcpClient = new Client({ name: "my-app", version: "1.0.0" });
-await mcpClient.connect(transport);
+const mcpClient = new Client({ name: 'my-app', version: '1.0.0' })
+await mcpClient.connect(transport)
 
 // Pass MCP clients to completion
 const result = completion({
   modelId,
   history,
-  mcp: [{ client: mcpClient }],
-});
+  mcp: [{ client: mcpClient }]
+})
 
 // Execute tool calls
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call();
+  const response = await toolCall.call()
 }
 
 // Clean up when done
-await mcpClient.close();
+await mcpClient.close()
 ```
 
 **Using inline tools with handlers:**
 
 ```typescript
-import { z } from "zod";
+import { z } from 'zod'
 
 const result = completion({
   modelId,
   history,
   tools: [
     {
-      name: "get_weather",
-      description: "Get weather for a city",
+      name: 'get_weather',
+      description: 'Get weather for a city',
       parameters: z.object({ city: z.string() }),
       handler: async (args) => {
-        return await fetchWeather(args.city);
-      },
-    },
-  ],
-});
+        return await fetchWeather(args.city)
+      }
+    }
+  ]
+})
 
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call(); // Executes your handler
+  const response = await toolCall.call() // Executes your handler
 }
 ```
 
@@ -4829,10 +4835,10 @@ The `embed()` function now accepts arrays, enabling efficient batch processing. 
 
 ```typescript
 // Single text → returns number[]
-const embedding = await embed({ modelId, text: "hello" });
+const embedding = await embed({ modelId, text: 'hello' })
 
 // Batch texts → returns number[][]
-const embeddings = await embed({ modelId, text: ["a", "b", "c"] });
+const embeddings = await embed({ modelId, text: ['a', 'b', 'c'] })
 ```
 
 Batch processing uses a default batch size of 1024 for optimal throughput.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,78 @@
 # Changelog
 
+## [0.19.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.19.1
+
+QVAC SDK 0.19.1 is a patch on the 0.19 line. Completion stats now report prompt-processing throughput, `deleteCache({ auto: true })` reclaims automatic KV caches without touching named ones, and `assessModelFit` can refuse a model from a computed floor when no calibration applies. Mobile `withQvacSDK` bundles no longer pull in the desktop-only fit subprocess, and `@qvac/rag` `^0.8.1` is the floor so Windows TurboVec installs the fixed package.
+
+`@qvac/sdk`, `@qvac/inference`, and `tetherto-qvac-sdk` all ship at 0.19.1. Install `@qvac/sdk` and `@qvac/inference` together at this version.
+
+## New APIs
+
+### Prompt-processing throughput
+
+`CompletionStats.promptTokensPerSecond` is the addon's prefill (prompt-processing) rate. `tokensPerSecond` remains decode throughput. Both fields are optional; they appear on `completionStats` events and on the aggregated `final.stats` for single and batch completions. The Python client models include the same field.
+
+```typescript
+const run = completion({ modelId, history, stream: true })
+const stats = await run.stats
+
+stats?.tokensPerSecond // decode throughput
+stats?.promptTokensPerSecond // prompt-processing (prefill) throughput
+```
+
+### Reclaim automatic KV caches
+
+`deleteCache({ auto: true })` drops every automatic cache that no in-flight turn is holding. Named, caller-owned caches are left alone. `{ all: true }` still deletes everything, including named caches.
+
+```typescript
+import { deleteCache } from '@qvac/sdk'
+
+await deleteCache({ auto: true })
+```
+
+### Computed floor when no calibration applies
+
+On platforms without a calibration fixture, `assessModelFit` used to return `unknown` even when the artifact plus KV cache already exceeded the budget. It now falls back to a computed floor (artifact bytes plus the llama.cpp KV cache at the narrowest default width). Over budget is `likely-too-large`; otherwise the verdict stays `unknown`. This path never returns `likely-fits`.
+
+Android compares the floor to the `system-memory` budget. iOS compares it to the `process-memory` budget, which now uses the per-process allowance from `bare-os`. Discrete GPUs without coefficients stay `unknown`.
+
+New result fields: `evidence` (`calibration` | `computed-only`) and `floorBytes`.
+
+```typescript
+import { assessModelFit, QWEN3_8B_INST_Q4_K_M } from '@qvac/sdk'
+
+const result = await assessModelFit({
+  models: [
+    {
+      model: QWEN3_8B_INST_Q4_K_M,
+      workload: { kind: 'llm', contextTokens: 8192 }
+    }
+  ]
+})
+
+result.verdict // "likely-fits" | "likely-too-large" | "unknown"
+result.evidence // "calibration" | "computed-only"
+result.floorBytes
+
+if (result.evidence === "computed-only" && result.verdict === "unknown") {
+  // uncalibrated, not a near-miss
+}
+```
+
+The assess-model-fit doc now includes a platform support matrix and a table of every `unknown` reason.
+
+## Features
+
+iOS `sample.memory.processAvailableBytes` is sourced from `bare-os` `availableMemory()` so the `process-memory` budget can form. Other platforms leave that metric unavailable.
+
+## Bug Fixes
+
+`withQvacSDK` mobile bundles defer `bare-runtime/spawn` and `@qvac/model-fit/process`, so expo prebuild no longer fails looking for a `bare-posix` android-arm64 prebuild that does not exist. Desktop advisory fit is unchanged.
+
+`@qvac/inference` now requires `@qvac/rag` `^0.8.1`. 0.8.0 could not open a TurboVec workspace on Windows.
+
 ## [0.19.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.19.0
@@ -311,25 +384,25 @@ QVAC SDK 0.18.0 adds VisionPsy Nano multimodal constants, Audio8 and CosyVoice3 
 **Before:**
 
 ```typescript
-import { loadModel, TOOLS_MODE } from '@qvac/sdk'
+import { loadModel, TOOLS_MODE } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic }
-})
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, tools: true, toolsMode: TOOLS_MODE.dynamic },
+});
 ```
 
 **After:**
 
 ```typescript
-import { loadModel } from '@qvac/sdk'
+import { loadModel } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, tools: true }
-})
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, tools: true },
+});
 ```
 
 Existing automatic KV-cache prefixes that were primed under dynamic tools mode are not reusable; the next turn rebuilds the prefix.
@@ -341,13 +414,13 @@ Existing automatic KV-cache prefixes that were primed under dynamic tools mode a
 **Before:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: 'very fast' })
+textToSpeech({ modelId, text, pace: "very fast" });
 ```
 
 **After:**
 
 ```typescript
-textToSpeech({ modelId, text, pace: 'fast' })
+textToSpeech({ modelId, text, pace: "fast" });
 ```
 
 ## New APIs
@@ -357,10 +430,12 @@ textToSpeech({ modelId, text, pace: 'fast' })
 One loaded LLM can run several `completion` calls at once. A new request takes a free slot without waiting for the whole batch to drain. Cancelling one request leaves the others running, and each result reports its own timings. Single-slot models and fine-tuning stay one-at-a-time.
 
 ```typescript
-const runs = prompts.map((p) => completion({ modelId, history: p, stream: true }))
-const outputs = await Promise.all(runs.map((r) => r.final))
+const runs = prompts.map((p) =>
+  completion({ modelId, history: p, stream: true }),
+);
+const outputs = await Promise.all(runs.map((r) => r.final));
 
-await cancel({ requestId: runs[0].requestId })
+await cancel({ requestId: runs[0].requestId });
 ```
 
 ### loadModel fallbackSrc
@@ -368,12 +443,12 @@ await cancel({ requestId: runs[0].requestId })
 If the primary `modelSrc` cannot be fetched, `loadModel` retries from `fallbackSrc` (URL or local path) so callers do not have to build their own origin failover.
 
 ```typescript
-import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
+import { loadModel, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  fallbackSrc: 'https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf'
-})
+  fallbackSrc: "https://mirror.example.com/llama-3.2-1b-instruct-q4_0.gguf",
+});
 ```
 
 ### AudioGen Cover From a Source Track
@@ -383,14 +458,14 @@ AudioGen can now generate a cover from source audio, not only a text caption. Pa
 ```typescript
 const cover = audioGen({
   modelId,
-  caption: 'orchestral arrangement with dramatic strings',
-  lyrics: '[Instrumental]',
-  taskType: 'cover-nofsq',
-  sourceAudio: '/path/to/source.wav',
-  referenceAudio: '/path/to/reference.mp3',
+  caption: "orchestral arrangement with dramatic strings",
+  lyrics: "[Instrumental]",
+  taskType: "cover-nofsq",
+  sourceAudio: "/path/to/source.wav",
+  referenceAudio: "/path/to/reference.mp3",
   audioCoverStrength: 1,
-  coverNoiseStrength: 0.75
-})
+  coverNoiseStrength: 0.75,
+});
 ```
 
 ### CosyVoice3 TTS
@@ -401,17 +476,17 @@ Load CosyVoice3 with `ttsEngine: "cosyvoice3"`. Companion files download with th
 const modelId = await loadModel({
   modelSrc: TTS_COSYVOICE3_LLM_COSYVOICE_Q8_0,
   modelConfig: {
-    ttsEngine: 'cosyvoice3',
-    instruct: { dialect: 'cantonese' },
-    seed: 42
-  }
-})
+    ttsEngine: "cosyvoice3",
+    instruct: { dialect: "cantonese" },
+    seed: 42,
+  },
+});
 const result = textToSpeech({
   modelId,
-  text: 'Hey there!',
+  text: "Hey there!",
   stream: false,
-  emotion: 'happy'
-})
+  emotion: "happy",
+});
 ```
 
 ### Audio8 TTS
@@ -422,13 +497,13 @@ Audio8 is a multilingual LM + codec stack with optional zero-shot cloning via re
 await loadModel({
   modelSrc: TTS_LM_MULTILINGUAL_AUDIO8_Q8_0,
   modelConfig: {
-    ttsEngine: 'audio8',
+    ttsEngine: "audio8",
     audio8CodecDecoderModelSrc: TTS_CODEC_DECODER_AUDIO8_Q8_0,
     audio8CodecEncoderModelSrc: TTS_CODEC_ENCODER_AUDIO8_Q8_0,
-    referenceAudioSrc: 'file:///path/to/voice.wav',
-    referenceText: 'Exactly what the recording says.'
-  }
-})
+    referenceAudioSrc: "file:///path/to/voice.wav",
+    referenceText: "Exactly what the recording says.",
+  },
+});
 ```
 
 ### Streaming Transcription Stats
@@ -436,12 +511,12 @@ await loadModel({
 `transcribeStream` sessions now expose `stats` after the stream ends (`audioDuration`, `realTimeFactor`).
 
 ```typescript
-const session = await transcribeStream({ modelId })
+const session = await transcribeStream({ modelId });
 for await (const event of session) {
   // streamed events
 }
-const stats = await session.stats
-console.log(stats?.audioDuration, stats?.realTimeFactor)
+const stats = await session.stats;
+console.log(stats?.audioDuration, stats?.realTimeFactor);
 ```
 
 ### Vision image_no_upscale
@@ -450,13 +525,13 @@ VisionPsy (and other llama.cpp multimodal loads) can set `image_no_upscale: "on"
 
 ```typescript
 await loadModel({
-  modelType: 'llm',
+  modelType: "llm",
   modelSrc: VISIONPSY_NANO_460M_MULTIMODAL_Q4_K_M,
   modelConfig: {
     projectionModelSrc: MMPROJ_VISIONPSY_NANO_460M_MULTIMODAL_Q8_0,
-    image_no_upscale: 'on'
-  }
-})
+    image_no_upscale: "on",
+  },
+});
 ```
 
 ## Features
@@ -858,13 +933,13 @@ Image generation now supports Ideogram 4 through the `sdcpp-generation` model ty
 ```typescript
 const modelId = await loadModel({
   modelSrc: IDEOGRAM_MODEL_URL,
-  modelType: 'sdcpp-generation',
+  modelType: "sdcpp-generation",
   modelConfig: {
     llmModelSrc: QWEN3_VL_MODEL_URL,
     vaeModelSrc: VAE_MODEL_URL,
-    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL
-  }
-})
+    uncondModelSrc: IDEOGRAM_UNCOND_MODEL_URL,
+  },
+});
 ```
 
 ### Per-Phase Diffusion Timing Stats
@@ -872,12 +947,12 @@ const modelId = await loadModel({
 Diffusion results now include a per-phase timing breakdown, so you can see where generation time goes — conditioning, the denoising loop, VAE decode, post-processing, and overall throughput.
 
 ```typescript
-const { stats } = await result
-console.log(stats.conditionerMs) // prompt conditioning time (ms)
-console.log(stats.denoiseMs) // denoising loop time (ms)
-console.log(stats.vaeMs) // VAE decode time (ms)
-console.log(stats.postProcessMs) // encode/upscale/mux time (ms)
-console.log(stats.stepsPerSecond) // denoising throughput (steps/s)
+const { stats } = await result;
+console.log(stats.conditionerMs); // prompt conditioning time (ms)
+console.log(stats.denoiseMs); // denoising loop time (ms)
+console.log(stats.vaeMs); // VAE decode time (ms)
+console.log(stats.postProcessMs); // encode/upscale/mux time (ms)
+console.log(stats.stepsPerSecond); // denoising throughput (steps/s)
 ```
 
 ### Python SDK Client
@@ -908,19 +983,19 @@ async with Client() as client:
 The VLA SDK now exposes GR00T as a first-class model, including its registry entry, hyperparameters, and helpers. GR00T uses a patch-based image input mode: when `hparams.imageInputMode` is `"patches"`, each camera image is supplied as a pre-patchified float buffer. A runnable usage example and desktop e2e ship alongside it.
 
 ```typescript
-import { loadModel, vlaHparams, vla, vlaPadState } from '@qvac/sdk'
+import { loadModel, vlaHparams, vla, vlaPadState } from "@qvac/sdk";
 
-const modelId = await loadModel({ modelSrc, modelType: 'ggml-vla' })
-const { hparams } = await vlaHparams({ modelId })
+const modelId = await loadModel({ modelSrc, modelType: "ggml-vla" });
+const { hparams } = await vlaHparams({ modelId });
 
-if (hparams.imageInputMode === 'patches') {
+if (hparams.imageInputMode === "patches") {
   // GR00T: each images[] entry is a pre-patchified buffer of imagePatchElems floats
   const images = Array.from(
     { length: hparams.numCameras },
-    () => new Float32Array(hparams.imagePatchElems)
-  )
-  const state = vlaPadState(robotState, hparams.maxStateDim)
-  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim)
+    () => new Float32Array(hparams.imagePatchElems),
+  );
+  const state = vlaPadState(robotState, hparams.maxStateDim);
+  const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim);
 
   const { actions, actionDim, chunkSize } = await vla({
     modelId,
@@ -930,8 +1005,8 @@ if (hparams.imageInputMode === 'patches') {
     state,
     tokens, // Qwen3-VL tokens, length hparams.tokenizerMaxLength
     mask,
-    noise
-  })
+    noise,
+  });
 }
 ```
 
@@ -1074,37 +1149,41 @@ QVAC SDK 0.15.0 introduces single-job batch completion for running many prompts 
 `batchCompletion` runs many prompts through a single loaded model in one job, streaming per-prompt deltas and returning ordered results. Each prompt can carry its own history, generation parameters, and optional per-prompt tools or MCP-sourced tools.
 
 ```typescript
-import { batchCompletion, loadModel, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
+import {
+  batchCompletion,
+  loadModel,
+  LLAMA_3_2_1B_INST_Q4_0,
+} from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, parallel: 4 }
-})
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, parallel: 4 },
+});
 
 const run = batchCompletion({
   modelId,
   prompts: [
     {
-      id: 'a',
-      history: [{ role: 'user', content: 'Reply with only APPLE.' }],
-      generationParams: { temp: 0, predict: 16 }
+      id: "a",
+      history: [{ role: "user", content: "Reply with only APPLE." }],
+      generationParams: { temp: 0, predict: 16 },
     },
     {
-      id: 'b',
-      history: [{ role: 'user', content: "What's the weather in Paris?" }],
+      id: "b",
+      history: [{ role: "user", content: "What's the weather in Paris?" }],
       tools: [getWeatherTool], // optional per-prompt tools
-      generationParams: { temp: 0, predict: 64 }
-    }
-  ]
-})
+      generationParams: { temp: 0, predict: 64 },
+    },
+  ],
+});
 
 for await (const { id, event } of run.events) {
-  if (event.type === 'contentDelta') process.stdout.write(`[${id}] ${event.text}`)
+  if (event.type === "contentDelta") process.stdout.write(`[${id}] ${event.text}`);
 }
 
-const results = await run.results // ordered, all-or-nothing on stream-level failure
-const stats = await run.stats // batch-level CompletionStats | undefined
+const results = await run.results; // ordered, all-or-nothing on stream-level failure
+const stats = await run.stats; // batch-level CompletionStats | undefined
 ```
 
 ### GPU Placement for Multimodal Vision Encoders
@@ -1116,9 +1195,9 @@ await loadModel({
   modelSrc: SMOLVLM2_500M_MULTIMODAL_Q8_0,
   modelConfig: {
     projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
-    'mmproj-use-gpu': true // true = GPU, false = CPU; omit to auto-select
-  }
-})
+    "mmproj-use-gpu": true, // true = GPU, false = CPU; omit to auto-select
+  },
+});
 ```
 
 ## Features
@@ -1129,14 +1208,14 @@ Supertonic TTS gains optional LavaSR post-processing: an enhancer and a denoiser
 
 ```typescript
 await sdk.loadModel({
-  ttsEngine: 'supertonic',
+  ttsEngine: "supertonic",
   modelSrc: TTS_MULTILINGUAL_SUPERTONIC3_Q8_0.src,
   // LavaSR post-processing (both optional)
   lavasrDenoiserModelSrc: TTS_DENOISER_LAVASR_FP16.src,
   lavasrEnhancerModelSrc: TTS_ENHANCER_LAVASR_FP16.src,
   // Supertonic-only output sample rate (8000-192000 Hz)
-  outputSampleRate: 48000
-})
+  outputSampleRate: 48000,
+});
 ```
 
 ### Japanese and Chinese Chatterbox TTS
@@ -1149,30 +1228,30 @@ import {
   TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
   TTS_MECAB_IPADIC_CHATTERBOX,
-  TTS_CANGJIE_ZH_CHATTERBOX
-} from '@qvac/sdk'
+  TTS_CANGJIE_ZH_CHATTERBOX,
+} from "@qvac/sdk";
 
 // Japanese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'ja',
+    ttsEngine: "chatterbox",
+    language: "ja",
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX
-  }
-})
+    mecabDictSrc: TTS_MECAB_IPADIC_CHATTERBOX,
+  },
+});
 
 // Chinese
 await loadModel({
   modelSrc: TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0,
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'zh',
+    ttsEngine: "chatterbox",
+    language: "zh",
     s3genModelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX_Q4_0,
-    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX
-  }
-})
+    cangjieTsvSrc: TTS_CANGJIE_ZH_CHATTERBOX,
+  },
+});
 ```
 
 ## Bug Fixes
@@ -1234,7 +1313,7 @@ The SDK and its native backends (llama.cpp / ggml) no longer print to the consol
 
 ```typescript
 // SDK and native logs printed to the console by default.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
 // → console fills with SDK + native output
 ```
 
@@ -1242,7 +1321,7 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
 
 ```typescript
 // Silent by default — no console output.
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0 });
 
 // Opt in:
 //   qvac.config.json → { "loggerConsoleOutput": true }                          // SDK logs
@@ -1258,14 +1337,14 @@ The bundled `bare-process` shim has been removed in favor of Bare primitives. Co
 
 ```typescript
 // process available as a global
-process.exit(0)
+process.exit(0);
 ```
 
 **After:**
 
 ```typescript
-import process from 'bare-process'
-process.exit(0)
+import process from "bare-process";
+process.exit(0);
 ```
 
 ### OCR Now Runs on GGML
@@ -1279,14 +1358,14 @@ The SDK's OCR path moves from ONNX to GGML-OCR 0.4.0. The legacy ONNX OCR model 
 `subscribeServerLogs` registers a single handler that receives all server-side logs, removing the need for per-ID `loggingStream()` calls.
 
 ```typescript
-import { subscribeServerLogs } from '@qvac/sdk'
+import { subscribeServerLogs } from "@qvac/sdk";
 
 const unsubscribe = subscribeServerLogs((log) => {
-  console.log(`[${log.level}] [${log.namespace}] ${log.message}`)
-})
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
+});
 
 // later
-unsubscribe()
+unsubscribe();
 ```
 
 ### Field-Level Validation Errors
@@ -1294,13 +1373,13 @@ unsubscribe()
 Invalid input now produces readable, field-level errors instead of opaque failures. A `RequestValidationFailedError` carries a message that points at the offending field.
 
 ```typescript
-import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk'
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
 
 try {
-  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } })
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
 } catch (err) {
   if (err instanceof RequestValidationFailedError) {
-    console.error(err.message)
+    console.error(err.message);
     // Invalid request:
     // ✖ Unrecognized key: "dtx_size"
     //   → at modelConfig
@@ -1315,20 +1394,20 @@ Completions can now cap or disable the reasoning channel per request or at load 
 ```typescript
 // Per-request: cap the reasoning channel at 128 tokens for a single run()
 await session.run({
-  history: [{ role: 'user', content: 'Solve this step by step' }],
-  reasoning_budget: 128 // -1 = unrestricted, 0 = disabled, N = cap at N tokens
-})
+  history: [{ role: "user", content: "Solve this step by step" }],
+  reasoning_budget: 128, // -1 = unrestricted, 0 = disabled, N = cap at N tokens
+});
 
 // Load-time default
-await loadModel(src, { reasoning_budget: 256 })
+await loadModel(src, { reasoning_budget: 256 });
 ```
 
 ```typescript
 // Drop this turn's reasoning block from the KV cache after generation
 await model.completion({
   history,
-  generationParams: { remove_thinking_from_context: true }
-})
+  generationParams: { remove_thinking_from_context: true },
+});
 ```
 
 The same `remove_thinking_from_context` flag is accepted on the CLI's OpenAI-compatible `/v1/chat/completions` request body.
@@ -1340,9 +1419,9 @@ A new `image_tile_mode` config controls how multimodal images are tiled before i
 ```typescript
 await loadModel({
   modelSrc: QWEN3_5_VL_MODEL,
-  modelType: 'llamacpp-completion',
-  modelConfig: { image_tile_mode: 'sequential' } // "disabled" | "batched" | "sequential" (default: "sequential")
-})
+  modelType: "llamacpp-completion",
+  modelConfig: { image_tile_mode: "sequential" }, // "disabled" | "batched" | "sequential" (default: "sequential")
+});
 ```
 
 ### Per-Engine TTS Language Validation and More Languages
@@ -1354,24 +1433,24 @@ import {
   TTS_CHATTERBOX_LANGUAGES,
   TTS_SUPERTONIC_LANGUAGES,
   type TtsChatterboxLanguage,
-  type TtsSupertonicLanguage
-} from '@qvac/sdk'
+  type TtsSupertonicLanguage,
+} from "@qvac/sdk";
 
 await loadModel({
   modelSrc: TTS_T3_TURBO_EN_CHATTERBOX_Q8_0,
-  modelType: 'tts-ggml',
+  modelType: "tts-ggml",
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'en',
+    ttsEngine: "chatterbox",
+    language: "en",
     s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX.src,
     streamChunkTokens: 25,
     streamFirstChunkTokens: 10,
     cfmSteps: 1,
     threads: 8,
     nGpuLayers: 99,
-    seed: 42
-  }
-})
+    seed: 42,
+  },
+});
 ```
 
 ### Parakeet 0.8 Runtime Fields and Explicit BCI Embedder Loading
@@ -1383,10 +1462,10 @@ const modelId = await loadModel({
   modelSrc: BCI_WINDOWED,
   modelConfig: {
     embedderModelSrc: BCI_EMBEDDER,
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    bciConfig: { day_idx: 1 }
-  }
-})
+    whisperConfig: { language: "en", temperature: 0.0 },
+    bciConfig: { day_idx: 1 },
+  },
+});
 ```
 
 ## Bug Fixes
@@ -1563,20 +1642,20 @@ QVAC SDK 0.13.0 broadens the SDK across video, neural-signal transcription, robo
 The video API now supports image-to-video generation for Wan image-to-video pipelines. Consumers can provide an initial frame through `init_image` and control denoising with `strength`, making it possible to animate a source image instead of generating entirely from text.
 
 ```typescript
-import fs from 'node:fs'
-import { video } from '@qvac/sdk'
+import fs from "node:fs";
+import { video } from "@qvac/sdk";
 
-const firstFrame = fs.readFileSync('portrait.png')
+const firstFrame = fs.readFileSync("portrait.png");
 const { outputs } = video({
   modelId,
-  mode: 'img2vid',
-  prompt: 'the subject slowly turns and smiles, cinematic lighting',
+  mode: "img2vid",
+  prompt: "the subject slowly turns and smiles, cinematic lighting",
   init_image: firstFrame,
-  strength: 0.85
-})
+  strength: 0.85,
+});
 
-const buffers = await outputs
-fs.writeFileSync('output.avi', buffers[0])
+const buffers = await outputs;
+fs.writeFileSync("output.avi", buffers[0]);
 ```
 
 This change also moves video dimension validation to the SDK schema boundary. Width and height now need to be multiples of 16, so invalid dimensions fail before they reach the native addon.
@@ -1584,13 +1663,13 @@ This change also moves video dimension validation to the SDK schema boundary. Wi
 **Before:**
 
 ```typescript
-video({ modelId, mode: 'txt2vid', prompt: '...', width: 520, height: 264 })
+video({ modelId, mode: "txt2vid", prompt: "...", width: 520, height: 264 });
 ```
 
 **After:**
 
 ```typescript
-video({ modelId, mode: 'txt2vid', prompt: '...', width: 528, height: 272 })
+video({ modelId, mode: "txt2vid", prompt: "...", width: 528, height: 272 });
 ```
 
 ## Worker Failures Are Now Typed SDK Errors
@@ -1598,15 +1677,15 @@ video({ modelId, mode: 'txt2vid', prompt: '...', width: 528, height: 272 })
 Bare worker crashes and SDK shutdown now surface as structured RPC errors instead of ambiguous failures. Applications can distinguish an unexpected worker death from an in-flight request that was cancelled because the SDK is closing.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
 
 try {
-  await sdk.embed({ modelId, text: 'hi' })
+  await sdk.embed({ modelId, text: "hi" });
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
-    console.error(err.exitCode, err.exitSignal)
+    console.error(err.exitCode, err.exitSignal);
   } else if (err instanceof WorkerShutdownError) {
-    console.error('The SDK closed while this request was in flight.')
+    console.error("The SDK closed while this request was in flight.");
   }
 }
 ```
@@ -1616,18 +1695,18 @@ try {
 The new Electron Forge plugin helps packaged desktop apps include only the native addon trees needed by their QVAC configuration. This reduces accidental bundling of unused prebuilds and keeps app packages closer to the target platform set.
 
 ```typescript
-const QvacForgePlugin = require('@qvac/sdk/electron-forge')
+const QvacForgePlugin = require("@qvac/sdk/electron-forge");
 
 module.exports = {
-  packagerConfig: { name: 'MyApp' },
+  packagerConfig: { name: "MyApp" },
   plugins: [
     new QvacForgePlugin({
-      configPath: './qvac.config.json',
-      hosts: ['darwin-arm64', 'darwin-x64'],
-      logLevel: 'info'
-    })
-  ]
-}
+      configPath: "./qvac.config.json",
+      hosts: ["darwin-arm64", "darwin-x64"],
+      logLevel: "info",
+    }),
+  ],
+};
 ```
 
 ## Completion and Transcription Metadata Are More Precise
@@ -1639,10 +1718,10 @@ Whisper transcription metadata now exposes backend and GPU stats in the final st
 ```typescript
 for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) {
   if (ev.done && ev.stats) {
-    console.log(ev.stats.backendDevice)
-    console.log(ev.stats.backendId)
-    console.log(ev.stats.gpuMemTotalMb)
-    console.log(ev.stats.gpuMemFreeMb)
+    console.log(ev.stats.backendDevice);
+    console.log(ev.stats.backendId);
+    console.log(ev.stats.gpuMemTotalMb);
+    console.log(ev.stats.gpuMemFreeMb);
   }
 }
 ```
@@ -1652,29 +1731,29 @@ for await (const ev of sdk.transcribe({ modelId, audioChunk, metadata: true })) 
 The SDK now includes BCI transcription backed by whisper.cpp. It supports both batch transcription from a `.bin` path or `Uint8Array`, and streaming duplex sessions over neural-signal chunks.
 
 ```typescript
-import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from '@qvac/sdk'
+import { loadModel, bciTranscribe, bciTranscribeStream, BCI_WINDOWED } from "@qvac/sdk";
 
-const modelId = await loadModel({ modelSrc: BCI_WINDOWED })
-const text = await bciTranscribe({ modelId, neuralData: './signal.bin' })
+const modelId = await loadModel({ modelSrc: BCI_WINDOWED });
+const text = await bciTranscribe({ modelId, neuralData: "./signal.bin" });
 
-const session = await bciTranscribeStream({ modelId, emit: 'delta' })
-session.write(chunk)
-session.end()
+const session = await bciTranscribeStream({ modelId, emit: "delta" });
+session.write(chunk);
+session.end();
 
 for await (const token of session) {
-  process.stdout.write(token)
+  process.stdout.write(token);
 }
 ```
 
 This release also integrates the pi05 VLA model path for robot-action inference. The VLA API can inspect model hparams, preprocess camera frames, and run action generation with the required image, token, mask, and noise inputs.
 
 ```typescript
-import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from '@qvac/sdk'
+import { loadModel, vla, vlaHparams, vlaPreprocessImage, PI05_BASE_Q_AGGRESSIVE } from "@qvac/sdk";
 
-const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: 'ggml-vla' })
-const { hparams } = await vlaHparams({ modelId })
-const size = hparams.visionImageSize
-const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }))
+const modelId = await loadModel({ modelSrc: PI05_BASE_Q_AGGRESSIVE, modelType: "ggml-vla" });
+const { hparams } = await vlaHparams({ modelId });
+const size = hparams.visionImageSize;
+const images = [cam0, cam1, cam2].map((px) => vlaPreprocessImage(px, w, h, { size }));
 
 const { actions } = await vla({
   modelId,
@@ -1684,8 +1763,8 @@ const { actions } = await vla({
   state: new Float32Array(0),
   tokens,
   mask,
-  noise
-})
+  noise,
+});
 ```
 
 ## Runtime Fixes and Dependency Cleanup
@@ -1737,9 +1816,9 @@ This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk
 React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
 
 ```typescript
-import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/sdk/models'
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
 // or on Bare-only clients:
-import { LLAMA_3_2_1B_INST_Q4_0 } from '@qvac/bare-sdk/models'
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
 ```
 
 ## Bug Fixes
@@ -1768,10 +1847,10 @@ v0.12.1 introduces two structured RPC errors that propagate from the worker brid
 - `WorkerShutdownError` — the SDK is shutting down (`sdk.close()` was called) while this request was still in flight. Safe to swallow on intentional teardown; surfaces an actionable label for callers who want to log it.
 
 ```typescript
-import { WorkerCrashedError, WorkerShutdownError } from '@qvac/sdk'
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
 
 try {
-  await sdk.embed({ modelId, text: 'hi' })
+  await sdk.embed({ modelId, text: "hi" });
 } catch (err) {
   if (err instanceof WorkerCrashedError) {
     // err.exitCode, err.exitSignal — worker died, decide whether to respawn.
@@ -1808,27 +1887,27 @@ The SDK TTS plugin now targets `@qvac/tts-ggml` instead of `@qvac/tts-onnx`. The
 ```typescript
 await loadModel({
   modelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
-  modelType: 'tts',
+  modelType: "tts",
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'en',
+    ttsEngine: "chatterbox",
+    language: "en",
     ttsSpeechEncoderSrc: TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX.src,
     ttsEmbedTokensSrc: TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX.src,
     ttsConditionalDecoderSrc: TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX.src,
-    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src
-  }
-})
+    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
+  },
+});
 ```
 
 **After:**
 
 ```typescript
-import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from '@qvac/sdk'
+import { TTS_S3GEN_MULTILINGUAL_CHATTERBOX } from "@qvac/sdk";
 
 await loadModel({
   modelSrc: TTS_S3GEN_MULTILINGUAL_CHATTERBOX,
-  modelType: 'tts'
-})
+  modelType: "tts",
+});
 ```
 
 New registry constants cover Chatterbox and Supertonic variants in GGUF form (`TTS_S3GEN_*`, `TTS_T3_*`, `TTS_*_SUPERTONIC_*`).
@@ -1841,26 +1920,26 @@ Building on the 0.11.0 single-file GGUF migration, Parakeet now targets `@qvac/t
 
 ```typescript
 await loadModel({
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'tdt',
+    modelType: "tdt",
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR
-  }
-})
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR,
+  },
+});
 ```
 
 **After:**
 
 ```typescript
-import { PARAKEET_TDT_0_6B_V3_Q8_0 } from '@qvac/sdk'
+import { PARAKEET_TDT_0_6B_V3_Q8_0 } from "@qvac/sdk";
 
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: 'parakeet'
-})
+  modelType: "parakeet",
+});
 ```
 
 ### `@qvac/bare-sdk` requires explicit plugin registration
@@ -1870,25 +1949,25 @@ Bare consumers that previously called `getRPC()` against the full `@qvac/sdk` wo
 **Before:**
 
 ```typescript
-import { getRPC } from '@qvac/sdk'
+import { getRPC } from "@qvac/sdk";
 
-const rpc = await getRPC()
-await rpc.loadModel({/* any built-in modelType works */})
+const rpc = await getRPC();
+await rpc.loadModel({ /* any built-in modelType works */ });
 ```
 
 **After:**
 
 ```typescript
-import { plugins } from '@qvac/bare-sdk'
-import { nmtPlugin } from '@qvac/bare-sdk/nmtcpp-translation/plugin'
-import { llmPlugin } from '@qvac/bare-sdk/llamacpp-completion/plugin'
+import { plugins } from "@qvac/bare-sdk";
+import { nmtPlugin } from "@qvac/bare-sdk/nmtcpp-translation/plugin";
+import { llmPlugin } from "@qvac/bare-sdk/llamacpp-completion/plugin";
 
-const sdk = plugins([nmtPlugin, llmPlugin])
+const sdk = plugins([nmtPlugin, llmPlugin]);
 
 await sdk.loadModel({
   modelSrc: BERGAMOT_EN_FR,
-  modelType: 'nmt'
-})
+  modelType: "nmt",
+});
 ```
 
 Install matching addon packages (`@qvac/translation-nmtcpp`, `@qvac/llm-llamacpp`, etc.) alongside `@qvac/bare-sdk`. `@qvac/sdk` remains the right choice for Node and Expo apps that want the full default worker.
@@ -1910,20 +1989,20 @@ import {
   vlaHparams,
   vlaPreprocessImage,
   vlaPadState,
-  SMOLVLA_LIBERO_VISION_Q8
-} from '@qvac/sdk'
+  SMOLVLA_LIBERO_VISION_Q8,
+} from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: SMOLVLA_LIBERO_VISION_Q8,
-  modelType: 'vla',
-  modelConfig: { backend: 'auto' }
-})
+  modelType: "vla",
+  modelConfig: { backend: "auto" },
+});
 
-const { hparams } = await vlaHparams({ modelId })
+const { hparams } = await vlaHparams({ modelId });
 const image = vlaPreprocessImage(pixels, width, height, {
-  size: hparams.visionImageSize
-})
-const state = vlaPadState(robotState, hparams.maxStateDim)
+  size: hparams.visionImageSize,
+});
+const state = vlaPadState(robotState, hparams.maxStateDim);
 
 const { actions, actionDim, chunkSize } = await vla({
   modelId,
@@ -1932,8 +2011,8 @@ const { actions, actionDim, chunkSize } = await vla({
   imgHeight: hparams.visionImageSize,
   state,
   tokens,
-  mask
-})
+  mask,
+});
 ```
 
 ### Image classification
@@ -1941,14 +2020,14 @@ const { actions, actionDim, chunkSize } = await vla({
 Classify JPEG/PNG buffers or raw RGB bytes with bundled MobileNetV3-Small or a custom GGUF:
 
 ```typescript
-import { loadModel, classify } from '@qvac/sdk'
+import { loadModel, classify } from "@qvac/sdk";
 
 const modelId = await loadModel({
-  modelType: 'classification',
-  modelConfig: { topK: 3 }
-})
+  modelType: "classification",
+  modelConfig: { topK: 3 },
+});
 
-const results = await classify({ modelId, image: jpegBytes })
+const results = await classify({ modelId, image: jpegBytes });
 // → [{ label: "food", confidence: 0.91 }, ...]
 ```
 
@@ -1957,24 +2036,24 @@ const results = await classify({ modelId, image: jpegBytes })
 Generate video frames from text prompts using WAN models:
 
 ```typescript
-import { video } from '@qvac/sdk'
+import { video } from "@qvac/sdk";
 
 const run = video({
   modelId,
-  mode: 'txt2vid',
-  prompt: 'a cat surfing a wave at sunset',
+  mode: "txt2vid",
+  prompt: "a cat surfing a wave at sunset",
   width: 480,
   height: 832,
   video_frames: 17,
   fps: 16,
-  steps: 20
-})
+  steps: 20,
+});
 
 for await (const tick of run.progressStream) {
-  console.log(`step ${tick.step}/${tick.totalSteps}`)
+  console.log(`step ${tick.step}/${tick.totalSteps}`);
 }
 
-const frames = await run.outputs
+const frames = await run.outputs;
 ```
 
 ### `@qvac/sdk/commands` for bundling and verification
@@ -1982,14 +2061,14 @@ const frames = await run.outputs
 Programmatic access to worker bundling and prebuild verification — the same primitives `qvac bundle` and `qvac verify bundle` use:
 
 ```typescript
-import { bundleSdk, verifyBundle } from '@qvac/sdk/commands'
+import { bundleSdk, verifyBundle } from "@qvac/sdk/commands";
 
-await bundleSdk({ projectRoot: process.cwd(), configPath: './qvac.config.json' })
+await bundleSdk({ projectRoot: process.cwd(), configPath: "./qvac.config.json" });
 await verifyBundle({
   projectRoot: process.cwd(),
-  addonsSource: './qvac/worker.bundle.js',
-  hosts: ['android-arm64', 'ios-arm64']
-})
+  addonsSource: "./qvac/worker.bundle.js",
+  hosts: ["android-arm64", "ios-arm64"],
+});
 ```
 
 ### RAG cancellation detection
@@ -1997,7 +2076,7 @@ await verifyBundle({
 Detect cancelled RAG operations without importing `@qvac/rag/errors`:
 
 ```typescript
-import { RAG_ERROR_CODES } from '@qvac/sdk'
+import { RAG_ERROR_CODES } from "@qvac/sdk";
 
 if (err.code === RAG_ERROR_CODES.OPERATION_CANCELLED) {
   // ingest was cancelled
@@ -2021,15 +2100,17 @@ Expo config plugins resolve `@qvac/sdk` from ancestor `node_modules` directories
 LLM completion now surfaces real input token counts in stats and throws a typed `ContextOverflowError` when the prompt exceeds the model context window — including across the Bare RPC boundary:
 
 ```typescript
-import { ContextOverflowError } from '@qvac/sdk'
+import { ContextOverflowError } from "@qvac/sdk";
 
-const run = sdk.completion({/* ... */})
+const run = sdk.completion({ /* ... */ });
 try {
-  const final = await run.final
-  console.log(final.stats?.promptTokens)
+  const final = await run.final;
+  console.log(final.stats?.promptTokens);
 } catch (err) {
   if (err instanceof ContextOverflowError) {
-    console.warn(`prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`)
+    console.warn(
+      `prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`,
+    );
   }
 }
 ```
@@ -2108,20 +2189,20 @@ override.
 **Before (Bare):**
 
 ```typescript
-import { unloadModel } from '@qvac/sdk'
+import { unloadModel } from "@qvac/sdk";
 
-await unloadModel({ modelId })
+await unloadModel({ modelId });
 // RPC connection closed → Bare worker host terminated.
 ```
 
 **After (Bare):**
 
 ```typescript
-import { unloadModel } from '@qvac/sdk'
+import { unloadModel } from "@qvac/sdk";
 
-await unloadModel({ modelId })
+await unloadModel({ modelId });
 // Worker survives; opt in to closing explicitly:
-await unloadModel({ modelId, autoClose: true })
+await unloadModel({ modelId, autoClose: true });
 ```
 
 ### Parakeet plugin moves to the 0.4.0 single-file GGUF API
@@ -2138,24 +2219,24 @@ Sortformer from GGUF metadata.
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_ENCODER_INT8,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8
-  }
-})
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
+  },
+});
 
 await loadModel({
   modelSrc: PARAKEET_CTC_FP32,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'ctc',
+    modelType: "ctc",
     parakeetCtcModelSrc: PARAKEET_CTC_FP32,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
-  }
-})
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
 ```
 
 **After:**
@@ -2163,13 +2244,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  modelType: 'parakeet'
-})
+  modelType: "parakeet",
+});
 
 await loadModel({
   modelSrc: PARAKEET_CTC_0_6B_Q8_0,
-  modelType: 'parakeet'
-})
+  modelType: "parakeet",
+});
 ```
 
 The new GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`,
@@ -2188,47 +2269,47 @@ hatch.
 **Before — downloadAsset:**
 
 ```typescript
-import { downloadAsset, cancel } from '@qvac/sdk'
+import { downloadAsset, cancel } from "@qvac/sdk";
 
-const op = downloadAsset({ assetSrc, onProgress })
-await cancel({ operation: 'downloadAsset', downloadKey: assetSrc.key, clearCache: true })
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
 ```
 
 **After — downloadAsset:** the decorated promise now exposes `op.requestId`
 synchronously, and `clearCache` is honoured on the `requestId` path.
 
 ```typescript
-import { downloadAsset, cancel } from '@qvac/sdk'
+import { downloadAsset, cancel } from "@qvac/sdk";
 
-const op = downloadAsset({ assetSrc, onProgress })
-await cancel({ requestId: op.requestId, clearCache: true })
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ requestId: op.requestId, clearCache: true });
 ```
 
 **Before — rag:**
 
 ```typescript
-import { ragIngest, cancel } from '@qvac/sdk'
+import { ragIngest, cancel } from "@qvac/sdk";
 
-ragIngest({ workspace: 'my-workspace', documents })
-await cancel({ operation: 'rag', workspace: 'my-workspace' })
+ragIngest({ workspace: "my-workspace", documents });
+await cancel({ operation: "rag", workspace: "my-workspace" });
 ```
 
 **After — rag (primary path, by `requestId`):**
 
 ```typescript
-import { ragIngest, cancel } from '@qvac/sdk'
+import { ragIngest, cancel } from "@qvac/sdk";
 
-const op = ragIngest({ workspace: 'my-workspace', documents })
-await cancel({ requestId: op.requestId })
+const op = ragIngest({ workspace: "my-workspace", documents });
+await cancel({ requestId: op.requestId });
 ```
 
 **After — rag (broad escape hatch, no `requestId` to hand):**
 
 ```typescript
-import { cancel } from '@qvac/sdk'
+import { cancel } from "@qvac/sdk";
 
 // Cancel every in-flight RAG operation running on the embedding model:
-await cancel({ modelId: ragEmbeddingModelId, kind: 'rag' })
+await cancel({ modelId: ragEmbeddingModelId, kind: "rag" });
 ```
 
 Every other `cancel(...)` shape still works: `cancel({ operation: "inference",
@@ -2248,26 +2329,33 @@ network round-trip. The pattern covers `completion`, `loadModel`, `embed`,
 the three cancellable RAG ops (`ragIngest`, `ragSaveEmbeddings`, `ragReindex`).
 
 ```typescript
-import { completion, loadModel, embed, downloadAsset, ragIngest, cancel } from '@qvac/sdk'
+import {
+  completion,
+  loadModel,
+  embed,
+  downloadAsset,
+  ragIngest,
+  cancel,
+} from "@qvac/sdk";
 
-const run = completion({ modelId, history })
-console.log(run.requestId)
+const run = completion({ modelId, history });
+console.log(run.requestId);
 
-const op = loadModel({ modelSrc: '...' })
-console.log(op.requestId) // synchronously, before await
-const modelId = await op // legacy unwrap still works
+const op = loadModel({ modelSrc: "..." });
+console.log(op.requestId);                    // synchronously, before await
+const modelId = await op;                     // legacy unwrap still works
 
-const handle = embed({ modelId, text: 'hello' })
-console.log(handle.requestId)
-await handle
+const handle = embed({ modelId, text: "hello" });
+console.log(handle.requestId);
+await handle;
 
-const download = downloadAsset({ assetSrc, onProgress })
-stopButton.onclick = () => cancel({ requestId: download.requestId })
-await download // rejects with InferenceCancelledError if cancelled
+const download = downloadAsset({ assetSrc, onProgress });
+stopButton.onclick = () => cancel({ requestId: download.requestId });
+await download;                                // rejects with InferenceCancelledError if cancelled
 
-const ingest = ragIngest({ workspace: 'ws-a', modelId, documents })
-console.log(ingest.requestId)
-await ingest
+const ingest = ragIngest({ workspace: "ws-a", modelId, documents });
+console.log(ingest.requestId);
+await ingest;
 ```
 
 The non-cancellable RAG ops (`ragChunk`, `ragSearch`, `ragDeleteEmbeddings`,
@@ -2291,19 +2379,17 @@ llama.cpp addon's opaque "job already set" error into a typed framework-level
 rejection.
 
 ```typescript
-import { completion, RequestRejectedByPolicyError } from '@qvac/sdk'
+import { completion, RequestRejectedByPolicyError } from "@qvac/sdk";
 
 try {
-  const run = completion({ modelId, history })
-  for await (const event of run.events) {
-    /* ... */
-  }
+  const run = completion({ modelId, history });
+  for await (const event of run.events) { /* ... */ }
 } catch (err) {
   if (err instanceof RequestRejectedByPolicyError) {
-    showBusy({ modelId: err.modelId, reason: err.reason })
-    return
+    showBusy({ modelId: err.modelId, reason: err.reason });
+    return;
   }
-  throw err
+  throw err;
 }
 ```
 
@@ -2315,10 +2401,10 @@ modelId, kind? }`). Two new client sugars wrap the broad shape so callers don't
 have to think about the wire representation:
 
 ```typescript
-import { cancel } from '@qvac/sdk'
+import { cancel } from "@qvac/sdk";
 
-await cancel({ modelId: 'llama-3.2-1b', kind: 'completion' })
-await cancel({ modelId: 'llama-3.2-1b' })
+await cancel({ modelId: "llama-3.2-1b", kind: "completion" });
+await cancel({ modelId: "llama-3.2-1b" });
 ```
 
 ### Plugin authors: declare cancel scope per handler
@@ -2334,7 +2420,7 @@ addon-side cancel actually interrupts compute. Plugin manifests that omit the
 field still load — it's optional.
 
 ```typescript
-import { definePlugin, defineHandler } from '@qvac/sdk'
+import { definePlugin, defineHandler } from "@qvac/sdk";
 
 definePlugin({
   manifestVersion: 1,
@@ -2343,13 +2429,11 @@ definePlugin({
       requestSchema,
       responseSchema,
       streaming: true,
-      cancel: { scope: 'model', hard: true },
-      handler: async function* (request, ctx) {
-        /* ... */
-      }
-    })
-  }
-})
+      cancel: { scope: "model", hard: true },
+      handler: async function* (request, ctx) { /* ... */ },
+    }),
+  },
+});
 ```
 
 ### Multi-GPU `split-mode`, `tensor-split`, and `main-gpu` on LLM and embed
@@ -2363,24 +2447,24 @@ convention (`splitMode`, `tensorSplit`, `mainGpu`).
 // LLM
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
+  modelType: "llm",
   modelConfig: {
-    'split-mode': 'layer', // "none" | "layer" | "row"
-    'tensor-split': '1,1', // proportional split across GPUs
-    'main-gpu': 0 // integer index or "integrated" | "dedicated"
-  }
-})
+    "split-mode": "layer",        // "none" | "layer" | "row"
+    "tensor-split": "1,1",        // proportional split across GPUs
+    "main-gpu": 0,                // integer index or "integrated" | "dedicated"
+  },
+});
 
 // Embed
 await loadModel({
   modelSrc: EMBEDDING_GEMMA_300M_Q8_0,
-  modelType: 'embed',
+  modelType: "embed",
   modelConfig: {
-    splitMode: 'layer',
-    tensorSplit: '1,1',
-    mainGpu: 0
-  }
-})
+    splitMode: "layer",
+    tensorSplit: "1,1",
+    mainGpu: 0,
+  },
+});
 ```
 
 ### Whisper VAD and end-of-turn events on `transcribeStream`
@@ -2391,24 +2475,23 @@ voice-activity probabilities and turn boundaries, so apps can build push-to-talk
 or barge-in UX without poll-the-text hacks.
 
 ```typescript
-import { transcribeStream } from '@qvac/sdk'
+import { transcribeStream } from "@qvac/sdk";
 
 const session = await transcribeStream({
-  modelId: 'whisper-base',
+  modelId: "whisper-base",
   emitVadEvents: true,
   endOfTurnSilenceMs: 800,
-  vadRunIntervalMs: 100
-})
+  vadRunIntervalMs: 100,
+});
 
 for await (const event of session) {
-  if (event.type === 'vad') console.log('speaking:', event.speaking, event.probability)
-  else if (event.type === 'endOfTurn')
-    console.log('turn ended after', event.silenceDurationMs, 'ms')
-  else if (event.type === 'text') process.stdout.write(event.text)
+  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
+  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
+  else if (event.type === "text") process.stdout.write(event.text);
 }
 
-session.write(audioChunk)
-session.end()
+session.write(audioChunk);
+session.end();
 ```
 
 `TranscribeStreamEvent`, `VadStateEvent`, `EndOfTurnEvent`, and
@@ -2427,20 +2510,20 @@ const session = await transcribeStream({
   modelId,
   parakeetStreamingConfig: {
     chunkMs: 1000,
-    emitPartials: true
-  }
-})
+    emitPartials: true,
+  },
+});
 
-ffmpeg.stdout.on('data', (chunk: Buffer) => session.write(chunk))
+ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
 
 for await (const event of session) {
   switch (event.type) {
-    case 'text':
-      process.stdout.write(event.text)
-      break
-    case 'endOfTurn':
-      console.log('\n[endOfTurn] turn boundary detected\n')
-      break
+    case "text":
+      process.stdout.write(event.text);
+      break;
+    case "endOfTurn":
+      console.log("\n[endOfTurn] turn boundary detected\n");
+      break;
   }
 }
 ```
@@ -2464,16 +2547,16 @@ framing; Gemma4 covers the native
 `<|tool_call>call:NAME{key:<|"|>val<|"|>,...}<tool_call|>` framing.
 
 ```typescript
-import { completion, type ToolDialect } from '@qvac/sdk'
+import { completion, type ToolDialect } from "@qvac/sdk";
 
 const result = completion({
-  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId,                         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: 'harmony' // optional explicit override
-})
+  toolDialect: "harmony",          // optional explicit override
+});
 
-const dialect: ToolDialect = 'harmony'
+const dialect: ToolDialect = "harmony";
 ```
 
 Qwen3.5 / Qwen3.6 and Gemma4 are auto-detected from the model name; the parsers
@@ -2489,19 +2572,19 @@ unrestricted, `0` = disabled. The SDK exposes it both as a load-time default on
 `LlmConfig` and as a per-request override on `GenerationParams`.
 
 ```typescript
-import { loadModel, completion } from '@qvac/sdk'
+import { loadModel, completion } from "@qvac/sdk";
 
 const modelId = await loadModel({
-  modelSrc: '/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf',
-  modelType: 'llm',
-  modelConfig: { ctx_size: 4096, reasoning_budget: -1 }
-})
+  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
+});
 
 const run = completion({
   modelId,
-  history: [{ role: 'user', content: 'Think step by step.' }],
-  generationParams: { reasoning_budget: 0 } // override per-request
-})
+  history: [{ role: "user", content: "Think step by step." }],
+  generationParams: { reasoning_budget: 0 }, // override per-request
+});
 ```
 
 The same bump fixes a regression where `system_prompt` (a JS-only
@@ -2519,26 +2602,26 @@ per-call `lora` field that takes an absolute filesystem path. A new load-time
 model or applied per-call (`"auto" | "immediately" | "at_runtime"`).
 
 ```typescript
-const refA = fs.readFileSync('scientist-a.jpg')
-const refB = fs.readFileSync('scientist-b.jpg')
+const refA = fs.readFileSync("scientist-a.jpg");
+const refB = fs.readFileSync("scientist-b.jpg");
 const { outputs } = diffusion({
   modelId,
-  prompt: 'a portrait using most visual traits from @image1 and the eyes from @image2',
+  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
   init_images: [refA, refB],
   width: 768,
-  height: 768
-})
+  height: 768,
+});
 
 const { outputs: loraOutputs } = diffusion({
   modelId,
-  prompt: 'a watercolor cat',
-  lora: '/home/user/loras/watercolor.safetensors'
-})
+  prompt: "a watercolor cat",
+  lora: "/home/user/loras/watercolor.safetensors",
+});
 
 await loadModel(modelSrc, {
-  modelType: 'diffusion',
-  modelConfig: { prediction: 'flux2_flow', lora_apply_mode: 'immediately' }
-})
+  modelType: "diffusion",
+  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
+});
 ```
 
 Relative LoRA paths are rejected: the SDK runs across processes with differing
@@ -2557,47 +2640,46 @@ without standing up a full diffusion pipeline.
 // Post-step upscale during diffusion
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: 'diffusion',
+  modelType: "diffusion",
   modelConfig: {
-    prediction: 'v',
+    prediction: "v",
     upscaler: {
-      type: 'esrgan',
-      model_src:
-        'https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth',
-      tile_size: 128
-    }
-  }
-})
+      type: "esrgan",
+      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+      tile_size: 128,
+    },
+  },
+});
 
 const { outputs } = diffusion({
   modelId,
-  prompt: 'an illustrated red fox portrait',
+  prompt: "an illustrated red fox portrait",
   width: 128,
   height: 128,
-  upscale: { repeats: 2 }
-})
+  upscale: { repeats: 2 },
+});
 ```
 
 ```typescript
 // Standalone upscale — no diffusion model required
-import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from '@qvac/sdk'
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
 
 const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
-  modelType: 'diffusion',
+  modelType: "diffusion",
   modelConfig: {
-    mode: 'upscale',
-    upscaler: { tile_size: 128 }
-  }
-})
+    mode: "upscale",
+    upscaler: { tile_size: 128 },
+  },
+});
 
 const { outputs, stats } = upscale({
   modelId,
-  image: pngBytes, // Uint8Array (PNG/JPEG)
-  repeats: 1 // each pass multiplies dims by the model's native scale factor
-})
+  image: pngBytes,        // Uint8Array (PNG/JPEG)
+  repeats: 1,             // each pass multiplies dims by the model's native scale factor
+});
 
-const [upscaledPng] = await outputs
-console.log(await stats) // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+const [upscaledPng] = await outputs;
+console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
 ```
 
 Calling `upscale()` against a model that wasn't loaded with `mode: "upscale"`
@@ -2748,10 +2830,10 @@ The DHT routing table is still populated lazily as `dht.connect()` issues lookup
 
 Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
 
-| Build              | Mean connection time | p50   | p95   |
-| ------------------ | -------------------- | ----- | ----- |
-| v0.10.1 (baseline) | 3.82s                | 3.71s | 4.94s |
-| v0.10.2 (this fix) | 1.18s                | 1.12s | 1.49s |
+| Build              | Mean connection time | p50    | p95    |
+| ------------------ | -------------------- | ------ | ------ |
+| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
+| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
 
 That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
 
@@ -2770,16 +2852,16 @@ This patch release adds a new tool-call dialect for OpenAI's `gpt-oss` (Harmony)
 `completion()` now supports a fourth tool-call dialect, `"harmony"`, used by OpenAI's `gpt-oss` family of models. The new dialect is wired into the same streaming/event surface as the existing dialects (`hermes`, `pythonic`, `json`), so tool calls emitted in Harmony frames are parsed and surfaced through the standard `CompletionEvent` stream. `gpt-oss-20b-Q4_K_M` auto-routes to the Harmony dialect; the `toolDialect` parameter is available as an explicit override on any model.
 
 ```typescript
-import { completion, type ToolDialect } from '@qvac/sdk'
+import { completion, type ToolDialect } from "@qvac/sdk";
 
 const run = completion({
-  modelId, // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  modelId,                 // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
   history,
   tools,
-  toolDialect: 'harmony' // optional explicit override
-})
+  toolDialect: "harmony",  // optional explicit override
+});
 
-const dialect: ToolDialect = 'harmony'
+const dialect: ToolDialect = "harmony";
 // ToolDialect is now "hermes" | "pythonic" | "json" | "harmony"
 ```
 
@@ -2878,22 +2960,20 @@ captured thinking and structured tool framing.
 **Before:**
 
 ```typescript
-const result = completion({ modelId, history, stream: true })
-for await (const token of result.tokenStream) {
-  /* ... */
-}
-const stats = await result.stats
+const result = completion({ modelId, history, stream: true });
+for await (const token of result.tokenStream) { /* ... */ }
+const stats = await result.stats;
 ```
 
 **After:**
 
 ```typescript
-const run = completion({ modelId, history, stream: true, captureThinking: true })
+const run = completion({ modelId, history, stream: true, captureThinking: true });
 for await (const event of run.events) {
-  if (event.type === 'contentDelta') process.stdout.write(event.text)
-  if (event.type === 'toolCall') console.log(event.call.name)
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === "toolCall") console.log(event.call.name);
 }
-const result = await run.final
+const result = await run.final;
 // result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
 ```
 
@@ -2915,35 +2995,35 @@ and `pluginInvokeStream` paths still surface `PLUGIN_HANDLER_NOT_FOUND` as befor
 **Before:**
 
 ```typescript
-import type { LoadModelOptions } from '@qvac/sdk'
+import type { LoadModelOptions } from "@qvac/sdk";
 
 const opts: LoadModelOptions = {
-  modelSrc: '/path/foo',
-  modelType: 'my-custom-plugin',
-  modelConfig: { whatever: 1 }
-}
-await loadModel(opts)
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
 ```
 
 **After:**
 
 ```typescript
-import type { LoadCustomPluginModelOptions } from '@qvac/sdk'
+import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
 
-const opts: LoadCustomPluginModelOptions<'my-custom-plugin'> = {
-  modelSrc: '/path/foo',
-  modelType: 'my-custom-plugin',
-  modelConfig: { whatever: 1 }
-}
-await loadModel(opts)
+const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
 // Or just drop the annotation — TS picks the right overload.
 ```
 
 ```typescript
-import { SDK_SERVER_ERROR_CODES } from '@qvac/sdk'
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
 
 try {
-  await transcribe({ modelId: llmModelId /* ... */ })
+  await transcribe({ modelId: llmModelId /* ... */ });
 } catch (e) {
   if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
     // Includes requested operation, loaded model type, supported operations,
@@ -2963,9 +3043,7 @@ the field name changed.
 ```typescript
 onProgress: (progress) => {
   if (progress.onnxInfo) {
-    console.log(
-      `[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`
-    )
+    console.log(`[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`);
   }
 }
 ```
@@ -2975,9 +3053,7 @@ onProgress: (progress) => {
 ```typescript
 onProgress: (progress) => {
   if (progress.fileSetInfo) {
-    console.log(
-      `[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`
-    )
+    console.log(`[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`);
   }
 }
 ```
@@ -3007,12 +3083,12 @@ delegated models defer to the provider. Useful for preflighting a built-in SDK c
 before issuing the RPC.
 
 ```typescript
-import { getLoadedModelInfo, transcribe } from '@qvac/sdk'
+import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
 
-const info = await getLoadedModelInfo({ modelId })
+const info = await getLoadedModelInfo({ modelId });
 
-if (info.isDelegated || info.handlers.includes('transcribeStream')) {
-  await transcribe({ modelId /* ... */ })
+if (info.isDelegated || info.handlers.includes("transcribeStream")) {
+  await transcribe({ modelId /* ... */ });
 }
 ```
 
@@ -3024,31 +3100,31 @@ schema-valid JSON. The output is guaranteed to parse against the supplied JSON S
 ```typescript
 const run = completion({
   modelId,
-  history: [{ role: 'user', content: "Extract: I'm Alice, 30, data engineer." }],
+  history: [{ role: "user", content: "Extract: I'm Alice, 30, data engineer." }],
   stream: true,
   responseFormat: {
-    type: 'json_schema',
+    type: "json_schema",
     json_schema: {
-      name: 'Person',
+      name: "Person",
       schema: {
-        type: 'object',
+        type: "object",
         properties: {
-          name: { type: 'string' },
-          age: { type: 'integer' },
-          occupation: { type: 'string' }
+          name: { type: "string" },
+          age: { type: "integer" },
+          occupation: { type: "string" },
         },
-        required: ['name', 'age', 'occupation'],
-        additionalProperties: false
-      }
-    }
-  }
-})
+        required: ["name", "age", "occupation"],
+        additionalProperties: false,
+      },
+    },
+  },
+});
 
 for await (const event of run.events) {
-  if (event.type === 'contentDelta') process.stdout.write(event.text)
+  if (event.type === "contentDelta") process.stdout.write(event.text);
 }
-const final = await run.final
-JSON.parse(final.contentText) // schema-valid
+const final = await run.final;
+JSON.parse(final.contentText); // schema-valid
 ```
 
 ### Dynamic tools mode
@@ -3059,35 +3135,29 @@ addon trims the previous tool block from the KV cache so rotation is free — no
 invalidate the cache or pin the tool set per-session.
 
 ```typescript
-import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
+import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: QWEN3_1_7B_INST_Q4,
-  modelType: 'llm',
+  modelType: "llm",
   modelConfig: {
     ctx_size: 4096,
     tools: true,
-    toolsMode: TOOLS_MODE.dynamic
-  }
-})
+    toolsMode: TOOLS_MODE.dynamic,
+  },
+});
 
 // Turn 1 — weather tools.
 const turn1 = completion({
-  modelId,
-  history,
-  kvCache,
-  stream: true,
-  tools: [{ name: 'get_weather', description: '...', parameters: weatherSchema }]
-})
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
+});
 
 // Turn 2 — same kvCache, different tools. Free rotation.
 const turn2 = completion({
-  modelId,
-  history,
-  kvCache,
-  stream: true,
-  tools: [{ name: 'get_horoscope', description: '...', parameters: horoscopeSchema }]
-})
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
+});
 ```
 
 ### Tool-call dialect routing
@@ -3099,15 +3169,12 @@ fine-tunes that emit native pythonic headers, which the auto-router defaults to 
 for empirical reasons.
 
 ```typescript
-import { completion, type ToolDialect } from '@qvac/sdk'
+import { completion, type ToolDialect } from "@qvac/sdk";
 
 const result = completion({
-  modelId,
-  history,
-  tools,
-  stream: true,
-  toolDialect: 'pythonic' // "hermes" | "pythonic" | "json"
-})
+  modelId, history, tools, stream: true,
+  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
+});
 ```
 
 ### img2img for diffusion models
@@ -3117,13 +3184,13 @@ SD/SDXL, and in-context conditioning on FLUX.2. `strength` controls how much of 
 source is preserved on SD/SDXL; FLUX.2 ignores it (the path is purely conditional).
 
 ```typescript
-const initImage = new Uint8Array(fs.readFileSync('input.png'))
+const initImage = new Uint8Array(fs.readFileSync("input.png"));
 const { outputs } = diffusion({
   modelId,
-  prompt: 'oil painting style, vibrant colors',
+  prompt: "oil painting style, vibrant colors",
   init_image: initImage,
-  strength: 0.5 // 0 = keep source, 1 = ignore source
-})
+  strength: 0.5, // 0 = keep source, 1 = ignore source
+});
 ```
 
 ### Sentence-level TTS streaming
@@ -3136,22 +3203,22 @@ exposes the int16 PCM samples plus the source sentence and chunk index.
 ```typescript
 const session = await textToSpeechStream({
   modelId: ttsModelId,
-  inputType: 'text',
+  inputType: "text",
   accumulateSentences: true,
-  sentenceDelimiterPreset: 'latin', // "latin" | "cjk" | "multilingual"
-  flushAfterMs: 400
-})
+  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400,
+});
 
-;(async () => {
+(async () => {
   for await (const delta of completion({ modelId: llmModelId /* ... */ }).tokenStream) {
-    session.write(delta)
+    session.write(delta);
   }
-  session.end()
-})()
+  session.end();
+})();
 
 for await (const chunk of session) {
   // chunk.buffer / chunk.chunkIndex / chunk.sentenceChunk
-  if (chunk.done) break
+  if (chunk.done) break;
 }
 ```
 
@@ -3163,9 +3230,9 @@ flag — enabling proper subtitle generation and timeline alignment instead of r
 concatenation.
 
 ```typescript
-const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true })
+const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true });
 for (const s of segments) {
-  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`)
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
 }
 ```
 
@@ -3176,12 +3243,12 @@ suspend/resume races. A new `state()` API reports the current lifecycle phase:
 `active`, `suspending`, `suspended`, or `resuming`.
 
 ```typescript
-import { state, suspend, resume, type LifecycleState } from '@qvac/sdk'
+import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
 
-await suspend()
-const current: LifecycleState = await state()
-if (current !== 'active') {
-  await resume()
+await suspend();
+const current: LifecycleState = await state();
+if (current !== "active") {
+  await resume();
 }
 ```
 
@@ -3192,12 +3259,12 @@ Two new SDK config knobs cover slow/unstable links: `registryDownloadMaxRetries`
 extends the per-block stream timeout beyond the default 60s.
 
 ```typescript
-import { setSDKConfig } from '@qvac/sdk'
+import { setSDKConfig } from "@qvac/sdk";
 
 setSDKConfig({
   registryDownloadMaxRetries: 5,
-  registryStreamTimeoutMs: 180_000
-})
+  registryStreamTimeoutMs: 180_000,
+});
 ```
 
 ### Auto KV-cache: replay the canonical assistant turn
@@ -3209,16 +3276,14 @@ guarantee a cache hit. Tool-call turns aren't auto-cached today and omit the fie
 fall back to `final.contentText` in that case.
 
 ```typescript
-const run = completion({ modelId, history, kvCache: true })
-for await (const _ of run.tokenStream) {
-  /* stream */
-}
-const final = await run.final
+const run = completion({ modelId, history, kvCache: true });
+for await (const _ of run.tokenStream) { /* stream */ }
+const final = await run.final;
 const nextHistory = [
   ...history,
-  { role: 'assistant', content: final.cacheableAssistantContent ?? final.contentText },
-  { role: 'user', content: 'follow-up question' }
-]
+  { role: "assistant", content: final.cacheableAssistantContent ?? final.contentText },
+  { role: "user", content: "follow-up question" },
+];
 ```
 
 ### LLM-addon cache API plumbed through SDK
@@ -3367,22 +3432,22 @@ The `ping()` API has been replaced by `heartbeat()`, which supports both local a
 **Before:**
 
 ```typescript
-import { ping } from '@qvac/sdk'
-const pong = await ping()
+import { ping } from "@qvac/sdk";
+const pong = await ping();
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from '@qvac/sdk'
+import { heartbeat } from "@qvac/sdk";
 
 // Local heartbeat (replaces ping)
-await heartbeat()
+await heartbeat();
 
 // Delegated heartbeat — check if a remote provider is alive
 await heartbeat({
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
-})
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
+});
 ```
 
 ---
@@ -3394,22 +3459,22 @@ await heartbeat({
 The SDK now supports LoRA finetuning of loaded LLM models. Training runs can be started, paused, resumed, cancelled, and inspected — all through a single `finetune()` function. Progress streams provide real-time loss and step metrics.
 
 ```typescript
-import { finetune } from '@qvac/sdk'
+import { finetune } from "@qvac/sdk";
 
 const handle = finetune({
   modelId,
   options: {
-    trainDatasetDir: './dataset/train',
-    validation: { type: 'dataset', path: './dataset/eval' },
-    outputParametersDir: './artifacts/lora',
-    numberOfEpochs: 2
-  }
-})
+    trainDatasetDir: "./dataset/train",
+    validation: { type: "dataset", path: "./dataset/eval" },
+    outputParametersDir: "./artifacts/lora",
+    numberOfEpochs: 2,
+  },
+});
 
 for await (const progress of handle.progressStream) {
-  console.log(progress.global_steps, progress.loss)
+  console.log(progress.global_steps, progress.loss);
 }
-const result = await handle.result
+const result = await handle.result;
 ```
 
 Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` to let the addon auto-detect whether to start fresh or resume.
@@ -3419,26 +3484,26 @@ Operations: `start`, `resume`, `pause`, `cancel`, `getState`. Omit `operation` t
 Stable Diffusion models are now integrated as a first-class SDK capability. Load a diffusion model and generate images with step-by-step progress tracking.
 
 ```typescript
-import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from '@qvac/sdk'
+import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: SD_V2_1_1B_Q8_0,
-  modelType: 'diffusion',
-  modelConfig: { prediction: 'v' }
-})
+  modelType: "diffusion",
+  modelConfig: { prediction: "v" },
+});
 
 const { progressStream, outputs, stats } = diffusion({
   modelId,
-  prompt: 'a cat sitting on a windowsill',
+  prompt: "a cat sitting on a windowsill",
   width: 512,
   height: 512,
-  steps: 20
-})
+  steps: 20,
+});
 
 for await (const { step, totalSteps } of progressStream) {
-  console.log(`${step}/${totalSteps}`)
+  console.log(`${step}/${totalSteps}`);
 }
-const buffers = await outputs
+const buffers = await outputs;
 ```
 
 ### Duplex Streaming Transcription (`transcribeStream`)
@@ -3446,16 +3511,16 @@ const buffers = await outputs
 A new bidirectional streaming API lets you feed audio incrementally and receive transcription segments as speech is detected, enabling real-time voice interfaces.
 
 ```typescript
-import { transcribeStream } from '@qvac/sdk'
+import { transcribeStream } from "@qvac/sdk";
 
-const session = await transcribeStream({ modelId })
-session.write(audioChunk)
-session.end()
+const session = await transcribeStream({ modelId });
+session.write(audioChunk);
+session.end();
 
 for await (const text of session) {
-  console.log(text)
+  console.log(text);
 }
-session.destroy()
+session.destroy();
 ```
 
 The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern still works but logs a deprecation warning — use `transcribe()` for batch transcription.
@@ -3465,10 +3530,10 @@ The previous single-shot `transcribeStream({ modelId, audioChunk })` pattern sti
 Mobile and desktop apps can now cleanly suspend and resume SDK operations when the app enters the background or foreground, preventing resource leaks and stale state.
 
 ```typescript
-import { suspend, resume } from '@qvac/sdk'
+import { suspend, resume } from "@qvac/sdk";
 
-await suspend() // app going to background
-await resume() // app returning to foreground
+await suspend(); // app going to background
+await resume();  // app returning to foreground
 ```
 
 ### Delegated Cancellation
@@ -3476,15 +3541,15 @@ await resume() // app returning to foreground
 Remote inference and downloads running on a delegation provider can now be cancelled from the consumer side.
 
 ```typescript
-import { cancel } from '@qvac/sdk'
+import { cancel } from "@qvac/sdk";
 
-await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
+await cancel({ operation: "inference", modelId: "delegated-model-id" });
 
 await cancel({
-  operation: 'downloadAsset',
-  downloadKey: 'download-key',
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
-})
+  operation: "downloadAsset",
+  downloadKey: "download-key",
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
+});
 ```
 
 ### Delegation Health Check Timeout
@@ -3494,14 +3559,14 @@ A new `healthCheckTimeout` option on the delegate config lets you control how lo
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
+  modelType: "llm",
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000
-  }
-})
+    healthCheckTimeout: 2000,
+  },
+});
 ```
 
 ### Addon Stats Across All Operations
@@ -3509,8 +3574,8 @@ await loadModel({
 All inference operations now return detailed performance stats from the underlying addons. Completion, transcription, translation, TTS, and embedding responses all include stats like `tokensPerSecond`, `timeToFirstToken`, `audioDuration`, and the new `backendDevice` field (`"cpu"` or `"gpu"`).
 
 ```typescript
-const { embedding, stats } = await embed({ modelId, text: 'hello' })
-console.log(stats?.backendDevice) // "cpu" | "gpu"
+const { embedding, stats } = await embed({ modelId, text: "hello" });
+console.log(stats?.backendDevice); // "cpu" | "gpu"
 ```
 
 ---
@@ -3633,22 +3698,22 @@ The `ping()` function has been replaced by `heartbeat()`, which extends health c
 **Before:**
 
 ```typescript
-import { ping } from '@qvac/sdk'
-const pong = await ping()
+import { ping } from "@qvac/sdk";
+const pong = await ping();
 ```
 
 **After:**
 
 ```typescript
-import { heartbeat } from '@qvac/sdk'
+import { heartbeat } from "@qvac/sdk";
 
 // Local heartbeat (replaces ping)
-await heartbeat()
+await heartbeat();
 
 // Delegated heartbeat — verify a remote provider is reachable
 await heartbeat({
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex', timeout: 3000 }
-})
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex", timeout: 3000 },
+});
 ```
 
 ---
@@ -3662,14 +3727,14 @@ Delegated model loading now supports an optional `healthCheckTimeout` parameter.
 ```typescript
 await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-  modelType: 'llm',
+  modelType: "llm",
   delegate: {
     topic: topicHex,
     providerPublicKey,
     timeout: 30_000,
-    healthCheckTimeout: 2000 // optional, defaults to 1500ms
-  }
-})
+    healthCheckTimeout: 2000, // optional, defaults to 1500ms
+  },
+});
 ```
 
 ### Delegated Cancellation
@@ -3678,14 +3743,14 @@ Cancel operations now route automatically to remote providers when the target mo
 
 ```typescript
 // Cancel delegated inference (routes automatically via model registry)
-await cancel({ operation: 'inference', modelId: 'delegated-model-id' })
+await cancel({ operation: "inference", modelId: "delegated-model-id" });
 
 // Cancel delegated remote download
 await cancel({
-  operation: 'downloadAsset',
-  downloadKey: 'download-key',
-  delegate: { topic: 'topicHex', providerPublicKey: 'peerHex' }
-})
+  operation: "downloadAsset",
+  downloadKey: "download-key",
+  delegate: { topic: "topicHex", providerPublicKey: "peerHex" },
+});
 ```
 
 ---
@@ -3730,11 +3795,11 @@ The embedding addon no longer accepts the raw tab-delimited config string. Use t
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: 'embeddings',
+  modelType: "embeddings",
   modelConfig: {
-    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
-  }
-})
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
 ```
 
 **After:**
@@ -3742,13 +3807,13 @@ await loadModel({
 ```typescript
 await loadModel({
   modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
-  modelType: 'embeddings',
+  modelType: "embeddings",
   modelConfig: {
     gpuLayers: 99,
-    device: 'gpu',
-    batchSize: 1024
-  }
-})
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
 ```
 
 ### Companion Model Sources Moved Into `modelConfig`
@@ -3759,76 +3824,76 @@ Top-level companion source fields (`projectionModelSrc`, `vadModelSrc`, `srcVoca
 
 ```typescript
 await loadModel({
-  modelType: 'llm',
-  modelSrc: '.../model.gguf',
-  projectionModelSrc: '.../mmproj.gguf'
-})
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  projectionModelSrc: ".../mmproj.gguf",
+});
 
 await loadModel({
-  modelType: 'whisper',
-  modelSrc: '.../model.bin',
-  vadModelSrc: '.../vad.bin'
-})
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  vadModelSrc: ".../vad.bin",
+});
 
 await loadModel({
-  modelType: 'nmt',
-  modelSrc: '.../model.intgemm.alphas.bin',
-  srcVocabSrc: '.../srcvocab.spm',
-  dstVocabSrc: '.../trgvocab.spm'
-})
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  srcVocabSrc: ".../srcvocab.spm",
+  dstVocabSrc: ".../trgvocab.spm",
+});
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelType: 'llm',
-  modelSrc: '.../model.gguf',
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
   modelConfig: {
-    projectionModelSrc: '.../mmproj.gguf'
-  }
-})
+    projectionModelSrc: ".../mmproj.gguf",
+  },
+});
 
 await loadModel({
-  modelType: 'whisper',
-  modelSrc: '.../model.bin',
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
   modelConfig: {
-    vadModelSrc: '.../vad.bin'
-  }
-})
+    vadModelSrc: ".../vad.bin",
+  },
+});
 
 await loadModel({
-  modelType: 'nmt',
-  modelSrc: '.../model.intgemm.alphas.bin',
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
   modelConfig: {
-    srcVocabSrc: '.../srcvocab.spm',
-    dstVocabSrc: '.../trgvocab.spm'
-  }
-})
+    srcVocabSrc: ".../srcvocab.spm",
+    dstVocabSrc: ".../trgvocab.spm",
+  },
+});
 ```
 
 Additionally, custom plugins must now provide a `loadConfigSchema`. For plugins that accept any config, use a passthrough schema:
 
 ```typescript
 const myPlugin: QvacPlugin = {
-  modelType: 'my-plugin',
-  displayName: 'My Plugin',
-  addonPackage: '@my/addon',
+  modelType: "my-plugin",
+  displayName: "My Plugin",
+  addonPackage: "@my/addon",
   loadConfigSchema: z.object({}).catchall(z.unknown()),
   createModel: (params) => ({ model, loader }),
-  handlers: {}
-}
+  handlers: {},
+};
 ```
 
 ### Parakeet Model Constants Renamed
 
 All existing Parakeet model constants now include a variant prefix (`TDT_`) to distinguish them from the new CTC and Sortformer variants. This is a find-and-replace migration:
 
-| Old Constant              | New Constant                  |
-| ------------------------- | ----------------------------- |
-| `PARAKEET_ENCODER_*`      | `PARAKEET_TDT_ENCODER_*`      |
-| `PARAKEET_DECODER_*`      | `PARAKEET_TDT_DECODER_*`      |
-| `PARAKEET_VOCAB`          | `PARAKEET_TDT_VOCAB`          |
+| Old Constant | New Constant |
+|---|---|
+| `PARAKEET_ENCODER_*` | `PARAKEET_TDT_ENCODER_*` |
+| `PARAKEET_DECODER_*` | `PARAKEET_TDT_DECODER_*` |
+| `PARAKEET_VOCAB` | `PARAKEET_TDT_VOCAB` |
 | `PARAKEET_PREPROCESSOR_*` | `PARAKEET_TDT_PREPROCESSOR_*` |
 
 ---
@@ -3845,24 +3910,24 @@ import {
   PARAKEET_TDT_ENCODER_DATA_FP32,
   PARAKEET_TDT_DECODER_FP32,
   PARAKEET_TDT_VOCAB,
-  PARAKEET_TDT_PREPROCESSOR_FP32
-} from '@qvac/sdk'
+  PARAKEET_TDT_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
 
 const modelId = await loadModel({
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelSrc: PARAKEET_TDT_ENCODER_FP32,
   modelConfig: {
     parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
     parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
     parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
     parakeetVocabSrc: PARAKEET_TDT_VOCAB,
-    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32
-  }
-})
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
+  },
+});
 
-const stream = transcribeStream({ modelId, audioInput: './audio.mp3' })
+const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
 for await (const chunk of stream) {
-  process.stdout.write(chunk)
+  process.stdout.write(chunk);
 }
 ```
 
@@ -3875,21 +3940,21 @@ Translate between language pairs that don't have a direct model by chaining thro
 ```typescript
 await loadModel({
   modelSrc: BERGAMOT_ES_EN,
-  modelType: 'nmt',
+  modelType: "nmt",
   modelConfig: {
-    engine: 'Bergamot',
-    from: 'es',
-    to: 'it',
+    engine: "Bergamot",
+    from: "es",
+    to: "it",
     pivotModel: {
       modelSrc: BERGAMOT_EN_IT,
       beamsize: 4,
       temperature: 0.3,
       topk: 100,
       normalize: 1,
-      lengthpenalty: 1.2
-    }
-  }
-})
+      lengthpenalty: 1.2,
+    },
+  },
+});
 ```
 
 ### SDK Profiler
@@ -3897,25 +3962,28 @@ await loadModel({
 A built-in profiler lets you measure SDK operation performance at runtime. Enable it globally or on a per-call basis:
 
 ```typescript
-import { profiler } from '@qvac/sdk'
+import { profiler } from "@qvac/sdk";
 
 profiler.enable({
-  mode: 'verbose',
-  includeServerBreakdown: true
-})
+  mode: "verbose",
+  includeServerBreakdown: true,
+});
 
 // Run operations, then export results
-console.log(profiler.exportSummary())
-console.log(profiler.exportTable())
-console.log(profiler.exportJSON({ includeRecentEvents: true }))
+console.log(profiler.exportSummary());
+console.log(profiler.exportTable());
+console.log(profiler.exportJSON({ includeRecentEvents: true }));
 
-profiler.disable()
+profiler.disable();
 ```
 
 Per-call profiling control is also available on `embed`, `completion`, `transcribe`, `translate`, `ragSearch`, and `invokePlugin`:
 
 ```typescript
-await embed({ modelId, text: 'hello' }, { profiling: { enabled: true } })
+await embed(
+  { modelId, text: "hello" },
+  { profiling: { enabled: true } },
+);
 ```
 
 ---
@@ -3931,15 +3999,15 @@ The SDK now supports two additional Parakeet model variants beyond the existing 
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_CTC_FP32_1,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'ctc',
+    modelType: "ctc",
     parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
     parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
-    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER
-  }
-})
-const text = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
 ```
 
 **Sortformer diarization** for speaker identification:
@@ -3947,13 +4015,13 @@ const text = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
 ```typescript
 const modelId = await loadModel({
   modelSrc: PARAKEET_SORTFORMER_FP32,
-  modelType: 'parakeet',
+  modelType: "parakeet",
   modelConfig: {
-    modelType: 'sortformer',
-    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32
-  }
-})
-const diarization = await transcribe({ modelId, audioChunk: '/path/to/audio.wav' })
+    modelType: "sortformer",
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
+  },
+});
+const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
 // Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
 ```
 
@@ -3982,24 +4050,20 @@ The profiler now captures detailed load/download metrics and stream profiling da
 ### Added Models
 
 **OCR:**
-
 - `OCR_DETECTOR_DB_MOBILENET_V3_LARGE`
 - `OCR_DETECTOR_DB_RESNET50`
 - `OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL`
 - `OCR_RECOGNIZER_PARSEQ`
 
 **Parakeet (CTC):**
-
 - `PARAKEET_CTC_FP32`, `PARAKEET_CTC_DATA_FP32`, `PARAKEET_CTC_VOCAB`, `PARAKEET_CTC_INT8`, `PARAKEET_CTC_CONFIG`
 - `PARAKEET_CTC_FP32_1`, `PARAKEET_CTC_DATA_FP32_1`, `PARAKEET_CTC_TOKENIZER`
 
 **Parakeet (Sortformer / EOU):**
-
 - `PARAKEET_SORTFORMER_FP32`
 - `PARAKEET_EOU_ENCODER_FP32`, `PARAKEET_EOU_DECODER_FP32`, `PARAKEET_EOU_TOKENIZER`
 
 **Parakeet (TDT — renamed from unprefixed):**
-
 - `PARAKEET_TDT_ENCODER_FP32`, `PARAKEET_TDT_ENCODER_DATA_FP32`, `PARAKEET_TDT_DECODER_FP32`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_FP32`
 - `PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_PREPROCESSOR_INT8`
 
@@ -4041,30 +4105,30 @@ Model constant names have been normalized for consistency. If your code referenc
 
 ```typescript
 // Before
-import { BERGAMOT_AREN } from '@qvac/sdk'
+import { BERGAMOT_AREN } from "@qvac/sdk";
 
 // After
-import { BERGAMOT_AR_EN } from '@qvac/sdk'
+import { BERGAMOT_AR_EN } from "@qvac/sdk";
 ```
 
 **Whisper models** have simplified names without author/repo prefixes:
 
 ```typescript
 // Before
-import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from '@qvac/sdk'
+import { WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16 } from "@qvac/sdk";
 
 // After
-import { WHISPER_EN_BASE_Q0F16 } from '@qvac/sdk'
+import { WHISPER_EN_BASE_Q0F16 } from "@qvac/sdk";
 ```
 
 **LLM models** have normalized version prefixes:
 
 ```typescript
 // Before
-import { QWEN_3_1_7B_INST_Q4 } from '@qvac/sdk'
+import { QWEN_3_1_7B_INST_Q4 } from "@qvac/sdk";
 
 // After
-import { QWEN3_1_7B_INST_Q4 } from '@qvac/sdk'
+import { QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
 ```
 
 ### HyperdriveItem Type Renamed to RegistryItem
@@ -4073,10 +4137,10 @@ The model metadata type has been renamed and restructured to support the new reg
 
 ```typescript
 // Before
-import type { HyperdriveItem } from '@qvac/sdk'
+import type { HyperdriveItem } from "@qvac/sdk";
 
 // After
-import type { RegistryItem } from '@qvac/sdk'
+import type { RegistryItem } from "@qvac/sdk";
 ```
 
 The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
@@ -4090,22 +4154,26 @@ The shape has also changed: `hyperdriveKey` and `hyperbeeKey` fields are replace
 Discover and search models directly through the SDK without needing a separate registry client package.
 
 ```typescript
-import { modelRegistryList, modelRegistrySearch, modelRegistryGetModel } from '@qvac/sdk'
+import {
+  modelRegistryList,
+  modelRegistrySearch,
+  modelRegistryGetModel,
+} from "@qvac/sdk";
 
 // List all available models
-const models = await modelRegistryList()
+const models = await modelRegistryList();
 
 // Search by engine type
-const llmModels = await modelRegistrySearch({ engine: '@qvac/llm-llamacpp' })
+const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
 
 // Search by text filter
-const whisperModels = await modelRegistrySearch({ filter: 'whisper' })
+const whisperModels = await modelRegistrySearch({ filter: "whisper" });
 
 // Search by quantization
-const q4Models = await modelRegistrySearch({ quantization: 'q4' })
+const q4Models = await modelRegistrySearch({ quantization: "q4" });
 
 // Get a specific model by path
-const model = await modelRegistryGetModel(registryPath, registrySource)
+const model = await modelRegistryGetModel(registryPath, registrySource);
 ```
 
 ### Plugin System
@@ -4113,22 +4181,22 @@ const model = await modelRegistryGetModel(registryPath, registrySource)
 Build custom model integrations with the new plugin architecture. Plugins support both request/reply and streaming patterns.
 
 ```typescript
-import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from '@qvac/sdk'
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
 
 // Invoke a plugin handler
 const result = await invokePlugin<MyResponse>({
   modelId,
-  handler: 'myHandler',
-  params: { key: 'value' }
-})
+  handler: "myHandler",
+  params: { key: "value" },
+});
 
 // Stream responses from a plugin
 for await (const chunk of invokePluginStream<MyStreamResponse>({
   modelId,
-  handler: 'myStreamHandler',
-  params: { key: 'value' }
+  handler: "myStreamHandler",
+  params: { key: "value" },
 })) {
-  console.log(chunk.result)
+  console.log(chunk.result);
 }
 ```
 
@@ -4139,25 +4207,25 @@ Clone voices from reference audio samples with the new Chatterbox engine.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: 'tts',
+  modelType: "tts",
   modelConfig: {
-    ttsEngine: 'chatterbox',
-    language: 'en',
+    ttsEngine: "chatterbox",
+    language: "en",
     ttsTokenizerSrc,
     ttsSpeechEncoderSrc,
     ttsEmbedTokensSrc,
     ttsConditionalDecoderSrc,
     ttsLanguageModelSrc,
-    referenceAudioSrc // Your voice sample
-  }
-})
+    referenceAudioSrc, // Your voice sample
+  },
+});
 
 const audio = await textToSpeech({
   modelId,
-  text: 'Hello in a cloned voice!',
-  inputType: 'text',
-  stream: false
-})
+  text: "Hello in a cloned voice!",
+  inputType: "text",
+  stream: false,
+});
 ```
 
 ### Supertonic TTS Engine (General Purpose)
@@ -4167,19 +4235,19 @@ High-quality text-to-speech with adjustable speed and inference steps.
 ```typescript
 const modelId = await loadModel({
   modelSrc,
-  modelType: 'tts',
+  modelType: "tts",
   modelConfig: {
-    ttsEngine: 'supertonic',
-    language: 'en',
+    ttsEngine: "supertonic",
+    language: "en",
     ttsTokenizerSrc,
     ttsTextEncoderSrc,
     ttsLatentDenoiserSrc,
     ttsVoiceDecoderSrc,
     ttsVoiceSrc,
-    ttsSpeed: 1.0, // Playback speed
-    ttsNumInferenceSteps: 5 // Quality vs speed tradeoff
-  }
-})
+    ttsSpeed: 1.0,           // Playback speed
+    ttsNumInferenceSteps: 5, // Quality vs speed tradeoff
+  },
+});
 ```
 
 ### CLI SDK Path Option
@@ -4203,10 +4271,10 @@ Model downloads now use `downloadBlob` for more efficient direct registry fetchi
 The `close()` function is now properly async and awaitable for clean shutdown:
 
 ```typescript
-import { close } from '@qvac/sdk'
+import { close } from "@qvac/sdk";
 
 // Now returns a Promise
-await close()
+await close();
 ```
 
 ### Engine-Addon Mapping Utilities
@@ -4214,10 +4282,10 @@ await close()
 Map between engine names and addon types:
 
 ```typescript
-import { resolveCanonicalEngine, getAddonFromEngine } from '@qvac/sdk'
+import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
 
-const engine = resolveCanonicalEngine('@qvac/llm-llamacpp') // "llamacpp-completion"
-const addon = getAddonFromEngine('llamacpp-completion') // "llm"
+const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
+const addon = getAddonFromEngine("llamacpp-completion");     // "llm"
 ```
 
 ---
@@ -4296,9 +4364,9 @@ The RAG system has been restructured for better control and flexibility. The mai
 ```typescript
 await ragSaveEmbeddings({
   modelId,
-  documents: ['Doc 1', 'Doc 2'],
-  chunk: false
-})
+  documents: ["Doc 1", "Doc 2"],
+  chunk: false,
+});
 ```
 
 **After:**
@@ -4319,7 +4387,6 @@ await ragSaveEmbeddings({
 ```
 
 Other RAG changes:
-
 - `ragSaveEmbeddings` no longer returns `droppedIndices`
 - `ragDeleteEmbeddings` now returns `void` instead of `boolean` (throws on failure)
 - `ragDeleteEmbeddings` no longer requires `modelId` (uses cached workspace)
@@ -4333,35 +4400,35 @@ No more string-based config! Use typed properties for embedding model configurat
 
 ```typescript
 await loadModel({
-  modelSrc: 'embed-model.gguf',
-  modelType: 'embeddings',
+  modelSrc: "embed-model.gguf",
+  modelType: "embeddings",
   modelConfig: {
-    config: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
-  }
-})
+    config: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
 ```
 
 **After:**
 
 ```typescript
 await loadModel({
-  modelSrc: 'embed-model.gguf',
-  modelType: 'embeddings',
+  modelSrc: "embed-model.gguf",
+  modelType: "embeddings",
   modelConfig: {
     gpuLayers: 99,
-    device: 'gpu',
-    batchSize: 1024
-  }
-})
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
 
 // Escape hatch for advanced CLI control
 await loadModel({
-  modelSrc: 'embed-model.gguf',
-  modelType: 'embeddings',
+  modelSrc: "embed-model.gguf",
+  modelType: "embeddings",
   modelConfig: {
-    rawConfig: '-ngl\t99\n-dev\tgpu\n--batch_size\t1024'
-  }
-})
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
 ```
 
 ### Translation Engine Must Be Specified
@@ -4373,9 +4440,9 @@ Loading translation models now requires an explicit `engine` field for type-safe
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: 'nmt',
-  modelConfig: { from: 'en', to: 'it' }
-})
+  modelType: "nmt",
+  modelConfig: { from: "en", to: "it" },
+});
 ```
 
 **After:**
@@ -4383,13 +4450,13 @@ const modelId = await loadModel({
 ```typescript
 const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
-  modelType: 'nmt',
+  modelType: "nmt",
   modelConfig: {
-    engine: 'Opus', // Required: "Opus" | "Bergamot" | "IndicTrans"
-    from: 'en',
-    to: 'it'
-  }
-})
+    engine: "Opus",  // Required: "Opus" | "Bergamot" | "IndicTrans"
+    from: "en",
+    to: "it",
+  },
+});
 ```
 
 ---
@@ -4401,28 +4468,28 @@ const modelId = await loadModel({
 A new translation engine option with support for batch translation and automatic vocabulary file derivation.
 
 ```typescript
-import { loadModel, translate, BERGAMOT_ENFR } from '@qvac/sdk'
+import { loadModel, translate, BERGAMOT_ENFR } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: BERGAMOT_ENFR,
-  modelType: 'nmt',
+  modelType: "nmt",
   modelConfig: {
-    engine: 'Bergamot',
-    from: 'en',
-    to: 'fr',
-    normalize: 1 // Bergamot-specific option
-  }
-})
+    engine: "Bergamot",
+    from: "en",
+    to: "fr",
+    normalize: 1,  // Bergamot-specific option
+  },
+});
 
 // Batch translation
 const result = translate({
   modelId,
-  text: ['Hello world', 'How are you?'],
-  modelType: 'nmt',
-  stream: false
-})
+  text: ["Hello world", "How are you?"],
+  modelType: "nmt",
+  stream: false,
+});
 
-const translated = await result.text
+const translated = await result.text;
 // "Bonjour le monde\nComment allez-vous?"
 ```
 
@@ -4439,23 +4506,23 @@ The SDK now uses import maps internally, improving compatibility across Node.js,
 Extract text from images with bounding boxes and confidence scores.
 
 ```typescript
-import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from '@qvac/sdk'
+import { loadModel, ocr, OCR_CRAFT_LATIN_RECOGNIZER } from "@qvac/sdk";
 
 const modelId = await loadModel({
   modelSrc: OCR_CRAFT_LATIN_RECOGNIZER,
-  modelType: 'ocr',
-  modelConfig: { langList: ['en'] }
-})
+  modelType: "ocr",
+  modelConfig: { langList: ["en"] },
+});
 
 // Get all text blocks at once
-const { blocks, done } = ocr({ modelId, image: '/path/to/image.png' })
-const result = await blocks
-await done
+const { blocks, done } = ocr({ modelId, image: "/path/to/image.png" });
+const result = await blocks;
+await done;
 
 // Or stream blocks as they're detected
-const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true })
+const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true });
 for await (const blocks of blockStream) {
-  console.log(blocks)
+  console.log(blocks);
   // [{ text: "Hello", bbox: [10, 20, 100, 50], confidence: 0.95 }]
 }
 ```
@@ -4467,15 +4534,15 @@ Load large models split across multiple files, from URLs or archives.
 ```typescript
 // Pattern-based sharded URLs (auto-detects shard pattern)
 await loadModel({
-  modelSrc: 'https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf',
-  modelType: 'llm'
-})
+  modelSrc: "https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf",
+  modelType: "llm",
+});
 
 // Archive-based shards (.tar.gz, .tar, .tgz)
 await loadModel({
-  modelSrc: 'https://huggingface.co/user/model/resolve/main/model.tar.gz',
-  modelType: 'llm'
-})
+  modelSrc: "https://huggingface.co/user/model/resolve/main/model.tar.gz",
+  modelType: "llm",
+});
 ```
 
 ### Device-Specific Model Configuration
@@ -4552,13 +4619,13 @@ The SDK now uses a config file instead of the `setConfig()` API. This simplifies
 **Before:**
 
 ```typescript
-import { setConfig, loadModel } from '@qvac/sdk'
+import { setConfig, loadModel } from "@qvac/sdk";
 
 await setConfig({
-  cacheDirectory: '/custom/cache/path'
-})
+  cacheDirectory: "/custom/cache/path",
+});
 
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
 ```
 
 **After:**
@@ -4572,10 +4639,10 @@ await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
 ```
 
 ```typescript
-import { loadModel } from '@qvac/sdk'
+import { loadModel } from "@qvac/sdk";
 
 // Config automatically loaded at initialization!
-await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: 'llama' })
+await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelType: "llama" });
 ```
 
 #### Config Resolution Order
@@ -4588,31 +4655,31 @@ The SDK searches for configuration in this order:
 
 #### Supported Formats
 
-| Format     | Filename           | Notes                         |
-| ---------- | ------------------ | ----------------------------- |
-| JSON       | `qvac.config.json` | Simplest option               |
-| JavaScript | `qvac.config.js`   | Use `export default`          |
+| Format     | Filename           | Notes                        |
+| ---------- | ------------------ | ---------------------------- |
+| JSON       | `qvac.config.json` | Simplest option              |
+| JavaScript | `qvac.config.js`   | Use `export default`         |
 | TypeScript | `qvac.config.ts`   | Fully typed with `QvacConfig` |
 
 **TypeScript example:**
 
 ```typescript
 // qvac.config.ts
-import type { QvacConfig } from '@qvac/sdk'
+import type { QvacConfig } from "@qvac/sdk";
 
 const config: QvacConfig = {
-  cacheDirectory: '/custom/cache/path',
-  swarmRelays: ['relay-key-1', 'relay-key-2']
-}
+  cacheDirectory: "/custom/cache/path",
+  swarmRelays: ["relay-key-1", "relay-key-2"],
+};
 
-export default config
+export default config;
 ```
 
 #### Migration Steps
 
 1. Remove all `setConfig()` calls from your code
 2. Create a config file in your project root
-3. _(Optional)_ For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
+3. *(Optional)* For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
 
 ---
 
@@ -4622,14 +4689,14 @@ Some model constants have been renamed for clarity, and duplicate constants have
 
 **Changes:**
 
-| Before                     | After                                      |
-| -------------------------- | ------------------------------------------ |
-| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                         |
-| `WHISPER_NORWEGIAN_TINY_1` | _(removed — use `WHISPER_NORWEGIAN_TINY`)_ |
-| `WHISPER_TINY_SILERO`      | _(removed — use `WHISPER_TINY`)_           |
-| `MARIAN_OPUS_EN_FR_Q4_0_1` | _(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)_ |
-| `MARIAN_OPUS_FR_EN_Q4_0_1` | _(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)_ |
-| `MARIAN_OPUS_IT_EN`        | _(removed — use `MARIAN_OPUS_EN_IT`)_      |
+| Before                     | After                                             |
+| -------------------------- | ------------------------------------------------- |
+| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                                |
+| `WHISPER_NORWEGIAN_TINY_1` | *(removed — use `WHISPER_NORWEGIAN_TINY`)*        |
+| `WHISPER_TINY_SILERO`      | *(removed — use `WHISPER_TINY`)*                  |
+| `MARIAN_OPUS_EN_FR_Q4_0_1` | *(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)*        |
+| `MARIAN_OPUS_FR_EN_Q4_0_1` | *(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)*        |
+| `MARIAN_OPUS_IT_EN`        | *(removed — use `MARIAN_OPUS_EN_IT`)*             |
 
 All model metadata and hyperdrive keys remain unchanged—only the constant names were affected.
 
@@ -4645,7 +4712,7 @@ The logging stream API has been simplified with consistent naming.
 
 ```typescript
 for await (const log of loggingStream({ modelId: myModelId })) {
-  console.log(log.message)
+  console.log(log.message);
 }
 ```
 
@@ -4653,7 +4720,7 @@ for await (const log of loggingStream({ modelId: myModelId })) {
 
 ```typescript
 for await (const log of loggingStream({ id: myModelId })) {
-  console.log(log.message)
+  console.log(log.message);
 }
 ```
 
@@ -4684,17 +4751,17 @@ You can now update a model's configuration without unloading it. Pass the existi
 ```typescript
 // Load model with initial config
 const modelId = await loadModel({
-  modelSrc: 'pear://.../whisper.gguf',
-  modelType: 'whisper',
-  modelConfig: { language: 'en' }
-})
+  modelSrc: "pear://.../whisper.gguf",
+  modelType: "whisper",
+  modelConfig: { language: "en" },
+});
 
 // Hot-reload with new config (same modelId, no reload delay)
 await loadModel({
   modelId,
-  modelType: 'whisper',
-  modelConfig: { language: 'es' }
-})
+  modelType: "whisper",
+  modelConfig: { language: "es" },
+});
 ```
 
 ---
@@ -4706,51 +4773,51 @@ The SDK now supports the Model Context Protocol (MCP) for tool integration. Pass
 **Using MCP clients:**
 
 ```typescript
-import { completion } from '@qvac/sdk'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { completion } from "@qvac/sdk";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 // Create and connect your MCP client
-const mcpClient = new Client({ name: 'my-app', version: '1.0.0' })
-await mcpClient.connect(transport)
+const mcpClient = new Client({ name: "my-app", version: "1.0.0" });
+await mcpClient.connect(transport);
 
 // Pass MCP clients to completion
 const result = completion({
   modelId,
   history,
-  mcp: [{ client: mcpClient }]
-})
+  mcp: [{ client: mcpClient }],
+});
 
 // Execute tool calls
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call()
+  const response = await toolCall.call();
 }
 
 // Clean up when done
-await mcpClient.close()
+await mcpClient.close();
 ```
 
 **Using inline tools with handlers:**
 
 ```typescript
-import { z } from 'zod'
+import { z } from "zod";
 
 const result = completion({
   modelId,
   history,
   tools: [
     {
-      name: 'get_weather',
-      description: 'Get weather for a city',
+      name: "get_weather",
+      description: "Get weather for a city",
       parameters: z.object({ city: z.string() }),
       handler: async (args) => {
-        return await fetchWeather(args.city)
-      }
-    }
-  ]
-})
+        return await fetchWeather(args.city);
+      },
+    },
+  ],
+});
 
 for (const toolCall of await result.toolCalls) {
-  const response = await toolCall.call() // Executes your handler
+  const response = await toolCall.call(); // Executes your handler
 }
 ```
 
@@ -4762,10 +4829,10 @@ The `embed()` function now accepts arrays, enabling efficient batch processing. 
 
 ```typescript
 // Single text → returns number[]
-const embedding = await embed({ modelId, text: 'hello' })
+const embedding = await embed({ modelId, text: "hello" });
 
 // Batch texts → returns number[][]
-const embeddings = await embed({ modelId, text: ['a', 'b', 'c'] })
+const embeddings = await embed({ modelId, text: ["a", "b", "c"] });
 ```
 
 Batch processing uses a default batch size of 1024 for optimal throughput.

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -365,11 +365,11 @@ Third-Party Model Licenses
   gte-large-gguf
     https://huggingface.co/ChristianAzinn/gte-large-gguf
   indic-conformer-ctc.f16
-    https://huggingface.co/ai4bharat/indic-conformer
+    https://huggingface.co/ai4bharat/indic-conformer-600m-multilingual
   indic-conformer-ctc.q4_0
-    https://huggingface.co/ai4bharat/indic-conformer
+    https://huggingface.co/ai4bharat/indic-conformer-600m-multilingual
   indic-conformer-ctc.q8_0
-    https://huggingface.co/ai4bharat/indic-conformer
+    https://huggingface.co/ai4bharat/indic-conformer-600m-multilingual
   lavasr-denoiser-f16
     https://huggingface.co/spaces/YatharthS
   lavasr-enhancer-f16
@@ -665,47 +665,48 @@ JavaScript Dependencies
 
   @hyperswarm/secret-stream@6.9.1
     https://github.com/holepunchto/hyperswarm-secret-stream
-  @qvac/asr-ggml@0.3.2
+  @qvac/asr-ggml@0.3.3
     https://github.com/tetherto/qvac
-  @qvac/audiogen-ggml@0.2.3
+  @qvac/audiogen-ggml@0.3.3
     https://github.com/tetherto/qvac
-  @qvac/bci-whispercpp@0.7.2
+  @qvac/bci-whispercpp@0.8.2
     https://github.com/tetherto/qvac
-  @qvac/classification-ggml@0.20.0
+  @qvac/classification-ggml@0.23.0
     https://github.com/tetherto/qvac
   @qvac/decoder-audio@0.5.0
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/diffusion-cpp@0.17.0
+  @qvac/diffusion-cpp@0.21.0
     https://github.com/tetherto/qvac
-  @qvac/embed-llamacpp@0.34.0
+  @qvac/embed-llamacpp@0.37.0
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
-  @qvac/fabric@0.6.0
+  @qvac/fabric@0.10.0
     https://github.com/tetherto/qvac
   @qvac/infer-base@0.4.2
     https://github.com/tetherto/qvac
   @qvac/infer-base@0.6.2
     https://github.com/tetherto/qvac
+  @qvac/inference@0.19.1
+    https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.45.0
+  @qvac/llm-llamacpp@0.49.1
     https://github.com/tetherto/qvac
-  @qvac/logging@0.1.0
-  @qvac/ocr-ggml@0.18.0
+  @qvac/logging@0.1.1
     https://github.com/tetherto/qvac
-  @qvac/rag@0.6.4
+  @qvac/ocr-ggml@0.21.0
     https://github.com/tetherto/qvac
   @qvac/registry-client@0.6.1
     https://github.com/tetherto/qvac
   @qvac/registry-schema@0.3.0
     https://github.com/tetherto/qvac
-  @qvac/translation-nmtcpp@0.10.0
+  @qvac/translation-nmtcpp@0.13.0
     https://github.com/tetherto/qvac
-  @qvac/tts-ggml@0.7.4
+  @qvac/tts-ggml@0.8.1
     https://github.com/tetherto/qvac
-  @qvac/vla-ggml@0.21.1
+  @qvac/vla-ggml@0.24.0
     https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
@@ -715,15 +716,15 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-abort
   bare-abort-controller@1.1.2
     https://github.com/holepunchto/bare-abort-controller
-  bare-addon-resolve@1.10.0
+  bare-addon-resolve@1.10.1
     https://github.com/holepunchto/bare-addon-resolve
   bare-ansi-escapes@2.2.3
     https://github.com/holepunchto/bare-ansi-escapes
   bare-assert@1.2.0
     https://github.com/holepunchto/bare-assert
-  bare-buffer@3.6.1
+  bare-buffer@3.7.1
     https://github.com/holepunchto/bare-buffer
-  bare-bundle@1.10.0
+  bare-bundle@1.11.0
     https://github.com/holepunchto/bare-bundle
   bare-bundle-id@1.0.2
     https://github.com/holepunchto/bare-bundle-id
@@ -735,15 +736,15 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-crypto
   bare-debug-log@2.0.0
     https://github.com/holepunchto/bare-debug-log
-  bare-dns@2.1.4
+  bare-dns@2.2.0
     https://github.com/holepunchto/bare-dns
   bare-encoding@1.0.3
     https://github.com/holepunchto/bare-encoding
-  bare-env@3.0.0
+  bare-env@3.0.1
     https://github.com/holepunchto/bare-env
-  bare-events@2.9.1
+  bare-events@2.9.2
     https://github.com/holepunchto/bare-events
-  bare-fetch@3.0.1
+  bare-fetch@3.2.1
     https://github.com/holepunchto/bare-fetch
   bare-ffmpeg@1.5.0
     https://github.com/holepunchto/bare-ffmpeg
@@ -751,59 +752,69 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-form-data
   bare-format@1.0.2
     https://github.com/holepunchto/bare-format
-  bare-fs@4.7.2
+  bare-fs@4.8.1
     https://github.com/holepunchto/bare-fs
   bare-gpu-info@0.1.1
     https://github.com/holepunchto/bare-gpu-info
-  bare-hrtime@2.1.1
+  bare-hrtime@2.1.2
     https://github.com/holepunchto/bare-hrtime
-  bare-http-parser@1.1.5
+  bare-http-parser@2.1.4
     https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.5.7
+  bare-http1@4.6.1
     https://github.com/holepunchto/bare-http1
-  bare-https@3.0.0
+  bare-https@3.1.0
     https://github.com/holepunchto/bare-https
-  bare-inspect@3.1.4
+  bare-inspect@3.1.10
     https://github.com/holepunchto/bare-inspect
-  bare-inspector@6.0.2
+  bare-inspector@6.1.0
     https://github.com/holepunchto/bare-inspector
+  bare-lief@0.2.7
+    https://github.com/holepunchto/bare-lief
+  bare-link@3.3.0
+    https://github.com/holepunchto/bare-link
   bare-mime@1.0.0
     https://github.com/holepunchto/bare-mime
-  bare-module@6.2.1
+  bare-module@6.4.0
     https://github.com/holepunchto/bare-module
-  bare-module-lexer@1.5.2
+  bare-module-lexer@1.6.6
     https://github.com/holepunchto/bare-module-lexer
-  bare-module-resolve@1.12.2
+  bare-module-resolve@1.12.5
     https://github.com/holepunchto/bare-module-resolve
-  bare-module-traverse@2.1.2
+  bare-module-traverse@2.5.5
     https://github.com/holepunchto/bare-module-traverse
-  bare-net@2.3.2
+  bare-net@2.3.3
     https://github.com/holepunchto/bare-net
   bare-os@3.9.3
     https://github.com/holepunchto/bare-os
-  bare-pack@2.1.3
+  bare-pack@2.2.2
     https://github.com/holepunchto/bare-pack
-  bare-path@3.0.1
+  bare-path@3.1.2
     https://github.com/holepunchto/bare-path
-  bare-pipe@4.2.2
+  bare-performance@2.1.1
+    https://github.com/holepunchto/bare-performance
+  bare-pipe@4.3.1
     https://github.com/holepunchto/bare-pipe
-  bare-process@4.4.1
+  bare-posix@1.0.1
+    https://github.com/holepunchto/bare-posix
+  bare-process@4.5.1
     https://github.com/holepunchto/bare-process
-  bare-rpc@1.3.3
+  bare-rpc@1.3.8
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.28.7
+  bare-runtime@1.32.0
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.28.7
+  bare-runtime-darwin-arm64@1.32.0
     https://github.com/holepunchto/bare-runtime
-  bare-semver@1.0.3
+  bare-semver@1.1.0
     https://github.com/holepunchto/bare-semver
   bare-signals@4.2.0
     https://github.com/holepunchto/bare-signals
-  bare-stdio@1.0.2
+  bare-signals@5.0.0
+    https://github.com/holepunchto/bare-signals
+  bare-stdio@1.0.3
     https://github.com/holepunchto/bare-stdio
-  bare-stream@2.13.3
+  bare-stream@2.13.4
     https://github.com/holepunchto/bare-stream
-  bare-structured-clone@1.5.5
+  bare-structured-clone@1.6.0
     https://github.com/holepunchto/bare-structured-clone
   bare-stylize@0.0.1
     https://github.com/holepunchto/bare-stylize
@@ -811,28 +822,30 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-subprocess
   bare-subprocess@6.1.0
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.5.1
+  bare-tcp@2.6.1
     https://github.com/holepunchto/bare-tcp
-  bare-tls@3.1.7
+  bare-tls@3.1.10
     https://github.com/holepunchto/bare-tls
-  bare-tty@5.1.1
+  bare-tty@5.2.1
     https://github.com/holepunchto/bare-tty
-  bare-type@1.1.0
+  bare-type@1.1.1
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.5
+  bare-type-stripper@0.1.6
+    https://github.com/holepunchto/bare-type-stripper
+  bare-url@2.5.4
     https://github.com/holepunchto/bare-url
   bare-utils@1.6.0
     https://github.com/holepunchto/bare-utils
   bare-v8-to-istanbul@1.0.2
-  bare-ws@3.0.0
+  bare-ws@3.1.0
     https://github.com/holepunchto/bare-ws
-  bare-zlib@1.4.0
+  bare-zlib@1.4.1
     https://github.com/holepunchto/bare-zlib
   blind-relay@1.6.1
     https://github.com/holepunchto/blind-relay
   brittle@3.19.1
     https://github.com/holepunchto/brittle
-  compact-encoding@3.2.0
+  compact-encoding@3.5.0
     https://github.com/holepunchto/compact-encoding
   compact-encoding-bitfield@1.1.0
     https://github.com/compact-encoding/compact-encoding-bitfield
@@ -842,11 +855,11 @@ JavaScript Dependencies
     https://github.com/holepunchto/device-file
   events-universal@1.0.1
     https://github.com/holepunchto/events-universal
-  fd-lock@2.1.1
+  fd-lock@2.2.0
     https://github.com/holepunchto/fd-lock
-  fs-native-extensions@1.5.0
+  fs-native-extensions@1.5.1
     https://github.com/holepunchto/fs-native-extensions
-  globbie@1.0.3
+  globbie@1.0.6
     https://github.com/holepunchto/globbie
   hyperblobs@2.12.1
     https://github.com/holepunchto/hyperblobs
@@ -854,21 +867,21 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-errors
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
-  hypercore-stats@2.4.0
+  hypercore-stats@2.5.1
     https://github.com/holepunchto/hypercore-stats
-  hypercore-storage@3.1.1
+  hypercore-storage@3.2.1
     https://github.com/holepunchto/hypercore-storage
-  hyperdb@6.7.0
+  hyperdb@6.9.0
     https://github.com/holepunchto/hyperdb
   hyperdht-address@1.1.1
     https://github.com/holepunchto/hyperdht-address
-  hyperdht-stats@1.10.0
+  hyperdht-stats@1.11.0
     https://github.com/holepunchto/hyperdht-stats
   hyperdispatch@1.6.0
     https://github.com/holepunchto/hyperdispatch
-  hyperdrive@13.3.2
+  hyperdrive@13.3.3
     https://github.com/holepunchto/hyperdrive
-  hyperschema@1.21.0
+  hyperschema@1.24.0
     https://github.com/holepunchto/hyperschema
   hyperswarm-stats@1.3.1
     https://github.com/holepunchto/hyperswarm-stats
@@ -878,7 +891,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/mirror-drive
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
-  paparam@1.10.1
+  paparam@1.13.0
     https://github.com/holepunchto/paparam
   passive-core-watcher@1.0.1
     https://github.com/holepunchto/passive-core-watcher
@@ -892,13 +905,13 @@ JavaScript Dependencies
     https://github.com/holepunchto/rache
   refcounter@1.0.0
     https://github.com/holepunchto/refcounter
-  require-addon@1.2.0
+  require-addon@1.3.0
     https://github.com/holepunchto/require-addon
   require-asset@1.2.2
     https://github.com/holepunchto/require-asset
   resource-on-exit@1.0.0
     https://github.com/holepunchto/bare-teardown
-  rocksdb-native@3.16.0
+  rocksdb-native@3.17.4
     https://github.com/holepunchto/rocksdb-native
   scope-lock@1.2.4
     https://github.com/holepunchto/scope-lock
@@ -908,7 +921,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/sub-encoder
   text-decoder@1.2.7
     https://github.com/holepunchto/text-decoder
-  udx-native@1.20.7
+  udx-native@1.21.1
     https://github.com/holepunchto/udx-native
   unslab@1.3.0
     https://github.com/holepunchto/unslab
@@ -925,7 +938,7 @@ JavaScript Dependencies
     https://github.com/chm-diederichs/noise-curve-ed
   quickbit-universal@2.2.0
     https://github.com/holepunchto/quickbit-universal
-  semver@7.8.4
+  semver@7.8.5
     https://github.com/npm/node-semver
   simdle-universal@1.1.2
     https://github.com/holepunchto/simdle-universal
@@ -938,7 +951,7 @@ JavaScript Dependencies
 
   @jridgewell/resolve-uri@3.1.2
     https://github.com/jridgewell/resolve-uri
-  @jridgewell/sourcemap-codec@1.5.5
+  @jridgewell/sourcemap-codec@1.6.0
     https://github.com/jridgewell/sourcemaps
   @jridgewell/trace-mapping@0.3.31
     https://github.com/jridgewell/sourcemaps
@@ -954,7 +967,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/codecs
   convert-source-map@2.0.0
     https://github.com/thlorenz/convert-source-map
-  corestore@7.10.1
+  corestore@7.12.4
     https://github.com/holepunchto/corestore
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
@@ -974,13 +987,13 @@ JavaScript Dependencies
     https://github.com/mafintosh/generate-string
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.33.1
+  hypercore@11.35.5
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.32.0
+  hyperdht@6.34.0
     https://github.com/holepunchto/hyperdht
-  hyperswarm@4.17.0
+  hyperswarm@4.17.1
     https://github.com/holepunchto/hyperswarm
   is-options@1.0.2
     https://github.com/mafintosh/is-options
@@ -988,19 +1001,17 @@ JavaScript Dependencies
     https://github.com/mikolalysenko/is-property
   kademlia-routing-table@1.0.6
     https://github.com/mafintosh/kademlia-routing-table
-  llm-splitter@0.2.0
-    https://github.com/nearform/llm-splitter
   mutexify@1.4.0
     https://github.com/mafintosh/mutexify
   nat-sampler@1.0.1
     https://github.com/mafintosh/nat-sampler
-  picomatch@4.0.4
+  picomatch@4.0.7
     https://github.com/micromatch/picomatch
   promaphore@1.0.0
     https://github.com/mafintosh/promaphore
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
-  protomux@3.11.0
+  protomux@3.12.0
     https://github.com/holepunchto/protomux
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
@@ -1034,9 +1045,9 @@ JavaScript Dependencies
     https://github.com/mafintosh/speedometer
   stackframe@1.3.4
     https://github.com/stacktracejs/stackframe
-  streamx@2.28.0
+  streamx@2.28.1
     https://github.com/mafintosh/streamx
-  tar-stream@3.2.0
+  tar-stream@3.2.1
     https://github.com/mafintosh/tar-stream
   teex@1.0.1
     https://github.com/mafintosh/teex
@@ -1056,10 +1067,10 @@ JavaScript Dependencies
     https://github.com/mafintosh/unordered-set
   varint@5.0.0
     https://github.com/chrisdickinson/varint
-  xache@1.2.1
+  xache@1.3.0
     https://github.com/mafintosh/xache
   z32@1.1.0
     https://github.com/mafintosh/z32
-  zod@4.4.3
+  zod@4.6.1
     https://github.com/colinhacks/zod
 

--- a/packages/sdk/changelog/0.19.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.19.1/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog v0.19.1
+
+Release Date: 2026-09-10
+
+## ✨ Features
+
+- Report the iOS per-process memory allowance. (see PR [#4359](https://github.com/tetherto/qvac/pull/4359))
+
+## 🔌 API
+
+- Add deleteCache({ auto: true }) to reclaim automatic KV caches. (see PR [#4248](https://github.com/tetherto/qvac/pull/4248)) - See [API changes](./api.md)
+- Pass prompt-processing throughput through completion stats. (see PR [#4295](https://github.com/tetherto/qvac/pull/4295)) - See [API changes](./api.md)
+- Refuse from the computed floor when no calibration applies. (see PR [#4358](https://github.com/tetherto/qvac/pull/4358)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Keep the desktop-only fit subprocess out of mobile bundles. (see PR [#4392](https://github.com/tetherto/qvac/pull/4392))
+
+## 📘 Docs
+
+- AssessModelFit support matrix, unknown reasons, and demo detail panels. (see PR [#4274](https://github.com/tetherto/qvac/pull/4274))
+
+## 🧹 Chores
+
+- Bump @qvac/rag to ^0.8.1. (see PR [#4367](https://github.com/tetherto/qvac/pull/4367))
+

--- a/packages/sdk/changelog/0.19.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.19.1/CHANGELOG_LLM.md
@@ -1,0 +1,73 @@
+# QVAC SDK v0.19.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.19.1
+
+QVAC SDK 0.19.1 is a patch on the 0.19 line. Completion stats now report prompt-processing throughput, `deleteCache({ auto: true })` reclaims automatic KV caches without touching named ones, and `assessModelFit` can refuse a model from a computed floor when no calibration applies. Mobile `withQvacSDK` bundles no longer pull in the desktop-only fit subprocess, and `@qvac/rag` `^0.8.1` is the floor so Windows TurboVec installs the fixed package.
+
+`@qvac/sdk`, `@qvac/inference`, and `tetherto-qvac-sdk` all ship at 0.19.1. Install `@qvac/sdk` and `@qvac/inference` together at this version.
+
+## New APIs
+
+### Prompt-processing throughput
+
+`CompletionStats.promptTokensPerSecond` is the addon's prefill (prompt-processing) rate. `tokensPerSecond` remains decode throughput. Both fields are optional; they appear on `completionStats` events and on the aggregated `final.stats` for single and batch completions. The Python client models include the same field.
+
+```typescript
+const run = completion({ modelId, history, stream: true })
+const stats = await run.stats
+
+stats?.tokensPerSecond // decode throughput
+stats?.promptTokensPerSecond // prompt-processing (prefill) throughput
+```
+
+### Reclaim automatic KV caches
+
+`deleteCache({ auto: true })` drops every automatic cache that no in-flight turn is holding. Named, caller-owned caches are left alone. `{ all: true }` still deletes everything, including named caches.
+
+```typescript
+import { deleteCache } from '@qvac/sdk'
+
+await deleteCache({ auto: true })
+```
+
+### Computed floor when no calibration applies
+
+On platforms without a calibration fixture, `assessModelFit` used to return `unknown` even when the artifact plus KV cache already exceeded the budget. It now falls back to a computed floor (artifact bytes plus the llama.cpp KV cache at the narrowest default width). Over budget is `likely-too-large`; otherwise the verdict stays `unknown`. This path never returns `likely-fits`.
+
+Android compares the floor to the `system-memory` budget. iOS compares it to the `process-memory` budget, which now uses the per-process allowance from `bare-os`. Discrete GPUs without coefficients stay `unknown`.
+
+New result fields: `evidence` (`calibration` | `computed-only`) and `floorBytes`.
+
+```typescript
+import { assessModelFit, QWEN3_8B_INST_Q4_K_M } from '@qvac/sdk'
+
+const result = await assessModelFit({
+  models: [
+    {
+      model: QWEN3_8B_INST_Q4_K_M,
+      workload: { kind: 'llm', contextTokens: 8192 }
+    }
+  ]
+})
+
+result.verdict // "likely-fits" | "likely-too-large" | "unknown"
+result.evidence // "calibration" | "computed-only"
+result.floorBytes
+
+if (result.evidence === "computed-only" && result.verdict === "unknown") {
+  // uncalibrated, not a near-miss
+}
+```
+
+The assess-model-fit doc now includes a platform support matrix and a table of every `unknown` reason.
+
+## Features
+
+iOS `sample.memory.processAvailableBytes` is sourced from `bare-os` `availableMemory()` so the `process-memory` budget can form. Other platforms leave that metric unavailable.
+
+## Bug Fixes
+
+`withQvacSDK` mobile bundles defer `bare-runtime/spawn` and `@qvac/model-fit/process`, so expo prebuild no longer fails looking for a `bare-posix` android-arm64 prebuild that does not exist. Desktop advisory fit is unchanged.
+
+`@qvac/inference` now requires `@qvac/rag` `^0.8.1`. 0.8.0 could not open a TurboVec workspace on Windows.
+

--- a/packages/sdk/changelog/0.19.1/api.md
+++ b/packages/sdk/changelog/0.19.1/api.md
@@ -1,0 +1,44 @@
+# 🔌 API Changes v0.19.1
+
+## Add deleteCache({ auto: true }) to reclaim automatic KV caches
+
+PR: [#4248](https://github.com/tetherto/qvac/pull/4248)
+
+```typescript
+import { deleteCache } from '@qvac/sdk'
+
+// Reclaim automatic caches; caller-owned named caches are untouched.
+await deleteCache({ auto: true })
+```
+
+---
+
+## Pass prompt-processing throughput through completion stats
+
+PR: [#4295](https://github.com/tetherto/qvac/pull/4295)
+
+```typescript
+const run = completion({ modelId, history, stream: true })
+const stats = await run.stats
+
+stats?.tokensPerSecond // decode throughput
+stats?.promptTokensPerSecond // prompt-processing (prefill) throughput
+```
+
+---
+
+## Refuse from the computed floor when no calibration applies
+
+PR: [#4358](https://github.com/tetherto/qvac/pull/4358)
+
+```typescript
+const result = await assessModelFit({ models: [{ model: QWEN3_8B_INST_Q4_K_M, workload: { kind: 'llm', contextTokens: 8192 } }] })
+// android-arm64: { verdict: 'likely-too-large', basis: 'system-memory',  evidence: 'computed-only', floorBytes: 5425000000, ... }
+// ios-arm64:     { verdict: 'likely-too-large', basis: 'process-memory', evidence: 'computed-only', floorBytes: 5425000000, ... }
+if (result.evidence === 'computed-only' && result.verdict === 'unknown') {
+  // uncalibrated, not a near-miss
+}
+```
+
+---
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -220,7 +220,7 @@
     "@qvac/diffusion-cpp": "^0.21.0",
     "@qvac/embed-llamacpp": "^0.37.0",
     "@qvac/error": "^0.1.1",
-    "@qvac/inference": "^0.19.0",
+    "@qvac/inference": "^0.19.1",
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/llm-llamacpp": "^0.49.1",
     "@qvac/logging": "^0.1.0",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/sdk` / `@qvac/inference` / `tetherto-qvac-sdk` 0.19.1 on `main`, per gitflow "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

Inference NOTICE keeps `main`'s `@qvac/model-fit@0.8.0` (from #4010, not in the 0.19.1 cut) and takes `@qvac/rag@0.8.1` from the release.

## Companion release PR

- https://github.com/tetherto/qvac/pull/4395

## Files

- `packages/inference/package.json` — version `0.19.0` → `0.19.1`
- `packages/sdk/package.json` — version `0.19.0` → `0.19.1`, `@qvac/inference` `^0.19.1`
- `packages/sdk-python/.../sdk_version.py` — `SDK_VERSION` `0.19.1`
- `packages/sdk/changelog/0.19.1/` — generated changelog files
- `packages/sdk/CHANGELOG.md` — aggregated changelog
- `packages/sdk/NOTICE`, `packages/inference/NOTICE` — updated attributions
- `docs/website/content/docs/reference/release-notes/index.mdx`, `docs/website/src/lib/versions.ts` — 0.19.1 docs notes
