### PR TITLE
QVAC-24633 fix: restore profiler object entry in the api reference

### DIFF
--- a/docs/website/content/docs/reference/api/v0.19.x.mdx
+++ b/docs/website/content/docs/reference/api/v0.19.x.mdx
@@ -12,7 +12,7 @@ description: One-page reference of all public functions and objects exported by 
 > **Fields intentionally omitted**: parameter descriptions, return field descriptions
 > (covered by IDE hover and `.d.ts` declarations).
 >
-> **Scope**: 53 functions in `packages/sdk/client/api/`.
+> **Scope**: 53 functions in `packages/sdk/client/api/` plus the `profiler` object.
 
 ---
 
@@ -2110,6 +2110,54 @@ while (walking) {
   const { frames } = worldStep({ modelId, keys: heldKeys }); // e.g. { W: true, L: true }
   for (const frame of await frames) display(frame);
 }
+```
+
+---
+
+## Objects
+
+### `profiler`
+
+QVAC Profiler
+
+**Shape**:
+
+```ts
+const profiler: {
+  clear(): void;
+  disable(): void;
+  enable(options?: ProfilerRuntimeOptions): void;
+  exportJSON(options?: { includeRecentEvents?: boolean }): ProfilerExport;
+  exportSummary(): string;
+  exportTable(): string;
+  getAggregates(): Record<string, AggregatedStats>;
+  getConfig(): ResolvedProfilerConfig;
+  isEnabled(): boolean;
+  onRecord(callback: (event: ProfilingEvent) => void): () => void;
+};
+```
+
+**Methods**:
+
+- **`clear()`** — Clears all aggregated data and the recent-events ring buffer.
+- **`disable()`** — Disables profiling.
+- **`enable(options?)`** — Enables profiling and resets all previously aggregated data.
+- **`exportJSON(options?)`** — Exports profiling data as a structured JSON object suitable for machine consumption.
+- **`exportSummary()`** — Exports a short, human-readable summary string of the aggregated stats.
+- **`exportTable()`** — Exports aggregated stats as a formatted ASCII table suitable for terminal output.
+- **`getAggregates()`** — Returns all aggregated stats keyed by operation name.
+- **`getConfig()`** — Returns the current effective profiler configuration.
+- **`isEnabled()`** — Returns whether profiling is currently enabled.
+- **`onRecord(callback)`** — Registers a listener for profiling events; returns an unsubscribe function.
+
+**Example**:
+```ts
+import { profiler } from "@qvac/inference";
+
+profiler.enable({ mode: "summary" });
+// ... run inference operations ...
+console.log(profiler.exportTable());
+profiler.disable();
 ```
 
 ---

--- a/docs/website/scripts/api-docs/audit-tsdoc.ts
+++ b/docs/website/scripts/api-docs/audit-tsdoc.ts
@@ -20,6 +20,10 @@ import type {
   ProjectReflection,
 } from "typedoc";
 import type { AuditDiagnostic, AuditOptions, AuditResult } from "./types.js";
+import {
+  CURATED_SINGLETON_NAMES,
+  convertCuratedSingletons,
+} from "./curated-singletons.js";
 
 // ---------------------------------------------------------------------------
 // TypeDoc bootstrap (shared by CLI + tests)
@@ -121,11 +125,23 @@ export async function auditTsDoc(
   // extraction logic in `extract.ts > extractApiObjects` so parity is
   // maintained. Each method is reported as `objectName.methodName` so the
   // audit table keeps them distinct from top-level functions.
-  const allVariables = project.getReflectionsByKind(
-    ReflectionKind.Variable,
-  ) as DeclarationReflection[];
+  //
+  // Singletons re-exported from a sibling package are absent from this project
+  // (TypeDoc models the re-export as an unresolvable `Reference`), so the
+  // caller passes their reflections in via `options.curatedVariables`.
+  const allVariables = [
+    ...(project.getReflectionsByKind(
+      ReflectionKind.Variable,
+    ) as DeclarationReflection[]),
+    ...((options.curatedVariables ?? []) as DeclarationReflection[]),
+  ];
 
   for (const decl of allVariables) {
+    // Audit object methods only for the curated singletons rendered in the API
+    // summary. Matched by exported name, like `extractApiObjects` — a source
+    // path filter breaks as soon as a declaration moves between packages.
+    if (!CURATED_SINGLETON_NAMES.has(decl.name)) continue;
+
     const declType: any = (decl as any).type;
     const children: any[] | undefined =
       declType?.declaration?.children ?? (decl as any).children;
@@ -142,10 +158,6 @@ export async function auditTsDoc(
       (decl as any).sources?.[0]?.file?.fullFileName ??
       "") as string;
     const normalizedPath = sourcePath.replace(/\\/g, "/");
-    // Audit object methods only for the curated objects we render in the
-    // API summary. Currently that's just the `profiler` object under
-    // `packages/sdk/profiling/`; new public objects must opt in here.
-    if (!normalizedPath.includes("/profiling/")) continue;
     if (normalizedPath.includes("/server/") || normalizedPath.includes("/examples/")) continue;
 
     for (const m of methodProps) {
@@ -390,7 +402,10 @@ if (isMain) {
 
   console.log(`Auditing TSDoc for SDK at: ${sdkPath}`);
   const project = await bootstrapProject(sdkPath);
-  const result = await auditTsDoc(project, sdkPath);
+  const { variables } = await convertCuratedSingletons(sdkPath, project);
+  const result = await auditTsDoc(project, sdkPath, {
+    curatedVariables: variables,
+  });
 
   if (strict && result.complete < result.total) {
     console.error(

--- a/docs/website/scripts/api-docs/curated-singletons.ts
+++ b/docs/website/scripts/api-docs/curated-singletons.ts
@@ -1,0 +1,129 @@
+/**
+ * Allow-list of the public object singletons rendered in the `## Objects`
+ * section of the API summary.
+ *
+ * `packages/sdk/src/index.ts` re-exports some of its public surface from
+ * sibling workspace packages. TypeDoc converts such a re-export as a
+ * `Reference` reflection whose target lives outside the SDK program, so the
+ * singleton never appears as a `Variable` in the SDK project and cannot be
+ * discovered by walking it. Each entry therefore names the package that owns
+ * the declaration, and the extractor converts that entry point in a second
+ * TypeDoc pass when the SDK project alone does not yield the singleton.
+ *
+ * Membership is an editorial decision: these objects show up on the
+ * single-page summary, so the bar is intentional. Extraction fails loudly when
+ * an entry cannot be resolved, so a future refactor that moves a declaration
+ * cannot silently drop a whole object from the page.
+ */
+import { existsSync } from "node:fs";
+import * as path from "path";
+import { Application, ReflectionKind } from "typedoc";
+import type { DeclarationReflection, ProjectReflection } from "typedoc";
+
+export interface CuratedSingleton {
+  /** Exported identifier, as re-exported from `packages/sdk/src/index.ts`. */
+  name: string;
+  /** Package directory owning the declaration, relative to the SDK package. */
+  packageDir: string;
+  /** TypeDoc entry point that declares the singleton, relative to `packageDir`. */
+  entryPoint: string;
+}
+
+export const CURATED_SINGLETONS: CuratedSingleton[] = [
+  {
+    // Re-exported by the SDK from `@qvac/inference/surface`.
+    name: "profiler",
+    packageDir: "../inference",
+    entryPoint: "src/profiling/index.ts",
+  },
+];
+
+export const CURATED_SINGLETON_NAMES: ReadonlySet<string> = new Set(
+  CURATED_SINGLETONS.map((s) => s.name),
+);
+
+/**
+ * Absolute path of a curated singleton's TypeDoc entry point.
+ */
+export function resolveCuratedEntryPoint(
+  sdkPath: string,
+  singleton: CuratedSingleton,
+): string {
+  return path
+    .resolve(sdkPath, singleton.packageDir, singleton.entryPoint)
+    .replace(/\\/g, "/");
+}
+
+/**
+ * Convert the packages owning the curated singletons that the SDK project does
+ * not expose as `Variable` reflections.
+ *
+ * The owning package cannot be added as a second entry point on the SDK
+ * conversion — it is not part of the SDK's tsconfig program — so it gets its
+ * own conversion, against its own tsconfig.
+ *
+ * Returns the resolved `Variable` reflections plus the projects they came from,
+ * so a caller can pull named types (`ProfilerExport`, …) out of them. Missing
+ * singletons are not reported here: `extract.ts > extractApiObjects` owns the
+ * loud failure so every way a singleton can drop off fails through one path.
+ */
+export async function convertCuratedSingletons(
+  sdkPath: string,
+  sdkProject: ProjectReflection,
+): Promise<{
+  variables: DeclarationReflection[];
+  projects: ProjectReflection[];
+}> {
+  const present = new Set(
+    (
+      sdkProject.getReflectionsByKind(
+        ReflectionKind.Variable,
+      ) as DeclarationReflection[]
+    ).map((v) => v.name),
+  );
+  const pending = CURATED_SINGLETONS.filter((s) => !present.has(s.name));
+  if (pending.length === 0) return { variables: [], projects: [] };
+
+  // One conversion per owning package, even when several singletons share it.
+  const byPackage = new Map<string, CuratedSingleton[]>();
+  for (const singleton of pending) {
+    const pkgDir = path.resolve(sdkPath, singleton.packageDir);
+    const group = byPackage.get(pkgDir);
+    if (group) group.push(singleton);
+    else byPackage.set(pkgDir, [singleton]);
+  }
+
+  const variables: DeclarationReflection[] = [];
+  const projects: ProjectReflection[] = [];
+
+  for (const [pkgDir, singletons] of byPackage) {
+    const tsconfigPath = path.join(pkgDir, "tsconfig.json").replace(/\\/g, "/");
+    if (!existsSync(tsconfigPath)) continue;
+
+    const app = await Application.bootstrapWithPlugins({
+      // Deduplicated: several singletons may share one entry point, and a
+      // repeated path makes TypeDoc fall back to directory expansion.
+      entryPoints: [
+        ...new Set(singletons.map((s) => resolveCuratedEntryPoint(sdkPath, s))),
+      ],
+      tsconfig: tsconfigPath,
+      excludePrivate: true,
+      excludeProtected: true,
+      excludeExternals: true,
+      skipErrorChecking: true,
+      plugin: ["typedoc-plugin-zod"],
+    });
+    const project = await app.convert();
+    if (!project) continue;
+    projects.push(project);
+
+    const wanted = new Set(singletons.map((s) => s.name));
+    for (const decl of project.getReflectionsByKind(
+      ReflectionKind.Variable,
+    ) as DeclarationReflection[]) {
+      if (wanted.has(decl.name)) variables.push(decl);
+    }
+  }
+
+  return { variables, projects };
+}

