### PR TITLE
QVAC-24933 feat[api]: add an mmproj-no-audio load config option

### DIFF
--- a/packages/embed-llamacpp/vcpkg-configuration.json
+++ b/packages/embed-llamacpp/vcpkg-configuration.json
@@ -4,6 +4,9 @@
     "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "registries": [
     {
       "kind": "git",

--- a/packages/fabric/vcpkg-configuration.json
+++ b/packages/fabric/vcpkg-configuration.json
@@ -4,6 +4,9 @@
     "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "registries": [
     {
       "kind": "git",

--- a/packages/llm-llamacpp/addon/src/handlers/LoadConfigHandlers.cpp
+++ b/packages/llm-llamacpp/addon/src/handlers/LoadConfigHandlers.cpp
@@ -61,6 +61,27 @@ handleImageNoUpscale(common_params& params, const std::string& raw) {
   }
 }
 
+// Drops the projector's audio encoder while keeping its vision encoder. The
+// addon already defaults this to true (see normalizeLoadForFit), so the
+// useful case here is an explicit "off", which loads the audio tower back.
+static void handleMmprojNoAudio(common_params& params, const std::string& raw) {
+  std::string val = raw;
+  std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+  if (val == "1" || val == "on" || val == "true") {
+    params.mmproj_no_audio = true;
+  } else if (val == "0" || val == "off" || val == "false") {
+    params.mmproj_no_audio = false;
+  } else {
+    throw qvac_errors::StatusError(
+        errors::ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        string_format(
+            "mmproj-no-audio must be 0/off/false or 1/on/true, got: %s",
+            raw.c_str()));
+  }
+}
+
 static void
 handleImageMaxTokens(common_params& params, const std::string& raw) {
   try {
@@ -100,6 +121,8 @@ const LoadConfigHandlerList LOAD_CONFIG_HANDLERS = {
     {"image_min_tokens", handleImageMinTokens},
     {"image-no-upscale", handleImageNoUpscale},
     {"image_no_upscale", handleImageNoUpscale},
+    {"mmproj-no-audio", handleMmprojNoAudio},
+    {"mmproj_no_audio", handleMmprojNoAudio},
 };
 
 void applyLoadConfigHandlers(

--- a/packages/llm-llamacpp/addon/src/model-interface/LoadFitNormalization.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LoadFitNormalization.cpp
@@ -750,6 +750,9 @@ NormalizedLoad normalizeLoadForFit(
         "embedded chat template is applied\n");
   }
 
+  // Skip the projector's audio encoder by default.
+  params.mmproj_no_audio = true;
+
   qvac_lib_inference_addon_llama::applyLoadConfigHandlers(
       params, configFilemap);
 

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -203,6 +203,10 @@ void MtmdLlmContext::initVisionContext() {
   mparams.n_threads = params_.cpuparams.n_threads;
   mparams.image_tile_mode = params_.image_tile_mode;
   mparams.image_no_upscale = params_.image_no_upscale;
+  // Defaulted to true in normalizeLoadForFit; mmproj-no-audio=0 turns it back
+  // off. Independent of mmproj_use_gpu, which picks the backend rather than
+  // the modality.
+  mparams.skip_audio = params_.mmproj_no_audio;
   // Forward the per-image token budget to the vision encoder. These were
   // previously dropped: the addon parsed image_min/max_tokens into
   // common_params but never copied them into mtmd_context_params, so a

--- a/packages/llm-llamacpp/test/unit/test_load_config_handlers.cpp
+++ b/packages/llm-llamacpp/test/unit/test_load_config_handlers.cpp
@@ -83,6 +83,16 @@ TEST(LoadConfigHandlers_ImageNoUpscale, RejectsUnknownValue) {
   EXPECT_THROW(applyLoadConfigHandlers(params, map), StatusError);
 }
 
+// Both spellings must be registered. The addon skips audio by default, so the
+// load-bearing case is "off": an alias missing from the table would leave the
+// caller unable to turn the audio encoder back on.
+TEST(LoadConfigHandlers_MmprojNoAudio, BothAliasesParse) {
+  EXPECT_TRUE(applyOne("mmproj-no-audio", "on").mmproj_no_audio);
+  EXPECT_TRUE(applyOne("mmproj_no_audio", "1").mmproj_no_audio);
+  EXPECT_FALSE(applyOne("mmproj-no-audio", "off").mmproj_no_audio);
+  EXPECT_FALSE(applyOne("mmproj_no_audio", "false").mmproj_no_audio);
+}
+
 TEST(LoadConfigHandlers_ImageTokens, ParsesMaxAndMin) {
   EXPECT_EQ(applyOne("image-max-tokens", "1024").image_max_tokens, 1024);
   EXPECT_EQ(applyOne("image-min-tokens", "16").image_min_tokens, 16);

--- a/packages/llm-llamacpp/vcpkg-configuration.json
+++ b/packages/llm-llamacpp/vcpkg-configuration.json
@@ -4,6 +4,9 @@
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "../../vcpkg-overlays/ports"
+  ],
   "registries": [
     {
       "kind": "git",

--- a/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
+++ b/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,234 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-fabric-llm.cpp
+  REF 90928fb374d57d9adbbb52bfed4c6573c11970c4
+  SHA512 fc0651d6026442c9145c2313aae15ed5bcc2e4eaa06ffccf81b554168ba4b9c76899b210896f937ef8d4148c333ac7329dfbf568b684537ce4a0e73415cccb0c
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+    vector-index GGML_VECTOR_INDEX
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+    hip-backend BUILD_HIP_BACKEND
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # The Android NDK ships only the C Vulkan headers; the ggml Vulkan backend
+  # additionally needs the C++ bindings (vulkan.hpp) and SPIRV-Headers, which as
+  # of b9840 ggml fetches itself via FetchContent (ggml/src/ggml-vulkan/CMakeLists.txt,
+  # `if (ANDROID)` block). The registry vcpkg-cmake sets FETCHCONTENT_FULLY_DISCONNECTED=ON
+  # globally, so allow the fetch here (same as the kleidiai path below).
+  list(APPEND PLATFORM_OPTIONS -DFETCHCONTENT_FULLY_DISCONNECTED=OFF)
+endif()
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID OR (VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS))
+  # Desktop Linux also needs GGML_BACKEND_DL=ON so that multiple GPU backends
+  # (Vulkan + HIP/ROCm) can coexist as separately-loaded modules, the same way
+  # Android dispatches CPU variants at runtime. Without DL the Linux build links
+  # a single static GPU backend and a second one (HIP) cannot be stacked.
+  # GGML_NATIVE is incompatible with DL, so CPU variants are dispatched via
+  # GGML_CPU_ALL_VARIANTS instead. Consumers must ship the core ggml/llama libs
+  # alongside their backend modules so the dynamically-linked .bare can resolve
+  # them at load time.
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# HIP/ROCm backend — opt-in via the 'hip-backend' feature (Linux + AMD only).
+# Only @qvac/vla-ggml requests it, so every other consumer builds with no HIP
+# and gains no ROCm dependency. Builds libqvac-ggml-hip.so as a standalone DL
+# module alongside Vulkan (GGML_BACKEND_DL is already ON above), so the addon
+# dlopen's whichever GPU backend BackendSelection picks at runtime. The `hip`
+# feature-dependency port forwards the system ROCm's find_package() configs.
+#
+# FAIL-SAFE: enable GGML_HIP only when a ROCm SDK is actually present. On a build
+# host without ROCm we skip HIP and build Vulkan/CPU only — the build never
+# hard-fails, and at runtime a missing HIP module just isn't loaded (the DL
+# loader skips it) so BackendSelection falls back to Vulkan/CPU. Targets gfx1151
+# (Strix Halo / Radeon 8060S); the HIP compiler + ROCM_PATH come from the build env.
+# linux-x64 only: AMD GPU hosts (Strix Halo / gfx1151) are x86_64, and the ROCm
+# dist is x64. On other arches (e.g. linux-arm64) HIP is skipped even if the
+# feature is requested — no ROCm requirement, no build break.
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND BUILD_GPU_BACKENDS AND BUILD_HIP_BACKEND)
+  # DETERMINISTIC: requesting hip-backend REQUIRES a ROCm SDK at build time. We
+  # must NOT silently skip when ROCm is absent — a host-dependent skip yields a
+  # no-HIP package with the SAME vcpkg ABI as a real HIP build, which the binary
+  # cache then conflates (cache poisoning: a no-ROCm build caches a no-HIP
+  # package that ROCm-equipped builds then restore). So ROCm present => HIP;
+  # ROCm absent => hard error (don't request hip-backend on a host without ROCm).
+  # The RUNTIME fail-safe is unchanged: an absent HIP module / non-AMD target is
+  # simply not loaded and BackendSelection falls back to Vulkan/CPU.
+  if(NOT (DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/cmake/hip/hip-config.cmake"))
+    message(FATAL_ERROR "qvac-fabric: hip-backend feature requires a ROCm SDK — set ROCM_PATH to a ROCm/TheRock install containing lib/cmake/hip/hip-config.cmake. Do not request hip-backend on a host without ROCm.")
+  endif()
+  message(STATUS "qvac-fabric: hip-backend ON — building GGML_HIP (gfx1151)")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_HIP=ON
+    -DAMDGPU_TARGETS=gfx1151
+    -DCMAKE_HIP_ARCHITECTURES=gfx1151)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+# Under GGML_BACKEND_DL the per-microarch backends ship as standalone
+# libqvac-ggml-*.so modules that the consumer dlopen's at runtime. Built with
+# -stdlib=libc++ they otherwise carry a runtime NEEDED dependency on the system
+# libc++.so.1 / libc++abi.so.1, so they silently fail to dlopen on any target
+# without libc++ installed (e.g. stock ubuntu-24.04 — no CPU backend registers,
+# inference aborts). Statically link the C++ runtime into the modules so they
+# are self-contained, matching how the addons link themselves. The module<->addon
+# boundary is the C ggml-backend ABI, so per-module libc++ copies never exchange
+# C++ objects. Linux only: Apple/iOS use Metal frameworks, Android ships
+# libc++_shared via the NDK STL, Windows uses the MSVC runtime.
+if(VCPKG_TARGET_IS_LINUX AND DL_BACKENDS)
+  string(APPEND VCPKG_LINKER_FLAGS " -static-libstdc++")
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_BUILD_APP=OFF
+    -DMTMD_VIDEO=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
+++ b/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,61 @@
+{
+  "name": "qvac-fabric",
+  "version": "10549.0.0",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "hip-backend": {
+      "description": "Build the ROCm/HIP GPU backend (libqvac-ggml-hip.so) for AMD GPUs on Linux as a DL module alongside Vulkan. Opt-in (only @qvac/vla-ggml requests it). Fail-safe: if no ROCm SDK is present at build time the HIP backend is skipped (Vulkan/CPU only). Targets gfx1151 (Strix Halo). The 'hip' dependency forwards the system ROCm find_package configs.",
+      "dependencies": [
+        {
+          "name": "hip",
+          "platform": "linux & x64"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    },
+    "vector-index": {
+      "description": "Build and install the ggml vector index library."
+    }
+  }
+}


### PR DESCRIPTION
Adds `mmproj-no-audio` (alias `mmproj_no_audio`), which loads a multimodal projector without its audio encoder. Accepts `0/off/false` and `1/on/true`. Enabled for the Gemma 4 multimodal integration test.