### PR TITLE
QVAC-24313 fix: reject tools requests when the model was loaded without tools: true

### DIFF
--- a/docs/website/content/docs/cli/http-server/index.mdx
+++ b/docs/website/content/docs/cli/http-server/index.mdx
@@ -514,6 +514,8 @@ curl http://localhost:11434/v1/chat/completions \
   }'
 ```
 
+A `tools` request for a model loaded without `config.tools: true` returns `400 tools_not_enabled` rather than answering in prose.
+
 #### Message content
 
 `messages[].content` accepts both the plain string form and the OpenAI **array-of-parts** form (`[{ "type": "text", "text": "…" }, …]`) that modern clients such as Cline and Open WebUI send. Parts of type `text` are concatenated into a single string; non-text parts (`image_url`, `input_audio`, `file`) are **silently dropped** — the chat surface is text-only and vision is out of scope. Both shapes below are valid:
@@ -667,7 +669,7 @@ The same generation parameters (`temperature`, `top_p`, `seed`, `max_output_toke
 
 When generation is truncated because it hit `max_output_tokens` / `max_tokens`, the response is returned with `status: "incomplete"` and `incomplete_details.reason: "max_output_tokens"` — the Responses-API analogue of chat's `finish_reason: "length"`. `usage.output_tokens` uses the same SDK-stats accounting as the other chat-category routes (`input_tokens` is `0`).
 
-The following Responses-API features are intentionally rejected with `400`: `conversation`, `background: true`, and built-in tools (`web_search`, `file_search`, `code_interpreter`). `function`-typed tools work normally.
+The following Responses-API features are intentionally rejected with `400`: `conversation`, `background: true`, and built-in tools (`web_search`, `file_search`, `code_interpreter`). `function`-typed tools work when the model was loaded with `config.tools: true`; otherwise the request returns `400 tools_not_enabled`.
 
 #### `GET /v1/responses/:id`
 

--- a/packages/cli/src/serve/extensions/openai/routes/chat.ts
+++ b/packages/cli/src/serve/extensions/openai/routes/chat.ts
@@ -10,6 +10,7 @@ import {
 } from '@/serve/extensions/openai/adapters/completion-result'
 import { requireModel } from '@/serve/core/plugins/require-model'
 import { logUnsupported } from '@/serve/core/plugins/log-unsupported'
+import { assertToolsEnabled } from '@/serve/lib/assert-tools-enabled'
 import {
   chatCompletionsBody,
   CHAT_UNSUPPORTED_PARAMS,
@@ -77,6 +78,8 @@ async function prepare(
     )
   }
 