--- a/docs/website/scripts/api-docs/extract.ts
+++ b/docs/website/scripts/api-docs/extract.ts
@@ -14,6 +14,12 @@ import type { DeclarationReflection, SignatureReflection } from "typedoc";
 import type { ApiFunction, ApiObject, ApiOverload, ExpandedType, TypeField, ErrorEntry, ApiData, StructuredType } from "./types.js";
 import { auditTsDoc } from "./audit-tsdoc.js";
 import {
+  CURATED_SINGLETONS,
+  CURATED_SINGLETON_NAMES,
+  convertCuratedSingletons,
+  resolveCuratedEntryPoint,
+} from "./curated-singletons.js";
+import {
   readSampleProse,
   readIndexSummaries,
   type SampleFunctionProse,
@@ -77,6 +83,17 @@ async function tryLoadCache(
   // rendering. Missing any of these from the sentinel leaves stale cache
   // hits when contributors change the helpers without touching SDK source.
   const newestSourceMtime = await getNewestMtime(sdkPath, ".ts");
+  // Curated singletons are declared outside the SDK package, so their sources
+  // must feed the sentinel too — otherwise editing `profiler` leaves a stale
+  // cache hit.
+  const curatedMtimes = await Promise.all(
+    CURATED_SINGLETONS.map((s) =>
+      getNewestMtime(
+        path.dirname(resolveCuratedEntryPoint(sdkPath, s)),
+        ".ts",
+      ).catch(() => 0),
+    ),
+  );
   const newestSamplesMtime = samplesDir
     ? await getNewestMtime(samplesDir, ".mdx").catch(() => 0)
     : 0;
@@ -93,6 +110,7 @@ async function tryLoadCache(
     path.join(SCRIPT_DIR, "zod-describe-extractor.ts"),
     path.join(SCRIPT_DIR, "audit-tsdoc.ts"),
     path.join(SCRIPT_DIR, "render.ts"),
+    path.join(SCRIPT_DIR, "curated-singletons.ts"),
   ];
   for (const file of helperFiles) {
     try {
@@ -107,6 +125,7 @@ async function tryLoadCache(
     newestSourceMtime,
     newestSamplesMtime,
     newestTemplatesMtime,
+    ...curatedMtimes,
     ...helperMtimes,
   );
 
@@ -185,8 +204,21 @@ export async function extractApiData(
   await loadZodDescriptions(resolveSdkSchemasDir(sdkPath));
   await loadSampleProse(options?.samplesDir);
 
+  // Curated singletons re-exported from a sibling package are absent from the
+  // SDK project, so convert their owning packages before anything walks the
+  // reflections. Their named types (`ProfilerExport`, …) live in those
+  // projects; `augmentTypeMap` keeps the SDK's own types authoritative.
+  const { variables: curatedVariables, projects: curatedProjects } =
+    await convertCuratedSingletons(sdkPath, project);
+  for (const curated of curatedProjects) augmentTypeMap(curated);
+  if (curatedVariables.length > 0) {
+    console.log(
+      `✓ Converted ${curatedVariables.length} curated singleton(s) from sibling packages`,
+    );
+  }
+
   console.log(`🔍 Auditing TSDoc completeness...`);
-  await auditTsDoc(project, sdkPath);
+  await auditTsDoc(project, sdkPath, { curatedVariables });
 
   const apiFunctions = extractApiFunctions(project);
   console.log(`✓ Extracted ${apiFunctions.length} API functions`);
@@ -215,7 +247,7 @@ export async function extractApiData(
   }
   console.log(`✓ Validation passed for all ${apiFunctions.length} functions`);
 
-  const apiObjects = extractApiObjects(project);
+  const apiObjects = extractApiObjects(project, curatedVariables);
   if (sampleProseCache.size > 0) {
     for (const obj of apiObjects) applySampleProseToObject(obj);
   }
@@ -877,12 +909,29 @@ function extractApiFunctions(project: any): ApiFunction[] {
 // TypeDoc object extraction (exported variables with object-like shapes)
 // ---------------------------------------------------------------------------
 
-function extractApiObjects(project: any): ApiObject[] {
+/**
+ * Build the `## Objects` section from the curated singleton allow-list.
+ *
+ * Candidates are matched by exported name, never by source path: the SDK
+ * re-exports part of its surface from sibling packages, and a path filter
+ * silently drops an object the moment a declaration moves. Every allow-listed
+ * name must produce an entry — otherwise extraction throws.
+ */
+function extractApiObjects(
+  project: any,
+  curatedVariables: DeclarationReflection[] = [],
+): ApiObject[] {
   const objects: ApiObject[] = [];
-  const allVars = project.getReflectionsByKind(ReflectionKind.Variable) as DeclarationReflection[];
+  const allVars = [
+    ...(project.getReflectionsByKind(
+      ReflectionKind.Variable,
+    ) as DeclarationReflection[]),
+    ...curatedVariables,
+  ];
 
   for (const refl of allVars) {
     const decl = refl as DeclarationReflection;
+    if (!CURATED_SINGLETON_NAMES.has(decl.name)) continue;
     const type = (decl as any).type;
     const props = extractTypeProperties(type, new Set<string>());
     if (!props || props.length === 0) continue;
@@ -895,11 +944,6 @@ function extractApiObjects(project: any): ApiObject[] {
     const sourcePath = (decl.sources?.[0]?.fullFileName ?? (decl as any).sources?.[0]?.file?.fullFileName ?? "") as string;
     const normalizedPath = sourcePath.replace(/\\/g, "/");
     if (normalizedPath && (normalizedPath.includes("/server/") || normalizedPath.includes("/examples/"))) continue;
-    // Object summary scope: only public, curated singletons. Today this is
-    // just `profiler` from `packages/sdk/profiling/`. Adding more curated
-    // objects here is a deliberate editorial decision — they show up on
-    // the single-page summary, so the bar should be intentional.
-    if (!normalizedPath.includes("/profiling/")) continue;
 
     const comment = decl.comment;
     const summary = comment?.summary;
@@ -941,6 +985,21 @@ function extractApiObjects(project: any): ApiObject[] {
         return readModuleJsDoc(sourcePath)?.examples ?? [];
       })(),
     });
+  }
+
+  const missing = [...CURATED_SINGLETON_NAMES].filter(
+    (name) => !objects.some((o) => o.name === name),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Curated public singleton(s) missing from the extracted API objects: ` +
+        `${missing.join(", ")}.\n\n` +
+        `These are allow-listed in scripts/api-docs/curated-singletons.ts and must ` +
+        `appear in the "## Objects" section. Likely causes:\n` +
+        `  1. The declaration moved — update the entry's packageDir/entryPoint.\n` +
+        `  2. The export was removed from packages/sdk/src/index.ts — drop the entry.\n` +
+        `  3. The value is no longer an object with callable properties.\n`,
+    );
   }
 
   return objects.sort((a, b) =>
@@ -1029,6 +1088,19 @@ function buildTypeMap(project: any): void {
   const interfaces = project.getReflectionsByKind(ReflectionKind.Interface) as DeclarationReflection[];
   for (const r of [...aliases, ...interfaces]) {
     typeMap.set(r.name, r);
+  }
+}
+
+/**
+ * Add a secondary project's named types to the lookup without disturbing the
+ * SDK's own entries. Used for the packages converted on behalf of the curated
+ * singletons: the SDK project stays authoritative on name collisions.
+ */
+function augmentTypeMap(project: any): void {
+  const aliases = project.getReflectionsByKind(ReflectionKind.TypeAlias) as DeclarationReflection[];
+  const interfaces = project.getReflectionsByKind(ReflectionKind.Interface) as DeclarationReflection[];
+  for (const r of [...aliases, ...interfaces]) {
+    if (!typeMap.has(r.name)) typeMap.set(r.name, r);
   }
 }
 
@@ -1374,9 +1446,12 @@ function initTsProgram(tsconfigPath: string): void {
 function readModuleJsDoc(
   fileName: string,
 ): { description: string; examples: string[] } | null {
-  if (!tsProgram) return null;
   const normalizedPath = fileName.replace(/\\/g, "/");
-  const sourceFile = tsProgram.getSourceFile(normalizedPath);
+  // Curated singletons are declared outside the SDK program (see
+  // `curated-singletons.ts`), so parse those files standalone.
+  const sourceFile =
+    tsProgram?.getSourceFile(normalizedPath) ??
+    readStandaloneSourceFile(normalizedPath);
   if (!sourceFile) return null;
 
   const fullText = sourceFile.getFullText();
@@ -1393,6 +1468,19 @@ function readModuleJsDoc(
 
   const raw = fullText.slice(jsdoc.pos, jsdoc.end);
   return parseJsDocBlock(raw);
+}
+
+/**
+ * Parse a single file into a `SourceFile` outside any program. Returns null
+ * when the file cannot be read.
+ */
+function readStandaloneSourceFile(fileName: string): ts.SourceFile | null {
+  try {
+    const text = fsSync.readFileSync(fileName, "utf-8");
+    return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
+  } catch {
+    return null;
+  }
 }
 
 function parseJsDocBlock(raw: string): { description: string; examples: string[] } {

--- a/docs/website/scripts/api-docs/types.ts
+++ b/docs/website/scripts/api-docs/types.ts
@@ -158,6 +158,12 @@ export interface AuditDiagnostic {
 export interface AuditOptions {
   strict?: boolean;
   quiet?: boolean;
+  /**
+   * Extra `Variable` reflections to audit alongside the project's own, for the
+   * curated singletons declared outside the SDK program. Typed loosely so this
+   * module stays free of a TypeDoc import.
+   */
+  curatedVariables?: unknown[];
 }
 
 export interface AuditResult {

--- a/docs/website/scripts/generate-api-docs.ts
+++ b/docs/website/scripts/generate-api-docs.ts
@@ -24,7 +24,8 @@
  *   1. Extract: TypeDoc walks the SDK and writes api-data.json (signatures,
  *      top-level descriptions, throws, examples, deprecated, errors). Scope
  *      is restricted to functions re-exported from
- *      `packages/sdk/client/api/index.ts` plus the `profiler` object.
+ *      `packages/sdk/client/api/index.ts` plus the curated public singletons
+ *      allow-listed in `scripts/api-docs/curated-singletons.ts`.
  *   2. Render: writes a single MDX through `single-page.njk`.
  *
  * Title-only mode (`--title-only`) skips extraction and the full render.

--- a/docs/website/tests/tsdoc-completeness.test.ts
+++ b/docs/website/tests/tsdoc-completeness.test.ts
@@ -4,6 +4,10 @@ import {
   bootstrapProject,
   auditTsDoc,
 } from "../scripts/api-docs/audit-tsdoc.js";
+import {
+  CURATED_SINGLETONS,
+  convertCuratedSingletons,
+} from "../scripts/api-docs/curated-singletons.js";
 import type { AuditResult } from "../scripts/api-docs/types.js";
 
 /**
@@ -33,8 +37,26 @@ describe("tsdoc-completeness", () => {
 
   beforeAll(async () => {
     const project = await bootstrapProject(SDK_PATH);
-    result = await auditTsDoc(project, SDK_PATH, { quiet: true });
-  }, 60_000);
+    const { variables } = await convertCuratedSingletons(SDK_PATH, project);
+    result = await auditTsDoc(project, SDK_PATH, {
+      quiet: true,
+      curatedVariables: variables,
+    });
+  }, 120_000);
+
+  it.each(CURATED_SINGLETONS.map((s) => s.name))(
+    "audits the methods of the curated singleton %s",
+    (name) => {
+      const methods = result.diagnostics.filter((d) =>
+        d.functionName.startsWith(`${name}.`),
+      );
+      expect(
+        methods.length,
+        `${name} contributed no method diagnostics — the singleton dropped out ` +
+          `of the audited surface`,
+      ).toBeGreaterThan(0);
+    },
+  );
 
   it(`overall completeness is at least ${COMPLETENESS_THRESHOLD}%`, () => {
     expect(result.completenessPercent).toBeGreaterThanOrEqual(


### PR DESCRIPTION
## What problem does this PR solve?

- The `## Objects` section and its `profiler` entry silently disappeared
  from the generated API Reference in v0.19.x. `profiler` is still public
  — the SDK re-exports it from `@qvac/inference/surface`.
- The generator gave no signal: extraction, validation and the smoke test
  all passed while a whole public object was missing from the page.

## How does it solve it?

- Root cause: `extractApiObjects()` only walks `Variable` reflections.
  Since `profiler` moved into `@qvac/inference`, the SDK re-export
  converts to an unresolvable `Reference`, so no `Variable` is emitted and
  the hard-coded `/profiling/` path filter was never reached.
- Replace the path filter with an explicit allow-list of curated public
  singletons, keyed by exported name (`scripts/api-docs/curated-singletons.ts`).
  Each entry declares its owning package, converted in a secondary TypeDoc
  pass against that package's own tsconfig.
- Extraction now fails loudly when an allow-listed singleton produces no
  object, instead of omitting it silently.
- `audit-tsdoc.ts` carried a mirrored copy of the same path filter; it uses
  the allow-list too, so page and audit scope stay in parity.
- The already-published v0.19.x page is patched by hand — the generator
  never rewrites a frozen minor.

## Tests

- Next-release dry run (`0.20.0`, scratch target): emits `## Objects` /
  `profiler` automatically, and the Scope line now counts the object.
- Same run on the pre-fix scripts reproduces the regression (0 objects, no
  section, smoke test still green).
- A deliberately unresolvable allow-list entry aborts the generator with
  exit code 1 and writes no file.
- Touching the profiler source in `@qvac/inference` invalidates the mtime
  cache; an untouched re-run still hits it.
- The block inserted into v0.19.x is byte-identical to a fresh render.
- `npx tsc --noEmit` clean; `vitest run` 263 tests pass (including a new
  assertion that every curated singleton stays in the audit surface);
  `npm run build` reports 0 broken links.