### PR TITLE
QVAC-24928 chore: bump speech addon versions for SDK 0.20.0 (asr-ggml 0.5.0, audiogen-ggml 0.4.0, tts-ggml 0.9.0, bci-whispercpp 0.9.1)

### DIFF
--- a/packages/asr-ggml/CHANGELOG.md
+++ b/packages/asr-ggml/CHANGELOG.md
@@ -14,6 +14,8 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-11
+
 ### Added
 
 - The published linux-x64 prebuild ships the CUDA backend again, next to
@@ -40,52 +42,42 @@ restarts at `0.1.0`; the two pre-merge histories are preserved verbatim as
   including locale prompting, cache-aware streaming operating points,
   conversion tooling, and a model-specific 320 ms streaming default.
 
-- Add Core ML (Apple Neural Engine) RTF benchmark lanes for the Parakeet TDT
-  models on the darwin-arm64 desktop runner, covering f16/q8_0/q4_0. A matrix
-  entry opts in with `"coreml": true`; the encoder then runs on the ANE via an
-  exported `<stem>-encoder.mlmodelc` sidecar while the TDT decoder stays on
-  Metal. Because the sidecar is picked up by presence alone — and one sidecar
-  serves every quantisation of its stem — Core ML entries run against an
-  isolated `models/coreml/` copy so the existing CPU and Metal lanes cannot
-  silently start measuring the Neural Engine. `activeBackend` is now derived
-  from the observed per-run `encoderOnCoreml` stat rather than the requested
-  backend, and the benchmark refuses to write an artifact whose label would not
-  match what actually ran, in either direction. Sidecars are pinned in
-  `test/integration/parakeet-coreml.manifest.json` and staged by
-  `scripts/stage-integration-models.mjs`; lanes skip themselves loudly where no
-  sidecar is staged, so the matrix is unaffected until one is published. Core ML
-  covers the offline TDT encoder only, and the aggregate report expects it for
-  the parakeet engine alone. Measured on an Apple M1 Pro: 1.20-1.27x faster than
-  the Metal lane (mean RTF, five runs per lane) — see the package README.
+- Run the Parakeet TDT offline encoder on the Apple Neural Engine (Core ML)
+  on darwin-arm64: when an exported `<stem>-encoder.mlmodelc` sidecar sits
+  next to the model, the encoder runs on the ANE while the TDT decoder stays
+  on Metal. The sidecar is picked up by presence alone, one sidecar serves
+  every quantisation of its stem, and the per-run `encoderOnCoreml` stat
+  reports whether it engaged. Covers the offline TDT encoder only. Measured
+  on an Apple M1 Pro: 1.20-1.27x faster than Metal (mean RTF over five runs
+  per variant) — see the package README.
 
 ### Changed
 
-- Raise the `speech-cpp` floor to 2026-09-10. Nemotron 3.5 ASR streaming is
-  now validated on Vulkan and CUDA: the encoder and the fused transducer
-  decode run on the GPU at all five cache-aware operating points, with
-  engine parity tests against NeMo references at each of them. The window
-  also extends the Parakeet Core ML offline-encoder path used by the
-  `coreml` build on Apple platforms.
+- Raise the `speech-cpp` floor to 2026-09-10 and floor `ggml-speech` at
+  2026-09-09#1. The engine window since 0.4.2 brings:
 
