### PR TITLE
chore[notask]: build qvac-fabric with -DLLAMA_OPENSSL=OFF (@qvac/fabric 0.10.1)

### DIFF
--- a/packages/fabric/CHANGELOG.md
+++ b/packages/fabric/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.10.1] - 2026-09-11
+
+### Changed
+
+- `qvac-fabric` is now built with `-DLLAMA_OPENSSL=OFF`, via a repo-local
+  overlay port that is otherwise a verbatim copy of the registry port for
+  `10297.1.1`. Upstream defaults `LLAMA_OPENSSL` to `ON`, so
+  `vendor/cpp-httplib` ran `find_package(OpenSSL)` and linked `OpenSSL::SSL` /
+  `OpenSSL::Crypto` into the installed `cpp-httplib` target whenever
+  `LLAMA_BUILD_COMMON` was on — which is always, since the port requests the
+  `llama` feature. Nothing in this addon uses httplib's HTTPS path, so the
+  prebuild no longer carries a build-host-dependent system OpenSSL it never
+  calls. Same fabric source (`REF v${VERSION}`, same SHA512) and the same
+  `version>=` floor as 0.10.0; only the configure flag differs.
+
 ## [0.10.0] - 2026-08-29
 
 ### Changed

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/fabric",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Shared bare addon hosting the qvac-fabric (forked llama.cpp + ggml) runtime for QVAC inference addons",
   "addon": true,
   "engines": {

--- a/packages/fabric/vcpkg-configuration.json
+++ b/packages/fabric/vcpkg-configuration.json
@@ -1,4 +1,5 @@
 {
+  "overlay-ports": ["../../vcpkg-overlays/ports"],
   "default-registry": {
     "kind": "git",
     "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",

--- a/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
+++ b/vcpkg-overlays/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,241 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-fabric-llm.cpp
+  REF v${VERSION}
+  SHA512 4a4a480c582899d6a8caf9fac6a3e51ea367e2b4c6beab1d1cc73edfb10f996ec1efa98d212846f8972d44a471fa1f4676cffb6da63794aa15b5390f6ea762b1
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+    vector-index GGML_VECTOR_INDEX
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+    hip-backend BUILD_HIP_BACKEND
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # The Android NDK ships only the C Vulkan headers; the ggml Vulkan backend
+  # additionally needs the C++ bindings (vulkan.hpp) and SPIRV-Headers, which as
+  # of b9840 ggml fetches itself via FetchContent (ggml/src/ggml-vulkan/CMakeLists.txt,
+  # `if (ANDROID)` block). The registry vcpkg-cmake sets FETCHCONTENT_FULLY_DISCONNECTED=ON
+  # globally, so allow the fetch here (same as the kleidiai path below).
+  list(APPEND PLATFORM_OPTIONS -DFETCHCONTENT_FULLY_DISCONNECTED=OFF)
+endif()
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID OR (VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS))
+  # Desktop Linux also needs GGML_BACKEND_DL=ON so that multiple GPU backends
+  # (Vulkan + HIP/ROCm) can coexist as separately-loaded modules, the same way
+  # Android dispatches CPU variants at runtime. Without DL the Linux build links
+  # a single static GPU backend and a second one (HIP) cannot be stacked.
+  # GGML_NATIVE is incompatible with DL, so CPU variants are dispatched via
+  # GGML_CPU_ALL_VARIANTS instead. Consumers must ship the core ggml/llama libs
+  # alongside their backend modules so the dynamically-linked .bare can resolve
+  # them at load time.
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# HIP/ROCm backend — opt-in via the 'hip-backend' feature (Linux + AMD only).
+# Only @qvac/vla-ggml requests it, so every other consumer builds with no HIP
+# and gains no ROCm dependency. Builds libqvac-ggml-hip.so as a standalone DL
+# module alongside Vulkan (GGML_BACKEND_DL is already ON above), so the addon
+# dlopen's whichever GPU backend BackendSelection picks at runtime. The `hip`
+# feature-dependency port forwards the system ROCm's find_package() configs.
+#
+# FAIL-SAFE: enable GGML_HIP only when a ROCm SDK is actually present. On a build
+# host without ROCm we skip HIP and build Vulkan/CPU only — the build never
+# hard-fails, and at runtime a missing HIP module just isn't loaded (the DL
+# loader skips it) so BackendSelection falls back to Vulkan/CPU. Targets gfx1151
+# (Strix Halo / Radeon 8060S); the HIP compiler + ROCM_PATH come from the build env.
+# linux-x64 only: AMD GPU hosts (Strix Halo / gfx1151) are x86_64, and the ROCm
+# dist is x64. On other arches (e.g. linux-arm64) HIP is skipped even if the
+# feature is requested — no ROCm requirement, no build break.
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND BUILD_GPU_BACKENDS AND BUILD_HIP_BACKEND)
+  # DETERMINISTIC: requesting hip-backend REQUIRES a ROCm SDK at build time. We
+  # must NOT silently skip when ROCm is absent — a host-dependent skip yields a
+  # no-HIP package with the SAME vcpkg ABI as a real HIP build, which the binary
+  # cache then conflates (cache poisoning: a no-ROCm build caches a no-HIP
+  # package that ROCm-equipped builds then restore). So ROCm present => HIP;
+  # ROCm absent => hard error (don't request hip-backend on a host without ROCm).
+  # The RUNTIME fail-safe is unchanged: an absent HIP module / non-AMD target is
+  # simply not loaded and BackendSelection falls back to Vulkan/CPU.
+  if(NOT (DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/cmake/hip/hip-config.cmake"))
+    message(FATAL_ERROR "qvac-fabric: hip-backend feature requires a ROCm SDK — set ROCM_PATH to a ROCm/TheRock install containing lib/cmake/hip/hip-config.cmake. Do not request hip-backend on a host without ROCm.")
+  endif()
+  message(STATUS "qvac-fabric: hip-backend ON — building GGML_HIP (gfx1151)")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_HIP=ON
+    -DAMDGPU_TARGETS=gfx1151
+    -DCMAKE_HIP_ARCHITECTURES=gfx1151)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+# Under GGML_BACKEND_DL the per-microarch backends ship as standalone
+# libqvac-ggml-*.so modules that the consumer dlopen's at runtime. Built with
+# -stdlib=libc++ they otherwise carry a runtime NEEDED dependency on the system
+# libc++.so.1 / libc++abi.so.1, so they silently fail to dlopen on any target
+# without libc++ installed (e.g. stock ubuntu-24.04 — no CPU backend registers,
+# inference aborts). Statically link the C++ runtime into the modules so they
+# are self-contained, matching how the addons link themselves. The module<->addon
+# boundary is the C ggml-backend ABI, so per-module libc++ copies never exchange
+# C++ objects. Linux only: Apple/iOS use Metal frameworks, Android ships
+# libc++_shared via the NDK STL, Windows uses the MSVC runtime.
+if(VCPKG_TARGET_IS_LINUX AND DL_BACKENDS)
+  string(APPEND VCPKG_LINKER_FLAGS " -static-libstdc++")
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    # OVERLAY-ONLY: the registry port leaves LLAMA_OPENSSL at its upstream
+    # default (ON), so vendor/cpp-httplib runs find_package(OpenSSL) and links
+    # OpenSSL::SSL / OpenSSL::Crypto into the installed cpp-httplib target
+    # whenever LLAMA_BUILD_COMMON is ON (i.e. the 'llama' feature). None of the
+    # addons use httplib's HTTPS path — model downloads go through the JS side —
+    # so that is a build-host-dependent system dependency bought for nothing.
+    -DLLAMA_OPENSSL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_BUILD_APP=OFF
+    -DMTMD_VIDEO=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
+++ b/vcpkg-overlays/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,61 @@
+{
+  "name": "qvac-fabric",
+  "version": "10297.1.1",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "hip-backend": {
+      "description": "Build the ROCm/HIP GPU backend (libqvac-ggml-hip.so) for AMD GPUs on Linux as a DL module alongside Vulkan. Opt-in (only @qvac/vla-ggml requests it). Fail-safe: if no ROCm SDK is present at build time the HIP backend is skipped (Vulkan/CPU only). Targets gfx1151 (Strix Halo). The 'hip' dependency forwards the system ROCm find_package configs.",
+      "dependencies": [
+        {
+          "name": "hip",
+          "platform": "linux & x64"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    },
+    "vector-index": {
+      "description": "Build and install the ggml vector index library."
+    }
+  }
+}


### PR DESCRIPTION
## 🎯 Problem

The registry `qvac-fabric` port turns `LLAMA_CURL` off but says nothing about OpenSSL, and upstream defaults it on:

```cmake
option(LLAMA_OPENSSL "llama: use openssl to support HTTPS" ON)
```

`vendor/cpp-httplib/CMakeLists.txt` acts on that — `find_package(OpenSSL)`, then `target_link_libraries(cpp-httplib PUBLIC OpenSSL::SSL OpenSSL::Crypto)` plus the `CPPHTTPLIB_OPENSSL_SUPPORT` define — whenever `LLAMA_BUILD_COMMON` is on. It always is here: the port requests the `llama` feature, and vcpkg configures fabric as the top-level project, so `LLAMA_STANDALONE` is `ON` and `LLAMA_BUILD_COMMON` defaults with it.

The result is a build-host-dependent system OpenSSL linked into the installed `cpp-httplib` target that this addon never calls — HTTPS model downloads happen on the JS side, not through httplib. Whether it gets picked up at all depends on what the build host happens to have installed, which is exactly the kind of input a prebuild should not have.

## 📝 How

A repo-local overlay port at `vcpkg-overlays/ports/qvac-fabric/`, copied from the registry port for `10297.1.1` — the version this release line pins — with one change:

```cmake
   -DLLAMA_CURL=OFF
+  -DLLAMA_OPENSSL=OFF
   -DLLAMA_BUILD_TESTS=OFF
```

`packages/fabric/vcpkg-configuration.json` gains `"overlay-ports": ["../../vcpkg-overlays/ports"]` to pick it up.

What deliberately does **not** change:

- **`vcpkg.json` is byte-identical** to the registry's, at version `10297.1.1`, which satisfies the existing `version>=` floor in `packages/fabric/vcpkg.json` unchanged.
- **`REF v${VERSION}` and the published SHA512 are kept**, so this builds the same fabric source as `0.10.0`. Only the configure flag differs — unlike a rollout overlay, nothing is re-pinned to a branch head.
- **`default-registry.baseline` is untouched.**
- Only `packages/fabric` points at the overlay; no other consumer on this branch is affected.

The overlay is the scoped way to land this on a release line. The durable fix is the same flag in the registry port itself (`tetherto/qvac-registry-vcpkg/ports/qvac-fabric/portfile.cmake`), which would need a new `qvac-fabric` port version and a rollout — worth doing as a follow-up, at which point this overlay comes back out.

## 🧪 Tested

- **Overlay version confirmed to be the one `@qvac/fabric` 0.10.0 actually resolves.** vcpkg uses minimal version selection, so the answer is `max(baseline, floor)` with `overrides` beating both, not the floor alone: `packages/fabric/vcpkg.json` declares `qvac-fabric version>= 10297.1.1` and no `overrides`; the registry baseline pinned in `vcpkg-configuration.json` (`f04e2447`) carries `qvac-fabric 9341.1.0`. `max(9341.1.0, 10297.1.1)` = **10297.1.1**, matching the 0.10.0 changelog entry (`10297.0.0 -> 10297.1.1`). Tag `v10297.1.1` exists at `9d181fe64`.
- Overlay diff verified against a fresh download of the registry blob for `10297.1.1` (`git-tree c1235541`): `portfile.cmake` differs only by the added flag and its comment; `vcpkg.json` is identical.
- `LLAMA_OPENSSL` confirmed to exist and be load-bearing at `v10297.1.1` — declared in the root `CMakeLists.txt`, consumed in `vendor/cpp-httplib/CMakeLists.txt:126`.
- Diff is 5 files: the 3 overlay/wiring files plus the version bump and changelog that `release-merge-guard` requires.
- **Not yet compiled.** This PR carries no CI labels, so `ci-router` enables only `sanity-checks` and `cpp-lint` — `prebuild` is gated on `run_prebuilds`. `cpp-lint` does resolve the package through vcpkg, so it exercises the overlay at configure time, but no prebuild is produced against the flag. Add `run-desktop-addon-tests` (or `run-coload-tests`) if you want a real compile before merge.

## ⚠️ Breaking

None. Build configuration only — no API, dependency, or fabric-source change. `@qvac/fabric` `0.10.0` → `0.10.1`.

Base is `release-fabric-0.10.1`, cut from the tip of `release-fabric-0.10.0` (`44dee0538`) with no other changes. `release-merge-guard` is live on merge and this PR satisfies it: package.json is `0.10.1`, matching the branch name, and the CHANGELOG is modified in the same push. Merging publishes `@qvac/fabric@0.10.1` under dist-tag `release-0.10` — auto-decide routes it there rather than `latest`, since `0.10.1` is below the current npm `latest` of `0.13.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
