### PR TITLE
QVAC-24329 feat[api]: add MTP self-speculative decoding support

### DIFF
--- a/packages/inference/src/plugins/builtin/llamacpp-completion/ops/completion-stats.ts
+++ b/packages/inference/src/plugins/builtin/llamacpp-completion/ops/completion-stats.ts
@@ -15,6 +15,8 @@ export function normalizeCompletionStats(stats: LlmStats | undefined) {
   const promptTokens = finiteNumber(stats.promptTokens)
   const generatedTokens = finiteNumber(stats.generatedTokens)
   const avgConcurrentSeq = finiteNumber(stats.avgConcurrentSeq)
+  const draftAccepted = finiteNumber(stats.draftAccepted)
+  const draftTotal = finiteNumber(stats.draftTotal)
 
   const normalized: CompletionStats = {
     ...(timeToFirstToken !== undefined && { timeToFirstToken }),
@@ -24,6 +26,8 @@ export function normalizeCompletionStats(stats: LlmStats | undefined) {
     ...(promptTokens !== undefined && { promptTokens }),
     ...(generatedTokens !== undefined && { generatedTokens }),
     ...(avgConcurrentSeq !== undefined && { avgConcurrentSeq }),
+    ...(draftAccepted !== undefined && { draftAccepted }),
+    ...(draftTotal !== undefined && { draftTotal }),
     ...(stats.backendDevice !== undefined && { backendDevice: stats.backendDevice })
   }
 
@@ -35,6 +39,8 @@ export function normalizeCompletionStats(stats: LlmStats | undefined) {
     promptTokens === undefined &&
     generatedTokens === undefined &&
     avgConcurrentSeq === undefined &&
+    draftAccepted === undefined &&
+    draftTotal === undefined &&
     stats.backendDevice === undefined
   ) {
     return undefined

--- a/packages/inference/src/schemas/completion-event.ts
+++ b/packages/inference/src/schemas/completion-event.ts
@@ -18,6 +18,16 @@ export const completionStatsSchema = z.object({
   // Non-empty addon stream pieces — prefer for usage reporting when present.
   emittedTokens: z.number().optional(),
   avgConcurrentSeq: z.number().optional(),
+  draftAccepted: z
+    .number()
+    .optional()
+    .describe(
+      'MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.'
+    ),
+  draftTotal: z
+    .number()
+    .optional()
+    .describe('MTP draft tokens proposed for this request. Zero when MTP is inactive.'),
   backendDevice: z.enum(['cpu', 'gpu']).optional()
 })
 

--- a/packages/inference/src/schemas/llamacpp-config.ts
+++ b/packages/inference/src/schemas/llamacpp-config.ts
@@ -135,6 +135,49 @@ export const llmConfigBaseSchema = z.object({
     .describe(
       "Flash attention: `'on'`, `'off'`, or `'auto'`. With `'auto'`, the backend decides. When unset, the addon defaults to `'off'` for BitNet models and `'on'` for other inference workloads. An explicit value overrides the BitNet default. Finetuning enforces its own setting. `'off'` is incompatible with `'split-mode': 'tensor'`."
     ),
+  'spec-type': z
+    .literal('draft-mtp')
+    .optional()
+    .describe(
+      "Enable MTP self-speculative decoding with `'draft-mtp'`. Off when unset. Requires a model with a bundled MTP head and `parallel: 1`; the addon falls back to normal decoding for models without the head or with `parallel > 1`."
+    ),
+  'spec-draft-n-max': z
+    .number()
+    .int()
+    .min(1)
+    .max(2147483647)
+    .optional()
+    .describe('Maximum draft tokens proposed per MTP verification round. Addon default 3.'),
+  'spec-draft-n-min': z
+    .number()
+    .int()
+    .min(0)
+    .max(2147483647)
+    .optional()
+    .describe('Minimum draft tokens to use in speculative decoding. Addon default 0.'),
+  'spec-draft-p-min': z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe('Minimum draft token probability for speculative decoding. Addon default 0.'),
+  'spec-draft-backend-sampling': z
+    .boolean()
+    .optional()
+    .describe(
+      'Enable backend sampling for the speculative draft context. Set false to disable it; unset keeps the addon default.'
+    ),
+  'spec-draft-device': z
+    .string()
+    .optional()
+    .describe('Comma-separated backend device names for the speculative draft context.'),
+  'spec-draft-ngl': z
+    .number()
+    .int()
+    .min(-1)
+    .max(2147483647)
+    .optional()
+    .describe('Draft GPU layer count. Unset keeps the addon default.'),
   'tensor-split': z
     .string()
     .optional()

--- a/packages/inference/src/utils/addon-responses.ts
+++ b/packages/inference/src/utils/addon-responses.ts
@@ -9,6 +9,8 @@ export interface LlmStats {
   promptTokens?: number
   generatedTokens?: number
   avgConcurrentSeq?: number
+  draftAccepted?: number
+  draftTotal?: number
   backendDevice?: 'cpu' | 'gpu'
   stopReason?:
     'none' | 'eos' | 'antiprompt' | 'predictionLimit' | 'sequenceLimit' | 'contextOverflow'

--- a/packages/inference/test/completion-stats.test.ts
+++ b/packages/inference/test/completion-stats.test.ts
@@ -7,6 +7,23 @@ import {
 } from '@/plugins/builtin/llamacpp-completion/ops/completion-stats'
 import type { LlmStats } from '@/utils/addon-responses'
 
+test('normalizeCompletionStats: preserves MTP counters, including inactive zeros', (t) => {
+  for (const stats of [
+    { draftAccepted: 7, draftTotal: 12 },
+    { draftAccepted: 0, draftTotal: 0 },
+    { draftTotal: 4 }
+  ]) {
+    const normalized = normalizeCompletionStats(stats)
+    t.alike(normalized, stats)
+  }
+})
+
+test('normalizeCompletionStats: omits absent and non-finite MTP counters', (t) => {
+  t.alike(normalizeCompletionStats({ generatedTokens: 5 }), { generatedTokens: 5 })
+  t.is(normalizeCompletionStats({ draftAccepted: NaN, draftTotal: Infinity }), undefined)
+  t.alike(normalizeCompletionStats({ draftAccepted: -Infinity, draftTotal: 4 }), { draftTotal: 4 })
+})
+
 test('normalizeCompletionStats: drops non-finite addon numbers', (t) => {
   const stats: LlmStats = {
     TTFT: Number.NaN,

--- a/packages/inference/test/llm-config-schema.test.ts
+++ b/packages/inference/test/llm-config-schema.test.ts
@@ -12,6 +12,59 @@ const LLM_BASE = {
   modelSrc: 'model.gguf'
 }
 
+const MTP_CONFIG = {
+  'spec-type': 'draft-mtp',
+  'spec-draft-n-max': 3,
+  'spec-draft-n-min': 0,
+  'spec-draft-p-min': 0.5,
+  'spec-draft-backend-sampling': false,
+  'spec-draft-device': 'CPU',
+  'spec-draft-ngl': 0
+} as const
+
+test('MTP config survives load options, wire validation, and device defaults', (t) => {
+  const request = loadModelOptionsToRequestSchema.parse({
+    ...LLM_BASE,
+    modelConfig: MTP_CONFIG
+  })
+  t.alike(request.modelConfig, MTP_CONFIG)
+  t.alike(loadModelSrcRequestSchema.parse(request).modelConfig, MTP_CONFIG)
+  t.alike(deviceConfigDefaultsSchema.parse({ llm: MTP_CONFIG }).llm, MTP_CONFIG)
+})
+
+test('MTP config remains opt-in and preserves the requested parallel slots', (t) => {
+  const defaults = llmConfigSchema.parse({})
+  for (const key of Object.keys(MTP_CONFIG)) t.absent(key in defaults)
+  const config = llmConfigBaseSchema.parse({ ...MTP_CONFIG, parallel: 4 })
+  t.is(config.parallel, 4)
+  t.is(config['spec-type'], 'draft-mtp')
+})
+
+test('MTP config rejects unsupported decoders and invalid tuning values', (t) => {
+  const invalid = [
+    { 'spec-type': 'draft' },
+    { 'spec-type': 'ngram,draft-mtp' },
+    { 'spec-draft-n-max': 0 },
+    { 'spec-draft-n-max': -1 },
+    { 'spec-draft-n-max': 1.5 },
+    { 'spec-draft-n-max': 2147483648 },
+    { 'spec-draft-n-min': -1 },
+    { 'spec-draft-n-min': 0.5 },
+    { 'spec-draft-p-min': -0.1 },
+    { 'spec-draft-p-min': 1.1 },
+    { 'spec-draft-backend-sampling': 'false' },
+    { 'spec-draft-ngl': -2 },
+    { 'spec-draft-ngl': 1.5 },
+    { 'spec-draft-model': 'draft.gguf' }
+  ]
+  for (const modelConfig of invalid) {
+    t.absent(
+      loadModelOptionsToRequestSchema.safeParse({ ...LLM_BASE, modelConfig }).success,
+      JSON.stringify(modelConfig)
+    )
+  }
+})
+
 test('llmConfigBaseSchema: accepts valid split-mode values', (t) => {
   t.is(llmConfigBaseSchema.safeParse({ 'split-mode': 'none' }).success, true)
   t.is(llmConfigBaseSchema.safeParse({ 'split-mode': 'layer' }).success, true)

--- a/packages/inference/test/llm-plugin-transform.test.ts
+++ b/packages/inference/test/llm-plugin-transform.test.ts
@@ -6,6 +6,27 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
   return llmConfigSchema.parse(overrides)
 }
 
+test('transformLlmConfig: forwards MTP tuning with native keys and string values', (t) => {
+  const result = transformLlmConfig(
+    makeConfig({
+      'spec-type': 'draft-mtp',
+      'spec-draft-n-max': 2,
+      'spec-draft-n-min': 0,
+      'spec-draft-p-min': 0.5,
+      'spec-draft-backend-sampling': false,
+      'spec-draft-device': 'CPU',
+      'spec-draft-ngl': 0
+    })
+  )
+  t.is(result['spec-type'], 'draft-mtp')
+  t.is(result['spec-draft-n-max'], '2')
+  t.is(result['spec-draft-n-min'], '0')
+  t.is(result['spec-draft-p-min'], '0.5')
+  t.is(result['spec-draft-backend-sampling'], 'false')
+  t.is(result['spec-draft-device'], 'CPU')
+  t.is(result['spec-draft-ngl'], '0')
+})
+
 test('transformLlmConfig: system_prompt is never forwarded to C++', (t) => {
   const config = makeConfig({ system_prompt: 'You are a helpful assistant.' })
   const result = transformLlmConfig(config)

--- a/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
+++ b/packages/sdk-python/src/tetherto/qvac_sdk/_generated/models/_internal.py
@@ -1114,6 +1114,20 @@ class BatchCompletionStreamResponseEventsItemEventCompletionStatsStats(
     generated_tokens: Annotated[float | None, Field(alias="generatedTokens")] = None
     emitted_tokens: Annotated[float | None, Field(alias="emittedTokens")] = None
     avg_concurrent_seq: Annotated[float | None, Field(alias="avgConcurrentSeq")] = None
+    draft_accepted: Annotated[
+        float | None,
+        Field(
+            alias="draftAccepted",
+            description="MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
+    draft_total: Annotated[
+        float | None,
+        Field(
+            alias="draftTotal",
+            description="MTP draft tokens proposed for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
     backend_device: Annotated[
         BatchCompletionStreamResponseEventsItemEventCompletionStatsStatsBackendDevice
         | None,
@@ -1246,6 +1260,20 @@ class BatchCompletionStreamResponseStats(GeneratedBaseModel):
     generated_tokens: Annotated[float | None, Field(alias="generatedTokens")] = None
     emitted_tokens: Annotated[float | None, Field(alias="emittedTokens")] = None
     avg_concurrent_seq: Annotated[float | None, Field(alias="avgConcurrentSeq")] = None
+    draft_accepted: Annotated[
+        float | None,
+        Field(
+            alias="draftAccepted",
+            description="MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
+    draft_total: Annotated[
+        float | None,
+        Field(
+            alias="draftTotal",
+            description="MTP draft tokens proposed for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
     backend_device: Annotated[
         BatchCompletionStreamResponseStatsBackendDevice | None,
         Field(
@@ -1990,6 +2018,20 @@ class CompletionOrchestrateResponseEventsItemCompletionStatsStats(GeneratedBaseM
     generated_tokens: Annotated[float | None, Field(alias="generatedTokens")] = None
     emitted_tokens: Annotated[float | None, Field(alias="emittedTokens")] = None
     avg_concurrent_seq: Annotated[float | None, Field(alias="avgConcurrentSeq")] = None
+    draft_accepted: Annotated[
+        float | None,
+        Field(
+            alias="draftAccepted",
+            description="MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
+    draft_total: Annotated[
+        float | None,
+        Field(
+            alias="draftTotal",
+            description="MTP draft tokens proposed for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
     backend_device: Annotated[
         CompletionOrchestrateResponseEventsItemCompletionStatsStatsBackendDevice | None,
         Field(
@@ -2517,6 +2559,20 @@ class CompletionStreamResponseEventsItemCompletionStatsStats(GeneratedBaseModel)
     generated_tokens: Annotated[float | None, Field(alias="generatedTokens")] = None
     emitted_tokens: Annotated[float | None, Field(alias="emittedTokens")] = None
     avg_concurrent_seq: Annotated[float | None, Field(alias="avgConcurrentSeq")] = None
+    draft_accepted: Annotated[
+        float | None,
+        Field(
+            alias="draftAccepted",
+            description="MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
+    draft_total: Annotated[
+        float | None,
+        Field(
+            alias="draftTotal",
+            description="MTP draft tokens proposed for this request. Zero when MTP is inactive.",
+        ),
+    ] = None
     backend_device: Annotated[
         CompletionStreamResponseEventsItemCompletionStatsStatsBackendDevice | None,
         Field(
@@ -7426,6 +7482,63 @@ class LoadModelSrcRequestLlamacppCompletionModelConfig(GeneratedBaseModel):
             alias="flash-attn",
             description="Flash attention: `'on'`, `'off'`, or `'auto'`. With `'auto'`, the backend decides. When unset, the addon defaults to `'off'` for BitNet models and `'on'` for other inference workloads. An explicit value overrides the BitNet default. Finetuning enforces its own setting. `'off'` is incompatible with `'split-mode': 'tensor'`.",
             title="LoadModelSrcRequestLlamacppCompletionModelConfigFlashAttn",
+        ),
+    ] = None
+    spec_type: Annotated[
+        Literal["draft-mtp"] | None,
+        Field(
+            alias="spec-type",
+            description="Enable MTP self-speculative decoding with `'draft-mtp'`. Off when unset. Requires a model with a bundled MTP head and `parallel: 1`; the addon falls back to normal decoding for models without the head or with `parallel > 1`.",
+        ),
+    ] = None
+    spec_draft_n_max: Annotated[
+        int | None,
+        Field(
+            alias="spec-draft-n-max",
+            description="Maximum draft tokens proposed per MTP verification round. Addon default 3.",
+            ge=1,
+            le=2147483647,
+        ),
+    ] = None
+    spec_draft_n_min: Annotated[
+        int | None,
+        Field(
+            alias="spec-draft-n-min",
+            description="Minimum draft tokens to use in speculative decoding. Addon default 0.",
+            ge=0,
+            le=2147483647,
+        ),
+    ] = None
+    spec_draft_p_min: Annotated[
+        float | None,
+        Field(
+            alias="spec-draft-p-min",
+            description="Minimum draft token probability for speculative decoding. Addon default 0.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None
+    spec_draft_backend_sampling: Annotated[
+        bool | None,
+        Field(
+            alias="spec-draft-backend-sampling",
+            description="Enable backend sampling for the speculative draft context. Set false to disable it; unset keeps the addon default.",
+        ),
+    ] = None
+    spec_draft_device: Annotated[
+        str | None,
+        Field(
+            alias="spec-draft-device",
+            description="Comma-separated backend device names for the speculative draft context.",
+        ),
+    ] = None
+    spec_draft_ngl: Annotated[
+        int | None,
+        Field(
+            alias="spec-draft-ngl",
+            description="Draft GPU layer count. Unset keeps the addon default.",
+            ge=-1,
+            le=2147483647,
         ),
     ] = None
     tensor_split: Annotated[

--- a/packages/sdk-python/tests/test_completion.py
+++ b/packages/sdk-python/tests/test_completion.py
@@ -63,7 +63,10 @@ def test_normalize_strips_think_blocks_and_unclosed_tail():
 # ---- run handles ----------------------------------------------------------------
 
 
-async def test_completion_aggregates_content_thinking_and_stats():
+@pytest.mark.parametrize("draft_accepted,draft_total", [(6, 9), (0, 0)])
+async def test_completion_aggregates_content_thinking_and_stats(
+    draft_accepted, draft_total
+):
     transport = FakeTransport(
         stream_items=[
             _chunk([_delta(0, "Hel"), _delta(1, "lo")]),
@@ -73,7 +76,11 @@ async def test_completion_aggregates_content_thinking_and_stats():
                     {
                         "type": "completionStats",
                         "seq": 3,
-                        "stats": {"generatedTokens": 5},
+                        "stats": {
+                            "generatedTokens": 5,
+                            "draftAccepted": draft_accepted,
+                            "draftTotal": draft_total,
+                        },
                     },
                     _done(
                         4,
@@ -101,6 +108,8 @@ async def test_completion_aggregates_content_thinking_and_stats():
     assert final.content_text == "Hello"
     assert final.thinking_text == " world"
     assert final.stats.generated_tokens == 5
+    assert final.stats.draft_accepted == draft_accepted
+    assert final.stats.draft_total == draft_total
     assert final.raw_full_text == "<think> world</think>Hello"
     # Cache string strips the think block out of the raw text.
     assert final.cacheable_assistant_content == "Hello"

--- a/packages/sdk-python/tests/test_llm_mtp.py
+++ b/packages/sdk-python/tests/test_llm_mtp.py
@@ -1,0 +1,28 @@
+"""MTP configuration uses native keys on the wire."""
+
+from __future__ import annotations
+
+from tetherto.qvac_sdk._generated.models import (
+    LoadModelSrcRequestLlamacppCompletionModelConfig,
+)
+
+
+def test_mtp_config_round_trip() -> None:
+    config = LoadModelSrcRequestLlamacppCompletionModelConfig(
+        spec_type="draft-mtp",
+        spec_draft_n_max=2,
+        spec_draft_n_min=0,
+        spec_draft_p_min=0.5,
+        spec_draft_backend_sampling=False,
+        spec_draft_device="CPU",
+        spec_draft_ngl=0,
+    )
+    assert config.model_dump(by_alias=True, exclude_none=True) == {
+        "spec-type": "draft-mtp",
+        "spec-draft-n-max": 2,
+        "spec-draft-n-min": 0,
+        "spec-draft-p-min": 0.5,
+        "spec-draft-backend-sampling": False,
+        "spec-draft-device": "CPU",
+        "spec-draft-ngl": 0,
+    }

--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -1414,6 +1414,14 @@
                           "avgConcurrentSeq": {
                             "type": "number"
                           },
+                          "draftAccepted": {
+                            "description": "MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+                            "type": "number"
+                          },
+                          "draftTotal": {
+                            "description": "MTP draft tokens proposed for this request. Zero when MTP is inactive.",
+                            "type": "number"
+                          },
                           "backendDevice": {
                             "type": "string",
                             "enum": ["cpu", "gpu"],
@@ -1537,6 +1545,14 @@
               "type": "number"
             },
             "avgConcurrentSeq": {
+              "type": "number"
+            },
+            "draftAccepted": {
+              "description": "MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+              "type": "number"
+            },
+            "draftTotal": {
+              "description": "MTP draft tokens proposed for this request. Zero when MTP is inactive.",
               "type": "number"
             },
             "backendDevice": {
@@ -2486,6 +2502,14 @@
                       "avgConcurrentSeq": {
                         "type": "number"
                       },
+                      "draftAccepted": {
+                        "description": "MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+                        "type": "number"
+                      },
+                      "draftTotal": {
+                        "description": "MTP draft tokens proposed for this request. Zero when MTP is inactive.",
+                        "type": "number"
+                      },
                       "backendDevice": {
                         "type": "string",
                         "enum": ["cpu", "gpu"],
@@ -3074,6 +3098,14 @@
                         "type": "number"
                       },
                       "avgConcurrentSeq": {
+                        "type": "number"
+                      },
+                      "draftAccepted": {
+                        "description": "MTP draft tokens accepted by the target for this request. Zero when MTP is inactive.",
+                        "type": "number"
+                      },
+                      "draftTotal": {
+                        "description": "MTP draft tokens proposed for this request. Zero when MTP is inactive.",
                         "type": "number"
                       },
                       "backendDevice": {
@@ -8677,6 +8709,43 @@
                       "type": "string",
                       "enum": ["on", "off", "auto"],
                       "title": "LoadModelSrcRequestLlamacppCompletionModelConfigFlashAttn"
+                    },
+                    "spec-type": {
+                      "description": "Enable MTP self-speculative decoding with `'draft-mtp'`. Off when unset. Requires a model with a bundled MTP head and `parallel: 1`; the addon falls back to normal decoding for models without the head or with `parallel > 1`.",
+                      "type": "string",
+                      "const": "draft-mtp"
+                    },
+                    "spec-draft-n-max": {
+                      "description": "Maximum draft tokens proposed per MTP verification round. Addon default 3.",
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 2147483647
+                    },
+                    "spec-draft-n-min": {
+                      "description": "Minimum draft tokens to use in speculative decoding. Addon default 0.",
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 2147483647
+                    },
+                    "spec-draft-p-min": {
+                      "description": "Minimum draft token probability for speculative decoding. Addon default 0.",
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "spec-draft-backend-sampling": {
+                      "description": "Enable backend sampling for the speculative draft context. Set false to disable it; unset keeps the addon default.",
+                      "type": "boolean"
+                    },
+                    "spec-draft-device": {
+                      "description": "Comma-separated backend device names for the speculative draft context.",
+                      "type": "string"
+                    },
+                    "spec-draft-ngl": {
+                      "description": "Draft GPU layer count. Unset keeps the addon default.",
+                      "type": "integer",
+                      "minimum": -1,
+                      "maximum": 2147483647
                     },
                     "tensor-split": {
                       "description": "Proportions for distributing layers/rows across GPUs, e.g. `'1,1'` (equal) or `'3,1'` (75/25).",

--- a/packages/sdk/e2e/tests/completion-tests.ts
+++ b/packages/sdk/e2e/tests/completion-tests.ts
@@ -715,6 +715,23 @@ export const completionContextOverflowWarmCache = createCompletionTest(
   { estimatedDurationMs: 30000, dependency: 'llm-small-ctx' }
 )
 
+export const completionMtp = createCompletionTest(
+  'completion-mtp',
+  {
+    history: [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      {
+        role: 'user',
+        content: 'What is the capital of France? Answer in one complete sentence.'
+      }
+    ],
+    stream: true,
+    generationParams: { ...DETERMINISTIC, predict: 64, reasoning_budget: 0 }
+  },
+  { validation: 'regex', pattern: '[Pp]aris' },
+  { dependency: 'none', estimatedDurationMs: 30000 }
+)
+
 export const completionTests = [
   completionStreaming,
   completionTemperature01,
@@ -759,6 +776,7 @@ export const completionTests = [
   completionReasoningBudgetUnrestricted,
   completionRemoveThinkingFromContext,
   completionStats,
+  completionMtp,
   completionStopReasonLength,
   completionContextBoundaryStop,
   completionContextOverflowPrefill,

--- a/packages/sdk/e2e/tests/shared/executors/completion-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/completion-executor.ts
@@ -1,4 +1,11 @@
-import { completion, ContextOverflowError, deleteCache } from '@qvac/sdk'
+import {
+  completion,
+  ContextOverflowError,
+  deleteCache,
+  loadModel,
+  unloadModel,
+  type CompletionStats
+} from '@qvac/sdk'
 import { ValidationHelpers, type TestResult, type Expectation } from '@qvac/test-suite'
 import { AbstractModelExecutor } from './abstract-model-executor.js'
 import { completionTests } from '../../completion-tests.js'
@@ -61,6 +68,9 @@ export class CompletionExecutor extends AbstractModelExecutor<typeof completionT
       }
       if (test.testId === 'completion-stats') {
         return [test.testId, this.statsVerification.bind(this)]
+      }
+      if (test.testId === 'completion-mtp') {
+        return [test.testId, this.mtpVerification.bind(this)]
       }
       if (test.testId === 'completion-concurrent-requests') {
         return [test.testId, this.concurrentRequests.bind(this)]
@@ -310,6 +320,72 @@ export class CompletionExecutor extends AbstractModelExecutor<typeof completionT
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       return { passed: false, output: `completion stats failed: ${errorMsg}` }
+    }
+  }
+
+  async mtpVerification(
+    params: CompletionTestParams,
+    expectation: Expectation
+  ): Promise<TestResult> {
+    // This pinned GGUF bundles the MTP head used by the addon PR's integration test.
+    const modelId = await loadModel({
+      modelSrc:
+        'https://huggingface.co/prithivMLmods/Qwen3.5-0.8B-MTP-GGUF/resolve/e84039e503be9c81c5bfe3f0b0d00a7636894d9d/Qwen3.5-0.8B.Q8_0.gguf',
+      modelType: 'llm',
+      modelConfig: {
+        ctx_size: 1024,
+        parallel: 1,
+        'spec-type': 'draft-mtp',
+        'spec-draft-n-max': 3,
+        reasoning_budget: 0
+      }
+    })
+
+    try {
+      const run = completion({ modelId, ...params } as CompletionFnParams)
+      let eventStats: CompletionStats | undefined
+      let streamedText = ''
+      for await (const event of run.events) {
+        if (event.type === 'contentDelta') streamedText += event.text
+        if (event.type === 'completionStats') eventStats = event.stats
+      }
+      const final = await run.final
+      const stats = await run.stats
+      const textValidation = ValidationHelpers.validate(final.contentText, expectation)
+      if (!textValidation.passed) return textValidation
+      if (streamedText !== final.contentText) {
+        return { passed: false, output: 'MTP content events do not match the final reply' }
+      }
+
+      const accepted = final.stats?.draftAccepted
+      const total = final.stats?.draftTotal
+      if (
+        typeof accepted !== 'number' ||
+        typeof total !== 'number' ||
+        !Number.isInteger(accepted) ||
+        !Number.isInteger(total) ||
+        accepted <= 0 ||
+        total <= 0 ||
+        accepted > total
+      ) {
+        return {
+          passed: false,
+          output:
+            `Expected active MTP with 0 < draftAccepted <= draftTotal, got ${JSON.stringify(final.stats)}. ` +
+            'Use an addon build containing PR #4390 and the pinned model with its bundled MTP head.'
+        }
+      }
+      if (
+        eventStats?.draftAccepted !== accepted ||
+        eventStats?.draftTotal !== total ||
+        stats?.draftAccepted !== accepted ||
+        stats?.draftTotal !== total
+      ) {
+        return { passed: false, output: 'MTP counters differ between events, final, and stats' }
+      }
+      return { passed: true, output: `MTP accepted ${accepted} of ${total} proposed tokens` }
+    } finally {
+      await unloadModel({ modelId })
     }
   }
 

--- a/packages/sdk/test/mtp-support.test.ts
+++ b/packages/sdk/test/mtp-support.test.ts
@@ -1,0 +1,38 @@
+import test from 'brittle'
+import {
+  batchCompletionStreamResponseSchema,
+  completionStreamResponseSchema
+} from '@qvac/inference/surface'
+import { buildFinalFromEvents } from '@/utils/aggregate-events'
+import type { CompletionStats } from '@qvac/sdk'
+
+test('SDK response parsing and final aggregation preserve optional MTP counters', (t) => {
+  for (const stats of [
+    { generatedTokens: 10, draftAccepted: 6, draftTotal: 9 },
+    { generatedTokens: 10, draftAccepted: 0, draftTotal: 0 },
+    { generatedTokens: 10 }
+  ]) {
+    const response = completionStreamResponseSchema.parse({
+      type: 'completionStream',
+      done: true,
+      events: [
+        { type: 'completionStats', seq: 0, stats },
+        { type: 'completionDone', seq: 1, stopReason: 'eos' }
+      ]
+    })
+    const { final, error } = buildFinalFromEvents(response.events, new Map())
+    t.is(error, undefined)
+    t.alike(final.stats, stats)
+  }
+})
+
+test('SDK batch response parsing preserves inactive MTP counters', (t) => {
+  const stats: CompletionStats = { draftAccepted: 0, draftTotal: 0 }
+  const response = batchCompletionStreamResponseSchema.parse({
+    type: 'batchCompletionStream',
+    done: true,
+    events: [],
+    stats
+  })
+  t.alike(response.stats, stats)
+})

--- a/packages/sdk/test/mtp-support.types.ts
+++ b/packages/sdk/test/mtp-support.types.ts
@@ -1,0 +1,31 @@
+import type { CompletionStats, LoadModelOptions } from '@qvac/sdk'
+import type { LlamacppCompletionConfig } from '@/schemas/public'
+
+const modelConfig: LlamacppCompletionConfig = {
+  'spec-type': 'draft-mtp',
+  'spec-draft-n-max': 3,
+  'spec-draft-n-min': 0,
+  'spec-draft-p-min': 0.5,
+  'spec-draft-backend-sampling': false,
+  'spec-draft-device': 'CPU',
+  'spec-draft-ngl': 0
+}
+
+const loadOptions: LoadModelOptions = {
+  modelType: 'llm',
+  modelSrc: '/models/model-with-mtp.gguf',
+  modelConfig
+}
+void loadOptions
+
+const unsupportedDecoder: LlamacppCompletionConfig = {
+  // @ts-expect-error Only MTP self-speculation is supported.
+  'spec-type': 'draft'
+}
+void unsupportedDecoder
+
+const stats: CompletionStats = { draftAccepted: 2, draftTotal: 3 }
+const accepted: number | undefined = stats.draftAccepted
+const total: number | undefined = stats.draftTotal
+void accepted
+void total


### PR DESCRIPTION
## What problem does this PR solve?

SDK users need to enable MTP self-speculative decoding and inspect draft-token acceptance statistics.

## How does it solve it?

- Expose opt-in MTP model settings and tuning options through the shared schemas and generated Python models.
- Preserve optional `draftAccepted` and `draftTotal` counters through completion events, final responses, and aggregated stats, including zero values.
- Add focused regression tests and a real-model `completion-mtp` SDK e2e test.

Requires an addon build containing https://github.com/tetherto/qvac/pull/4390. MTP requires a model with a bundled MTP head and `parallel: 1`; image turns use normal decoding.

## How was it tested?

- Passed 64 targeted inference tests, 2 SDK tests, and 12 Python tests.
- Passed inference and SDK TypeScript, lint, and contract checks.
- Typechecked the e2e suite against the rebuilt workspace SDK. Live MTP execution is pending an addon build containing #4390.

## API Changes

```typescript
import { completion, loadModel, unloadModel } from '@qvac/sdk'

const modelId = await loadModel({
  modelType: 'llm',
  modelSrc: '/models/model-with-mtp.gguf',
  modelConfig: {
    'spec-type': 'draft-mtp',
    'spec-draft-n-max': 3,
    parallel: 1
  }
})

try {
  const run = completion({
    modelId,
    history: [{ role: 'user', content: 'Explain how rain forms.' }]
  })
  const { stats } = await run.final
  console.log(stats?.draftAccepted, stats?.draftTotal)
} finally {
  await unloadModel({ modelId })
}
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217945745427314