+  assertToolsEnabled(req.qvacModel!.entry.config, sdk.tools, req.qvacModel!.alias)
+
   return {
     ...sdk,
     sdkModelId,
@@ -131,7 +134,8 @@ ends with \`data: [DONE]\\n\\n\` (OpenAI compatibility).
 
 **Tools + structured output**: combining \`tools\` with
 \`response_format: { type: 'json_object' | 'json_schema' }\` is rejected with
-\`invalid_response_format\`.
+\`invalid_response_format\`. A \`tools\` request for a model loaded without
+\`config.tools: true\` is rejected with \`tools_not_enabled\`.
 
 **Ignored params** (warned, not rejected): \`logit_bias\`, \`n\`, \`user\`,
 \`seed\`, \`logprobs\`, \`top_logprobs\`, \`frequency_penalty\`,

--- a/packages/cli/src/serve/extensions/openai/routes/responses.ts
+++ b/packages/cli/src/serve/extensions/openai/routes/responses.ts
@@ -6,6 +6,7 @@ import { HttpError } from '@/serve/lib/http-error'
 import { initSSE } from '@/serve/lib/sse'
 import { requireModel } from '@/serve/core/plugins/require-model'
 import { logUnsupported } from '@/serve/core/plugins/log-unsupported'
+import { assertToolsEnabled } from '@/serve/lib/assert-tools-enabled'
 import {
   responsesBody,
   responsesIdParams,
@@ -73,6 +74,7 @@ addressable via GET / DELETE / input_items.
 - \`background: true\` → \`400 background_not_supported\` (only synchronous responses)
 - \`tools[].type\` other than \`function\` (e.g. \`web_search\`, \`file_search\`, \`code_interpreter\`) → \`400 invalid_tool_type\`
 - structured output (\`json_object\`/\`json_schema\`) combined with non-empty \`tools\` → \`400 invalid_response_format\`
+- \`tools\` on a model loaded without \`config.tools: true\` → \`400 tools_not_enabled\`
 
 **Streaming** (\`stream: true\`) emits the OpenAI Responses SSE event sequence
 (\`response.created\` → \`response.output_text.delta\` … → \`response.completed\`)
@@ -148,6 +150,8 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
           'Structured output (json_object/json_schema) cannot be combined with "tools".'
         )
       }
+
+      assertToolsEnabled(req.qvacModel!.entry.config, sdk.tools, req.qvacModel!.alias)
 
       let history = sdk.history
       if (sdk.previousResponseId) {

--- a/packages/cli/src/serve/lib/assert-tools-enabled.ts
+++ b/packages/cli/src/serve/lib/assert-tools-enabled.ts
@@ -1,0 +1,15 @@
+import { HttpError } from '@/serve/lib/http-error'
+
+export function assertToolsEnabled(
+  modelConfig: Record<string, unknown>,
+  tools: { length: number } | undefined,
+  modelAlias: string
+): void {
+  if (!tools || tools.length === 0) return
+  if (modelConfig['tools'] === true) return
+  throw new HttpError(
+    400,
+    'tools_not_enabled',
+    `Model "${modelAlias}" was loaded without tool calling. Set serve.models.${modelAlias}.config.tools to true and reload the model.`
+  )
+}

--- a/packages/cli/test/e2e/openai/chat-tools-flag.test.ts
+++ b/packages/cli/test/e2e/openai/chat-tools-flag.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test'
+import { createServer } from '../helpers/server.js'
+import { JSON_HEADERS, assertStatusAndError } from '../helpers/http.js'
+
+const TOOLS = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get weather',
+      parameters: { type: 'object', properties: { city: { type: 'string' } } }
+    }
+  }
+]
+
+const CONFIG = {
+  serve: {
+    models: {
+      'test-llm': { model: 'QWEN3_600M_INST_Q4', preload: false, config: { ctx_size: 2048 } }
+    }
+  }
+}
+
+describe('serve: tools load flag', () => {
+  it('chat: tools request without config.tools returns 400 tools_not_enabled', async (t) => {
+    const app = await createServer(t, {
+      config: CONFIG,
+      loadModelOverride: async () => 'mock-model-id'
+    })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: JSON_HEADERS,
+      payload: {
+        model: 'test-llm',
+        messages: [{ role: 'user', content: 'What is the weather in Lagos?' }],
+        tools: TOOLS
+      }
+    })
+    assertStatusAndError(res, 400, 'tools_not_enabled')
+  })
+
+  it('responses: tools request without config.tools returns 400 tools_not_enabled', async (t) => {
+    const app = await createServer(t, {
+      config: CONFIG,
+      loadModelOverride: async () => 'mock-model-id'
+    })
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/responses',
+      headers: JSON_HEADERS,
+      payload: {
+        model: 'test-llm',
+        input: 'What is the weather in Lagos?',
+        tools: TOOLS
+      }
+    })
+    assertStatusAndError(res, 400, 'tools_not_enabled')
+  })
+})

--- a/packages/cli/test/unit/extensions/openai/assert-tools-enabled.test.ts
+++ b/packages/cli/test/unit/extensions/openai/assert-tools-enabled.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { assertToolsEnabled } from '@/serve/lib/assert-tools-enabled'
+import { HttpError } from '@/serve/lib/http-error'
+
+const TOOLS = [{ name: 'get_weather' }]
+
+describe('assertToolsEnabled', () => {
+  it('rejects a tools request when the model was loaded without tools: true', () => {
+    assert.throws(
+      () => assertToolsEnabled({ ctx_size: 2048 }, TOOLS, 'my-llm'),
+      (err: unknown) =>
+        err instanceof HttpError &&
+        err.status === 400 &&
+        err.code === 'tools_not_enabled' &&
+        err.message.includes('serve.models.my-llm.config.tools')
+    )
+  })
+
+  it('allows a tools request when the model was loaded with tools: true', () => {
+    assert.doesNotThrow(() => assertToolsEnabled({ tools: true }, TOOLS, 'my-llm'))
+  })
+
+  it('does not reject when the request has no tools', () => {
+    assert.doesNotThrow(() => assertToolsEnabled({}, undefined, 'my-llm'))
+    assert.doesNotThrow(() => assertToolsEnabled({}, [], 'my-llm'))
+  })
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `qvac serve openai` accepted `tools` on `POST /v1/chat/completions` and `POST /v1/responses` even when the model was loaded without `config.tools: true`.
- Inference never injected tool defs, so the server returned `200` prose with `finish_reason: "stop"` and no `tool_calls`. Clients saw a successful answer instead of a tool call.
- Closes https://github.com/tetherto/qvac/issues/4131

## 📝 How does it solve it?

- Chat and Responses reject a non-empty `tools` array when the loaded model's `config.tools` is not `true`.
- Response is `400 tools_not_enabled` and tells the caller to set `serve.models.<alias>.config.tools` to `true` and reload.
- HTTP docs now say that a `tools` request without that load flag is a 400, not a normal completion.

## 🧪 How was it tested?

- Unit tests for `assertToolsEnabled` (reject without flag, allow with `tools: true`, no-op when `tools` is empty). Ran locally with `npx tsx --test`.
- Serve inject e2e for chat and Responses `400 tools_not_enabled` with `loadModelOverride`. Not run locally (no built `@qvac/sdk` dist).
