### PR TITLE
QVAC-24658 feat: run llama fit in-process on mobile

### DIFF
--- a/packages/inference/src/resources/model-fit/native-probe/advisory-fit.ts
+++ b/packages/inference/src/resources/model-fit/native-probe/advisory-fit.ts
@@ -148,9 +148,8 @@ async function resolveRunFit(
 ): Promise<typeof runIsolatedFit> {
   if (explicit !== undefined) return explicit
   if (mobile) {
-    const { runInProcessFit } = await import(
-      '@/resources/model-fit/native-probe/run-in-process-fit'
-    )
+    const { runInProcessFit } =
+      await import('@/resources/model-fit/native-probe/run-in-process-fit')
     return runInProcessFit as typeof runIsolatedFit
   }
   return (await import('@/resources/model-fit/native-probe/run-isolated-fit')).runIsolatedFit

--- a/packages/inference/src/resources/model-fit/native-probe/advisory-fit.ts
+++ b/packages/inference/src/resources/model-fit/native-probe/advisory-fit.ts
@@ -138,13 +138,21 @@ async function defaultResidentModelBytes(): Promise<number> {
 }
 
 /**
- * Also lazy: the supervisor pulls the Bare process launcher and the packaged
- * runner path, and a disabled check must not load either.
+ * Also lazy: the desktop supervisor pulls the Bare process launcher, and a
+ * disabled check must not load it. Mobile uses in-process `fitParams` instead
+ * of spawn (`bare-runtime/spawn` stays deferred from the mobile pack).
  */
 async function resolveRunFit(
-  explicit: typeof runIsolatedFit | undefined
+  explicit: typeof runIsolatedFit | undefined,
+  mobile: boolean
 ): Promise<typeof runIsolatedFit> {
   if (explicit !== undefined) return explicit
+  if (mobile) {
+    const { runInProcessFit } = await import(
+      '@/resources/model-fit/native-probe/run-in-process-fit'
+    )
+    return runInProcessFit as typeof runIsolatedFit
+  }
   return (await import('@/resources/model-fit/native-probe/run-isolated-fit')).runIsolatedFit
 }
 
@@ -201,10 +209,10 @@ function report(logger: Logger, input: AdvisoryFitInput, outcome: AdvisoryFitOut
   }
 
   // `unsupported-load` covers every load this check refuses up front — all
-  // non-llama.cpp model types and mobile — so at `info` it would tag every
-  // whisper/tts/ocr load on every start. `debug` for those; `info` where a
-  // child ran (or should have) and produced no verdict, because there "why was
-  // there no evidence" is the most useful thing this check can report.
+  // non-llama.cpp model types — so at `info` it would tag every whisper/tts/ocr
+  // load on every start. `debug` for those; `info` where a fitter ran (or
+  // should have) and produced no verdict, because there "why was there no
+  // evidence" is the most useful thing this check can report.
   const line = `${prefix} no fit evidence: ${outcome.reason}${
     outcome.message === undefined ? '' : ` (${outcome.message})`
   }`
@@ -232,13 +240,13 @@ export async function runAdvisoryFitCheck(
     logger ??= getEngineLogger()
     if (!(await resolveEnabled(options.enabled))) return unknown('disabled')
 
+    const mobile = await resolveMobile(options.mobile)
     const plan = createLlamaFitRequest({
       modelType: input.modelType,
       modelPath: input.modelPath,
       modelConfig: input.modelConfig,
       artifacts: input.artifacts,
-      isShardedModel: input.isShardedModel,
-      isMobile: await resolveMobile(options.mobile)
+      isShardedModel: input.isShardedModel
     })
 
     if (!plan.supported) {
@@ -250,7 +258,7 @@ export async function runAdvisoryFitCheck(
     const residentBytes = await (options.residentModelBytes ?? defaultResidentModelBytes)()
     const residentReserveMiB = Math.ceil(residentBytes / BYTES_PER_MIB)
 
-    const runFit = await resolveRunFit(options.runFit)
+    const runFit = await resolveRunFit(options.runFit, mobile)
     // Always sent, even with a zero reserve: relying on the addon default for
     // the base margin would leave two sources of truth that match today and
     // diverge silently if the addon default moves.

--- a/packages/inference/src/resources/model-fit/native-probe/create-llama-fit-request.ts
+++ b/packages/inference/src/resources/model-fit/native-probe/create-llama-fit-request.ts
@@ -89,7 +89,7 @@ const UNSUPPORTED_KEYS: readonly string[] = ['lora', 'projection_model_src']
  * M4 Pro against `@qvac/model-fit@0.8.0`: an 18.3 GiB model at 32k context
  * still reports `fits` on `device: 'cpu'` (and it does decode — at 0.1 tok/s).
  * That answer carries no admission information, so it is refused here rather
- * than spending a child process to produce it.
+ * than spending a fit call to produce it.
  */
 function isCpuLoad(params: Record<string, string>): boolean {
   return params['device']?.toLowerCase() === 'cpu'
@@ -105,7 +105,6 @@ export interface CreateLlamaFitRequestParams {
   modelConfig: unknown
   artifacts?: Record<string, string> | undefined
   isShardedModel: boolean
-  isMobile: boolean
 }
 
 function loadKindFor(modelType: CanonicalModelType): LlamaLoadKind | undefined {
@@ -161,15 +160,11 @@ function contextFloor(params: Record<string, string>): number | undefined {
  * Builds a protocol-v2 fit request from the same resolved model config the real
  * load is about to use, or explains why this load cannot be answered for.
  *
- * Structural shapes the SDK owns are refused here so no child process starts.
- * Value-level policy (device names, symbolic GPU selection, context bounds)
- * stays inside `@qvac/model-fit`, which reports `unsupported-config` for it.
+ * Structural shapes the SDK owns are refused here so the fitter is not asked
+ * a question it cannot answer. Value-level policy (device names, symbolic GPU
+ * selection, context bounds) stays inside `@qvac/model-fit`.
  */
 export function createLlamaFitRequest(params: CreateLlamaFitRequestParams): LlamaFitRequestPlan {
-  if (params.isMobile) {
-    return unsupported('mobile has no disposable process boundary')
-  }
-
   const loadKind = loadKindFor(params.modelType)
   if (loadKind === undefined) {
     return unsupported(`model type is not a llama.cpp load: ${params.modelType}`)

--- a/packages/inference/src/resources/model-fit/native-probe/run-in-process-fit.ts
+++ b/packages/inference/src/resources/model-fit/native-probe/run-in-process-fit.ts
@@ -1,0 +1,143 @@
+import type { FitConfig, FitResult } from '@qvac/model-fit'
+import type { AbortSignal } from 'bare-abort-controller'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import type { FitLlamaProcessConfig, LlamaLoadKind } from '@qvac/model-fit/process'
+
+import { generateShortHash } from '@/utils/formatting'
+import type { IsolatedFitUnknownReason } from '@/resources/model-fit/native-probe/run-isolated-fit'
+
+export interface RunInProcessFitOptions {
+  signal?: AbortSignal
+  timeoutMs?: number
+  fit?: (config: FitConfig) => FitResult | Promise<FitResult>
+  stateDir?: string
+}
+
+function parseOptionalInt(value: string | undefined) {
+  if (value === undefined) return undefined
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) return undefined
+  return parsed
+}
+
+export function toFitConfig(config: FitLlamaProcessConfig) {
+  const nCtx = parseOptionalInt(config.params['ctx_size'])
+  const nGpuLayers = parseOptionalInt(config.params['gpu_layers'])
+  const nBatch = parseOptionalInt(config.params['batch_size'])
+  return {
+    modelPath: config.modelPath,
+    ...(config.backendsDir !== undefined && { backendsDir: config.backendsDir }),
+    ...(config.marginMiB !== undefined && { marginMiB: config.marginMiB }),
+    ...(config.nCtxMin !== undefined && { nCtxMin: config.nCtxMin }),
+    ...(nCtx !== undefined && nCtx > 0 && { nCtx }),
+    ...(nGpuLayers !== undefined && { nGpuLayers }),
+    ...(nBatch !== undefined && { nBatch })
+  }
+}
+
+function markerPath(stateDir: string, config: FitConfig) {
+  const key = generateShortHash(
+    JSON.stringify({
+      modelPath: config.modelPath,
+      nCtx: config.nCtx,
+      nCtxMin: config.nCtxMin,
+      nGpuLayers: config.nGpuLayers,
+      marginMiB: config.marginMiB
+    })
+  )
+  return path.join(stateDir, `${key}.running`)
+}
+
+export function crashMarkerPath(stateDir: string, config: FitLlamaProcessConfig) {
+  return markerPath(stateDir, toFitConfig(config))
+}
+
+function exists(file: string) {
+  try {
+    fs.accessSync(file)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function writeMarker(file: string) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, '')
+}
+
+function clearMarker(file: string) {
+  try {
+    fs.unlinkSync(file)
+  } catch {
+    // Marker cleanup must not turn an advisory fit into a load failure.
+  }
+}
+
+function unknown(reason: IsolatedFitUnknownReason, message: string) {
+  return { status: 'unknown', reason, message }
+}
+
+function formatError(error: unknown) {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+}
+
+async function defaultFit(config: FitConfig) {
+  const { fitParams } = await import('@qvac/model-fit')
+  return fitParams(config)
+}
+
+async function resolveStateDir(explicit: string | undefined) {
+  if (explicit !== undefined) return explicit
+  const { getCacheDir } = await import('@/utils/cache/paths')
+  return getCacheDir('model-fit')
+}
+
+/**
+ * In-process llama.cpp fit for hosts with no disposable child (Android/iOS).
+ *
+ * `fitParams` is a blocking native call. A leftover `.running` marker means a
+ * previous call aborted the process; that model is `unknown` so the next launch
+ * does not retry the same abort.
+ */
+export async function runInProcessFit(
+  _loadKind: LlamaLoadKind,
+  config: FitLlamaProcessConfig,
+  options: RunInProcessFitOptions = {}
+) {
+  if (options.signal?.aborted === true) {
+    return unknown('cancelled', 'In-process fit was cancelled')
+  }
+
+  const fitConfig = toFitConfig(config)
+  const stateDir = await resolveStateDir(options.stateDir)
+  const marker = markerPath(stateDir, fitConfig)
+
+  if (exists(marker)) {
+    clearMarker(marker)
+    return unknown(
+      'crashed',
+      'Previous in-process fit did not finish; treating this model as unknown'
+    )
+  }
+
+  try {
+    writeMarker(marker)
+  } catch (error) {
+    return unknown(
+      'invocation-error',
+      `Fit crash marker could not be written: ${formatError(error)}`
+    )
+  }
+
+  try {
+    const fit = options.fit ?? defaultFit
+    const result = await fit(fitConfig)
+    return { status: 'completed' as const, result }
+  } catch (error) {
+    return unknown('invocation-error', formatError(error))
+  } finally {
+    clearMarker(marker)
+  }
+}

--- a/packages/inference/src/resources/model-fit/native-probe/run-in-process-fit.ts
+++ b/packages/inference/src/resources/model-fit/native-probe/run-in-process-fit.ts
@@ -14,6 +14,40 @@ export interface RunInProcessFitOptions {
   stateDir?: string
 }
 
+/**
+ * Stable `ggml_type` ordinals from `ggml.h` (the header `fitParams` is compiled
+ * against). Names llama.cpp has kept numbered since the enum was frozen:
+ * F32=0, F16=1, Q4_0=2, Q4_1=3, (4/5 removed Q4_2/Q4_3), Q5_0=6, Q5_1=7,
+ * Q8_0=8, Q8_1=9, IQ4_NL=20, BF16=30. Unmapped names (TurboQuant/PolarQuant)
+ * fail the conversion instead of silently projecting against llama defaults.
+ */
+const GGML_TYPE: Record<string, number> = {
+  f32: 0,
+  f16: 1,
+  q4_0: 2,
+  q4_1: 3,
+  q5_0: 6,
+  q5_1: 7,
+  q8_0: 8,
+  q8_1: 9,
+  iq4_nl: 20,
+  bf16: 30
+}
+
+/** `enum llama_flash_attn_type` — domain checked in `@qvac/model-fit` index.js. */
+const FLASH_ATTN_TYPE: Record<string, number> = {
+  auto: -1,
+  off: 0,
+  on: 1
+}
+
+/** `enum llama_split_mode`. */
+const SPLIT_MODE: Record<string, number> = {
+  none: 0,
+  layer: 1,
+  row: 2
+}
+
 function parseOptionalInt(value: string | undefined) {
   if (value === undefined) return undefined
   const parsed = Number(value)
@@ -21,10 +55,41 @@ function parseOptionalInt(value: string | undefined) {
   return parsed
 }
 
+function lookup(table: Record<string, number>, value: string | undefined, label: string) {
+  if (value === undefined) return undefined
+  const mapped = table[value.toLowerCase()]
+  if (mapped === undefined) {
+    throw new TypeError(`Unsupported ${label} for in-process fit: ${value}`)
+  }
+  return mapped
+}
+
+function param(config: FitLlamaProcessConfig, ...keys: string[]) {
+  for (const key of keys) {
+    const value = config.params[key]
+    if (value !== undefined) return value
+  }
+  return undefined
+}
+
 export function toFitConfig(config: FitLlamaProcessConfig) {
-  const nCtx = parseOptionalInt(config.params['ctx_size'])
-  const nGpuLayers = parseOptionalInt(config.params['gpu_layers'])
-  const nBatch = parseOptionalInt(config.params['batch_size'])
+  const nCtx = parseOptionalInt(param(config, 'ctx_size', 'ctx-size'))
+  const nGpuLayers = parseOptionalInt(
+    param(config, 'gpu_layers', 'gpu-layers', 'n-gpu-layers', 'n_gpu_layers')
+  )
+  const nBatch = parseOptionalInt(param(config, 'batch_size', 'batch-size'))
+  const mainGpu = parseOptionalInt(param(config, 'main-gpu', 'main_gpu'))
+  const typeK = lookup(GGML_TYPE, param(config, 'cache-type-k'), 'KV cache type')
+  const typeV = lookup(GGML_TYPE, param(config, 'cache-type-v'), 'KV cache type')
+  const flashAttnType = lookup(
+    FLASH_ATTN_TYPE,
+    param(config, 'flash-attn', 'flash_attn'),
+    'flash-attn'
+  )
+  const splitMode = lookup(SPLIT_MODE, param(config, 'split-mode', 'split_mode'), 'split-mode')
+  // device, load_mode, parallel, and tensor-split are fit evidence on the
+  // process path but are not fields on public FitConfig — omitting them here
+  // is the API limit, not a silent default.
   return {
     modelPath: config.modelPath,
     ...(config.backendsDir !== undefined && { backendsDir: config.backendsDir }),
@@ -32,25 +97,33 @@ export function toFitConfig(config: FitLlamaProcessConfig) {
     ...(config.nCtxMin !== undefined && { nCtxMin: config.nCtxMin }),
     ...(nCtx !== undefined && nCtx > 0 && { nCtx }),
     ...(nGpuLayers !== undefined && { nGpuLayers }),
-    ...(nBatch !== undefined && { nBatch })
+    ...(nBatch !== undefined && { nBatch }),
+    ...(mainGpu !== undefined && { mainGpu }),
+    ...(typeK !== undefined && { typeK }),
+    ...(typeV !== undefined && { typeV }),
+    ...(flashAttnType !== undefined && { flashAttnType }),
+    ...(splitMode !== undefined && { splitMode })
   }
 }
 
-function markerPath(stateDir: string, config: FitConfig) {
-  const key = generateShortHash(
-    JSON.stringify({
-      modelPath: config.modelPath,
-      nCtx: config.nCtx,
-      nCtxMin: config.nCtxMin,
-      nGpuLayers: config.nGpuLayers,
-      marginMiB: config.marginMiB
-    })
-  )
-  return path.join(stateDir, `${key}.running`)
+function markerKey(config: FitConfig) {
+  return generateShortHash(JSON.stringify(config))
+}
+
+function runningMarkerPath(stateDir: string, config: FitConfig) {
+  return path.join(stateDir, `${markerKey(config)}.running`)
+}
+
+function crashedMarkerPathForConfig(stateDir: string, config: FitConfig) {
+  return path.join(stateDir, `${markerKey(config)}.crashed`)
 }
 
 export function crashMarkerPath(stateDir: string, config: FitLlamaProcessConfig) {
-  return markerPath(stateDir, toFitConfig(config))
+  return runningMarkerPath(stateDir, toFitConfig(config))
+}
+
+export function crashedMarkerPath(stateDir: string, config: FitLlamaProcessConfig) {
+  return crashedMarkerPathForConfig(stateDir, toFitConfig(config))
 }
 
 function exists(file: string) {
@@ -72,6 +145,16 @@ function clearMarker(file: string) {
     fs.unlinkSync(file)
   } catch {
     // Marker cleanup must not turn an advisory fit into a load failure.
+  }
+}
+
+function persistCrash(running: string, crashed: string) {
+  try {
+    writeMarker(crashed)
+    clearMarker(running)
+  } catch {
+    // Keep `.running` if `.crashed` could not be written so the next launch
+    // still skips native instead of retrying the abort.
   }
 }
 
@@ -98,8 +181,8 @@ async function resolveStateDir(explicit: string | undefined) {
  * In-process llama.cpp fit for hosts with no disposable child (Android/iOS).
  *
  * `fitParams` is a blocking native call. A leftover `.running` marker means a
- * previous call aborted the process; that model is `unknown` so the next launch
- * does not retry the same abort.
+ * previous call aborted the process. That is converted to `.crashed` so later
+ * launches skip native for the same path+config instead of retrying the abort.
  */
 export async function runInProcessFit(
   _loadKind: LlamaLoadKind,
@@ -110,12 +193,19 @@ export async function runInProcessFit(
     return unknown('cancelled', 'In-process fit was cancelled')
   }
 
-  const fitConfig = toFitConfig(config)
-  const stateDir = await resolveStateDir(options.stateDir)
-  const marker = markerPath(stateDir, fitConfig)
+  let fitConfig: FitConfig
+  try {
+    fitConfig = toFitConfig(config)
+  } catch (error) {
+    return unknown('invocation-error', formatError(error))
+  }
 
-  if (exists(marker)) {
-    clearMarker(marker)
+  const stateDir = await resolveStateDir(options.stateDir)
+  const running = runningMarkerPath(stateDir, fitConfig)
+  const crashed = crashedMarkerPathForConfig(stateDir, fitConfig)
+
+  if (exists(crashed) || exists(running)) {
+    persistCrash(running, crashed)
     return unknown(
       'crashed',
       'Previous in-process fit did not finish; treating this model as unknown'
@@ -123,7 +213,7 @@ export async function runInProcessFit(
   }
 
   try {
-    writeMarker(marker)
+    writeMarker(running)
   } catch (error) {
     return unknown(
       'invocation-error',
@@ -138,6 +228,6 @@ export async function runInProcessFit(
   } catch (error) {
     return unknown('invocation-error', formatError(error))
   } finally {
-    clearMarker(marker)
+    clearMarker(running)
   }
 }

--- a/packages/inference/test/native-probe-advisory-fit.test.ts
+++ b/packages/inference/test/native-probe-advisory-fit.test.ts
@@ -194,7 +194,7 @@ test('advisory fit: the env opt-out disables the check without logging', async (
   t.is(records.length, 0)
 })
 
-test('advisory fit: never launches a child on mobile', async (t) => {
+test('advisory fit: runs the fitter on mobile', async (t) => {
   const { logger } = recordingLogger()
   const { calls, runFit } = fitReturning({ status: 'completed', result: FIT_PLAN })
 
@@ -207,11 +207,11 @@ test('advisory fit: never launches a child on mobile', async (t) => {
 
   t.alike(outcome, {
     ...PROVENANCE,
-    verdict: 'unknown',
-    reason: 'unsupported-load',
-    message: 'mobile has no disposable process boundary'
+    verdict: 'fit',
+    reason: 'fits',
+    plan: { nCtx: 4096, nGpuLayers: 32, nGpuDevices: 1 }
   })
-  t.is(calls.length, 0)
+  t.is(calls.length, 1)
 })
 
 test('advisory fit: absorbs a supervisor that rejects', async (t) => {

--- a/packages/inference/test/native-probe-create-llama-fit-request.test.ts
+++ b/packages/inference/test/native-probe-create-llama-fit-request.test.ts
@@ -45,8 +45,7 @@ function completionRequest(overrides: Record<string, unknown> = {}) {
     modelType: ModelType.llamacppCompletion,
     modelPath: '/models/model.gguf',
     modelConfig: { ...COMPLETION_CONFIG, ...overrides },
-    isShardedModel: false,
-    isMobile: false
+    isShardedModel: false
   })
 }
 
@@ -125,8 +124,7 @@ test('createLlamaFitRequest: refuses a multimodal load', (t) => {
       modelPath: '/models/model.gguf',
       modelConfig: COMPLETION_CONFIG,
       artifacts: { projectionModelPath: '/models/mmproj.gguf' },
-      isShardedModel: false,
-      isMobile: false
+      isShardedModel: false
     }),
     { supported: false, detail: 'multimodal projection loads are not representable' }
   )
@@ -138,23 +136,9 @@ test('createLlamaFitRequest: refuses a sharded load', (t) => {
       modelType: ModelType.llamacppCompletion,
       modelPath: '/models/model-00001-of-00003.gguf',
       modelConfig: COMPLETION_CONFIG,
-      isShardedModel: true,
-      isMobile: false
+      isShardedModel: true
     }),
     { supported: false, detail: 'sharded models are not representable' }
-  )
-})
-
-test('createLlamaFitRequest: refuses every load on mobile before inspecting it', (t) => {
-  t.alike(
-    createLlamaFitRequest({
-      modelType: ModelType.llamacppCompletion,
-      modelPath: '/models/model.gguf',
-      modelConfig: { some_new_load_knob: 7 },
-      isShardedModel: true,
-      isMobile: true
-    }),
-    { supported: false, detail: 'mobile has no disposable process boundary' }
   )
 })
 
@@ -164,8 +148,7 @@ test('createLlamaFitRequest: refuses a model type that is not a llama.cpp load',
       modelType: ModelType.whispercppTranscription,
       modelPath: '/models/whisper.bin',
       modelConfig: {},
-      isShardedModel: false,
-      isMobile: false
+      isShardedModel: false
     }),
     {
       supported: false,
@@ -179,8 +162,7 @@ test('createLlamaFitRequest: forwards only fit-relevant embedding load settings'
     modelType: ModelType.llamacppEmbedding,
     modelPath: '/models/embed.gguf',
     modelConfig: EMBEDDING_CONFIG,
-    isShardedModel: false,
-    isMobile: false
+    isShardedModel: false
   })
 
   t.ok(plan.supported)

--- a/packages/inference/test/native-probe-run-in-process-fit.test.ts
+++ b/packages/inference/test/native-probe-run-in-process-fit.test.ts
@@ -4,8 +4,11 @@ import os from 'bare-os'
 import path from 'bare-path'
 import type { FitConfig, FitResult } from '@qvac/model-fit'
 
+import { ModelType } from '@/schemas/index'
+import { createLlamaFitRequest } from '@/resources/model-fit/native-probe/create-llama-fit-request'
 import {
   crashMarkerPath,
+  crashedMarkerPath,
   runInProcessFit,
   toFitConfig
 } from '@/resources/model-fit/native-probe/run-in-process-fit'
@@ -59,6 +62,134 @@ test('toFitConfig: omits auto context so the fitter can choose', (t) => {
   t.absent('nCtx' in config)
 })
 
+test('toFitConfig: maps KV, flash, split, and main-gpu onto FitConfig', (t) => {
+  t.alike(
+    toFitConfig({
+      modelPath: '/models/model.gguf',
+      params: {
+        device: 'gpu',
+        ctx_size: '4096',
+        gpu_layers: '99',
+        'cache-type-k': 'q8_0',
+        'cache-type-v': 'q8_0',
+        'flash-attn': 'on',
+        'split-mode': 'layer',
+        'main-gpu': '0'
+      }
+    }),
+    {
+      modelPath: '/models/model.gguf',
+      nCtx: 4096,
+      nGpuLayers: 99,
+      typeK: 8,
+      typeV: 8,
+      flashAttnType: 1,
+      splitMode: 1,
+      mainGpu: 0
+    }
+  )
+})
+
+test('toFitConfig: maps embedding flash_attn, batch, and split', (t) => {
+  t.alike(
+    toFitConfig({
+      modelPath: '/models/model.gguf',
+      params: {
+        gpu_layers: '99',
+        batch_size: '1024',
+        flash_attn: 'auto',
+        'split-mode': 'none'
+      }
+    }),
+    {
+      modelPath: '/models/model.gguf',
+      nGpuLayers: 99,
+      nBatch: 1024,
+      flashAttnType: -1,
+      splitMode: 0
+    }
+  )
+})
+
+test('toFitConfig: converts the params createLlamaFitRequest actually forwards', (t) => {
+  const completion = createLlamaFitRequest({
+    modelType: ModelType.llamacppCompletion,
+    modelPath: '/models/model.gguf',
+    modelConfig: {
+      ctx_size: 4096,
+      gpu_layers: 99,
+      device: 'gpu',
+      'cache-type-k': 'q8_0',
+      'cache-type-v': 'q8_0',
+      'flash-attn': 'on',
+      'main-gpu': 0,
+      'split-mode': 'layer'
+    },
+    isShardedModel: false
+  })
+  t.ok(completion.supported)
+  if (!completion.supported) return
+  t.alike(toFitConfig(completion.config), {
+    modelPath: '/models/model.gguf',
+    nCtxMin: 4096,
+    nCtx: 4096,
+    nGpuLayers: 99,
+    typeK: 8,
+    typeV: 8,
+    flashAttnType: 1,
+    splitMode: 1,
+    mainGpu: 0
+  })
+  t.absent('nUbatch' in toFitConfig(completion.config))
+  t.absent('swaFull' in toFitConfig(completion.config))
+
+  const embedding = createLlamaFitRequest({
+    modelType: ModelType.llamacppEmbedding,
+    modelPath: '/models/embed.gguf',
+    modelConfig: {
+      device: 'gpu',
+      gpuLayers: 99,
+      batchSize: 1024,
+      flashAttention: 'auto'
+    },
+    isShardedModel: false
+  })
+  t.ok(embedding.supported)
+  if (!embedding.supported) return
+  t.alike(toFitConfig(embedding.config), {
+    modelPath: '/models/embed.gguf',
+    nGpuLayers: 99,
+    nBatch: 1024,
+    flashAttnType: -1
+  })
+})
+
+test('toFitConfig: flash-attn true is not treated as on', (t) => {
+  try {
+    toFitConfig({
+      modelPath: '/models/model.gguf',
+      params: { 'flash-attn': 'true' }
+    })
+    t.fail('expected flash-attn true to fail conversion')
+  } catch (error) {
+    t.ok(error instanceof TypeError)
+    t.ok(/Unsupported flash-attn/.test(String(error)))
+  }
+})
+
+test('toFitConfig: unmapped KV cache type fails instead of omitting', (t) => {
+  try {
+    toFitConfig({
+      modelPath: '/models/model.gguf',
+      params: { 'cache-type-k': 'tbq4_0' }
+    })
+    t.fail('expected unmapped KV cache type to fail conversion')
+  } catch (error) {
+    t.ok(error instanceof TypeError)
+    t.ok(/Unsupported KV cache type/.test(String(error)))
+  }
+})
+
 test('runInProcessFit: returns the native projection', async (t) => {
   const stateDir = tempDir()
   const calls: FitConfig[] = []
@@ -74,6 +205,7 @@ test('runInProcessFit: returns the native projection', async (t) => {
   t.alike(result, { status: 'completed', result: FIT_PLAN })
   t.alike(calls, [toFitConfig(CONFIG)])
   t.is(exists(crashMarkerPath(stateDir, CONFIG)), false)
+  t.is(exists(crashedMarkerPath(stateDir, CONFIG)), false)
 })
 
 test('runInProcessFit: leftover crash marker is unknown and skips the native call', async (t) => {
@@ -94,6 +226,28 @@ test('runInProcessFit: leftover crash marker is unknown and skips the native cal
   if (result.status !== 'unknown') return
   t.is(result.reason, 'crashed')
   t.is(exists(crashMarkerPath(stateDir, CONFIG)), false)
+  t.is(exists(crashedMarkerPath(stateDir, CONFIG)), true)
+})
+
+test('runInProcessFit: leftover crashed marker keeps skipping native', async (t) => {
+  const stateDir = tempDir()
+  fs.mkdirSync(stateDir, { recursive: true })
+  fs.writeFileSync(crashedMarkerPath(stateDir, CONFIG), '')
+  let called = 0
+
+  const result = await runInProcessFit('completion', CONFIG, {
+    stateDir,
+    fit: () => {
+      called += 1
+      return FIT_PLAN
+    }
+  })
+
+  t.is(called, 0)
+  t.is(result.status, 'unknown')
+  if (result.status !== 'unknown') return
+  t.is(result.reason, 'crashed')
+  t.is(exists(crashedMarkerPath(stateDir, CONFIG)), true)
 })
 
 test('runInProcessFit: a thrown fit still clears the crash marker', async (t) => {
@@ -112,6 +266,29 @@ test('runInProcessFit: a thrown fit still clears the crash marker', async (t) =>
     message: 'TypeError: native exploded'
   })
   t.is(exists(crashMarkerPath(stateDir, CONFIG)), false)
+  t.is(exists(crashedMarkerPath(stateDir, CONFIG)), false)
+})
+
+test('runInProcessFit: unmapped params are invocation-error and skip native', async (t) => {
+  const stateDir = tempDir()
+  let called = 0
+  const config = {
+    modelPath: '/models/model.gguf',
+    params: { 'cache-type-k': 'tbq4_0' }
+  }
+
+  const result = await runInProcessFit('completion', config, {
+    stateDir,
+    fit: () => {
+      called += 1
+      return FIT_PLAN
+    }
+  })
+
+  t.is(called, 0)
+  t.is(result.status, 'unknown')
+  if (result.status !== 'unknown') return
+  t.is(result.reason, 'invocation-error')
 })
 
 function exists(file: string) {

--- a/packages/inference/test/native-probe-run-in-process-fit.test.ts
+++ b/packages/inference/test/native-probe-run-in-process-fit.test.ts
@@ -1,0 +1,124 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import os from 'bare-os'
+import path from 'bare-path'
+import type { FitConfig, FitResult } from '@qvac/model-fit'
+
+import {
+  crashMarkerPath,
+  runInProcessFit,
+  toFitConfig
+} from '@/resources/model-fit/native-probe/run-in-process-fit'
+
+const CONFIG = {
+  modelPath: '/models/model.gguf',
+  params: { device: 'gpu', ctx_size: '4096', gpu_layers: '99' },
+  nCtxMin: 4096,
+  marginMiB: 1024
+}
+
+const FIT_PLAN: FitResult = {
+  status: 0,
+  fits: true,
+  reason: 'fits',
+  maxDevices: 1,
+  nDevices: 1,
+  nGpuDevices: 1,
+  nGpuLayers: 32,
+  nCtx: 4096,
+  nBatch: 512,
+  nUbatch: 512,
+  tensorSplit: [1],
+  buftOverrides: [],
+  splitMode: 1,
+  mainGpu: 0,
+  typeK: 1,
+  typeV: 1,
+  flashAttnType: 1
+}
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'qvac-in-process-fit-'))
+}
+
+test('toFitConfig: forwards path, context, offload, and margin', (t) => {
+  t.alike(toFitConfig(CONFIG), {
+    modelPath: '/models/model.gguf',
+    marginMiB: 1024,
+    nCtxMin: 4096,
+    nCtx: 4096,
+    nGpuLayers: 99
+  })
+})
+
+test('toFitConfig: omits auto context so the fitter can choose', (t) => {
+  const config = toFitConfig({
+    modelPath: '/models/model.gguf',
+    params: { ctx_size: '0' }
+  })
+  t.absent('nCtx' in config)
+})
+
+test('runInProcessFit: returns the native projection', async (t) => {
+  const stateDir = tempDir()
+  const calls: FitConfig[] = []
+
+  const result = await runInProcessFit('completion', CONFIG, {
+    stateDir,
+    fit: (config) => {
+      calls.push(config)
+      return FIT_PLAN
+    }
+  })
+
+  t.alike(result, { status: 'completed', result: FIT_PLAN })
+  t.alike(calls, [toFitConfig(CONFIG)])
+  t.is(exists(crashMarkerPath(stateDir, CONFIG)), false)
+})
+
+test('runInProcessFit: leftover crash marker is unknown and skips the native call', async (t) => {
+  const stateDir = tempDir()
+  fs.writeFileSync(crashMarkerPath(stateDir, CONFIG), '')
+  let called = 0
+
+  const result = await runInProcessFit('completion', CONFIG, {
+    stateDir,
+    fit: () => {
+      called += 1
+      return FIT_PLAN
+    }
+  })
+
+  t.is(called, 0)
+  t.is(result.status, 'unknown')
+  if (result.status !== 'unknown') return
+  t.is(result.reason, 'crashed')
+  t.is(exists(crashMarkerPath(stateDir, CONFIG)), false)
+})
+
+test('runInProcessFit: a thrown fit still clears the crash marker', async (t) => {
+  const stateDir = tempDir()
+
+  const result = await runInProcessFit('completion', CONFIG, {
+    stateDir,
+    fit: () => {
+      throw new TypeError('native exploded')
+    }
+  })
+
+  t.alike(result, {
+    status: 'unknown',
+    reason: 'invocation-error',
+    message: 'TypeError: native exploded'
+  })
+  t.is(exists(crashMarkerPath(stateDir, CONFIG)), false)
+})
+
+function exists(file: string) {
+  try {
+    fs.accessSync(file)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/sdk/src/expo/plugins/withMobileBundle.ts
+++ b/packages/sdk/src/expo/plugins/withMobileBundle.ts
@@ -17,10 +17,9 @@ const { withDangerousMod } = configPlugins
 const DEFERRED_MODULES = ['expo-file-system', 'react-native-bare-kit']
 
 /**
- * Desktop-only modules deferred so bare-pack stops walking into them. They back
- * the advisory fit check, which mobile refuses at runtime, but the imports are
- * static and pull in `bare-process` -> `bare-posix`, which ships no
- * `android-arm64` prebuild and fails bundle verification.
+ * Desktop-only spawn path, deferred so bare-pack does not walk `bare-process`
+ * -> `bare-posix` (no `android-arm64` prebuild). Mobile advisory uses
+ * in-process `@qvac/model-fit` (`fitParams`), not this subprocess.
  */
 const MOBILE_UNSUPPORTED_MODULES = ['bare-runtime/spawn', '@qvac/model-fit/process']
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Android and iOS `loadModel` advisory always returned `unknown` (`mobile has no disposable process boundary`), so there was no llama.cpp engine projection on device.
- Apps need that projection for the assessModelFit. The desktop spawn path cannot run on mobile.

## 📝 How does it solve it?

- On mobile, advisory calls in-process `@qvac/model-fit` `fitParams` instead of spawning a child.
- `bare-runtime/spawn` and `@qvac/model-fit/process` stay deferred from the mobile pack (posix / no `android-arm64` prebuild). The `@qvac/model-fit` root is packed so the native fitter ships.
- A leftover crash marker treats that model as `unknown` on the next launch so a forced abort is not retried immediately.
- Fail-open is unchanged: a projected miss still loads. Persist, Android `backendsDir`, and assessModelFit fitFacts stay with the parent tickets.

## 🧪 How was it tested?

- Unit tests: `native-probe-advisory-fit`, `native-probe-create-llama-fit-request`, `native-probe-run-in-process-fit`, `native-probe-run-isolated-fit` — 70/70 pass.
