### PR TITLE
fix: fail the mobile test runner on an out-of-band fatal error

### DIFF
--- a/packages/asr-ggml/test/mobile/integration-runtime.cjs
+++ b/packages/asr-ggml/test/mobile/integration-runtime.cjs
@@ -20,19 +20,22 @@ proc.env.NO_GPU = 'false'
 // @qvac/tts-ggml@0.2.1 ggml_backend_is_cpu dlopen crash -- as an
 // unhandledRejection on the worklet thread; a log-only handler turned that
 // into a false-green Device Farm run. Catch to avoid the abrupt SIGABRT,
-// record the first failure, and force a non-zero exit on drain so CI sees it.
-let _integrationFatalError = null
+// record every failure, and force a non-zero exit on drain so CI sees it.
+//
+// The exit code is only half of it: the harness reports per-runner results, so
+// runIntegrationModule below must also fail the runner the error happened in.
+const _integrationFatalErrors = []
 if (typeof Bare !== 'undefined' && typeof Bare.on === 'function') {
   Bare.on('unhandledRejection', (reason) => {
-    if (!_integrationFatalError) _integrationFatalError = reason || new Error('unhandledRejection')
+    _integrationFatalErrors.push(reason || new Error('unhandledRejection'))
     console.error('[integration-runner] Unhandled rejection:', reason instanceof Error ? reason.stack : reason)
   })
   Bare.on('uncaughtException', (err) => {
-    if (!_integrationFatalError) _integrationFatalError = err || new Error('uncaughtException')
+    _integrationFatalErrors.push(err || new Error('uncaughtException'))
     console.error('[integration-runner] Uncaught exception:', err instanceof Error ? err.stack : err)
   })
   Bare.on('beforeExit', () => {
-    if (!_integrationFatalError) return
+    if (_integrationFatalErrors.length === 0) return
     console.error('[integration-runner] FATAL: failing run due to an earlier unhandled error.')
     if (typeof Bare.exit === 'function') Bare.exit(1)
     else if (typeof process !== 'undefined' && process.exit) process.exit(1)
@@ -47,8 +50,17 @@ async function runIntegrationModule (relativeModulePath, options = {}) {
     return 'missing'
   }
 
+  const fatalMark = _integrationFatalErrors.length
   const moduleUrl = pathToFileURL(modulePath).href
   await import(moduleUrl)
+
+  // Yield once so a rejection raised in the module's final tick reaches the
+  // handler, then surface it the same way an import failure already is: by
+  // throwing. Returning normally is what let a failed model load report PASS.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  if (_integrationFatalErrors.length > fatalMark) {
+    throw _integrationFatalErrors[fatalMark]
+  }
   return modulePath
 }
 

--- a/packages/embed-llamacpp/test/mobile/integration-runtime.cjs
+++ b/packages/embed-llamacpp/test/mobile/integration-runtime.cjs
@@ -12,25 +12,28 @@ const { pathToFileURL } = require('bare-url')
 // @qvac/tts-ggml@0.2.1 ggml_backend_is_cpu dlopen crash -- as an
 // unhandledRejection on the worklet thread; a log-only handler turned that
 // into a false-green Device Farm run. Catch to avoid the abrupt SIGABRT,
-// record the first failure, and force a non-zero exit on drain so CI sees it.
-let _integrationFatalError = null
+// record every failure, and force a non-zero exit on drain so CI sees it.
+//
+// The exit code is only half of it: the harness reports per-runner results, so
+// runIntegrationModule below must also fail the runner the error happened in.
+const _integrationFatalErrors = []
 if (typeof Bare !== 'undefined' && typeof Bare.on === 'function') {
   Bare.on('unhandledRejection', (reason) => {
-    if (!_integrationFatalError) _integrationFatalError = reason || new Error('unhandledRejection')
+    _integrationFatalErrors.push(reason || new Error('unhandledRejection'))
     console.error(
       '[integration-runner] Unhandled rejection:',
       reason instanceof Error ? reason.stack : reason
     )
   })
   Bare.on('uncaughtException', (err) => {
-    if (!_integrationFatalError) _integrationFatalError = err || new Error('uncaughtException')
+    _integrationFatalErrors.push(err || new Error('uncaughtException'))
     console.error(
       '[integration-runner] Uncaught exception:',
       err instanceof Error ? err.stack : err
     )
   })
   Bare.on('beforeExit', () => {
-    if (!_integrationFatalError) return
+    if (_integrationFatalErrors.length === 0) return
     console.error('[integration-runner] FATAL: failing run due to an earlier unhandled error.')
     if (typeof Bare.exit === 'function') Bare.exit(1)
     else if (typeof process !== 'undefined' && process.exit) process.exit(1)
@@ -90,6 +93,25 @@ global.__shouldRunTest = function shouldRunTest(testName) {
   return __filterRe.test(testName)
 }
 
+// Fails the runner when the module raised a fatal error out of band. brittle's
+// own tally never sees those: a failed model load that rejects outside the
+// awaited chain left the runner reporting PASS with sub-tests never executed,
+// and Device Farm went green (run 34533640427). Returns null when clean.
+function fatalSummarySince(mark) {
+  if (_integrationFatalErrors.length <= mark) return null
+  const err = _integrationFatalErrors[mark]
+  return {
+    total: 1,
+    passed: 0,
+    failed: 1,
+    error: {
+      message: (err && err.message) || String(err),
+      code: err && err.code,
+      stack: err && err.stack
+    }
+  }
+}
+
 async function runIntegrationModule(relativeModulePath, options = {}) {
   const modulePath = path.join(__dirname, relativeModulePath)
 
@@ -98,6 +120,7 @@ async function runIntegrationModule(relativeModulePath, options = {}) {
     return { modulePath: 'missing', summary: { total: 0, passed: 0, failed: 0 } }
   }
 
+  const fatalMark = _integrationFatalErrors.length
   const moduleUrl = pathToFileURL(modulePath).href
   try {
     await import(moduleUrl)
@@ -117,6 +140,17 @@ async function runIntegrationModule(relativeModulePath, options = {}) {
       }
     }
   }
+  // Yield once so a rejection raised in the module's final tick reaches the
+  // handler before we decide the verdict.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const fatal = fatalSummarySince(fatalMark)
+  if (fatal) {
+    console.error(
+      `[integration-runner] ${relativeModulePath} raised a fatal error outside the test tally; failing it.`
+    )
+    return { modulePath, summary: fatal }
+  }
+
   return { modulePath, summary: null }
 }
 

--- a/packages/llm-llamacpp/test/mobile/integration-runtime.cjs
+++ b/packages/llm-llamacpp/test/mobile/integration-runtime.cjs
@@ -12,25 +12,28 @@ const { pathToFileURL } = require('bare-url')
 // @qvac/tts-ggml@0.2.1 ggml_backend_is_cpu dlopen crash -- as an
 // unhandledRejection on the worklet thread; a log-only handler turned that
 // into a false-green Device Farm run. Catch to avoid the abrupt SIGABRT,
-// record the first failure, and force a non-zero exit on drain so CI sees it.
-let _integrationFatalError = null
+// record every failure, and force a non-zero exit on drain so CI sees it.
+//
+// The exit code is only half of it: the harness reports per-runner results, so
+// runIntegrationModule below must also fail the runner the error happened in.
+const _integrationFatalErrors = []
 if (typeof Bare !== 'undefined' && typeof Bare.on === 'function') {
   Bare.on('unhandledRejection', (reason) => {
-    if (!_integrationFatalError) _integrationFatalError = reason || new Error('unhandledRejection')
+    _integrationFatalErrors.push(reason || new Error('unhandledRejection'))
     console.error(
       '[integration-runner] Unhandled rejection:',
       reason instanceof Error ? reason.stack : reason
     )
   })
   Bare.on('uncaughtException', (err) => {
-    if (!_integrationFatalError) _integrationFatalError = err || new Error('uncaughtException')
+    _integrationFatalErrors.push(err || new Error('uncaughtException'))
     console.error(
       '[integration-runner] Uncaught exception:',
       err instanceof Error ? err.stack : err
     )
   })
   Bare.on('beforeExit', () => {
-    if (!_integrationFatalError) return
+    if (_integrationFatalErrors.length === 0) return
     console.error('[integration-runner] FATAL: failing run due to an earlier unhandled error.')
     if (typeof Bare.exit === 'function') Bare.exit(1)
     else if (typeof process !== 'undefined' && process.exit) process.exit(1)
@@ -165,6 +168,26 @@ global.__shouldRunTest = function shouldRunTest(testName) {
   return __filterRe.test(testName)
 }
 
+// Fails the runner when the module raised a fatal error out of band. brittle's
+// own tally never sees those: on b10796 a failed mmproj load rejected outside
+// the awaited chain, so this runner reported PASS with two of its seven
+// sub-tests never executed, and Device Farm went green (run 34533640427).
+// Returns null when the module was clean.
+function fatalSummarySince(mark) {
+  if (_integrationFatalErrors.length <= mark) return null
+  const err = _integrationFatalErrors[mark]
+  return {
+    total: 1,
+    passed: 0,
+    failed: 1,
+    error: {
+      message: (err && err.message) || String(err),
+      code: err && err.code,
+      stack: err && err.stack
+    }
+  }
+}
+
 async function runIntegrationModule(relativeModulePath) {
   const modulePath = path.join(__dirname, relativeModulePath)
 
@@ -173,6 +196,7 @@ async function runIntegrationModule(relativeModulePath) {
     return { modulePath: 'missing', summary: { total: 0, passed: 0, failed: 0 } }
   }
 
+  const fatalMark = _integrationFatalErrors.length
   const moduleUrl = pathToFileURL(modulePath).href
   try {
     await import(moduleUrl)
@@ -192,6 +216,18 @@ async function runIntegrationModule(relativeModulePath) {
       }
     }
   }
+
+  // Yield once so a rejection raised in the module's final tick reaches the
+  // handler before we decide the verdict.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const fatal = fatalSummarySince(fatalMark)
+  if (fatal) {
+    console.error(
+      `[integration-runner] ${relativeModulePath} raised a fatal error outside the test tally; failing it.`
+    )
+    return { modulePath, summary: fatal }
+  }
+
   return { modulePath, summary: null }
 }
 

--- a/packages/llm-llamacpp/test/unit/_fixtures/fatal-runner-child.cjs
+++ b/packages/llm-llamacpp/test/unit/_fixtures/fatal-runner-child.cjs
@@ -1,0 +1,13 @@
+'use strict'
+
+// Runs in a child process: loading the runtime installs a beforeExit hook that
+// exits non-zero once a fatal error is recorded, which would take the whole
+// unit suite down if this ran in-process.
+require('../../mobile/integration-runtime.cjs')
+
+async function main() {
+  const res = await global.runIntegrationModule('../unit/_fixtures/reject-module.mjs')
+  console.log('RESULT ' + JSON.stringify(res.summary))
+}
+
+main()

--- a/packages/llm-llamacpp/test/unit/_fixtures/reject-module.mjs
+++ b/packages/llm-llamacpp/test/unit/_fixtures/reject-module.mjs
@@ -1,0 +1,6 @@
+// Mimics the failure shape that went green on Device Farm: the module body
+// completes, but a promise rejects outside the awaited chain (a model load that
+// errors instead of crashing). brittle's tally never sees it — only the
+// runtime's unhandledRejection handler does.
+Promise.reject(new Error('[MtmdLlm] Failed to load vision model'))
+export default true

--- a/packages/llm-llamacpp/test/unit/mobile-runner-fatal.test.js
+++ b/packages/llm-llamacpp/test/unit/mobile-runner-fatal.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+// A model load that fails instead of crashing rejects outside the awaited
+// chain. brittle records nothing, so the mobile runner used to return no
+// summary at all — the harness read that as PASS and Device Farm went green
+// with two of seven sub-tests never executed (run 34533640427). The runner must
+// fail the runner it happened in, and exit non-zero.
+//
+// Runs in a child process on purpose: loading the runtime installs a beforeExit
+// hook that exits(1) once a fatal error is recorded.
+
+const test = require('brittle')
+const path = require('bare-path')
+const { spawn } = require('bare-subprocess')
+
+const CHILD = path.join(__dirname, '_fixtures/fatal-runner-child.cjs')
+
+function runChild() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(Bare.argv[0], [CHILD], { stdio: 'pipe' })
+    let out = ''
+    child.stdout.on('data', (d) => {
+      out += d.toString()
+    })
+    child.stderr.on('data', (d) => {
+      out += d.toString()
+    })
+    child.on('error', reject)
+    child.on('exit', (code) => resolve({ code, out }))
+  })
+}
+
+test('an out-of-band rejection fails the runner instead of reporting a pass', async function (t) {
+  const { code, out } = await runChild()
+
+  const line = out.split('\n').find((l) => l.startsWith('RESULT '))
+  t.ok(line, `child printed a result (got: ${out.slice(0, 400)})`)
+
+  const summary = JSON.parse(line.slice('RESULT '.length))
+  t.ok(summary, 'a summary is returned — null is what made this a false green')
+  t.is(summary.failed, 1, 'the module is reported as failed')
+  t.is(summary.passed, 0)
+  t.ok(
+    summary.error && /Failed to load vision model/.test(summary.error.message),
+    'the original error is carried through for the log'
+  )
+  t.is(code, 1, 'and the process still exits non-zero')
+})

--- a/packages/ocr-ggml/test/mobile/integration-runtime.cjs
+++ b/packages/ocr-ggml/test/mobile/integration-runtime.cjs
@@ -10,26 +10,29 @@ const { pathToFileURL } = require('bare-url')
 // only fails to resolve once several ggml addons are co-loaded) as an
 // unhandledRejection on the worklet thread. Without a hard exit the run can
 // SIGABRT (ambiguous timeout) or a log-only handler would falsely pass. Catch,
-// record the first failure, and force a non-zero exit on drain.
-let _integrationFatalError = null
+// record every failure, and force a non-zero exit on drain.
+//
+// The exit code is only half of it: the harness reports per-runner results, so
+// runIntegrationModule below must also fail the runner the error happened in.
+const _integrationFatalErrors = []
 const _bareHost = typeof globalThis !== 'undefined' ? globalThis.Bare : undefined
 if (_bareHost && typeof _bareHost.on === 'function') {
   _bareHost.on('unhandledRejection', (reason) => {
-    if (!_integrationFatalError) _integrationFatalError = reason || new Error('unhandledRejection')
+    _integrationFatalErrors.push(reason || new Error('unhandledRejection'))
     console.error(
       '[integration-runner] Unhandled rejection:',
       reason instanceof Error ? reason.stack : reason
     )
   })
   _bareHost.on('uncaughtException', (err) => {
-    if (!_integrationFatalError) _integrationFatalError = err || new Error('uncaughtException')
+    _integrationFatalErrors.push(err || new Error('uncaughtException'))
     console.error(
       '[integration-runner] Uncaught exception:',
       err instanceof Error ? err.stack : err
     )
   })
   _bareHost.on('beforeExit', () => {
-    if (!_integrationFatalError) return
+    if (_integrationFatalErrors.length === 0) return
     console.error('[integration-runner] FATAL: failing run due to an earlier unhandled error.')
     if (typeof _bareHost.exit === 'function') _bareHost.exit(1)
     else if (typeof globalThis.process !== 'undefined' && globalThis.process.exit)
@@ -89,6 +92,25 @@ global.__shouldRunTest = function shouldRunTest(testName) {
   return __filterRe.test(testName)
 }
 
+// Fails the runner when the module raised a fatal error out of band. brittle's
+// own tally never sees those: a failed model load that rejects outside the
+// awaited chain left the runner reporting PASS with sub-tests never executed,
+// and Device Farm went green (run 34533640427). Returns null when clean.
+function fatalSummarySince(mark) {
+  if (_integrationFatalErrors.length <= mark) return null
+  const err = _integrationFatalErrors[mark]
+  return {
+    total: 1,
+    passed: 0,
+    failed: 1,
+    error: {
+      message: (err && err.message) || String(err),
+      code: err && err.code,
+      stack: err && err.stack
+    }
+  }
+}
+
 async function runIntegrationModule(relativeModulePath, options = {}) {
   const modulePath = path.join(__dirname, relativeModulePath)
 
@@ -97,8 +119,20 @@ async function runIntegrationModule(relativeModulePath, options = {}) {
     return { modulePath: 'missing', summary: { total: 0, passed: 0, failed: 0 } }
   }
 
+  const fatalMark = _integrationFatalErrors.length
   const moduleUrl = pathToFileURL(modulePath).href
   await import(moduleUrl)
+  // Yield once so a rejection raised in the module's final tick reaches the
+  // handler before we decide the verdict.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const fatal = fatalSummarySince(fatalMark)
+  if (fatal) {
+    console.error(
+      `[integration-runner] ${relativeModulePath} raised a fatal error outside the test tally; failing it.`
+    )
+    return { modulePath, summary: fatal }
+  }
+
   return { modulePath, summary: null }
 }
 

--- a/packages/translation-nmtcpp/test/mobile/integration-runtime.cjs
+++ b/packages/translation-nmtcpp/test/mobile/integration-runtime.cjs
@@ -9,26 +9,29 @@ const { pathToFileURL } = require('bare-url')
 // only fails to resolve once several ggml addons are co-loaded) as an
 // unhandledRejection on the worklet thread. Without a hard exit the run can
 // SIGABRT (ambiguous timeout) or a log-only handler would falsely pass. Catch,
-// record the first failure, and force a non-zero exit on drain.
-let _integrationFatalError = null
+// record every failure, and force a non-zero exit on drain.
+//
+// The exit code is only half of it: the harness reports per-runner results, so
+// runIntegrationModule below must also fail the runner the error happened in.
+const _integrationFatalErrors = []
 const _bareHost = typeof globalThis !== 'undefined' ? globalThis.Bare : undefined
 if (_bareHost && typeof _bareHost.on === 'function') {
   _bareHost.on('unhandledRejection', (reason) => {
-    if (!_integrationFatalError) _integrationFatalError = reason || new Error('unhandledRejection')
+    _integrationFatalErrors.push(reason || new Error('unhandledRejection'))
     console.error(
       '[integration-runner] Unhandled rejection:',
       reason instanceof Error ? reason.stack : reason
     )
   })
   _bareHost.on('uncaughtException', (err) => {
-    if (!_integrationFatalError) _integrationFatalError = err || new Error('uncaughtException')
+    _integrationFatalErrors.push(err || new Error('uncaughtException'))
     console.error(
       '[integration-runner] Uncaught exception:',
       err instanceof Error ? err.stack : err
     )
   })
   _bareHost.on('beforeExit', () => {
-    if (!_integrationFatalError) return
+    if (_integrationFatalErrors.length === 0) return
     console.error('[integration-runner] FATAL: failing run due to an earlier unhandled error.')
     if (typeof _bareHost.exit === 'function') _bareHost.exit(1)
     else if (typeof globalThis.process !== 'undefined' && globalThis.process.exit)
@@ -46,8 +49,17 @@ async function runIntegrationModule(relativeModulePath, options = {}) {
     return 'missing'
   }
 
+  const fatalMark = _integrationFatalErrors.length
   const moduleUrl = pathToFileURL(modulePath).href
   await import(moduleUrl)
+
+  // Yield once so a rejection raised in the module's final tick reaches the
+  // handler, then surface it the same way an import failure already is: by
+  // throwing. Returning normally is what let a failed model load report PASS.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  if (_integrationFatalErrors.length > fatalMark) {
+    throw _integrationFatalErrors[fatalMark]
+  }
 
   if (global.gc) {
     global.gc()

--- a/packages/vla-ggml/test/mobile/integration-runtime.cjs
+++ b/packages/vla-ggml/test/mobile/integration-runtime.cjs
@@ -10,26 +10,29 @@ const { pathToFileURL } = require('bare-url')
 // only fails to resolve once several ggml addons are co-loaded) as an
 // unhandledRejection on the worklet thread. Without a hard exit the run can
 // SIGABRT (ambiguous timeout) or a log-only handler would falsely pass. Catch,
-// record the first failure, and force a non-zero exit on drain.
-let _integrationFatalError = null
+// record every failure, and force a non-zero exit on drain.
+//
+// The exit code is only half of it: the harness reports per-runner results, so
+// runIntegrationModule below must also fail the runner the error happened in.
+const _integrationFatalErrors = []
 const _bareHost = typeof globalThis !== 'undefined' ? globalThis.Bare : undefined
 if (_bareHost && typeof _bareHost.on === 'function') {
   _bareHost.on('unhandledRejection', (reason) => {
-    if (!_integrationFatalError) _integrationFatalError = reason || new Error('unhandledRejection')
+    _integrationFatalErrors.push(reason || new Error('unhandledRejection'))
     console.error(
       '[integration-runner] Unhandled rejection:',
       reason instanceof Error ? reason.stack : reason
     )
   })
   _bareHost.on('uncaughtException', (err) => {
-    if (!_integrationFatalError) _integrationFatalError = err || new Error('uncaughtException')
+    _integrationFatalErrors.push(err || new Error('uncaughtException'))
     console.error(
       '[integration-runner] Uncaught exception:',
       err instanceof Error ? err.stack : err
     )
   })
   _bareHost.on('beforeExit', () => {
-    if (!_integrationFatalError) return
+    if (_integrationFatalErrors.length === 0) return
     console.error('[integration-runner] FATAL: failing run due to an earlier unhandled error.')
     if (typeof _bareHost.exit === 'function') _bareHost.exit(1)
     else if (typeof globalThis.process !== 'undefined' && globalThis.process.exit)
@@ -89,6 +92,25 @@ global.__shouldRunTest = function shouldRunTest(testName) {
   return __filterRe.test(testName)
 }
 
+// Fails the runner when the module raised a fatal error out of band. brittle's
+// own tally never sees those: a failed model load that rejects outside the
+// awaited chain left the runner reporting PASS with sub-tests never executed,
+// and Device Farm went green (run 34533640427). Returns null when clean.
+function fatalSummarySince(mark) {
+  if (_integrationFatalErrors.length <= mark) return null
+  const err = _integrationFatalErrors[mark]
+  return {
+    total: 1,
+    passed: 0,
+    failed: 1,
+    error: {
+      message: (err && err.message) || String(err),
+      code: err && err.code,
+      stack: err && err.stack
+    }
+  }
+}
+
 async function runIntegrationModule(relativeModulePath, options = {}) {
   const modulePath = path.join(__dirname, relativeModulePath)
 
@@ -97,8 +119,20 @@ async function runIntegrationModule(relativeModulePath, options = {}) {
     return { modulePath: 'missing', summary: { total: 0, passed: 0, failed: 0 } }
   }
 
+  const fatalMark = _integrationFatalErrors.length
   const moduleUrl = pathToFileURL(modulePath).href
   await import(moduleUrl)
+  // Yield once so a rejection raised in the module's final tick reaches the
+  // handler before we decide the verdict.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const fatal = fatalSummarySince(fatalMark)
+  if (fatal) {
+    console.error(
+      `[integration-runner] ${relativeModulePath} raised a fatal error outside the test tally; failing it.`
+    )
+    return { modulePath, summary: fatal }
+  }
+
   return { modulePath, summary: null }
 }
 


### PR DESCRIPTION
## Summary

A mobile test module that raises a fatal error **outside** the awaited chain is currently reported as a pass, and the Device Farm run goes green.

`runIntegrationModule` returns no summary when the dynamic import resolves cleanly. brittle's own tally never sees an out-of-band rejection, so the harness — which reports per-runner results — reads "no failures" and marks the runner PASS. The runtime's existing handler does record the error and force a non-zero exit on drain, but the mobile harness never looks at the app's exit code.

## The run that exposed it

[34533640427](https://github.com/tetherto/qvac/actions/runs/34533640427) (llm, iOS) reports:

```json
"crashed": false,
"summary": { "total": 1, "passed": 1, "failed": 0 },
"tests": [ { "title": "runGemma4Test", "status": "passed" } ]
```

while its device log shows `ok 1` … `ok 5`, then:

```
ggml_backend_metal_buffer_type_alloc_buffer: failed to allocate Metal buffer of 618071168 bytes (out of memory)
[MtmdLlm] Failed to load vision model from …/mmproj-google_gemma-4-E2B-it-f16.gguf
[integration-runner] Unhandled rejection: … at gemma4.test.js:602
```

and **no `ok 6`, no `ok 7`** — two sub-tests never executed, run green.

This is the same class of failure the runtime's own comment already describes (the `@qvac/tts-ggml@0.2.1` dlopen false-green); the exit-code half was fixed then, the per-runner half was not.

## Change

- the handler records **every** fatal error instead of only the first, so a runner can tell "an earlier module failed" from "this one did"
- `runIntegrationModule` compares the count across the module it just ran and fails that runner
- one macrotask yield before the check, so a rejection raised in the module's final tick is attributed to the module that caused it rather than the next one

Two shapes, matching what each addon already does with an import failure:

| addon | on fatal |
|---|---|
| llm-llamacpp, embed-llamacpp, ocr-ggml, vla-ggml | return `{ total: 1, passed: 0, failed: 1, error }` |
| asr-ggml, translation-nmtcpp | throw |

## Test

`packages/llm-llamacpp/test/unit/mobile-runner-fatal.test.js` runs the runtime in a **child process** — loading it installs a `beforeExit` hook that exits non-zero, which would take the whole unit suite down in-process — against a fixture that rejects out of band, and asserts `failed: 1`, the original error carried through, and a non-zero exit.

```
ok 2 - a summary is returned — null is what made this a false green
ok 3 - the module is reported as failed
ok 6 - and the process still exits non-zero
# asserts = 6/6 pass
```

Confirmed it fails against the pre-change runtime: `RESULT null`.

## Note for reviewers

This will turn red any run that was quietly green because something rejected out of band. That is the intent, but it may surface pre-existing failures in other addons that nobody has seen yet.

`asr-ggml`'s runtime file is not prettier-formatted — it already wasn't before this change, so the addition matches the file's local style rather than reformatting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