-- Raise the `speech-cpp` floor to 2026-09-09 (ggml-speech 2026-09-09#1).
-  Parakeet CPU transcription is 2.2 to 2.6x faster on x86 desktops: the TDT
-  decoder runs as ggml graphs instead of a host loop, positional projections
-  are cached per graph, and the encoder drops several full-tensor copies.
-  ggml now builds with tinyBLAS on linux-x64 and darwin-arm64, and the
-  linux-x64 prebuild ships the per-arch CPU backend modules beside the addon
-  (AVX-512 hosts no longer run the AVX2 kernels), the same hybrid layout the
-  cuda build already used. The window also carries the memory-fit preflight
-  APIs, the hybrid RNN-T head, and Nemotron OpenCL support.
-
-- Raise the `speech-cpp` floor to 2026-09-03. Silero VAD now honors
-  `use_gpu`: the compute backends match the weight placement, fixing the
-  ggml_backend_sched abort ("pre-allocated tensor in a buffer that cannot
-  run the operation") that killed every `use_gpu=true` VAD context init on
-  GPU builds (Metal, Vulkan, CUDA, HIP), and the VAD LSTM input is made
-  contiguous to satisfy the CUDA mul-mat-vec kernel's stride requirement.
-  The addon creates its VAD context with the default (CPU) parameters, so
-  runtime behavior is unchanged; the fix matters for anything that opts
-  VAD into the GPU.
+  - Nemotron 3.5 ASR streaming validated on Vulkan and CUDA: the encoder and
+    the fused transducer decode run on the GPU at all five cache-aware
+    operating points, with engine parity tests against NeMo references at
+    each of them. The window also extends the Parakeet Core ML
+    offline-encoder path on Apple platforms and adds Nemotron OpenCL
+    support.
+  - Parakeet CPU transcription 2.2 to 2.6x faster on x86 desktops: the TDT
+    decoder runs as ggml graphs instead of a host loop, positional
+    projections are cached per graph, and the encoder drops several
+    full-tensor copies. ggml now builds with tinyBLAS on linux-x64 and
+    darwin-arm64, and the linux-x64 prebuild ships the per-arch CPU backend
+    modules beside the addon (AVX-512 hosts no longer run the AVX2 kernels),
+    the same hybrid layout the cuda build already used. The window also
+    carries the memory-fit preflight APIs and the hybrid RNN-T head.
+  - Silero VAD now honors `use_gpu`: the compute backends match the weight
+    placement, fixing the ggml_backend_sched abort ("pre-allocated tensor in
+    a buffer that cannot run the operation") that killed every `use_gpu=true`
+    VAD context init on GPU builds (Metal, Vulkan, CUDA, HIP), and the VAD
+    LSTM input is made contiguous to satisfy the CUDA mul-mat-vec kernel's
+    stride requirement. The addon creates its VAD context with the default
+    (CPU) parameters, so runtime behavior is unchanged; the fix matters for
+    anything that opts VAD into the GPU.
 
 - **Per-platform prebuild packages.** `@qvac/asr-ggml` is now a meta package
   that ships the JavaScript wrapper only; native prebuilds install through

--- a/packages/asr-ggml/package.json
+++ b/packages/asr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/asr-ggml",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Multi-engine ASR (Whisper + NVIDIA Parakeet) inference addon for qvac on the Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/audiogen-ggml/CHANGELOG.md
+++ b/packages/audiogen-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-11
+
 ### Added
 
 - The published linux-x64 prebuild ships the CUDA backend again, next to

--- a/packages/audiogen-ggml/package.json
+++ b/packages/audiogen-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/audiogen-ggml",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Audio generation (music) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-09-11
+
 ### Changed
 
 - Raise the `speech-cpp` floor to 2026-09-10, aligning bci-whispercpp with

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-11
+
 ### Added
 
 - The published linux-x64 prebuild ships the CUDA backend again, next to

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic + parler + cosyvoice3 + audio8 engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## What

Version bumps for the SDK 0.20.0 release, in a standalone PR:

- `@qvac/asr-ggml` 0.4.2 -> **0.5.0**
- `@qvac/audiogen-ggml` 0.3.3 -> **0.4.0**
- `@qvac/tts-ggml` 0.8.1 -> **0.9.0**
- `@qvac/bci-whispercpp` 0.9.0 -> **0.9.1**

Each package's `CHANGELOG.md` `[Unreleased]` tag is flipped to the released
version, dated 2026-09-11. Rebased on #4407, so the released sections carry
the CUDA linux-x64 prebuild re-enable and the speech-cpp 2026-09-10 stack
alignment.

## Changelog consistency

- **asr-ggml**: the three separate unreleased "raise the `speech-cpp` floor"
  entries (2026-09-03, 2026-09-09, 2026-09-10) are consolidated into a single
  entry stating the final floors (`speech-cpp` 2026-09-10, `ggml-speech`
  2026-09-09#1) with the consumer-visible effects of the whole window as
  sub-bullets, so the floor raise is mentioned once.
- **asr-ggml**: the Core ML entry is trimmed to the consumer-visible behavior
  (ANE sidecar pickup, `encoderOnCoreml` stat, measured speedup); the CI
  benchmark-lane internals are dropped per the changelog guidelines.
- Floors in each changelog match the package's `vcpkg.json` after the #4407
  alignment: `speech-cpp` 2026-09-10 everywhere, `ggml-speech` 2026-09-09#1
  where directly floored (asr, audiogen, tts). Each released section states
  its floor raise exactly once. `vcpkg-configuration.json` baselines are
  untouched.
- Platform sub-packages take their version from the meta package at publish
  time (`scripts/ci/slice-platform-packages.mjs`), so `package.json` is the
  only version source to bump.

## Release train

The consumer-side range update (`packages/sdk` dependencies,
`packages/inference` peer/dev dependencies, `pnpm-lock.yaml`) is a separate
stacked PR based on this branch; merge this PR first. `pnpm-lock.yaml` is
deliberately untouched here so the two PRs do not overlap on it; the stacked
PR restores full lock consistency.

Generated with [Claude Code](https://claude.com/claude-code)
